### PR TITLE
Fix contribution types layout in chrome

### DIFF
--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -81,7 +81,10 @@ const styles = ({ palette, spacing, mixins }: Theme) => createStyles({
     paddingLeft: spacing.unit * 4,
     borderBottom: `1px solid ${palette.grey['300']}`,
     borderRight: `5px solid ${palette.grey['300']}`,
-    marginBottom: spacing.unit * 4,
+    marginBottom: spacing.unit * 4
+  },
+  regionSettings: {
+    display: 'flex',
     flexDirection: 'row'
   },
   contributionTypes: {
@@ -243,9 +246,11 @@ class ContributionTypesComponent extends React.Component<Props, ContributionType
         <FormControl component={'fieldset' as 'div'} className={classes.region}>
           <FormLabel component={'legend' as 'label'}>{region}</FormLabel>
 
-          {this.renderOnOffs(settings, region)}
+          <div className={classes.regionSettings}>
+            {this.renderOnOffs(settings, region)}
 
-          {this.renderDefaultRadios(getDefault(), region)}
+            {this.renderDefaultRadios(getDefault(), region)}
+          </div>
         </FormControl>
       </div>
     );


### PR DESCRIPTION
Chrome [doesn't allow flex box](https://stackoverflow.com/a/28078942) on `<fieldset>` elements. (It works in firefox, but it's non-standard).
This change adds an inner div.

Before:
<img width="459" alt="Screenshot 2019-04-23 at 09 55 43" src="https://user-images.githubusercontent.com/1513454/56568024-07bc3300-65ae-11e9-8768-61dd068eb39f.png">

After:
<img width="618" alt="Screenshot 2019-04-23 at 09 55 55" src="https://user-images.githubusercontent.com/1513454/56568025-07bc3300-65ae-11e9-8f4b-5827318c6ef8.png">
