### PR TITLE
PROD webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fetch DEV config by getting `membership` janus credentials and running:
 Build the client:
 ```
 npm install
-npm run build
+npm run build-dev
 ```
 
 Run the play server:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-router-dom": "^4.3.1"
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "webpack --config webpack.prod.js",
+    "build-dev": "webpack --config webpack.dev.js",
     "watch": "webpack --config webpack.config.js --watch"
   }
 }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const TSConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+module.exports = {
+    entry: './public/src/main.tsx',
+    output: {
+        path: path.resolve(__dirname, './public/build'),
+        filename: 'app.bundle.js'
+    },
+    module: {
+        rules: [
+            {
+                test: /^(?!.*\.spec\.tsx?$).*\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/
+            }
+        ]
+    },
+    resolve: {
+        modules: [path.resolve(__dirname, 'src'), 'node_modules'],
+        plugins: [new TSConfigPathsPlugin()],
+        extensions: ['.ts', '.tsx', '.js']
+    },
+
+    mode: 'development',
+    devtool: 'cheap-module-eval-source-map',
+    devServer: {
+        contentBase: path.join(__dirname, '/public/build'),
+        compress: true,
+        port: 9001,
+        publicPath: '/public/build'
+    }
+};

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -22,13 +22,7 @@ module.exports = {
         extensions: ['.ts', '.tsx', '.js']
     },
 
-    // Currently hardcoded for development
-    mode: 'development',
-    devtool: 'cheap-module-eval-source-map',
-    devServer: {
-        contentBase: path.join(__dirname, '/public/build'),
-        compress: true,
-        port: 9001,
-        publicPath: '/public/build'
-    }
+    mode: 'production',
+    devtool: 'cheap-module-eval-source-map'
 };
+


### PR DESCRIPTION
as it should be `production` mode.

Unrelated, but I noticed the webpack.dev.js currently has some `devServer` config but we're not using it. We should make use of it