### PR TITLE
Make epic-tests file lockable

### DIFF
--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -8,5 +8,11 @@ import models.EpicTests._
 import scala.concurrent.ExecutionContext
 
 class EpicTestsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String)(implicit ec: ExecutionContext)
-  extends SettingsController[EpicTests](authAction, components, stage, filename = "epic-tests.json") {
+  extends LockableSettingsController[EpicTests](
+    authAction,
+    components,
+    stage,
+    dataBucket = "support-admin-console", //TODO - use a different bucket for public data
+    dataFilename = "epic-tests.json",
+    lockFilename = "epic-tests.lock") {
 }

--- a/app/controllers/LockableSettingsController.scala
+++ b/app/controllers/LockableSettingsController.scala
@@ -1,0 +1,125 @@
+package controllers
+
+import java.time.OffsetDateTime
+
+import cats.data.EitherT
+import cats.implicits._
+import com.gu.googleauth.AuthAction
+import controllers.LockableSettingsController.LockableSettingsResponse
+import io.circe.{Decoder, Encoder}
+import io.circe.syntax._
+import io.circe.generic.auto._
+import play.api.libs.circe.Circe
+import play.api.mvc._
+import services.{S3Json, VersionedS3Data}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class LockStatus(locked: Boolean, email: Option[String], timestamp: Option[OffsetDateTime])
+
+object LockStatus {
+  val unlocked = LockStatus(locked = false, None, None)
+  def locked(email: String) = LockStatus(locked = true, Some(email), Some(OffsetDateTime.now))
+}
+
+object LockableSettingsController {
+  // The model returned by this controller for GET requests
+  case class LockableSettingsResponse[T](value: T, version: String, status: LockStatus)
+}
+
+class LockableSettingsController[T : Decoder : Encoder](
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  stage: String,
+  dataBucket: String,
+  dataFilename: String,
+  lockFilename: String)(implicit ec: ExecutionContext) extends AbstractController(components) with Circe {
+
+  private val lockBucket = "support-admin-console"
+  private val lockKey = s"$stage/locks/$lockFilename"
+
+  private val dataKey = s"$stage/$dataFilename"
+
+  private val s3Client = services.S3
+
+  private def withLockStatus(f: VersionedS3Data[LockStatus] => Future[Result]): Future[Result] =
+    S3Json.getFromJson[LockStatus](lockBucket, lockKey)(s3Client).flatMap {
+      case Right(fromS3) => f(fromS3)
+      case Left(error) => Future.successful(InternalServerError(error))
+    }
+
+  private def setLockStatus(lockStatus: VersionedS3Data[LockStatus]) =
+    S3Json.putAsJson(lockBucket, lockKey, lockStatus)(s3Client)
+
+  /**
+    * Returns current version of the settings in s3 as json, with the lock status.
+    * The s3 data is validated against the model.
+    */
+  def get= authAction.async {
+    withLockStatus { case VersionedS3Data(lockStatus, _) =>
+      S3Json.getFromJson[T](dataBucket, dataKey)(s3Client).map {
+        case Right(VersionedS3Data(value, version)) =>
+          Ok(S3Json.noNulls(LockableSettingsResponse(value, version, lockStatus).asJson))
+
+        case Left(error) => InternalServerError(error)
+      }
+    }
+  }
+
+  /**
+    * Updates the file in s3 if the user currently has a lock on the file, and releases the lock if successful.
+    * The POSTed json is validated against the model.
+    */
+  def set = authAction.async(circe.json[VersionedS3Data[T]]) { request =>
+    withLockStatus { case VersionedS3Data(lockStatus, lockFileVersion) =>
+      if (lockStatus.email.contains(request.user.email)) {
+        val result: EitherT[Future, String, Unit] = for {
+          _ <- EitherT(S3Json.putAsJson(dataBucket, dataKey, request.body)(s3Client))
+          _ <- EitherT(setLockStatus(VersionedS3Data(LockStatus.unlocked, lockFileVersion)))
+        } yield ()
+
+        result.value.map {
+          case Right(_) => Ok("updated")
+          case Left(error) => InternalServerError(error)
+        }
+      } else {
+        Future.successful(Conflict(s"You do not currently have $dataFilename open for edit"))
+      }
+    }
+  }
+
+  /**
+    * Updates the lock file if there is not already a lock
+    */
+  def lock = authAction.async { request =>
+    withLockStatus { case VersionedS3Data(lockStatus, lockFileVersion) =>
+      if (!lockStatus.locked) {
+        val newLockStatus = LockStatus.locked(request.user.email)
+
+        setLockStatus(VersionedS3Data(newLockStatus, lockFileVersion)).map {
+          case Right(_) => Ok("locked")
+          case Left(error) => InternalServerError(error)
+        }
+      } else {
+        Future.successful(Conflict(s"File $dataFilename is already locked"))
+      }
+    }
+  }
+
+  /**
+    * Updates the lock file to an unlocked status if this user currently has a lock
+    */
+  def unlock = authAction.async { request =>
+    withLockStatus { case VersionedS3Data(lockStatus, lockFileVersion) =>
+      if (lockStatus.email.contains(request.user.email)) {
+        setLockStatus(VersionedS3Data(LockStatus.unlocked, lockFileVersion)) map {
+          case Right(_) => Ok("unlocked")
+          case Left(error) => InternalServerError(error)
+        }
+      } else {
+        Future.successful(BadRequest(s"File $dataFilename is not currently locked by this user"))
+      }
+    }
+  }
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -29,6 +29,8 @@ POST  /support-frontend/amounts/update              controllers.AmountsControlle
 # ----- epic tests ----- #
 GET   /frontend/epic-tests                          controllers.EpicTestsController.get
 POST  /frontend/epic-tests/update                   controllers.EpicTestsController.set
+POST  /frontend/epic-tests/lock                     controllers.EpicTestsController.lock
+POST  /frontend/epic-tests/unlock                   controllers.EpicTestsController.unlock
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
This PR introduces the concept of lockable s3 files. This is done using the new `LockableSettingsController`. It covers the backend changes only.

This is to ensure only 1 user can edit a file at a time (a simpler alternative to concurrent editing).
It is implemented by maintaining a separate `.lock` file in s3, which records the lock status of the data file, plus the email address and timestamp if it is locked.

`LockableSettingsController` has 3 handlers:
- get - returns current version of the file in s3 as json, with the lock status.
- set - updates the file in s3 if the user currently has a lock on the file, and releases the lock if successful.
- lock - updates the lock file to a locked status if there is not already a lock
- unlock - updates the lock file to an unlocked status if this user currently has a lock

Note that we assign locks by email address, so if a user begins editing the file and then opens the page again in another browser session they could overwrite their own unsaved changes.

TODO in another PR - client-side changes to support locking