### PR TITLE
Delete epic test

### DIFF
--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -21,7 +21,7 @@ import {
 import EditableTextField from "../helpers/editableTextField"
 import { Region } from '../../utils/models';
 import EpicTestVariantsList from './epicTestVariantsList';
-import { renderVisibilityIcons, renderVisibilityHelpText } from './utilities';
+import { renderVisibilityIcons, renderVisibilityHelpText, renderDeleteIcon } from './utilities';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
@@ -79,6 +79,9 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   deleteButton: {
     marginTop: spacing.unit * 2,
     float: "right"
+  },
+  isDeleted: {
+    color: "#f44336"
   }
 });
 
@@ -102,6 +105,10 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
   state: EpicTestEditorState = {
     validationStatus: {}
   };
+
+  isEditable = () => {
+    return this.props.editMode && !this.props.isDeleted;
+  }
 
   // TODO - set hasCountryName
   updateTest = (update: (test: EpicTest) => EpicTest) => {
@@ -136,10 +143,10 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
   };
 
   renderDeleteTestButton = (testName: string) => {
-    return this.props.editMode && (
+    return this.isEditable() && (
       <ButtonWithConfirmationPopup
         buttonText="Delete test"
-        confirmationText={`Are you sure? This cannot be undone!`}
+        confirmationText={`Are you sure? This can't be undone without cancelling entire edit session!`}
         onConfirm={() => this.props.onDelete(testName)}
         icon={<DeleteSweepIcon />}
         color={'secondary'}
@@ -154,7 +161,8 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
       <div className={classes.container}>
         <Typography variant={'h2'} className={classes.h2}>
           {this.props.test && this.props.test.name}
-          { this.props.hasChanged && <span className={classes.hasChanged}>&nbsp;(modified)</span> }
+          { (this.props.hasChanged && !this.props.isDeleted) && <span className={classes.hasChanged}>&nbsp;(modified)</span> }
+          { this.props.isDeleted && <span className={classes.isDeleted}>&nbsp;(to be deleted)</span>}
         </Typography>
 
         <div className={classes.switchWithIcon}>
@@ -164,7 +172,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
               <Switch
                 checked={test.isOn}
                 onChange={this.onSwitchChange("isOn")}
-                disabled={!this.props.editMode}
+                disabled={!this.isEditable()}
               />
             }
             label={`Test is ${test.isOn ? "live" : "draft"}`}
@@ -182,7 +190,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
               <Switch
                 checked={test.isLiveBlog}
                 onChange={this.onSwitchChange("isLiveBlog")}
-                disabled={!this.props.editMode}
+                disabled={!this.isEditable()}
               />
             }
             label="Liveblog Epic"
@@ -195,7 +203,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
               <Switch
                 checked={test.highPriority}
                 onChange={this.onSwitchChange("highPriority")}
-                disabled={!this.props.editMode}
+                disabled={!this.isEditable()}
               />
             }
             label="High priority"
@@ -208,7 +216,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             variants={test.variants}
             onVariantsListChange={this.onVariantsChange}
             testName={test.name}
-            editMode={this.props.editMode}
+            editMode={this.isEditable()}
             onValidationChange={onFieldValidationChange(this)('variantsList')}
           />
         </div>
@@ -221,7 +229,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             onSubmit={this.onListChange("tagIds")}
             label="Display on tags:"
             helperText="Separate each tag with a comma"
-            editEnabled={this.props.editMode}
+            editEnabled={this.isEditable()}
           />
 
           <EditableTextField
@@ -229,7 +237,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             onSubmit={this.onListChange("sections")}
             label="Display on sections:"
             helperText="Separate each section with a comma"
-            editEnabled={this.props.editMode}
+            editEnabled={this.isEditable()}
           />
 
           <EditableTextField
@@ -237,7 +245,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             onSubmit={this.onListChange("excludedTagIds")}
             label="Excluded tags:"
             helperText="Separate each tag with a comma"
-            editEnabled={this.props.editMode}
+            editEnabled={this.isEditable()}
           />
 
           <EditableTextField
@@ -245,7 +253,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             onSubmit={this.onListChange("excludedSections")}
             label="Excluded sections:"
             helperText="Separate each section with a comma"
