### PR TITLE
Move epic test editor to top level

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "build-dev": "webpack --config webpack.dev.js",
-    "watch": "webpack --config webpack.config.js --watch"
+    "watch": "webpack --config webpack.dev.js --watch"
   }
 }

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -261,6 +261,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
           />
         </div>
 
+        {/*TODO - fix positioning, flexbox?*/}
         {this.state.tests.map(test => (<EpicTestEditor
           test={this.state.tests.find(test => test.name === this.state.selectedTestName)}
           onChange={this.onTestChange}

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -93,7 +93,14 @@ const styles = ({ spacing, typography }: Theme) => createStyles({
   },
   warning: {
     fontSize: typography.pxToRem(20),
-  }
+  },
+  testListAndEditor: {
+    display: "flex"
+  },
+  testsList: {
+    minWidth: "250px",
+    padding: 0
+  },
 });
 
 interface EpicTestFormProps extends WithStyles<typeof styles> {}
@@ -251,7 +258,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
           {this.renderButtonsBar()}
         </div>
 
-        <div>
+        <div className={classes.testListAndEditor}>
           <EpicTestsList
             tests={this.state.tests}
             selectedTestName={this.state.selectedTestName}
@@ -259,16 +266,17 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
             onSelectedTestName={this.onSelectedTestName}
             editMode={this.state.editMode}
           />
-        </div>
 
-        {/*TODO - fix positioning, flexbox?*/}
-        {this.state.tests.map(test => (<EpicTestEditor
-          test={this.state.tests.find(test => test.name === this.state.selectedTestName)}
-          onChange={this.onTestChange}
-          visible={test.name === this.state.selectedTestName}
-          key={test.name}
-          editMode={this.state.editMode}
-        />))}
+          {this.state.tests.map(test =>
+            (<EpicTestEditor
+              test={this.state.tests.find(test => test.name === this.state.selectedTestName)}
+              onChange={this.onTestChange}
+              visible={test.name === this.state.selectedTestName}
+              key={test.name}
+              editMode={this.state.editMode}
+            />)
+          )}
+        </div>
       </>
     )
   }

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -97,10 +97,6 @@ const styles = ({ spacing, typography }: Theme) => createStyles({
   testListAndEditor: {
     display: "flex"
   },
-  testsList: {
-    minWidth: "250px",
-    padding: 0
-  },
 });
 
 interface EpicTestFormProps extends WithStyles<typeof styles> {}

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import update from 'immutability-helper';
 import {createStyles, Theme, withStyles, WithStyles, CssBaseline, Typography} from "@material-ui/core";
-import SaveIcon from '@material-ui/icons/Save';
+import EpicTestEditor from './epicTestEditor';
 import LockOpenIcon from '@material-ui/icons/LockOpen'
 import RefreshIcon from '@material-ui/icons/Refresh';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
@@ -161,6 +161,11 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
     });
   };
 
+  onTestChange = (updatedTest: EpicTest): void => {
+    const updatedTests = this.state.tests.map(test => test.name === updatedTest.name ? updatedTest : test);
+    this.onTestsChange(updatedTests);
+  };
+
   onSelectedTestName = (testName: string): void => {
       this.setState({
         selectedTestName: testName
@@ -255,6 +260,14 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
             editMode={this.state.editMode}
           />
         </div>
+
+        {this.state.tests.map(test => (<EpicTestEditor
+          test={this.state.tests.find(test => test.name === this.state.selectedTestName)}
+          onChange={this.onTestChange}
+          visible={test.name === this.state.selectedTestName}
+          key={test.name}
+          editMode={this.state.editMode}
+        />))}
       </>
     )
   }

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -10,11 +10,10 @@ import NewNameCreator from './newNameCreator';
 
 
 const styles = () => createStyles({
-  testListAndEditor: {
-    display: "flex"
+  root: {
+    width: "250px",
   },
   testsList: {
-    minWidth: "250px",
     padding: 0
   },
   test: {
@@ -132,16 +131,16 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
 
     return (
       <>
-        {this.props.editMode && (
-          <NewNameCreator
-            text="test"
-            existingNames={ this.props.tests.map(test => test.name) }
-            onValidName={this.createTest}
-            editEnabled={this.props.editMode}
-          />
-        )}
+        <div className={classes.root}>
+          {this.props.editMode && (
+            <NewNameCreator
+              text="test"
+              existingNames={ this.props.tests.map(test => test.name) }
+              onValidName={this.createTest}
+              editEnabled={this.props.editMode}
+            />
+          )}
 
-        <div className={classes.testListAndEditor}>
           <List className={classes.testsList} component="nav">
             {this.props.tests.map((test, index) => {
               const classNames = this.props.selectedTestName === test.name ? `${classes.test} ${classes.selectedTest}` :

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -6,7 +6,6 @@ import {
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import { EpicTest } from './epicTestsForm';
-import EpicTestEditor from './epicTestEditor';
 import NewNameCreator from './newNameCreator';
 
 
@@ -76,11 +75,6 @@ interface EpicTestListProps extends WithStyles<typeof styles> {
 }
 
 class EpicTestsList extends React.Component<EpicTestListProps> {
-
-  onTestChange = (updatedTest: EpicTest): void => {
-    const updatedTests = this.props.tests.map(test => test.name === updatedTest.name ? updatedTest : test);
-    this.props.onUpdate(updatedTests);
-  };
 
   createTest = (newTestName: string) => {
     const newTest: EpicTest = {
@@ -176,15 +170,6 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
               )
             })}
           </List>
-
-          {this.props.tests.map(test => (<EpicTestEditor
-            test={this.props.tests.find(test => test.name === this.props.selectedTestName)}
-            onChange={this.onTestChange}
-            visible={test.name === this.props.selectedTestName}
-            key={test.name}
-            editMode={this.props.editMode}
-          />))}
-
         </div>
       </>
     )


### PR DESCRIPTION
Small refactor, no UI/functional change.
Currently the `EpicTestEditor` components are created inside the `EpicTestsList` component. This is unnecessary - all state is held in the `EpicTestsForm`.
This PR moves them up into the top level (`EpicTestsForm`).