### PR TITLE
Add archive endpoint to epic tests backend

### DIFF
--- a/app/controllers/LockableSettingsController.scala
+++ b/app/controllers/LockableSettingsController.scala
@@ -45,7 +45,7 @@ class LockableSettingsController[T : Decoder : Encoder](
     cacheControl = None
   )
 
-  private val s3Client = services.S3
+  val s3Client = services.S3
 
   private def withLockStatus(f: VersionedS3Data[LockStatus] => Future[Result]): Future[Result] =
     S3Json.getFromJson[LockStatus](lockObjectSettings)(s3Client).flatMap {

--- a/conf/routes
+++ b/conf/routes
@@ -32,6 +32,7 @@ POST  /frontend/epic-tests/update                   controllers.EpicTestsControl
 POST  /frontend/epic-tests/lock                     controllers.EpicTestsController.lock
 POST  /frontend/epic-tests/unlock                   controllers.EpicTestsController.unlock
 POST  /frontend/epic-tests/takecontrol              controllers.EpicTestsController.takecontrol
+POST  /frontend/epic-tests/archive                  controllers.EpicTestsController.archive
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
Allows the client to send a single epic test for archiving. It is saved to a new file at:
`support-admin-console/<STAGE>/archived-epic-tests/<TEST NAME>.json`

When we build a UI for managing these archived tests we'll need new endpoints for listing and fetching.