-            editEnabled={this.props.editMode}
+            editEnabled={this.isEditable()}
           />
 
           <Typography variant={'h3'} className={classes.h3}>Audience</Typography>
@@ -265,7 +273,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
                 onChange={this.onLocationsChange}
                 input={<Input id="locations-select-multiple-checkbox" />}
                 renderValue={selected => (selected as string[]).join(', ')}
-                disabled={!this.props.editMode}
+                disabled={!this.isEditable()}
               >
                 {Object.values(Region).map(region => (
                   <MenuItem key={region} value={region} >
@@ -295,7 +303,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
                     key={cohort}
                     control={<Radio />}
                     label={cohort}
-                    disabled={!this.props.editMode}
+                    disabled={!this.isEditable()}
                   />
                 )}
               </RadioGroup>
@@ -313,7 +321,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             }}
             label="Max views count"
             helperText="Must be a number"
-            editEnabled={this.props.editMode}
+            editEnabled={this.isEditable()}
             validation={
               {
                 isValid: (value: string) => isNumber(value),
@@ -328,7 +336,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
                 <Switch
                   checked={test.alwaysAsk}
                   onChange={this.onSwitchChange("alwaysAsk")}
-                  disabled={!this.props.editMode}
+                  disabled={!this.isEditable()}
                 />
               }
               label={`Always ask`}
@@ -341,7 +349,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
                 <Switch
                   checked={test.useLocalViewLog}
                   onChange={this.onSwitchChange("useLocalViewLog")}
-                  disabled={!this.props.editMode}
+                  disabled={!this.isEditable()}
                 />
               }
               label={`Use local view log`}

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -23,6 +23,8 @@ import { Region } from '../../utils/models';
 import EpicTestVariantsList from './epicTestVariantsList';
 import { renderVisibilityIcons, renderVisibilityHelpText } from './utilities';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
+import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
+import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 
 const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
 
@@ -73,6 +75,10 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   visibilityHelperText: {
     marginTop: spacing.unit * 1.8,
     marginLeft: spacing.unit
+  },
+  deleteButton: {
+    marginTop: spacing.unit * 2,
+    float: "right"
   }
 });
 
@@ -82,7 +88,8 @@ interface EpicTestEditorProps extends WithStyles<typeof styles> {
   onChange: (updatedTest: EpicTest) => void,
   onValidationChange: (isValid: boolean) => void,
   visible: boolean,
-  editMode: boolean
+  editMode: boolean,
+  onDelete: (testName: string) => void
 }
 
 interface EpicTestEditorState {
@@ -125,6 +132,18 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
   onLocationsChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedLocations = [...event.target.value] as Region[];
     this.updateTest(test => ({...test, "locations": selectedLocations}));
+  };
+
+  renderDeleteTestButton = (testName: string) => {
+    return this.props.editMode && (
+      <ButtonWithConfirmationPopup
+        buttonText="Delete test"
+        confirmationText={`Are you sure? This cannot be undone!`}
+        onConfirm={() => this.props.onDelete(testName)}
+        icon={<DeleteSweepIcon />}
+        color={'secondary'}
+      />
+    );
   };
 
   renderEditor = (test: EpicTest): React.ReactNode => {
@@ -327,6 +346,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
               label={`Use local view log`}
             />
           </div>
+          <div className={classes.deleteButton}>{this.renderDeleteTestButton(test.name)}</div>
         </div>
       </div>
     )
@@ -336,7 +356,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     return (
       this.props.test ? this.props.visible && this.renderEditor(this.props.test) : null
     )
