### PR TITLE
Add client-side functionality to archive tests

### DIFF
--- a/public/src/components/epicTests/epicTestActionBar.tsx
+++ b/public/src/components/epicTests/epicTestActionBar.tsx
@@ -157,15 +157,17 @@ class EpicTestActionBar extends React.Component<ActionBarProps> {
     const counts = {
       deleted: 0,
       created: 0,
-      modified: 0
+      modified: 0,
+      archived: 0
     };
     Object.keys(modifiedTests).forEach(key => {
       if (modifiedTests[key].isDeleted) counts.deleted++;
       else if (modifiedTests[key].isNew) counts.created++;
+      else if (modifiedTests[key].isArchived) counts.archived++;
       else counts.modified++;
     });
 
-    const statusLine = (status: 'deleted' | 'created' | 'modified') => counts[status] > 0 &&
+    const statusLine = (status: 'deleted' | 'created' | 'modified' | 'archived') => counts[status] > 0 &&
       <span>
         <br />&bull; {`${counts[status]} test${counts[status] !== 1 ? "s" : ""} ${status}`}
       </span>;
@@ -176,6 +178,7 @@ class EpicTestActionBar extends React.Component<ActionBarProps> {
         {statusLine('deleted')}
         {statusLine('created')}
         {statusLine('modified')}
+        {statusLine('archived')}
       </>
     );
   };

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -86,7 +86,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
     float: 'right'
   },
   isDeleted: {
-    color: '#f44336'
+    color: '#ab0613'
   },
   isArchived: {
     color: '#a1845c'

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -43,7 +43,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   h3: {
     fontSize: typography.pxToRem(28),
     fontWeight: typography.fontWeightMedium,
-    margin: '10px 0 15px 0'
+    margin: '10px 0 15px'
   },
   hasChanged: {
     color: 'orange'
@@ -51,7 +51,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   h4: {
     fontSize: typography.pxToRem(24),
     fontWeight: typography.fontWeightMedium,
-    margin: '20px 0 15px 0'
+    margin: '20px 0 15px'
   },
   select: {
     minWidth: "460px",
@@ -113,13 +113,13 @@ interface EpicTestEditorState {
   validationStatus: ValidationStatus
 }
 
+const areYouSure = `Are you sure? This can't be undone without cancelling entire edit session!`;
+
 class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditorState> {
 
   state: EpicTestEditorState = {
     validationStatus: {}
   };
-
-  areYouSure = `Are you sure? This can't be undone without cancelling entire edit session!`;
 
   isEditable = () => {
     return this.props.editMode && !this.props.isDeleted && !this.props.isArchived;
@@ -171,7 +171,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     return this.isEditable() && (
       <ButtonWithConfirmationPopup
         buttonText="Delete test"
-        confirmationText={this.areYouSure}
+        confirmationText={areYouSure}
         onConfirm={() => this.props.onDelete(testName)}
         icon={<DeleteSweepIcon />}
       />
@@ -182,7 +182,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     return this.isEditable() && (
       <ButtonWithConfirmationPopup
         buttonText="Archive test"
-        confirmationText={this.areYouSure}
+        confirmationText={areYouSure}
         onConfirm={() => this.props.onArchive(testName)}
         icon={<ArchiveIcon />}
       />

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -84,7 +84,8 @@ export type ModifiedTests = {
   [testName: string]: {
     isValid: boolean,
     isDeleted: boolean,
-    isNew: boolean
+    isNew: boolean,
+    isArchived: boolean
   }
 };
 
@@ -187,6 +188,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
           [modifiedTestName]: {
             isValid: true, // not already modified, assume it's valid until told otherwise
             isDeleted: false,
+            isArchived: false,
             isNew: !this.state.tests.some(test => test.name === modifiedTestName)
           }
         }
@@ -220,7 +222,12 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
   onTestDelete = (testName: string): void => {
     const updatedState = this.state.modifiedTests[testName] ?
       { ...this.state.modifiedTests[testName], isDeleted: true } :
-      { isValid: true, isDeleted: true, isNew: false};
+      {
+        isValid: true,
+        isDeleted: true,
+        isNew: false,
+        isArchived: false
+      };
 
     this.setState({
       modifiedTests: {
@@ -229,6 +236,24 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       }
     });
   };
+
+  onTestArchive = (testName: string): void => {
+    const updatedState = this.state.modifiedTests[testName] ?
+    { ...this.state.modifiedTests[testName], isArchived: true } :
+    {
+      isValid: true,
+      isDeleted: false,
+      isNew: false,
+      isArchived: true
+    };
+
+    this.setState({
+      modifiedTests: {
+        ...this.state.modifiedTests,
+        [testName]: updatedState
+      }
+    });
+  }
 
   onSelectedTestName = (testName: string): void => {
       this.setState({
@@ -292,7 +317,9 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
                       key={test.name}
                       editMode={this.state.editMode}
                       onDelete={this.onTestDelete}
+                      onArchive={this.onTestArchive}
                       isDeleted={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isDeleted}
+                      isArchived={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isArchived}
                       isNew={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isNew}
                     />)
                   ) : (<Typography className={classes.viewText}>Click on a test on the left to view contents.</Typography>)}

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -80,14 +80,17 @@ export interface LockStatus {
   timestamp?: string
 };
 
+
+export interface TestStatus {
+  isValid: boolean,
+  isDeleted: boolean,
+  isNew: boolean,
+  isArchived: boolean
+}
+
 // Stores tests which have been modified
 export type ModifiedTests = {
-  [testName: string]: {
-    isValid: boolean,
-    isDeleted: boolean,
-    isNew: boolean,
-    isArchived: boolean
-  }
+  [testName: string]: TestStatus
 };
 
 type EpicTestsFormState = EpicTests & {

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -70,24 +70,18 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
   deleted: {
     backgroundColor: '#dcdcdc',
     '&:hover': {
-      backgroundColor: '#ededed'
+      backgroundColor: '#999999'
     }
-  },
-  deletedLabel: {
-    backgroundColor: '#ab0613',
-    borderRadius: '2px',
-    padding: '2px',
-    margin: '2px 0 0 0',
-    color: 'white'
   },
   toBeDeleted: {
     fontSize: typography.pxToRem(10),
     fontWeight: typography.fontWeightMedium,
-    backgroundColor: '#f44336',
+    backgroundColor: '#ab0613',
     borderRadius: '2px',
     padding: '2px',
     width: '75px',
-    textAlign: 'center'
+    textAlign: 'center',
+    color: 'white'
   },
   deletedIcon: {
     color: '#ab0613'

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -68,13 +68,17 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
     'flex-shrink': '1'
   },
   deleted: {
-    backgroundColor: '#999999'
+    backgroundColor: '#dcdcdc',
+    '&:hover': {
+      backgroundColor: '#ededed'
+    }
   },
   deletedLabel: {
-    backgroundColor: 'red',
+    backgroundColor: '#ab0613',
     borderRadius: '2px',
     padding: '2px',
-    margin: '2px 0 0 0'
+    margin: '2px 0 0 0',
+    color: 'white'
   },
   toBeDeleted: {
     fontSize: typography.pxToRem(10),
@@ -85,8 +89,14 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
     width: '75px',
     textAlign: 'center'
   },
+  deletedIcon: {
+    color: '#ab0613'
+  },
   archived: {
-    backgroundColor: '#e7d4b9'
+    backgroundColor: '#e7d4b9',
+    '&:hover': {
+      backgroundColor: '#eacca0'
+    }
   },
   toBeArchived: {
     fontSize: typography.pxToRem(10),
@@ -220,11 +230,12 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
   }
 
   renderDeletedOrArchivedIcon = (testStatus: TestStatus): React.ReactNode => {
+    const { classes } = this.props;
     if (testStatus.isDeleted) {
-      return <DeleteForeverIcon color={'error'} />;
+      return <DeleteForeverIcon className={classes.deletedIcon} />;
     }
     else if (testStatus.isArchived) {
-      return <ArchiveIcon className={this.props.classes.archiveIcon} />;
+      return <ArchiveIcon className={classes.archiveIcon} />;
     }
     return null;
   }

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -86,21 +86,20 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
     textAlign: 'center'
   },
   archived: {
-    backgroundColor: '#6b5840',
-    color: 'white'
+    backgroundColor: '#e7d4b9'
   },
-  tobeArchived: {
+  toBeArchived: {
     fontSize: typography.pxToRem(10),
     fontWeight: typography.fontWeightMedium,
-    backgroundColor: '#eacca0',
+    backgroundColor: '#a1845c',
     borderRadius: '2px',
     padding: '2px',
     width: '75px',
     textAlign: 'center',
-    color: 'black'
+    color: 'white'
   },
   archiveIcon: {
-    color: '#eacca0'
+    color: '#a1845c'
   },
   spacer: {
     minHeight: spacing(6)
@@ -280,6 +279,8 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                         <Typography className={classes.testName}noWrap={true}>{test.name.replace(toStrip, '')}</Typography>
 
                         {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>To be deleted</Typography></div>)}
+
+                        {(testStatus && testStatus.isArchived) && (<div><Typography className={classes.toBeArchived}>To be archived</Typography></div>)}
                       </div>
                       {testStatus && (testStatus.isDeleted || testStatus.isArchived) ? this.renderDeletedOrArchivedIcon(testStatus) : renderVisibilityIcons(test.isOn)}
                     </ListItem>

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -5,7 +5,7 @@ import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import ArchiveIcon from '@material-ui/icons/Archive';
 import { renderVisibilityIcons } from './utilities';
-import {EpicTest, ModifiedTests, UserCohort} from './epicTestsForm';
+import {EpicTest, ModifiedTests, UserCohort, TestStatus} from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
 import { MaxViewsDefaults } from './maxViewsEditor';
 
@@ -133,14 +133,6 @@ interface EpicTestListProps extends WithStyles<typeof styles> {
   onSelectedTestName: (testName: string) => void,
   editMode: boolean
 }
-
-interface TestStatus {
-  isValid: boolean,
-  isDeleted: boolean,
-  isNew: boolean,
-  isArchived: boolean
-}
-
 class EpicTestsList extends React.Component<EpicTestListProps> {
 
   createTest = (newTestName: string) => {

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import {Button, createStyles, List, ListItem, Theme, Typography, withStyles, WithStyles, Tooltip, createMuiTheme, MuiThemeProvider} from "@material-ui/core";
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
-import {renderDeleteIcon, renderVisibilityIcons} from './utilities';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
+import ArchiveIcon from '@material-ui/icons/Archive';
+import { renderVisibilityIcons } from './utilities';
 import {EpicTest, ModifiedTests, UserCohort} from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
-import {MaxViewsDefaults} from "./maxViewsEditor";
+import { MaxViewsDefaults } from './maxViewsEditor';
 
 
 const styles = ( { typography, spacing }: Theme ) => createStyles({
@@ -16,40 +18,40 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
     padding: 0
   },
   test: {
-    border: "1px solid #999999",
-    borderRadius: "10px",
-    marginBottom: "5px",
-    display: "flex",
-    justifyContent: "space-between",
-    padding: "5px",
-    height: "60px",
-    "&:hover": {
-      background: "#ededed"
+    border: '1px solid #999999',
+    borderRadius: '10px',
+    marginBottom: '5px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '5px',
+    height: '60px',
+    '&:hover': {
+      background: '#ededed'
     }
   },
   selectedTest: {
-    background: "#dcdcdc"
+    background: '#dcdcdc'
   },
   validTest: {
-    boxShadow: "0 0 10px green"
+    boxShadow: '0 0 10px green'
   },
   invalidTest: {
-    boxShadow: "0 0 10px red"
+    boxShadow: '0 0 10px red'
   },
   singleButtonContainer: {
-    display: "block"
+    display: 'block'
   },
   buttonsContainer: {
-    marginRight: "10px",
-    minWidth: "20px"
+    marginRight: '10px',
+    minWidth: '20px'
   },
   arrowButton: {
-    padding: "2px",
-    margin: "2px 0 2px 0",
-    width: "20px",
-    height: "20px",
-    borderRadius: "50%",
-    minWidth: "20px"
+    padding: '2px',
+    margin: '2px 0 2px 0',
+    width: '20px',
+    height: '20px',
+    borderRadius: '50%',
+    minWidth: '20px'
   },
   testText: {
     textAlign: "left",
@@ -58,36 +60,53 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
     marginRight: "10px"
   },
   testIndicator: {
-    width: "20px",
-    height: "20px"
+    width: '20px',
+    height: '20px'
   },
   arrowIcon: {
-    height: "20px",
-    "flex-shrink": "1"
+    height: '20px',
+    'flex-shrink': '1'
   },
   deleted: {
-    backgroundColor: "#999999"
+    backgroundColor: '#999999'
   },
   deletedLabel: {
-    backgroundColor: "red",
-    borderRadius: "2px",
-    padding: "2px",
-    margin: "2px 0 0 0"
+    backgroundColor: 'red',
+    borderRadius: '2px',
+    padding: '2px',
+    margin: '2px 0 0 0'
   },
   toBeDeleted: {
     fontSize: typography.pxToRem(10),
     fontWeight: typography.fontWeightMedium,
-    backgroundColor: "#f44336",
-    borderRadius: "2px",
-    padding: "2px",
-    width: "75px",
-    textAlign: "center"
+    backgroundColor: '#f44336',
+    borderRadius: '2px',
+    padding: '2px',
+    width: '75px',
+    textAlign: 'center'
+  },
+  archived: {
+    backgroundColor: '#6b5840',
+    color: 'white'
+  },
+  tobeArchived: {
+    fontSize: typography.pxToRem(10),
+    fontWeight: typography.fontWeightMedium,
+    backgroundColor: '#eacca0',
+    borderRadius: '2px',
+    padding: '2px',
+    width: '75px',
+    textAlign: 'center',
+    color: 'black'
+  },
+  archiveIcon: {
+    color: '#eacca0'
   },
   spacer: {
     minHeight: spacing(6)
   },
   testName: {
-    fontSize: "0.875rem"
+    fontSize: '0.875rem'
   }
 });
 
@@ -110,6 +129,13 @@ interface EpicTestListProps extends WithStyles<typeof styles> {
   onUpdate: (tests: EpicTest[], modifiedTestName?: string) => void,
   onSelectedTestName: (testName: string) => void,
   editMode: boolean
+}
+
+interface TestStatus {
+  isValid: boolean,
+  isDeleted: boolean,
+  isNew: boolean,
+  isArchived: boolean
 }
 
 class EpicTestsList extends React.Component<EpicTestListProps> {
@@ -143,7 +169,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     this.props.onSelectedTestName(testName);
   };
 
-  moveTestUp = (name: string) => {
+  moveTestUp = (name: string): void => {
     const newTests = [...this.props.tests];
     const indexOfName = newTests.findIndex(test => test.name === name);
     if (indexOfName > 0) {
@@ -154,7 +180,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     this.props.onUpdate(newTests, name);
   }
 
-  moveTestDown = (name: string) => {
+  moveTestDown = (name: string): void => {
     const newTests = [...this.props.tests];
     const indexOfName = newTests.findIndex(test => test.name === name);
     if (indexOfName < newTests.length - 1) {
@@ -194,6 +220,16 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
     )
   }
 
+  renderDeletedOrArchivedIcon = (testStatus: TestStatus): React.ReactNode => {
+    if (testStatus.isDeleted) {
+      return <DeleteForeverIcon color={'error'} />;
+    }
+    else if (testStatus.isArchived) {
+      return <ArchiveIcon className={this.props.classes.archiveIcon} />;
+    }
+    return null;
+  }
+
   render(): React.ReactNode {
     const { classes } = this.props;
 
@@ -217,15 +253,16 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
 
               const classNames = [
                 classes.test,
-                testStatus && testStatus.isValid && !testStatus.isDeleted? classes.validTest : '',
+                testStatus && testStatus.isValid && !testStatus.isDeleted && !testStatus.isArchived ? classes.validTest : '',
                 testStatus && !testStatus.isValid ? classes.invalidTest : '',
                 this.props.selectedTestName === test.name ? classes.selectedTest : '',
-                testStatus && testStatus.isDeleted ? classes.deleted : ''
+                testStatus && testStatus.isDeleted ? classes.deleted : '',
+                testStatus && testStatus.isArchived ? classes.archived : ''
               ].join(' ');
 
               return (
                 <MuiThemeProvider
-                  theme={theme} 
+                  theme={theme}
                   key={index}
                 >
                   <Tooltip
@@ -244,7 +281,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
 
                         {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>To be deleted</Typography></div>)}
                       </div>
-                      {testStatus && testStatus.isDeleted ? renderDeleteIcon() : renderVisibilityIcons(test.isOn)}
+                      {testStatus && (testStatus.isDeleted || testStatus.isArchived) ? this.renderDeletedOrArchivedIcon(testStatus) : renderVisibilityIcons(test.isOn)}
                     </ListItem>
                   </Tooltip>
                 </MuiThemeProvider>

--- a/public/src/components/epicTests/utilities.tsx
+++ b/public/src/components/epicTests/utilities.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
-import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
+
 import { Typography } from "@material-ui/core";
 
-export const renderVisibilityIcons = (isOn: boolean) => {
+export const renderVisibilityIcons = (isOn: boolean): React.ReactNode => {
   return (
     isOn ?
       <VisibilityIcon color={'action'} />
@@ -13,17 +13,11 @@ export const renderVisibilityIcons = (isOn: boolean) => {
   );
 };
 
-export const renderVisibilityHelpText = (isOn: boolean) => {
+export const renderVisibilityHelpText = (isOn: boolean): React.ReactNode => {
   return (
     isOn ?
     <Typography color={'textSecondary'}>(Visible to readers at <a href="https://www.theguardian.com">theguardian.com</a>)</Typography>
     :
     <Typography color={'textSecondary'}>(Only visible at <a href="https://www.theguardian.com">theguardian.com</a> if you add <em>#show-draft-epics</em> at the end of the url)</Typography>
   );
-};
-
-export const renderDeleteIcon = () => {
-  return (
-    <DeleteForeverIcon color={'error'} />
-  )
 };

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -1,3 +1,5 @@
+import { EpicTest } from "../components/epicTests/epicTestsForm";
+
 export enum SupportFrontendSettingsType {
   switches = 'switches',
   contributionTypes = 'contribution-types',
@@ -62,4 +64,8 @@ export function fetchFrontendSettings(settingsType: FrontendSettingsType): Promi
 
 export function saveFrontendSettings(settingsType: FrontendSettingsType, data: any): Promise<Response> {
   return saveSettings(`/frontend/${settingsType}/update`, data);
+}
+
+export function archiveEpicTest(test: EpicTest): Promise<Response> {
+  return saveSettings('/frontend/epic-tests/archive', test);
 }


### PR DESCRIPTION
Also connected client-side functionality to archive endpoint.

### Add archive button next to delete button (only in edit mode): 
![image](https://user-images.githubusercontent.com/15648334/66228954-ab227f80-e6d8-11e9-99bf-d041313c431d.png)

### Highlight archived tests in list:
<img width="305" alt="image" src="https://user-images.githubusercontent.com/15648334/67866863-7cee5f00-fb21-11e9-8850-a032053fc1c4.png">

### Show number of archived tests in save popover:
![image](https://user-images.githubusercontent.com/15648334/66228929-95ad5580-e6d8-11e9-9e96-118de273e56e.png)

### Show to be archived in heading:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/15648334/67867290-161d7580-fb22-11e9-9238-bc7bea3f798d.png">

