### PR TITLE
Make delete variant button grey

### DIFF
--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -107,7 +107,6 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
         confirmationText={`Are you sure? This cannot be undone!`}
         onConfirm={() => this.props.onDelete()}
         icon={<DeleteSweepIcon />}
-        color={'secondary'}
       />
     );
   }


### PR DESCRIPTION
The delete button was a garish pink which invited being clicked on - now it's grey.

<img width="277" alt="image" src="https://user-images.githubusercontent.com/15648334/65343834-e8ade580-dbcd-11e9-8eaa-15d7299e77a0.png">

