### PR TITLE
Support public s3 files

### DIFF
--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -4,6 +4,7 @@ import com.gu.googleauth.AuthAction
 import play.api.mvc.{AnyContent, ControllerComponents}
 import models.EpicTests
 import models.EpicTests._
+import services.S3Client.S3ObjectSettings
 
 import scala.concurrent.ExecutionContext
 
@@ -12,7 +13,10 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
     authAction,
     components,
     stage,
-    dataBucket = "support-admin-console", //TODO - use a different bucket for public data
-    dataFilename = "epic-tests.json",
-    lockFilename = "epic-tests.lock") {
+    name = "epic-tests",
+    dataObjectSettings = S3ObjectSettings(
+      bucket = "gu-contributions-public",
+      key = s"epic/$stage/epic-tests.json",
+      publicRead = true)  // This data will be requested by dotcom
+  ) {
 }

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -1,11 +1,15 @@
 package services
 
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata, PutObjectRequest}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.{Decoder, Encoder, Json, Printer}
 import io.circe.parser.decode
 import io.circe.syntax._
-import services.S3Client.RawVersionedS3Data
+import services.S3Client.{RawVersionedS3Data, S3ObjectSettings}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -13,12 +17,14 @@ import scala.util.control.NonFatal
 case class VersionedS3Data[T](value: T, version: String)
 
 trait S3Client {
-  def get(bucket: String, key: String)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]]
-  def put(bucket: String, key: String, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]]
+  def get(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]]
+  def put(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]]
 }
 
 object S3Client {
   type RawVersionedS3Data = VersionedS3Data[String]
+
+  case class S3ObjectSettings(bucket: String, key: String, publicRead: Boolean)
 }
 
 object S3 extends S3Client with StrictLogging {
@@ -29,9 +35,9 @@ object S3 extends S3Client with StrictLogging {
     .withCredentials(Aws.credentialsProvider)
     .build()
 
-  def get(bucket: String, key: String)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
+  def get(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
     try {
-      val s3Object = s3Client.getObject(bucket, key)
+      val s3Object = s3Client.getObject(objectSettings.bucket, objectSettings.key)
 
       val version = s3Object.getObjectMetadata.getVersionId
 
@@ -43,26 +49,36 @@ object S3 extends S3Client with StrictLogging {
 
     } catch {
       case NonFatal(e) =>
-        logger.error(s"Error reading $bucket/$key from S3: ${e.getMessage}", e)
+        logger.error(s"Error reading $objectSettings from S3: ${e.getMessage}", e)
         Left(s"Error reading from S3: ${e.getMessage}")
     }
   }
 
-  def put(bucket: String, key: String, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
+  def put(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
     try {
-      val currentVersion = s3Client.getObject(bucket, key).getObjectMetadata.getVersionId
+      val currentVersion = s3Client.getObject(objectSettings.bucket, objectSettings.key).getObjectMetadata.getVersionId
 
       if (currentVersion == data.version) {
-        s3Client.putObject(bucket, key, data.value)
+        val request = new PutObjectRequest(
+          objectSettings.bucket,
+          objectSettings.key,
+          new ByteArrayInputStream(data.value.getBytes(StandardCharsets.UTF_8)),
+          new ObjectMetadata()
+        )
+
+        s3Client.putObject(
+          if (objectSettings.publicRead) request.withCannedAcl(CannedAccessControlList.PublicRead)
+          else request
+        )
         Right[String, RawVersionedS3Data](data)
       } else {
-        logger.warn(s"Cannot update S3 object $bucket/$key because provided version (${data.version}) does not match latest version ($currentVersion)")
+        logger.warn(s"Cannot update S3 object $objectSettings because provided version (${data.version}) does not match latest version ($currentVersion)")
         Left(s"Can't save your settings because someone else has updated them since they were last fetched")
       }
 
     } catch {
       case NonFatal(e) =>
-        logger.error(s"Error writing $bucket/$key to S3: ${e.getMessage}", e)
+        logger.error(s"Error writing $objectSettings to S3: ${e.getMessage}", e)
         Left(s"Error writing to S3: ${e.getMessage}")
     }
   }
@@ -73,22 +89,21 @@ object S3Json extends StrictLogging {
   private val printer = Printer.spaces2.copy(dropNullValues = true)
   def noNulls(json: Json): String = printer.pretty(json)
 
-  def getFromJson[T : Decoder](bucket: String, key: String)(s3: S3Client)(implicit ec: ExecutionContext): Future[Either[String,VersionedS3Data[T]]] =
-    s3.get(bucket, key).map { result: Either[String, RawVersionedS3Data] =>
+  def getFromJson[T : Decoder](objectSettings: S3ObjectSettings)(s3: S3Client)(implicit ec: ExecutionContext): Future[Either[String,VersionedS3Data[T]]] =
+    s3.get(objectSettings).map { result: Either[String, RawVersionedS3Data] =>
       result.flatMap { raw =>
         decode[T](raw.value) match {
           case Right(decoded) => Right(raw.copy(value = decoded))
           case Left(error) =>
-            logger.error(s"Error decoding json from S3 ($bucket/$key): ${error.getMessage}", error)
-            Left(s"Error decoding json from S3 ($bucket/$key): ${error.getMessage}")
+            logger.error(s"Error decoding json from S3 ($objectSettings): ${error.getMessage}", error)
+            Left(s"Error decoding json from S3 ($objectSettings): ${error.getMessage}")
         }
       }
     }
 
-  def putAsJson[T: Encoder](bucket: String, key: String, data: VersionedS3Data[T])(s3: S3Client)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] =
+  def putAsJson[T: Encoder](objectSettings: S3ObjectSettings, data: VersionedS3Data[T])(s3: S3Client)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] =
     s3.put(
-      bucket,
-      key,
+      objectSettings,
       data.copy(value = noNulls(data.value.asJson))
     )
 }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -99,6 +99,13 @@ Resources:
           - Effect: Allow
             Action: s3:*
             Resource: !Sub arn:aws:s3:::support-admin-console/${Stage}/*
+      - PolicyName: PublicSettingsBucket
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action: s3:*
+            Resource: !Sub arn:aws:s3:::gu-contributions-public/${Stage}/*
       - PolicyName: GoogleServiceAccountCertificate
         PolicyDocument:
           Version: 2012-10-17


### PR DESCRIPTION
Currently, the epic tool publishes the data to the `support-admin-console` bucket. This bucket is private, and we should not mix private/public files in one bucket.

The epic tests file needs to be public so that users' browsers can request it.
So I've created a new s3 bucket, `gu-contributions-public`, for this purpose. (The file will also be behind fastly.)
The new bucket allows files to be public ('Block public access' is off), but each file does still need to have its [ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) set to `public-read` to become public.

This change:
1. introduces a new type, `S3ObjectSettings`, to help identify which s3 objects should be public
2. uses the new `gu-contributions-public` bucket for the epic-tests.json file, but not for any other files
3. sets the ACL to `public-read` on `epic-tests.json` only