### PR TITLE
Do not block publication if a deleted test is invalid

### DIFF
--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -309,7 +309,9 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
           icon={<CloudUploadIcon />}
           disabled={
             Object.keys(this.state.modifiedTests).length === 0 ||
-            Object.keys(this.state.modifiedTests).some(name => !this.state.modifiedTests[name].isValid)
+            Object.keys(this.state.modifiedTests).some(name =>
+              !this.state.modifiedTests[name].isValid && !this.state.modifiedTests[name].isDeleted
+            )
           }
           />
           <ButtonWithConfirmationPopup


### PR DESCRIPTION
another edge case. Currently the 'Publish' button is disabled even if an invalid test has been deleted