### PR TITLE
Use type assertions

### DIFF
--- a/public/src/components/amounts/amounts.tsx
+++ b/public/src/components/amounts/amounts.tsx
@@ -32,7 +32,7 @@ interface DataFromServer {
 }
 
 function isRegion(s: string): s is Region {
-  return Object.values(Region).includes(s)
+  return Object.values(Region).includes(s as Region)
 }
 
 const emptyAmounts: Amounts = {

--- a/public/src/components/amounts/amounts.tsx
+++ b/public/src/components/amounts/amounts.tsx
@@ -9,7 +9,7 @@ import SaveIcon from '@material-ui/icons/Save';
 import RefreshIcon from '@material-ui/icons/Refresh';
 
 import {fetchSettings, saveSettings, SettingsType} from '../../utils/requests';
-import {ContributionType, Region} from '../../utils/models';
+import {ContributionType, Region, isRegion} from '../../utils/models';
 import AmountInput from './amountInput';
 import Amount from './amount';
 
@@ -29,10 +29,6 @@ type AmountsRegions = {
 interface DataFromServer {
   value: AmountsRegions,
   version: string,
-}
-
-function isRegion(s: string): s is Region {
-  return Object.values(Region).includes(s as Region)
 }
 
 const emptyAmounts: Amounts = {

--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -13,7 +13,7 @@ import Button from '@material-ui/core/Button';
 import SaveIcon from '@material-ui/icons/Save';
 import RefreshIcon from '@material-ui/icons/Refresh';
 
-import {ContributionType, Region} from '../utils/models';
+import {ContributionType, Region, isContributionType, isRegion} from '../utils/models';
 import {fetchSettings, saveSettings, SettingsType} from '../utils/requests';
 
 interface ContributionTypeSetting {
@@ -28,14 +28,6 @@ type ContributionTypes = {
 interface DataFromServer {
   value: ContributionTypes,
   version: string,
-}
-
-function isRegion(s: string): s is Region {
-  return Object.values(Region).includes(s as Region)
-}
-
-function isContributionType(s: string): s is ContributionType {
-  return Object.values(ContributionType).includes(s as ContributionType)
 }
 
 const allContributionTypes = [

--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -31,11 +31,11 @@ interface DataFromServer {
 }
 
 function isRegion(s: string): s is Region {
-  return Object.values(Region).includes(s)
+  return Object.values(Region).includes(s as Region)
 }
 
 function isContributionType(s: string): s is ContributionType {
-  return Object.values(ContributionType).includes(s)
+  return Object.values(ContributionType).includes(s as ContributionType)
 }
 
 const allContributionTypes = [

--- a/public/src/utils/models.tsx
+++ b/public/src/utils/models.tsx
@@ -13,3 +13,11 @@ export enum Region {
   AUDCountries = 'AUDCountries',
   NZDCountries = 'NZDCountries'
 }
+
+export function isRegion(s: string): s is Region {
+  return Object.values(Region).includes(s as Region)
+}
+
+export function isContributionType(s: string): s is ContributionType {
+  return Object.values(ContributionType).includes(s as ContributionType)
+}


### PR DESCRIPTION
This changes some functions for checking if a string is in an enum.
I'm not sure why this has only now started failing type checking, the build now fails with e.g.
`Argument of type 'string' is not assignable to parameter of type 'Region'`