### PR TITLE
Close s3 object after read

### DIFF
--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -50,6 +50,7 @@ object S3 extends S3Client with StrictLogging {
       val stream = s3Object.getObjectContent
       val raw: String = scala.io.Source.fromInputStream(stream).mkString
       stream.close()
+      s3Object.close()
 
       Right[String,RawVersionedS3Data](VersionedS3Data(raw, version))
 


### PR DESCRIPTION
clearly it's not enough to close the input stream. It seems to use up the connection pool unless we call this
https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/S3Object.html#close--