### PR TITLE
Fastly cache purging

### DIFF
--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -3,12 +3,23 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc.{AnyContent, ControllerComponents}
 import models.EpicTests
-import models.EpicTests._
+import play.api.libs.ws.WSClient
+import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
 
 import scala.concurrent.ExecutionContext
 
-class EpicTestsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String)(implicit ec: ExecutionContext)
+object EpicTestsController {
+  def fastlyPurger(stage: String, ws: WSClient)(implicit ec: ExecutionContext): Option[FastlyPurger] = {
+    stage match {
+      case "PROD" => Some(new FastlyPurger("https://support.theguardian.com/epic-tests.json", ws))
+      case "CODE" => Some(new FastlyPurger("https://support.code.dev-theguardian.com/epic-tests.json", ws))
+      case _ => None
+    }
+  }
+}
+
+class EpicTestsController(authAction: AuthAction[AnyContent], components: ControllerComponents, ws: WSClient, stage: String)(implicit ec: ExecutionContext)
   extends LockableSettingsController[EpicTests](
     authAction,
     components,
@@ -20,6 +31,7 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
       publicRead = true,  // This data will be requested by dotcom
       cacheControl = Some("max-age=30"),
       surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
-    )
+    ),
+    fastlyPurger = EpicTestsController.fastlyPurger(stage, ws)
   ) {
 }

--- a/app/services/FastlyPurger.scala
+++ b/app/services/FastlyPurger.scala
@@ -1,0 +1,29 @@
+package services
+
+import com.typesafe.scalalogging.StrictLogging
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FastlyPurger(url: String, ws: WSClient)(implicit val ec: ExecutionContext) extends StrictLogging {
+
+  private def errorMessage = s"Update succeeded but failed to purge the fastly cache, speak to a Developer!"
+
+  def purge: Future[Either[String,Unit]] = {
+    val result = ws.url(url).get.map { result =>
+      result.status match {
+        case 200 =>
+          logger.info(s"Purged fastly cache for $url")
+          Right(())
+        case other =>
+          logger.error(s"Failed to purge fastly cache for $url: status $other, ${result.body}")
+          Left(errorMessage)
+      }
+    }
+
+    result.recover { case error =>
+      logger.error(s"Failed to purge fastly cache for $url. Error: ${error.getMessage}", error)
+      Left(errorMessage)
+    }
+  }
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -54,7 +54,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new SwitchesController(authAction, controllerComponents, stage),
     new ContributionTypesController(authAction, controllerComponents, stage),
     new AmountsController(authAction, controllerComponents, stage),
-    new EpicTestsController(authAction, controllerComponents, stage),
+    new EpicTestsController(authAction, controllerComponents, wsClient, stage),
     assets
   )
 }


### PR DESCRIPTION
[This PR](https://github.com/guardian/support-admin-console/pull/41) introduces a long TTL in the fastly cache.
So we need to purge the cache each time the s3 file is updated. A new `FastlyPurger` class is optionally passed into the `LockableSettingsController` to purge the cache after updating the file in s3.