### PR TITLE
Set surrogate-control on epic-tests.json

### DIFF
--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -18,6 +18,6 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
       bucket = "gu-contributions-public",
       key = s"epic/$stage/epic-tests.json",
       publicRead = true,  // This data will be requested by dotcom
-      cacheControl = Some("public, max-age=86400")) // Cache for a day, and use cache purging after updates
+      cacheControl = Some("max-age=86400")) // Cache for a day, and use cache purging after updates
   ) {
 }

--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -17,6 +17,7 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
     dataObjectSettings = S3ObjectSettings(
       bucket = "gu-contributions-public",
       key = s"epic/$stage/epic-tests.json",
-      publicRead = true)  // This data will be requested by dotcom
+      publicRead = true,  // This data will be requested by dotcom
+      cacheControl = Some("public, max-age=86400")) // Cache for a day, and use cache purging after updates
   ) {
 }

--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -18,6 +18,8 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
       bucket = "gu-contributions-public",
       key = s"epic/$stage/epic-tests.json",
       publicRead = true,  // This data will be requested by dotcom
-      cacheControl = Some("max-age=86400")) // Cache for a day, and use cache purging after updates
+      cacheControl = Some("max-age=30"),
+      surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
+    )
   ) {
 }

--- a/app/controllers/LockableSettingsController.scala
+++ b/app/controllers/LockableSettingsController.scala
@@ -39,7 +39,8 @@ class LockableSettingsController[T : Decoder : Encoder](
   private val lockObjectSettings = S3ObjectSettings(
     bucket = "support-admin-console",
     key = s"$stage/locks/$name.lock",
-    publicRead = false
+    publicRead = false,
+    cacheControl = None
   )
 
   private val s3Client = services.S3

--- a/app/controllers/SettingsController.scala
+++ b/app/controllers/SettingsController.scala
@@ -17,7 +17,8 @@ abstract class SettingsController[T : Decoder : Encoder](authAction: AuthAction[
   private val dataObjectSettings = S3ObjectSettings(
     bucket = "support-admin-console",
     key = s"$stage/$filename",
-    publicRead = false
+    publicRead = false,
+    cacheControl = None
   )
   private val s3Client = services.S3
 

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -59,8 +59,10 @@ object S3 extends S3Client with StrictLogging {
       val currentVersion = s3Client.getObject(objectSettings.bucket, objectSettings.key).getObjectMetadata.getVersionId
 
       if (currentVersion == data.version) {
+
         val metadata = new ObjectMetadata()
-        objectSettings.cacheControl.foreach(metadata.setCacheControl)
+        // https://docs.fastly.com/en/guides/how-caching-and-cdns-work#surrogate-headers
+        objectSettings.cacheControl.foreach(cc => metadata.addUserMetadata("surrogate-control", cc))
 
         val request = new PutObjectRequest(
           objectSettings.bucket,

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -24,7 +24,13 @@ trait S3Client {
 object S3Client {
   type RawVersionedS3Data = VersionedS3Data[String]
 
-  case class S3ObjectSettings(bucket: String, key: String, publicRead: Boolean, cacheControl: Option[String])
+  case class S3ObjectSettings(
+    bucket: String,
+    key: String,
+    publicRead: Boolean,
+    cacheControl: Option[String] = None,
+    surrogateControl: Option[String] = None
+  )
 }
 
 object S3 extends S3Client with StrictLogging {
@@ -62,7 +68,8 @@ object S3 extends S3Client with StrictLogging {
 
         val metadata = new ObjectMetadata()
         // https://docs.fastly.com/en/guides/how-caching-and-cdns-work#surrogate-headers
-        objectSettings.cacheControl.foreach(cc => metadata.addUserMetadata("surrogate-control", cc))
+        objectSettings.cacheControl.foreach(metadata.setCacheControl)
+        objectSettings.surrogateControl.foreach(cc => metadata.addUserMetadata("surrogate-control", cc))
 
         val request = new PutObjectRequest(
           objectSettings.bucket,

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -48,7 +48,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
   val objectSettings = S3ObjectSettings(
     bucket = "bucket",
     key = "key",
-    publicRead = false
+    publicRead = false,
+    cacheControl = None
   )
 
   val dummyS3Client = new S3Client {


### PR DESCRIPTION
Make fastly cache the file.
see https://docs.fastly.com/en/guides/how-caching-and-cdns-work#surrogate-headers
TODO - purge the fastly cache after updates