### PR TITLE
Track and highlight modified epic tests

### DIFF
--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -117,7 +117,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps> {
       <div className={classes.container}>
         <Typography variant={'h2'} className={classes.h2}>
           {this.props.test && this.props.test.name}
-          { this.props.hasChanged && <span className={classes.hasChanged}>(modified)</span> }
+          { this.props.hasChanged && <span className={classes.hasChanged}>&nbsp;(modified)</span> }
         </Typography>
 
         <div>

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -38,6 +38,9 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
     fontWeight: typography.fontWeightMedium,
     margin: "10px 0 15px 0"
   },
+  hasChanged: {
+    color: 'red'
+  },
   h3: {
     fontSize: typography.pxToRem(24),
     fontWeight: typography.fontWeightMedium,
@@ -61,6 +64,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
 
 interface EpicTestEditorProps extends WithStyles<typeof styles> {
   test?: EpicTest,
+  hasChanged: boolean,
   onChange: (updatedTest: EpicTest) => void,
   visible: boolean,
   editMode: boolean
@@ -111,7 +115,10 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps> {
 
     return (
       <div className={classes.container}>
-        <Typography variant={'h2'} className={classes.h2}>{this.props.test && this.props.test.name}</Typography>
+        <Typography variant={'h2'} className={classes.h2}>
+          {this.props.test && this.props.test.name}
+          { this.props.hasChanged && <span className={classes.hasChanged}>(modified)</span> }
+        </Typography>
 
         <div>
           <FormControlLabel

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -161,23 +161,20 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       });
   };
 
-  onTestsChange = (updatedTests: EpicTest[]): void => {
+  onTestsChange = (updatedTests: EpicTest[], modifiedTestName?: string): void => {
+    const modifiedTestNames = modifiedTestName && !this.state.modifiedTestNames.includes(modifiedTestName) ?
+      this.state.modifiedTestNames.concat([modifiedTestName]) :
+      this.state.modifiedTestNames;
+
     this.setState({
-      tests: updatedTests
+      tests: updatedTests,
+      modifiedTestNames
     });
   };
 
   onTestChange = (updatedTest: EpicTest): void => {
-    const modifiedTestNames = this.state.modifiedTestNames.includes(updatedTest.name) ?
-      this.state.modifiedTestNames :
-      this.state.modifiedTestNames.concat([updatedTest.name]);
-
     const updatedTests = this.state.tests.map(test => test.name === updatedTest.name ? updatedTest : test);
-
-    this.setState({
-      tests: updatedTests,
-      modifiedTestNames: modifiedTestNames
-    });
+    this.onTestsChange(updatedTests, updatedTest.name);
   };
 
   onSelectedTestName = (testName: string): void => {
@@ -230,7 +227,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
         <div>
           <ButtonWithConfirmationPopup
           buttonText="Publish"
-          confirmationText="Are you sure? This will replace all live tests!"
+          confirmationText={`Are you sure? This will update ${this.state.modifiedTestNames.length} tests!`}
           onConfirm={this.save}
           icon={<CloudUploadIcon />}
           />

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -227,9 +227,10 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
         <div>
           <ButtonWithConfirmationPopup
           buttonText="Publish"
-          confirmationText={`Are you sure? This will update ${this.state.modifiedTestNames.length} tests!`}
+          confirmationText={`Are you sure? This will update ${this.state.modifiedTestNames.length} test(s)!`}
           onConfirm={this.save}
           icon={<CloudUploadIcon />}
+          disabled={this.state.modifiedTestNames.length === 0}
           />
           <ButtonWithConfirmationPopup
           buttonText="Cancel"

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -75,7 +75,8 @@ interface LockStatus {
 type EpicTestsFormState = EpicTests & {
   selectedTestName?: string,
   editMode: boolean,
-  lockStatus: LockStatus
+  lockStatus: LockStatus,
+  modifiedTestNames: string[]
 };
 
 const styles = ({ spacing, typography }: Theme) => createStyles({
@@ -111,7 +112,8 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       tests: [],
       selectedTestName: undefined,
       editMode: false,
-      lockStatus: { locked: false }
+      lockStatus: { locked: false },
+      modifiedTestNames: [],
     };
     this.previousStateFromServer = null;
   }
@@ -127,7 +129,8 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
         this.setState({
           ...serverData.value,
           lockStatus: serverData.status,
-          editMode: serverData.status.email === serverData.userEmail
+          editMode: serverData.status.email === serverData.userEmail,
+          modifiedTestNames: []
         });
       });
   };
@@ -165,8 +168,16 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
   };
 
   onTestChange = (updatedTest: EpicTest): void => {
+    const modifiedTestNames = this.state.modifiedTestNames.includes(updatedTest.name) ?
+      this.state.modifiedTestNames :
+      this.state.modifiedTestNames.concat([updatedTest.name]);
+
     const updatedTests = this.state.tests.map(test => test.name === updatedTest.name ? updatedTest : test);
-    this.onTestsChange(updatedTests);
+
+    this.setState({
+      tests: updatedTests,
+      modifiedTestNames: modifiedTestNames
+    });
   };
 
   onSelectedTestName = (testName: string): void => {
@@ -257,6 +268,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
         <div className={classes.testListAndEditor}>
           <EpicTestsList
             tests={this.state.tests}
+            modifiedTestNames={this.state.modifiedTestNames}
             selectedTestName={this.state.selectedTestName}
             onUpdate={this.onTestsChange}
             onSelectedTestName={this.onSelectedTestName}
@@ -266,6 +278,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
           {this.state.tests.map(test =>
             (<EpicTestEditor
               test={this.state.tests.find(test => test.name === this.state.selectedTestName)}
+              hasChanged={this.state.modifiedTestNames.includes(test.name)}
               onChange={this.onTestChange}
               visible={test.name === this.state.selectedTestName}
               key={test.name}

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -99,7 +99,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     }
     const newTestList = [...this.props.tests, newTest];
 
-    this.props.onUpdate(newTestList);
+    this.props.onUpdate(newTestList, newTestName);
 
     this.props.onSelectedTestName(newTest.name);
   }

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -72,7 +72,7 @@ interface EpicTestListProps extends WithStyles<typeof styles> {
   tests: EpicTest[],
   modifiedTestNames: string[],
   selectedTestName: string | undefined,
-  onUpdate: (tests: EpicTest[]) => void,
+  onUpdate: (tests: EpicTest[], modifiedTestName?: string) => void,
   onSelectedTestName: (testName: string) => void,
   editMode: boolean
 }
@@ -112,22 +112,22 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     const newTests = [...this.props.tests];
     const indexOfName = newTests.findIndex(test => test.name === name);
     if (indexOfName > 0) {
-      const beforeElement = newTests[indexOfName - 1]
+      const beforeElement = newTests[indexOfName - 1];
       newTests[indexOfName-1] = newTests[indexOfName];
       newTests[indexOfName] = beforeElement;
     }
-    this.props.onUpdate(newTests);
+    this.props.onUpdate(newTests, name);
   }
 
   moveTestDown = (name: string) => {
     const newTests = [...this.props.tests];
     const indexOfName = newTests.findIndex(test => test.name === name);
     if (indexOfName < newTests.length - 1) {
-      const afterElement = newTests[indexOfName + 1]
+      const afterElement = newTests[indexOfName + 1];
       newTests[indexOfName + 1] = newTests[indexOfName];
       newTests[indexOfName] = afterElement;
     }
-    this.props.onUpdate(newTests);
+    this.props.onUpdate(newTests, name);
   }
 
   render(): React.ReactNode {

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -31,6 +31,9 @@ const styles = () => createStyles({
   selectedTest: {
     background: "#dcdcdc"
   },
+  modifiedTest: {
+    border: "1px solid red"
+  },
   singleButtonContainer: {
     display: "block"
   },
@@ -67,6 +70,7 @@ const styles = () => createStyles({
 
 interface EpicTestListProps extends WithStyles<typeof styles> {
   tests: EpicTest[],
+  modifiedTestNames: string[],
   selectedTestName: string | undefined,
   onUpdate: (tests: EpicTest[]) => void,
   onSelectedTestName: (testName: string) => void,
@@ -143,8 +147,12 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
 
           <List className={classes.testsList} component="nav">
             {this.props.tests.map((test, index) => {
-              const classNames = this.props.selectedTestName === test.name ? `${classes.test} ${classes.selectedTest}` :
-                `${classes.test}`;
+
+              const classNames = [
+                classes.test,
+                this.props.modifiedTestNames.includes(test.name) ? classes.modifiedTest : '',
+                this.props.selectedTestName === test.name ? classes.selectedTest : '',
+              ].join(' ');
 
               return (
                 <ListItem

--- a/public/src/components/helpers/buttonWithConfirmationPopup.tsx
+++ b/public/src/components/helpers/buttonWithConfirmationPopup.tsx
@@ -25,6 +25,7 @@ interface ButtonWithConfirmationPopupProps extends WithStyles<typeof styles> {
   onConfirm: () => void,
   color?: ButtonProps["color"],
   icon: ReactElement<SvgIconProps>,
+  disabled?: boolean
 }
 
 interface ButtonWithConfirmationPopupState {
@@ -59,7 +60,12 @@ class ButtonWithConfirmationPopup extends React.Component<ButtonWithConfirmation
 
     return (
       <>
-        <Button variant="contained" color={this.props.color} onClick={this.onClick} className={classes.button}>
+        <Button
+          disabled={this.props.disabled}
+          variant="contained"
+          color={this.props.color}
+          onClick={this.onClick}
+          className={classes.button}>
             {this.props.icon}&nbsp;{this.props.buttonText}
         </Button>
         <Popover

--- a/public/src/components/helpers/buttonWithConfirmationPopup.tsx
+++ b/public/src/components/helpers/buttonWithConfirmationPopup.tsx
@@ -24,7 +24,7 @@ interface ButtonWithConfirmationPopupProps extends WithStyles<typeof styles> {
   confirmationText: string,
   onConfirm: () => void,
   color?: ButtonProps["color"],
-  icon: ReactElement<SvgIconProps>
+  icon: ReactElement<SvgIconProps>,
 }
 
 interface ButtonWithConfirmationPopupState {
@@ -32,58 +32,59 @@ interface ButtonWithConfirmationPopupState {
   anchorElement?: HTMLAnchorElement
 }
 
-class ButtonWithConfirmationPopup extends React.Component<ButtonWithConfirmationPopupProps, ButtonWithConfirmationPopupState> {state:ButtonWithConfirmationPopupState = {
-  popoverOpen: false,
-  anchorElement: undefined
-}
+class ButtonWithConfirmationPopup extends React.Component<ButtonWithConfirmationPopupProps, ButtonWithConfirmationPopupState> {
+  state: ButtonWithConfirmationPopupState = {
+    popoverOpen: false,
+    anchorElement: undefined
+  }
 
-onClick = (event: React.MouseEvent<HTMLAnchorElement>) =>  {
-  this.setState({
-    popoverOpen: true,
-    anchorElement: event.currentTarget
-  })
-}
+  onClick = (event: React.MouseEvent<HTMLAnchorElement>) =>  {
+    this.setState({
+      popoverOpen: true,
+      anchorElement: event.currentTarget
+    })
+  }
 
-handleConfirm = () => {
-  this.setState({ popoverOpen: false });
-  this.props.onConfirm();
-}
+  handleConfirm = () => {
+    this.setState({ popoverOpen: false });
+    this.props.onConfirm();
+  }
 
-handleCancel = () => {
-  this.setState({ popoverOpen: false });
-}
+  handleCancel = () => {
+    this.setState({ popoverOpen: false });
+  }
 
-render(): React.ReactNode {
-  const { classes } = this.props;
+  render(): React.ReactNode {
+    const { classes } = this.props;
 
-  return (
-    <>
-      <Button variant="contained" color={this.props.color} onClick={this.onClick} className={classes.button}>
-          {this.props.icon}&nbsp;{this.props.buttonText}
-      </Button>
-      <Popover
-        open={this.state.popoverOpen}
-        anchorEl={this.state.anchorElement}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'center',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
-        }}
+    return (
+      <>
+        <Button variant="contained" color={this.props.color} onClick={this.onClick} className={classes.button}>
+            {this.props.icon}&nbsp;{this.props.buttonText}
+        </Button>
+        <Popover
+          open={this.state.popoverOpen}
+          anchorEl={this.state.anchorElement}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
 
-      >
-        <div className={classes.popover}>
-          <Typography className={classes.message}>{this.props.confirmationText}</Typography>
-          <Button variant="contained" color="primary" onClick={this.handleConfirm}>Confirm</Button>
-          <span>&nbsp;&nbsp;</span>
-          <Button onClick={this.handleCancel}>Cancel</Button>
-        </div>
-      </Popover>
-  </>
-  )
-}
+        >
+          <div className={classes.popover}>
+            <Typography className={classes.message}>{this.props.confirmationText}</Typography>
+            <Button variant="contained" color="primary" onClick={this.handleConfirm}>Confirm</Button>
+            <span>&nbsp;&nbsp;</span>
+            <Button onClick={this.handleCancel}>Cancel</Button>
+          </div>
+        </Popover>
+    </>
+    )
+  }
 }
 
 export default withStyles(styles)(ButtonWithConfirmationPopup);


### PR DESCRIPTION
The styling could be (a lot) better, I'll leave that for later...

### Highlight any modified tests in the list (red border), and say `(modified)` after the test name:
<img width="829" alt="Screenshot 2019-09-11 at 11 57 40" src="https://user-images.githubusercontent.com/1513454/64691749-6154c980-d48b-11e9-990b-5ef07c0b1f0d.png">

### If no tests have changed then the `Publish` button is disabled:
<img width="690" alt="Screenshot 2019-09-11 at 11 55 51" src="https://user-images.githubusercontent.com/1513454/64691668-2a7eb380-d48b-11e9-8210-458b2cc0a3b7.png">

### Publish button confirmation says how many tests have changed:
<img width="690" alt="Screenshot 2019-09-11 at 11 56 37" src="https://user-images.githubusercontent.com/1513454/64691705-42563780-d48b-11e9-8ddc-9476c317a541.png">