-  }
+  };
 }
 
 export default withStyles(styles)(EpicTestEditor);

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -89,7 +89,8 @@ interface EpicTestEditorProps extends WithStyles<typeof styles> {
   onValidationChange: (isValid: boolean) => void,
   visible: boolean,
   editMode: boolean,
-  onDelete: (testName: string) => void
+  onDelete: (testName: string) => void,
+  isDeleted: boolean
 }
 
 interface EpicTestEditorState {

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -9,6 +9,7 @@ import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup'
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 
+
 const styles = ({ palette, spacing, typography }: Theme) => createStyles({
   container: {
     width: "100%",
@@ -99,11 +100,11 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
     this.updateVariant(variant => ({...variant, [fieldName]: updatedBool}))
   };
 
-  renderDeleteButton = (variantName: string) => {
+  renderDeleteVariantButton = (variantName: string) => {
     return this.props.editMode && (
       <ButtonWithConfirmationPopup
         buttonText="Delete variant"
-        confirmationText={`Are you sure?`}
+        confirmationText={`Are you sure? This cannot be undone!`}
         onConfirm={() => this.props.onDelete(variantName)}
         icon={<DeleteSweepIcon />}
         color={'secondary'}
@@ -181,7 +182,7 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
             editEnabled={this.props.editMode}
           />
 
-          <div className={classes.deleteButton}>{this.renderDeleteButton(variant.name)}</div>
+          <div className={classes.deleteButton}>{this.renderDeleteVariantButton(variant.name)}</div>
 
         </>
     )

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -250,8 +250,8 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
     const numberDeleted = Object.keys(this.state.modifiedTests).filter(key => this.state.modifiedTests[key].isDeleted).length;
     return (
       <div>Are you sure? This will:
-          <br />&bull; update {`${numberModified} test${numberModified > 1 ? "s" : ""}`}
-          <br />&bull; delete {`${numberDeleted} test${numberDeleted > 1 ? "s" : ""}`}</div>
+          <br />&bull; update {`${numberModified} test${numberModified !== 1 ? "s" : ""}`}
+          <br />&bull; delete {`${numberDeleted} test${numberDeleted !== 1 ? "s" : ""}`}</div>
     );
   };
 
@@ -297,7 +297,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
           />
           <ButtonWithConfirmationPopup
           buttonText="Cancel"
-          confirmationText="Are you sure? All unpublished data will be lost!"
+          confirmationText="Are you sure? All modified and deleted tests will be lost!"
           onConfirm={() => this.cancel()}
           icon={<RefreshIcon />}
           />

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -19,6 +19,7 @@ import {
 import EpicTestsList from "./epicTestsList";
 import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
 
+
 export enum UserCohort {
   Everyone = 'Everyone',
   AllExistingSupporters = 'AllExistingSupporters',
@@ -110,7 +111,7 @@ const styles = ({ spacing, typography }: Theme) => createStyles({
   },
   testListAndEditor: {
     display: "flex"
-  },
+  }
 });
 
 interface EpicTestFormProps extends WithStyles<typeof styles> {}
@@ -203,6 +204,13 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       })
     }
   };
+
+  onTestDelete = (testName: string): void => {
+    const updatedTests = this.state.tests.filter(test => test.name !== testName);
+    this.setState({
+      tests: updatedTests
+    });
+  }
 
   onSelectedTestName = (testName: string): void => {
       this.setState({
@@ -316,9 +324,11 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
               visible={test.name === this.state.selectedTestName}
               key={test.name}
               editMode={this.state.editMode}
+              onDelete={this.onTestDelete}
             />)
           )}
         </div>
+
       </>
     )
   }

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -350,6 +350,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
               key={test.name}
               editMode={this.state.editMode}
               onDelete={this.onTestDelete}
+              isDeleted={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isDeleted}
             />)
           )}
         </div>

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import update from 'immutability-helper';
 import {createStyles, Theme, withStyles, WithStyles, CssBaseline, Typography} from "@material-ui/core";
 import EpicTestEditor from './epicTestEditor';
@@ -81,7 +81,8 @@ interface LockStatus {
 // Stores tests which have been modified
 export type ModifiedTests = {
   [testName: string]: {
-    isValid: boolean
+    isValid: boolean,
+    isDeleted: boolean
   }
 };
 
@@ -155,9 +156,11 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
   };
 
   save = () => {
+    const updatedTests = this.state.tests.filter(test =>
+      !(this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isDeleted));
     const newState = update(this.state.previousStateFromServer, {
       value: {
-        tests: { $set: this.state.tests }
+        tests: { $set: updatedTests }
       }
     });
 
@@ -179,7 +182,10 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       this.setState({
         modifiedTests: {
           ...this.state.modifiedTests,
-          [modifiedTestName]: {isValid: true}  // not already modified, assume it's valid until told otherwise
+          [modifiedTestName]: {
+            isValid: true, // not already modified, assume it's valid until told otherwise
+            isDeleted: false
+          }
         }
       })
     }
