### PR TITLE
Epic tests - add visibility icons

### DIFF
--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -19,8 +19,10 @@ import {
   withStyles
 } from "@material-ui/core";
 import EditableTextField from "../helpers/editableTextField"
-import { Region, isRegion } from '../../utils/models';
+import { Region } from '../../utils/models';
 import EpicTestVariantsList from './epicTestVariantsList';
+import { renderVisibilityIcons, renderVisibilityHelpText } from './utilities';
+
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
   container: {
@@ -59,6 +61,16 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   radio: {
     paddingTop: "20px",
     marginBottom: "10px"
+  },
+  visibilityIcons: {
+    marginTop: spacing.unit * 1.5
+  },
+  switchWithIcon: {
+    display: "flex"
+  },
+  visibilityHelperText: {
+    marginTop: spacing.unit * 1.8,
+    marginLeft: spacing.unit
   }
 });
 
@@ -120,7 +132,8 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps> {
           { this.props.hasChanged && <span className={classes.hasChanged}>&nbsp;(modified)</span> }
         </Typography>
 
-        <div>
+        <div className={classes.switchWithIcon}>
+          <div>
           <FormControlLabel
             control={
               <Switch
@@ -129,8 +142,13 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps> {
                 disabled={!this.props.editMode}
               />
             }
-            label={`Test is ${test.isOn ? "on" : "off"}`}
+            label={`Test is ${test.isOn ? "live" : "draft"}`}
           />
+          </div>
+
+          <div className={classes.visibilityIcons}>{renderVisibilityIcons(test.isOn)}</div>
+          <div className={classes.visibilityHelperText}>{renderVisibilityHelpText(test.isOn)}</div>
+
         </div>
 
         <div>

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -5,6 +5,8 @@ import {
 } from "@material-ui/core";
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import { EpicTest } from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
 
@@ -57,10 +59,6 @@ const styles = () => createStyles({
   testIndicator: {
     width: "20px",
     height: "20px"
-  },
-  testIsOn: {
-    backgroundColor: "#ffe500",
-    borderRadius: "50%"
   },
   arrowIcon: {
     height: "20px",
@@ -129,7 +127,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     }
     this.props.onUpdate(newTests, name);
   }
-  
+
   renderReorderButtons = (testName: string, index: number) => {
     return (
       <div className={this.props.classes.buttonsContainer}>
@@ -157,6 +155,15 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
         </div>
       </div>
     )
+  }
+
+  renderVisibilityIcons = (isOn: boolean) => {
+    return (
+      isOn ?
+        <VisibilityIcon color={'action'} />
+        :
+        <VisibilityOffIcon color={'disabled'} />
+    );
   }
 
   render(): React.ReactNode {
@@ -193,8 +200,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                   <div className={classes.testText}>
                     <Typography>{test.name}</Typography>
                   </div>
-                  <div className={ `${classes.testIndicator} ${test.isOn ? classes.testIsOn : null}` }></div>
-
+                  {this.renderVisibilityIcons(test.isOn)}
                 </ListItem>
               )
             })}

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -5,8 +5,7 @@ import {
 } from "@material-ui/core";
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
-import VisibilityIcon from '@material-ui/icons/Visibility';
-import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import { renderVisibilityIcons } from './utilities';
 import { EpicTest } from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
 
@@ -157,15 +156,6 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     )
   }
 
-  renderVisibilityIcons = (isOn: boolean) => {
-    return (
-      isOn ?
-        <VisibilityIcon color={'action'} />
-        :
-        <VisibilityOffIcon color={'disabled'} />
-    );
-  }
-
   render(): React.ReactNode {
     const { classes } = this.props;
 
@@ -200,7 +190,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                   <div className={classes.testText}>
                     <Typography>{test.name}</Typography>
                   </div>
-                  {this.renderVisibilityIcons(test.isOn)}
+                  {renderVisibilityIcons(test.isOn)}
                 </ListItem>
               )
             })}

--- a/public/src/components/epicTests/utilities.tsx
+++ b/public/src/components/epicTests/utilities.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import { Typography } from "@material-ui/core";
+
+export const renderVisibilityIcons = (isOn: boolean) => {
+  return (
+    isOn ?
+      <VisibilityIcon color={'action'} />
+      :
+      <VisibilityOffIcon color={'disabled'} />
+  );
+};
+
+export const renderVisibilityHelpText = (isOn: boolean) => {
+  return (
+    isOn ?
+    <Typography color={'textSecondary'}>(Visible at <a href="https://www.theguardian.com/">theguardian.com</a>)</Typography>
+    :
+    <Typography color={'textSecondary'}>(Visible at <a href="https://www.theguardian.com#show-draft-epics">theguardian.com#show-draft-epics</a>)</Typography>
+  );
+}


### PR DESCRIPTION
Replaced the yellow dot with visibility icons to indicate if a test is live/on/visible or not.

<img width="269" alt="image" src="https://user-images.githubusercontent.com/15648334/64792428-4f4d5680-d571-11e9-8745-f781997a82ae.png">

After discussion with team, also added icon to editor along with some helper text to indicate where the live/draft tests can be viewed.

<img width="469" alt="image" src="https://user-images.githubusercontent.com/15648334/64860532-5cc41880-d625-11e9-8972-fb0a0bab05ee.png">

<img width="356" alt="image" src="https://user-images.githubusercontent.com/15648334/64860545-677ead80-d625-11e9-9df7-274f122fdedb.png">
