### PR TITLE
Only fetch s3 object metadata

### DIFF
--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -63,7 +63,9 @@ object S3 extends S3Client with StrictLogging {
 
   def put(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
     try {
-      val currentVersion = s3Client.getObject(objectSettings.bucket, objectSettings.key).getObjectMetadata.getVersionId
+      val currentObject = s3Client.getObject(objectSettings.bucket, objectSettings.key)
+      val currentVersion = currentObject.getObjectMetadata.getVersionId
+      currentObject.close()
 
       if (currentVersion == data.version) {
 

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -48,9 +48,12 @@ object S3 extends S3Client with StrictLogging {
       val version = s3Object.getObjectMetadata.getVersionId
 
       val stream = s3Object.getObjectContent
-      val raw: String = scala.io.Source.fromInputStream(stream).mkString
-      stream.close()
-      s3Object.close()
+      val raw: String = try {
+        scala.io.Source.fromInputStream(stream).mkString
+      } finally {
+        stream.close()
+        s3Object.close()
+      }
 
       Right[String,RawVersionedS3Data](VersionedS3Data(raw, version))
 

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -66,9 +66,7 @@ object S3 extends S3Client with StrictLogging {
 
   def put(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
     try {
-      val currentObject = s3Client.getObject(objectSettings.bucket, objectSettings.key)
-      val currentVersion = currentObject.getObjectMetadata.getVersionId
-      currentObject.close()
+      val currentVersion = s3Client.getObjectMetadata(objectSettings.bucket, objectSettings.key).getVersionId
 
       if (currentVersion == data.version) {
 


### PR DESCRIPTION
we're still getting `Timeout waiting for connection from pool` errors when the app has been running for a while.
The `put` function fetches the current object before updating it, even though it doesn't read the content stream. The s3 object should then be closed - this is likely the cause.
However, we can just fetch the object metadata instead, since that's all we need.

@JoemG