### PR TITLE
Upgrade instance type to t3

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -60,7 +60,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
       - !Ref InstanceSecurityGroup
-      InstanceType: t2.micro
+      InstanceType: t3.micro
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: true
       UserData:


### PR DESCRIPTION
We're migrating to newer-generation instance types because they're a bit cheaper for the same performance.

Have tested CODE and it seems fine