### PR TITLE
Allow ssh via bastion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Refresh automatically:
 ```
 npm run watch
 ```
+
+
+### SSH
+You must ssh via the bastion, e.g. using [ssm-scala](https://github.com/guardian/ssm-scala):
+
+`ssm ssh --profile membership --bastion-tags contributions-store-bastion,support,PROD --tags admin-console,support,CODE -a -x --newest`

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -32,6 +32,9 @@ Parameters:
     Description: Kings Place IP range
     Type: String
     Default: 77.91.248.0/21
+  BastionSecurityGroup:
+    Description: Bastion's security group for SSH
+    Type: String
 
 Resources:
   AutoScalingGroup:
@@ -223,7 +226,7 @@ Resources:
       - IpProtocol: tcp
         FromPort: 22
         ToPort: 22
-        CidrIp: !Ref KingsPlaceIP
+        SourceSecurityGroupId: !Ref BastionSecurityGroup
       - IpProtocol: tcp
         FromPort: 9000
         ToPort: 9000


### PR DESCRIPTION
Sometimes it's useful to ssh onto our ec2 instances to investigate issues.
This hasn't been possible since we [moved instances into the private subnets](https://github.com/guardian/support-admin-console/pull/20).

The solution is to ssh via the bastion host. To do this, we need to grant access to port 22 (the ssh port) from the bastion's security group.

This will need to be done for all of our servers, I'll create a trello card for it