@@ -199,16 +205,25 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       this.setState({
         modifiedTests: {
           ...this.state.modifiedTests,
-          [testName]: {isValid}
+          [testName]: {
+            ...this.state.modifiedTests[testName],
+            isValid
+          }
         }
-      })
+      });
     }
   };
 
   onTestDelete = (testName: string): void => {
-    const updatedTests = this.state.tests.filter(test => test.name !== testName);
+    const updatedState = this.state.modifiedTests[testName] ?
+      { ...this.state.modifiedTests[testName], isDeleted: true } :
+      { isValid: true, isDeleted: true};
+
     this.setState({
-      tests: updatedTests
+      modifiedTests: {
+        ...this.state.modifiedTests,
+        [testName]: updatedState
+      }
     });
   }
 
@@ -227,6 +242,16 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
   requestTakeControl = () => {
     requestTakeControl(FrontendSettingsType.epicTests).then(response =>
       response.ok ? this.fetchStateFromServer() : alert("Error - can't take back control!")
+    );
+  };
+
+  buildConfirmationText = (modifiedTests: ModifiedTests): ReactElement => {
+    const numberModified = Object.keys(this.state.modifiedTests).filter(key => !this.state.modifiedTests[key].isDeleted).length;
+    const numberDeleted = Object.keys(this.state.modifiedTests).filter(key => this.state.modifiedTests[key].isDeleted).length;
+    return (
+      <div>Are you sure? This will:
+          <br />&bull; update {`${numberModified} test${numberModified > 1 ? "s" : ""}`}
+          <br />&bull; delete {`${numberDeleted} test${numberDeleted > 1 ? "s" : ""}`}</div>
     );
   };
 
@@ -262,7 +287,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
         <div>
           <ButtonWithConfirmationPopup
           buttonText="Publish"
-          confirmationText={`Are you sure? This will update ${Object.keys(this.state.modifiedTests).length} test(s)!`}
+          confirmationText={this.buildConfirmationText(this.state.modifiedTests)}
           onConfirm={this.save}
           icon={<CloudUploadIcon />}
           disabled={

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -121,8 +121,8 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     this.props.onSelectedTestName(newTest.name);
   }
 
