### PR TITLE
Add space between text and buttons on popup message

### DIFF
--- a/public/src/components/helpers/buttonWithConfirmationPopup.tsx
+++ b/public/src/components/helpers/buttonWithConfirmationPopup.tsx
@@ -14,7 +14,8 @@ const styles = ({ spacing, typography }: Theme) => createStyles({
   },
   message: {
     fontSize: typography.pxToRem(18),
-    fontWeight: typography.fontWeightMedium
+    fontWeight: typography.fontWeightMedium,
+    marginBottom: spacing.unit
   }
 });
 


### PR DESCRIPTION
Before (it was a bit cramped): 
<img width="469" alt="image" src="https://user-images.githubusercontent.com/15648334/65506068-a1bc3a80-dec2-11e9-8c97-f49541c7f49d.png">

After: 
<img width="490" alt="image" src="https://user-images.githubusercontent.com/15648334/65505949-5b66db80-dec2-11e9-9314-39a11eddbd20.png">

<img width="529" alt="image" src="https://user-images.githubusercontent.com/15648334/65505974-6a4d8e00-dec2-11e9-8356-b7b7a992197d.png">
