### PR TITLE
Make alwaysAsk false by default

### DIFF
--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -106,7 +106,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
       sections: [],
       excludedTagIds: [],
       excludedSections: [],
-      alwaysAsk: true,
+      alwaysAsk: false,
       userCohort: undefined,
       isLiveBlog: false,
       hasCountryName: false,


### PR DESCRIPTION
This is to be consistent with existing behaviour. Most tests do not have it set to true