### PR TITLE
CTA object

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -32,6 +32,8 @@ object UserCohort extends Enum[UserCohort] with CirceEnum[UserCohort] {
   case object PostAskPauseSingleContributors extends UserCohort
 }
 
+case class Cta(text: Option[String], baseUrl: Option[String])
+
 case class EpicVariant(
   name: String,
   heading: Option[String],
@@ -40,8 +42,7 @@ case class EpicVariant(
   footer: Option[String] = None,
   showTicker: Boolean = false,
   backgroundImageUrl: Option[String] = None,
-  ctaText: Option[String] = None,
-  supportBaseURL: Option[String] = None
+  cta: Option[Cta]
 )
 
 case class EpicTest(

--- a/public/src/components/epicTests/ctaEditor.tsx
+++ b/public/src/components/epicTests/ctaEditor.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { Cta } from "./epicTestsForm";
+import {createStyles, FormControlLabel, Switch, Theme, withStyles, WithStyles} from "@material-ui/core";
+import EditableTextField from "../helpers/editableTextField"
+
+const styles = ({ palette, spacing, typography }: Theme) => createStyles({
+  fields: {
+    marginLeft: "20px"
+  }
+});
+
+const defaultText = "Support The Guardian";
+const defaultBaseUrl = "https://support.theguardian.com/contribute";
+
+export const defaultCta = {
+  text: defaultText,
+  baseUrl: defaultBaseUrl
+};
+
+interface Props extends WithStyles<typeof styles> {
+  cta?: Cta,
+  update: (cta?: Cta) => void,
+  editMode: boolean
+}
+
+class CtaEditor extends React.Component<Props> {
+
+  renderFields = (cta: Cta) => {
+    return (
+      <div className={this.props.classes.fields}>
+        <EditableTextField
+          required
+          text={cta.text || defaultText}
+          onSubmit={(value) =>
+            this.props.update({...cta, text: value})
+          }
+          label="Button text:"
+          editEnabled={this.props.editMode}
+        />
+
+        <EditableTextField
+          required
+          text={cta.baseUrl || defaultBaseUrl}
+          onSubmit={(value) =>
+            this.props.update({...cta, baseUrl: value})
+          }
+          label="Button destination:"
+          editEnabled={this.props.editMode}
+        />
+      </div>
+    )
+  };
+
+  toggleCta = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const ctaEnabled = event.target.checked;
+    if (ctaEnabled) {
+      this.props.update(defaultCta)
+    } else {
+      this.props.update(undefined)
+    }
+  };
+
+  render(): React.ReactNode {
+    return (
+      <div>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={!!this.props.cta}
+              onChange={this.toggleCta}
+              disabled={!this.props.editMode}
+            />
+          }
+          label="Has CTA button"
+        />
+        { this.props.cta && this.renderFields(this.props.cta) }
+      </div>
+    )
+  }
+}
+
+export default withStyles(styles)(CtaEditor);

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { EpicVariant, EpicTest } from "./epicTestsForm";
-import {
-  List, ListItem, Theme, createStyles, WithStyles, withStyles, Select, FormControl, InputLabel, MenuItem, Input, Checkbox, ListItemText, Typography
-} from "@material-ui/core";
-import EditableTextField from "../helpers/editableTextField"
+import {EpicVariant, EpicTest, Cta} from "./epicTestsForm";
+import {Theme, createStyles, WithStyles, withStyles, Typography} from "@material-ui/core";
+import EditableTextField from "../helpers/editableTextField";
+import CtaEditor from "./ctaEditor";
 import Switch from "@material-ui/core/Switch";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 
