### PR TITLE
Added a new feature switch to 'enable' the US Stripe account

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -37,5 +37,6 @@ case class SupportFrontendSwitches(
   oneOffPaymentMethods: PaymentMethodsSwitch,
   recurringPaymentMethods: PaymentMethodsSwitch,
   experiments: Map[String, ExperimentSwitch],
-  optimize: SwitchState
+  optimize: SwitchState,
+  usStripeAccount: SwitchState
 )

--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -39,7 +39,7 @@ function isContributionType(s: string): s is ContributionType {
 }
 
 const allContributionTypes = [
-  {contributionType: ContributionType.ONE_OFF, label: 'One-off'},
+  {contributionType: ContributionType.ONE_OFF, label: 'Single'},
   {contributionType: ContributionType.MONTHLY, label: 'Monthly'},
   {contributionType: ContributionType.ANNUAL, label: 'Annual'}
 ];

--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -39,7 +39,7 @@ function isContributionType(s: string): s is ContributionType {
 }
 
 const allContributionTypes = [
-  {contributionType: ContributionType.ONE_OFF, label: 'Single'},
+  {contributionType: ContributionType.ONE_OFF, label: 'One-off'},
   {contributionType: ContributionType.MONTHLY, label: 'Monthly'},
   {contributionType: ContributionType.ANNUAL, label: 'Annual'}
 ];

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -35,6 +35,7 @@ interface Switches {
     [p in RecurringPaymentMethod]: SwitchState
   },
   optimize: SwitchState,
+  usStripeAccount: SwitchState,
   experiments: {
     [featureSwitch: string]: {
       name: string,
@@ -108,6 +109,7 @@ class Switchboard extends React.Component<Props, Switches> {
         existingDirectDebit: SwitchState.Off,
       },
       optimize: SwitchState.Off,
+      usStripeAccount: SwitchState.Off,
       experiments: {},
     };
     this.previousStateFromServer = null;
@@ -179,7 +181,7 @@ class Switchboard extends React.Component<Props, Switches> {
           <div>
             {/* as "div", as "label" typecasts are to get around this issue: https://github.com/mui-org/material-ui/issues/13744 */}
             <FormControl component={'fieldset' as 'div'} className={classes.formControl}>
-              <FormLabel component={'legend' as 'label'}>One-off contributions</FormLabel>
+              <FormLabel component={'legend' as 'label'}>Single contributions</FormLabel>
               {/*
               It seems no matter how I set up the types, Object.entries and Object.keys
               give a string type to the object keys. This is a bit of a shame since it would be nice
@@ -246,6 +248,16 @@ class Switchboard extends React.Component<Props, Switches> {
                   />
                 }
                 label="Google Optimize"
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={switchStateToBoolean(this.state.usStripeAccount)}
+                    onChange={(event) => this.setState({usStripeAccount: booleanToSwitchState(event.target.checked)})}
+                    value={switchStateToBoolean(this.state.usStripeAccount)}
+                  />
+                }
+                label="US Stripe Account for Single contributions"
               />
             </FormControl>
           </div>

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -31,7 +31,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |          "state": "On"
       |        }
       |      },
-      |      "optimize": "Off"
+      |      "optimize": "Off",
+      |      "usStripeAccount": "On"
       |}
     """.stripMargin
 
@@ -40,7 +41,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       PaymentMethodsSwitch(On,On,None, None, None),
       PaymentMethodsSwitch(On,On,Some(On), Some(On), Some(On)),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
-      optimize = Off
+      optimize = Off,
+      usStripeAccount = On
     ),
     version = "v1"
   )


### PR DESCRIPTION
Added a new feature switch to 'enable' the US Stripe account to be used for US Single Contributions on support-frontend.

I've added the switch to the JSON files setting: DEV (On), CODE (On) and PROD (Off).