### PR TITLE
Max views settings

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -45,6 +45,12 @@ case class EpicVariant(
   cta: Option[Cta]
 )
 
+case class MaxViews(
+  maxViewsCount: Int,
+  maxViewsDays: Int,
+  minDaysBetweenViews: Int
+)
+
 case class EpicTest(
   name: String,
   isOn: Boolean,
@@ -54,12 +60,12 @@ case class EpicTest(
   excludedTagIds: List[String] = Nil,
   excludedSections: List[String] = Nil,
   alwaysAsk: Boolean = false,
+  maxViews: Option[MaxViews],
   userCohort: Option[UserCohort] = None,
   isLiveBlog: Boolean = false,
   hasCountryName: Boolean = false,
   variants: List[EpicVariant],
   highPriority: Boolean = false,
-  maxViewsCount: Int,
   useLocalViewLog: Boolean = false
 )
 

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EpicTest, EpicVariant, UserCohort } from "./epicTestsForm";
+import { EpicTest, EpicVariant, UserCohort, MaxViews } from "./epicTestsForm";
 import {
   Checkbox,
   FormControl,
@@ -21,12 +21,11 @@ import {
 import EditableTextField from "../helpers/editableTextField"
 import { Region } from '../../utils/models';
 import EpicTestVariantsList from './epicTestVariantsList';
+import MaxViewsEditor from './maxViewsEditor';
 import { renderVisibilityIcons, renderVisibilityHelpText, renderDeleteIcon } from './utilities';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
-
-const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
   container: {
@@ -327,53 +326,28 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
               </RadioGroup>
           </FormControl>
 
-          <EditableTextField
-            text={test.maxViewsCount.toString()}
-            onSubmit={ value => {
-              if (isNumber(value)) {
-                this.updateTest(test => ({
-                  ...test,
-                  maxViewsCount: Number(value)
-                }))
-              }
-            }}
-            label="Max views count"
-            helperText="Must be a number"
-            editEnabled={this.isEditable()}
-            validation={
-              {
-                isValid: (value: string) => isNumber(value),
-                onChange: onFieldValidationChange(this)("maxViewsCount")
-              }
+          <Typography variant={'h3'} className={this.props.classes.h3}>View frequency settings:</Typography>
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={test.useLocalViewLog}
+                onChange={this.onSwitchChange("useLocalViewLog")}
+                disabled={!this.isEditable()}
+              />
             }
-            isNumberField
+            label={`Use private view counter for this test (instead of the global one)`}
           />
 
-          <div>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={test.alwaysAsk}
-                  onChange={this.onSwitchChange("alwaysAsk")}
-                  disabled={!this.isEditable()}
-                />
-              }
-              label={`Always ask`}
-            />
-          </div>
+          <MaxViewsEditor
+            test={test}
+            editMode={this.isEditable()}
+            onChange={(alwaysAsk: boolean, maxViews: MaxViews) =>
+              this.updateTest(test => ({ ...test, alwaysAsk, maxViews }))
+            }
+            onValidationChange={onFieldValidationChange(this)('maxViews')}
+          />
 
-          <div>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={test.useLocalViewLog}
-                  onChange={this.onSwitchChange("useLocalViewLog")}
-                  disabled={!this.isEditable()}
-                />
-              }
-              label={`Use local view log`}
-            />
-          </div>
           <div className={classes.deleteButton}>{this.renderDeleteTestButton(test.name)}</div>
         </div>
       </div>

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -43,6 +43,12 @@ export interface EpicVariant {
   cta?: Cta
 }
 
+export interface MaxViews {
+  maxViewsCount: number,
+  maxViewsDays: number,
+  minDaysBetweenViews: number
+}
+
 export interface EpicTest {
   name: string,
   isOn: boolean,
@@ -52,12 +58,12 @@ export interface EpicTest {
   excludedTagIds: string[],
   excludedSections: string[],
   alwaysAsk: boolean,
+  maxViews?: MaxViews,
   userCohort?: UserCohort,
   isLiveBlog: boolean,
   hasCountryName: boolean,
   variants: EpicVariant[],
   highPriority: boolean,
-  maxViewsCount: number,
   useLocalViewLog: boolean
 }
 

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -5,6 +5,7 @@ import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import {renderDeleteIcon, renderVisibilityIcons} from './utilities';
 import {EpicTest, ModifiedTests, UserCohort} from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
+import {MaxViewsDefaults} from "./maxViewsEditor";
 
 
 const styles = ( { typography }: Theme ) => createStyles({
@@ -105,12 +106,12 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
       excludedTagIds: [],
       excludedSections: [],
       alwaysAsk: false,
+      maxViews: MaxViewsDefaults,
       userCohort: UserCohort.AllNonSupporters,  // matches the default in dotcom
       isLiveBlog: false,
       hasCountryName: false,
       variants: [],
       highPriority: false,
-      maxViewsCount: 4,
       useLocalViewLog: false
     }
     const newTestList = [...this.props.tests, newTest];

--- a/public/src/components/epicTests/maxViewsEditor.tsx
+++ b/public/src/components/epicTests/maxViewsEditor.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import {
+  createStyles, FormControl,
+  FormControlLabel,
+  InputLabel, Radio,
+  RadioGroup,
+  Theme,
+  withStyles,
+  WithStyles
+} from "@material-ui/core";
+import EditableTextField from "../helpers/editableTextField"
+import {onFieldValidationChange, ValidationStatus} from "../helpers/validation";
+import {EpicTest, MaxViews} from "./epicTestsForm";
+
+const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
+
+export const MaxViewsDefaults: MaxViews = {
+  maxViewsCount: 4,
+  maxViewsDays: 30,
+  minDaysBetweenViews: 0
+};
+
+const styles = ({ spacing, typography}: Theme) => createStyles({
+  button: {
+    marginTop: '20px'
+  },
+  formControl: {
+    marginTop: spacing.unit * 2,
+    marginBottom: spacing.unit,
+    display: "block",
+  },
+  selectLabel: {
+    fontSize: typography.pxToRem(22),
+    fontWeight: typography.fontWeightMedium,
+    color: "black"
+  },
+  radio: {
+    paddingTop: "20px",
+    marginBottom: "10px"
+  },
+  maxViewsContainer: {
+    marginTop: '10px',
+    marginLeft: '20px'
+  }
+});
+
+type AskStrategy = 'AlwaysAsk' | 'MaxViews';
+
+type MaxViewsFieldName = 'maxViewsCount' | 'maxViewsDays' | 'minDaysBetweenViews';
+
+interface Props extends WithStyles<typeof styles> {
+  test: EpicTest,
+  editMode: boolean,
+  onChange: (alwaysAsk: boolean, maxViews: MaxViews) => void,
+  onValidationChange: (isValid: boolean) => void
+}
+
+interface State {
+  validationStatus: ValidationStatus
+}
+
+class MaxViewsEditor extends React.Component<Props, State> {
+  state: State = {
+    validationStatus: {}
+  };
+
+  buildField = (fieldName: MaxViewsFieldName, label: string) => {
+    const test = this.props.test;
+
+    return (<EditableTextField
+      text={test.maxViews ? test.maxViews[fieldName].toString() : MaxViewsDefaults[fieldName].toString()}
+      onSubmit={ (value: string) => {
+        if (isNumber(value)) {
+          this.props.onChange(
+            this.props.test.alwaysAsk,
+            {
+              ...this.props.test.maxViews || MaxViewsDefaults,
+              [fieldName]: Number(value)
+            }
+          )
+        }
+      }}
+      label={label}
+      helperText="Must be a number"
+      editEnabled={this.props.editMode}
+      validation={
+        {
+          isValid: (value: string) => isNumber(value),
+          onChange: onFieldValidationChange(this)(fieldName)
+        }
+      }
+      isNumberField
+    />)
+  };
+
+  onRadioChange(askStrategy: AskStrategy) {
+    this.props.onChange(
+      askStrategy === 'AlwaysAsk',
+      this.props.test.maxViews || MaxViewsDefaults
+    )
+  }
+
+  render(): React.ReactNode {
+    const classes = this.props.classes;
+
+    return (
+      <>
+        <FormControl
+          className={classes.formControl}>
+          <InputLabel
+            className={classes.selectLabel}
+            shrink
+            htmlFor="ask-strategy">
+            Ask strategy:
+          </InputLabel>
+
+          <RadioGroup
+            className={classes.radio}
+            value={this.props.test.alwaysAsk ? 'AlwaysAsk' : 'MaxViews'}
+            onChange={(event, value) => {
+              if (value === 'AlwaysAsk' || value === 'MaxViews') this.onRadioChange(value)
+            }}
+          >
+            <FormControlLabel
+              value={'AlwaysAsk'}
+              key={'AlwaysAsk'}
+              control={<Radio />}
+              label={'Always ask'}
+              disabled={!this.props.editMode}
+            />
+            <FormControlLabel
+              value={'MaxViews'}
+              key={'MaxViews'}
+              control={<Radio />}
+              label={'Use max views settings...'}
+              disabled={!this.props.editMode}
+            />
+          </RadioGroup>
+        </FormControl>
+
+        { !this.props.test.alwaysAsk &&
+          <div className={classes.maxViewsContainer}>
+            {this.buildField('maxViewsCount', 'Max views count')}
+            {this.buildField('maxViewsDays', 'Number of days')}
+            {this.buildField('minDaysBetweenViews', 'Min days between views')}
+          </div>
+        }
+      </>
+    )
+  }
+}
+
+export default withStyles(styles)(MaxViewsEditor);

--- a/public/src/components/epicTests/maxViewsEditor.tsx
+++ b/public/src/components/epicTests/maxViewsEditor.tsx
@@ -17,6 +17,7 @@ const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
 export const MaxViewsDefaults: MaxViews = {
   maxViewsCount: 4,
   maxViewsDays: 30,
+  // This is not available in the UI because we currently never change it. We can add it later if it's needed
   minDaysBetweenViews: 0
 };
 
@@ -142,7 +143,6 @@ class MaxViewsEditor extends React.Component<Props, State> {
           <div className={classes.maxViewsContainer}>
             {this.buildField('maxViewsCount', 'Max views count')}
             {this.buildField('maxViewsDays', 'Number of days')}
-            {this.buildField('minDaysBetweenViews', 'Min days between views')}
           </div>
         }
       </>


### PR DESCRIPTION
Creates a new section in the Test Editor component, 'View frequency settings'.

This includes:
- useLocalViewLog (I've given it a friendlier description in the UI)
- alwaysAsk
- maxViews

alwaysAsk and the maxViews settings are now displayed as 2 radio buttons, because the 'always ask' strategy overrides maxViews.

The `minDaysBetweenViews` value will always be 0 (the default), and is not in the UI. This is because we haven't changed this from 0 for a long time and so is overcomplicating things.

### alwaysAsk selected:
<img width="507" alt="Screenshot 2019-09-23 at 12 01 13" src="https://user-images.githubusercontent.com/1513454/65420751-ddd79880-ddf9-11e9-8c14-9dfeab1f7671.png">


### alwaysAsk not selected:
<img width="507" alt="Screenshot 2019-09-23 at 12 01 05" src="https://user-images.githubusercontent.com/1513454/65420757-e16b1f80-ddf9-11e9-8f2f-519c116bc72e.png">