@@ -64,9 +63,7 @@ enum VariantFieldNames {
   highlightedText = "highlightedText",
   footer = "footer",
   showTicker = "showTicker",
-  backgroundImageUrl = "backgroundImageUrl",
-  ctaText = "ctaText",
-  supportBaseURL = "supportBaseURL"
+  backgroundImageUrl = "backgroundImageUrl"
 }
 class EpicTestVariantEditor extends React.Component<Props> {
 
@@ -74,7 +71,11 @@ class EpicTestVariantEditor extends React.Component<Props> {
     if (this.props.variant) {
       this.props.onVariantChange(update(this.props.variant));
     }
-  }
+  };
+
+  onCtaUpdate = (cta?: Cta): void => {
+    this.updateVariant(variant => ({...variant, cta}));
+  };
 
   onTextChange = (fieldName: string) => (updatedString: string): void => {
     this.updateVariant(variant => ({...variant, [fieldName]: updatedString}));
@@ -82,7 +83,7 @@ class EpicTestVariantEditor extends React.Component<Props> {
 
   onParagraphsChange = (fieldName: string) => (updatedParagraphs: string): void => {
     this.updateVariant(variant => ({...variant, [fieldName]: updatedParagraphs.split("\n")}));
-  }
+  };
 
   onVariantSwitchChange = (fieldName: string) => (event: React.ChangeEvent<HTMLInputElement>):void =>  {
     const updatedBool = event.target.checked;
@@ -114,20 +115,10 @@ class EpicTestVariantEditor extends React.Component<Props> {
             editEnabled={this.props.editMode}
           />
 
-          <EditableTextField
-            required
-            text={variant.ctaText || "Support The Guardian"}
-            onSubmit={this.onTextChange(VariantFieldNames.ctaText)}
-            label="Button text:"
-            editEnabled={this.props.editMode}
-          />
-
-          <EditableTextField
-            required
-            text={variant.supportBaseURL || "https://support.theguardian.com/contribute"}
-            onSubmit={this.onTextChange(VariantFieldNames.supportBaseURL)}
-            label="Button destination:"
-            editEnabled={this.props.editMode}
+          <CtaEditor
+            cta={variant.cta}
+            update={this.onCtaUpdate}
+            editMode={this.props.editMode}
           />
 
           <Typography variant={'h5'} className={classes.h5}>Optional</Typography>

--- a/public/src/components/epicTests/epicTestVariantsList.tsx
+++ b/public/src/components/epicTests/epicTestVariantsList.tsx
@@ -6,6 +6,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import EpicTestVariantEditor from './epicTestVariantEditor';
 import { EpicVariant } from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
+import {defaultCta} from "./ctaEditor";
 
 
 const styles = ({ typography }: Theme) => createStyles({
@@ -67,8 +68,7 @@ class EpicTestVariantsList extends React.Component<EpicTestVariantsListProps, Ep
       footer: "",
       showTicker: false,
       backgroundImageUrl: "",
-      ctaText: "",
-      supportBaseURL: ""
+      cta: defaultCta
     };
 
     this.props.onVariantsListChange([...this.props.variants, newVariant]);

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -26,6 +26,11 @@ export enum UserCohort {
   PostAskPauseSingleContributors = 'PostAskPauseSingleContributors'
 }
 
+export interface Cta {
+  text?: string,
+  baseUrl?: string
+}
+
 export interface EpicVariant {
   name: string,
   heading?: string,
@@ -34,8 +39,7 @@ export interface EpicVariant {
   footer?: string,
   showTicker: boolean,
   backgroundImageUrl?: string,
-  ctaText?: string,
-  supportBaseURL?: string
+  cta?: Cta
 }
 
 export interface EpicTest {


### PR DESCRIPTION
The CTA (aka the 'Contribute' button) is optional, because the 'thank you' epic does not include one.
This PR makes it more explicit in the model and the UI, by adding an optional `Cta` type to the `Variant` model and putting the `text` and `baseUrl` fields inside it.

The user can toggle the existence of the CTA. By default, a new variant has a CTA with fields populated with the default values.

### CTA enabled:
![Screenshot 2019-09-13 at 13 29 00](https://user-images.githubusercontent.com/1513454/64862610-e2969280-d62a-11e9-954b-cf30cb308ab2.png)

### CTA disabled:
![Screenshot 2019-09-13 at 13 29 05](https://user-images.githubusercontent.com/1513454/64862612-e2969280-d62a-11e9-9e10-54c088416211.png)
