### PR TITLE
Added switches for 'existingCard' and 'existingDirectDebit'

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -24,7 +24,13 @@ case object SwitchState {
 
 case class ExperimentSwitch(name: String, description: String, state: SwitchState)
 
-case class PaymentMethodsSwitch(stripe: SwitchState, payPal: SwitchState, directDebit: Option[SwitchState])
+case class PaymentMethodsSwitch(
+  stripe: SwitchState,
+  payPal: SwitchState,
+  directDebit: Option[SwitchState],
+  existingCard: Option[SwitchState],
+  existingDirectDebit: Option[SwitchState]
+)
 
 case class SupportFrontendSwitches(
   oneOffPaymentMethods: PaymentMethodsSwitch,

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -41,7 +41,7 @@ enum OneOffPaymentMethod {
 }
 
 enum RecurringPaymentMethod {
-  stripe = 'stripe', payPal = 'payPal', directDebit = 'directDebit'
+  stripe = 'stripe', payPal = 'payPal', directDebit = 'directDebit', existingCard = 'existingCard', existingDirectDebit = 'existingDirectDebit'
 }
 
 type PaymentMethod = OneOffPaymentMethod | RecurringPaymentMethod;
@@ -81,6 +81,8 @@ function paymentMethodToHumanReadable(paymentMethod: string): string {
     case RecurringPaymentMethod.directDebit: return 'Direct Debit';
     case RecurringPaymentMethod.payPal: return 'PayPal';
     case RecurringPaymentMethod.stripe: return 'Stripe';
+    case RecurringPaymentMethod.existingCard: return 'Existing Card';
+    case RecurringPaymentMethod.existingDirectDebit: return 'Existing Direct Debit';
     default: return 'Unknown';
   }
 }
@@ -121,6 +123,8 @@ class Switchboard extends React.Component<Props, Switches> {
         stripe: SwitchState.Off,
         payPal: SwitchState.Off,
         directDebit: SwitchState.Off,
+        existingCard: SwitchState.Off,
+        existingDirectDebit: SwitchState.Off,
       },
       optimize: SwitchState.Off,
       experiments: {},

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -20,7 +20,9 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |      "recurringPaymentMethods": {
       |        "stripe": "On",
       |        "payPal": "On",
-      |        "directDebit": "On"
+      |        "directDebit": "On",
+      |        "existingCard": "On",
+      |        "existingDirectDebit": "On"
       |      },
       |      "experiments": {
       |        "newFlow": {
@@ -35,8 +37,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
 
   val expectedDecoded = VersionedS3Data(
     SupportFrontendSwitches(
-      PaymentMethodsSwitch(On,On,None),
-      PaymentMethodsSwitch(On,On,Some(On)),
+      PaymentMethodsSwitch(On,On,None, None, None),
+      PaymentMethodsSwitch(On,On,Some(On), Some(On), Some(On)),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
       optimize = Off
     ),


### PR DESCRIPTION
In preparation for https://github.com/guardian/support-frontend/pull/1673 we need the ability to turn on/off the new 'existing payment methods' (card and direct debit separately).

Since the payment methods section of `support-admin-console` switches has some corresponding code for each switch, changes were required here.

![image](https://user-images.githubusercontent.com/19289579/54610373-d13e4600-4a4c-11e9-92b4-cc705b154640.png)