-  onTestSelected = (event: React.MouseEvent<HTMLInputElement>): void => {
-    this.props.onSelectedTestName(event.currentTarget.innerText)
+  onTestSelected = (testName: string) => (event: React.MouseEvent<HTMLInputElement>): void => {
+    this.props.onSelectedTestName(testName);
   };
 
   moveTestUp = (name: string) => {
@@ -207,7 +207,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
               return (
                 <ListItem
                   className={classNames}
-                  onClick={this.onTestSelected}
+                  onClick={this.onTestSelected(test.name)}
                   key={index}
                 >
                   { this.props.editMode && this.renderReorderButtons(test.name, index) }

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -65,6 +65,9 @@ const styles = () => createStyles({
   arrowIcon: {
     height: "20px",
     "flex-shrink": "1"
+  },
+  deleted: {
+    backgroundColor: "#767676"
   }
 });
 
@@ -184,6 +187,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                 testStatus && testStatus.isValid ? classes.validTest : '',
                 testStatus && !testStatus.isValid ? classes.invalidTest : '',
                 this.props.selectedTestName === test.name ? classes.selectedTest : '',
+                testStatus && testStatus.isDeleted ? classes.deleted : ''
               ].join(' ');
 
               return (

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -213,7 +213,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                   { this.props.editMode && this.renderReorderButtons(test.name, index) }
                   <div className={classes.testText}>
                     <Typography>{test.name}</Typography>
-                    {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>To be deleted</Typography></div>)}
+                    {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>DELETED</Typography></div>)}
                   </div>
                   {testStatus && testStatus.isDeleted ? renderDeleteIcon() : renderVisibilityIcons(test.isOn)}
                 </ListItem>

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
-
 import {
-  List, ListItem, createStyles, WithStyles, withStyles, Typography, Button
+  List, ListItem, createStyles, WithStyles, withStyles, Typography, Button, Theme
 } from "@material-ui/core";
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
-import { renderVisibilityIcons } from './utilities';
+import { renderVisibilityIcons, renderDeleteIcon } from './utilities';
 import {EpicTest, ModifiedTests} from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
 
 
-const styles = () => createStyles({
+const styles = ( { typography }: Theme ) => createStyles({
   root: {
     width: "250px",
   },
@@ -67,7 +66,22 @@ const styles = () => createStyles({
     "flex-shrink": "1"
   },
   deleted: {
-    backgroundColor: "#767676"
+    backgroundColor: "#999999"
+  },
+  deletedLabel: {
+    backgroundColor: "red",
+    borderRadius: "2px",
+    padding: "2px",
+    margin: "2px 0 0 0"
+  },
+  toBeDeleted: {
+    fontSize: typography.pxToRem(10),
+    fontWeight: typography.fontWeightMedium,
+    backgroundColor: "#f44336",
+    borderRadius: "2px",
+    padding: "2px",
+    width: "75px",
+    textAlign: "center"
   }
 });
 
@@ -184,7 +198,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
 
               const classNames = [
                 classes.test,
-                testStatus && testStatus.isValid ? classes.validTest : '',
+                testStatus && testStatus.isValid && !testStatus.isDeleted? classes.validTest : '',
                 testStatus && !testStatus.isValid ? classes.invalidTest : '',
                 this.props.selectedTestName === test.name ? classes.selectedTest : '',
                 testStatus && testStatus.isDeleted ? classes.deleted : ''
@@ -199,8 +213,9 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                   { this.props.editMode && this.renderReorderButtons(test.name, index) }
                   <div className={classes.testText}>
                     <Typography>{test.name}</Typography>
+                    {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>To be deleted</Typography></div>)}
                   </div>
-                  {renderVisibilityIcons(test.isOn)}
+                  {testStatus && testStatus.isDeleted ? renderDeleteIcon() : renderVisibilityIcons(test.isOn)}
                 </ListItem>
               )
             })}

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -213,7 +213,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                   { this.props.editMode && this.renderReorderButtons(test.name, index) }
                   <div className={classes.testText}>
                     <Typography>{test.name}</Typography>
-                    {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>DELETED</Typography></div>)}
+                    {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>To be deleted</Typography></div>)}
                   </div>
                   {testStatus && testStatus.isDeleted ? renderDeleteIcon() : renderVisibilityIcons(test.isOn)}
                 </ListItem>

--- a/public/src/components/epicTests/utilities.tsx
+++ b/public/src/components/epicTests/utilities.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import { Typography } from "@material-ui/core";
 
 export const renderVisibilityIcons = (isOn: boolean) => {
@@ -19,4 +20,10 @@ export const renderVisibilityHelpText = (isOn: boolean) => {
     :
     <Typography color={'textSecondary'}>(Visible at <a href="https://www.theguardian.com#show-draft-epics">theguardian.com#show-draft-epics</a>)</Typography>
   );
+}
+
+export const renderDeleteIcon = () => {
+  return (
+    <DeleteForeverIcon color={'error'} />
+  )
 }

--- a/public/src/components/helpers/buttonWithConfirmationPopup.tsx
+++ b/public/src/components/helpers/buttonWithConfirmationPopup.tsx
@@ -21,7 +21,7 @@ const styles = ({ spacing, typography }: Theme) => createStyles({
 
 interface ButtonWithConfirmationPopupProps extends WithStyles<typeof styles> {
   buttonText: string,
-  confirmationText: string,
+  confirmationText: string | ReactElement,
   onConfirm: () => void,
   color?: ButtonProps["color"],
   icon: ReactElement<SvgIconProps>,


### PR DESCRIPTION
Addition of a 'delete test' button. Deleted tests will appear in the test list on the left and be disabled for editing. They will be fully deleted upon publish. Deletion can only be reversed by pressing 'cancel' button at the all-test level.

<img width="582" alt="image" src="https://user-images.githubusercontent.com/15648334/65162376-085bd700-da31-11e9-927f-e154faa2cf6e.png">
