### PR TITLE
Fetching archived epic tests

### DIFF
--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -62,7 +62,7 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
     val testData = request.body
     val objectSettings = archiveObjectSettings(stage, s"${testData.name}.json")
 
-    S3Json.createAsJson(objectSettings, testData)(s3Client).map {
+    S3Json.createOrUpdateAsJson(objectSettings, testData)(s3Client).map {
       case Right(_) => Ok("archived")
       case Left(error) =>
         logger.error(s"Failed to archive test: $testData. Error was: $error")

--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -3,6 +3,7 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc.{AnyContent, ControllerComponents}
 import models.{EpicTest, EpicTests}
+import EpicTestsController._
 import play.api.libs.ws.WSClient
 import services.{FastlyPurger, S3Json, VersionedS3Data}
 import services.S3Client.S3ObjectSettings
@@ -20,6 +21,20 @@ object EpicTestsController {
       case _ => None
     }
   }
+
+  // For extracting the epic test name from an S3 key
+  private val testNamePattern = """^.*/([\w-].*)\.json$""".r
+
+  def extractTestName(key: String): Option[String] = key match {
+    case EpicTestsController.testNamePattern(name) => Some(name)
+    case _ => None
+  }
+
+  def archiveObjectSettings(stage: String, fileName: String) = S3ObjectSettings(
+    bucket = "support-admin-console",
+    key = s"$stage/archived-epic-tests/$fileName",
+    publicRead = false
+  )
 }
 
 class EpicTestsController(authAction: AuthAction[AnyContent], components: ControllerComponents, ws: WSClient, stage: String)(implicit ec: ExecutionContext)
@@ -45,11 +60,7 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
     */
   def archive = authAction.async(circe.json[VersionedS3Data[EpicTest]]) { request =>
     val testData = request.body
-    val objectSettings = S3ObjectSettings(
-      bucket = "support-admin-console",
-      key = s"$stage/archived-epic-tests/${testData.value.name}.json",
-      publicRead = false
-    )
+    val objectSettings = archiveObjectSettings(stage, s"${testData.value.name}.json")
 
     S3Json.putAsJson(objectSettings, testData)(s3Client).map {
       case Right(_) => Ok("archived")
@@ -59,21 +70,33 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
     }
   }
 
+  /**
+    * Fetches all archived test file keys from S3 and returns just the test names
+    */
   def archivedTestNames = authAction.async { request =>
-    s3Client.listKeys(S3ObjectSettings(
-      bucket = "support-admin-console",
-      key = s"$stage/archived-epic-tests/",
-      publicRead = false
-    )).map {
-      case Right(list) =>
-        val files: List[String] = list.collect { case key if key.endsWith(".json") =>
-          key.split('/').lastOption
-        }.flatten
+    val objectSettings = archiveObjectSettings(stage, fileName = "")
 
-        Ok(S3Json.noNulls(files.asJson))
+    s3Client.listKeys(objectSettings).map {
+      case Right(keys) =>
+        val testNames: List[String] = keys.flatMap(extractTestName)
+        Ok(S3Json.noNulls(testNames.asJson))
 
       case Left(error) =>
         logger.error(s"Failed to fetch list of archived test names: $error")
+        InternalServerError(error)
+    }
+  }
+
+  /**
+    * Returns the archived test data for the given name
+    */
+  def getArchivedTest(testName: String) = authAction.async { request =>
+    val objectSettings = archiveObjectSettings(stage, s"$testName.json")
+
+    S3Json.getFromJson[EpicTest](objectSettings)(s3Client) map {
+      case Right(VersionedS3Data(test, _)) => Ok(test.asJson)
+      case Left(error) =>
+        logger.error(s"Failed to get archived test $testName: $error")
         InternalServerError(error)
     }
   }

--- a/app/controllers/EpicTestsController.scala
+++ b/app/controllers/EpicTestsController.scala
@@ -58,11 +58,11 @@ class EpicTestsController(authAction: AuthAction[AnyContent], components: Contro
     * Overwrites any existing archived test of the same name.
     * Removing the test from the current active tests list is done separately.
     */
-  def archive = authAction.async(circe.json[VersionedS3Data[EpicTest]]) { request =>
+  def archive = authAction.async(circe.json[EpicTest]) { request =>
     val testData = request.body
-    val objectSettings = archiveObjectSettings(stage, s"${testData.value.name}.json")
+    val objectSettings = archiveObjectSettings(stage, s"${testData.name}.json")
 
-    S3Json.putAsJson(objectSettings, testData)(s3Client).map {
+    S3Json.createAsJson(objectSettings, testData)(s3Client).map {
       case Right(_) => Ok("archived")
       case Left(error) =>
         logger.error(s"Failed to archive test: $testData. Error was: $error")

--- a/app/controllers/LockableSettingsController.scala
+++ b/app/controllers/LockableSettingsController.scala
@@ -54,7 +54,7 @@ class LockableSettingsController[T : Decoder : Encoder](
     }
 
   private def setLockStatus(lockStatus: VersionedS3Data[LockStatus]) =
-    S3Json.putAsJson(lockObjectSettings, lockStatus)(s3Client)
+    S3Json.updateAsJson(lockObjectSettings, lockStatus)(s3Client)
 
   private def purgeFastlyCache: EitherT[Future,String,Unit] =
     fastlyPurger
@@ -84,7 +84,7 @@ class LockableSettingsController[T : Decoder : Encoder](
     withLockStatus { case VersionedS3Data(lockStatus, lockFileVersion) =>
       if (lockStatus.email.contains(request.user.email)) {
         val result: EitherT[Future, String, Unit] = for {
-          _ <- EitherT(S3Json.putAsJson(dataObjectSettings, request.body)(s3Client))
+          _ <- EitherT(S3Json.updateAsJson(dataObjectSettings, request.body)(s3Client))
           _ <- EitherT(setLockStatus(VersionedS3Data(LockStatus.unlocked, lockFileVersion)))
         } yield ()
 

--- a/app/controllers/SettingsController.scala
+++ b/app/controllers/SettingsController.scala
@@ -38,7 +38,7 @@ abstract class SettingsController[T : Decoder : Encoder](authAction: AuthAction[
     * The POSTed json is validated against the model.
     */
   def set = authAction.async(circe.json[VersionedS3Data[T]]) { request =>
-    S3Json.putAsJson(dataObjectSettings, request.body)(s3Client).map {
+    S3Json.updateAsJson(dataObjectSettings, request.body)(s3Client).map {
       case Right(_) => Ok("updated")
       case Left(error) => InternalServerError(error)
     }

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -20,7 +20,7 @@ case class VersionedS3Data[T](value: T, version: String)
 trait S3Client {
   def get(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]]
   def update(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]]
-  def create(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]]
+  def createOrUpdate(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]]
   def listKeys(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String, List[String]]]
 }
 
@@ -115,7 +115,7 @@ object S3 extends S3Client with StrictLogging {
     }
   }
 
-  def create(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]] =
+  def createOrUpdate(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]] =
     Future(put(objectSettings, data).map(_ => data))
 
   def listKeys(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String, List[String]]] = {
@@ -151,8 +151,8 @@ object S3Json extends StrictLogging {
       data.copy(value = noNulls(data.value.asJson))
     )
 
-  def createAsJson[T: Encoder](objectSettings: S3ObjectSettings, data: T)(s3: S3Client)(implicit ec: ExecutionContext): Future[Either[String,String]] =
-    s3.create(
+  def createOrUpdateAsJson[T: Encoder](objectSettings: S3ObjectSettings, data: T)(s3: S3Client)(implicit ec: ExecutionContext): Future[Either[String,String]] =
+    s3.createOrUpdate(
       objectSettings,
       noNulls(data.asJson)
     )

--- a/conf/routes
+++ b/conf/routes
@@ -33,6 +33,7 @@ POST  /frontend/epic-tests/lock                     controllers.EpicTestsControl
 POST  /frontend/epic-tests/unlock                   controllers.EpicTestsController.unlock
 POST  /frontend/epic-tests/takecontrol              controllers.EpicTestsController.takecontrol
 POST  /frontend/epic-tests/archive                  controllers.EpicTestsController.archive
+GET   /frontend/epic-tests/archive/:testName        controllers.EpicTestsController.getArchivedTest(testName: String)
 GET   /frontend/epic-tests/archived-test-names      controllers.EpicTestsController.archivedTestNames
 
 # Map static resources from the /public folder to the /assets URL path

--- a/conf/routes
+++ b/conf/routes
@@ -33,6 +33,7 @@ POST  /frontend/epic-tests/lock                     controllers.EpicTestsControl
 POST  /frontend/epic-tests/unlock                   controllers.EpicTestsController.unlock
 POST  /frontend/epic-tests/takecontrol              controllers.EpicTestsController.takecontrol
 POST  /frontend/epic-tests/archive                  controllers.EpicTestsController.archive
+GET   /frontend/epic-tests/archived-test-names      controllers.EpicTestsController.archivedTestNames
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -139,6 +139,9 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
   };
 
   fetchStateFromServer = (): void => {
+    fetch('/frontend/epic-tests/archived-test-names').then(result => {
+      return result
+    });
     fetchFrontendSettings(FrontendSettingsType.epicTests)
       .then(serverData => {
         this.setState({

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -139,9 +139,6 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
   };
 
   fetchStateFromServer = (): void => {
-    fetch('/frontend/epic-tests/archived-test-names').then(result => {
-      return result
-    });
     fetchFrontendSettings(FrontendSettingsType.epicTests)
       .then(serverData => {
         this.setState({

--- a/test/controllers/EpicTestsControllerSpec.scala
+++ b/test/controllers/EpicTestsControllerSpec.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class EpicTestsControllerSpec extends FlatSpec with Matchers {
+  it should "extract the epic test name" in {
+    EpicTestsController.extractTestName("CODE/archived-epic-tests/my-test-name.json") should be(Some("my-test-name"))
+  }
+
+  it should "ignore if path with no file" in {
+    EpicTestsController.extractTestName("CODE/archived-epic-tests/") should be(None)
+  }
+}

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -62,7 +62,9 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       }
     }
 
-    def put(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future(Right(data))
+    def update(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future(Right(data))
+
+    def create(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]] = Future(Right(data))
 
     def listKeys(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String, List[String]]] = Future(Right(Nil))
   }
@@ -84,7 +86,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
     import ExecutionContext.Implicits.global
 
     val result = Await.result(
-      S3Json.putAsJson[SupportFrontendSwitches](objectSettings, expectedDecoded)(dummyS3Client),
+      S3Json.updateAsJson[SupportFrontendSwitches](objectSettings, expectedDecoded)(dummyS3Client),
       1.second
     )
     val diff = JsonDiff.diff(expectedJson, result.right.value.value, false)

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -64,7 +64,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
 
     def update(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future(Right(data))
 
-    def create(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]] = Future(Right(data))
+    def createOrUpdate(objectSettings: S3ObjectSettings, data: String)(implicit ec: ExecutionContext): Future[Either[String,String]] = Future(Right(data))
 
     def listKeys(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String, List[String]]] = Future(Right(Nil))
   }

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -63,6 +63,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
     }
 
     def put(objectSettings: S3ObjectSettings, data: RawVersionedS3Data)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future(Right(data))
+
+    def listKeys(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String, List[String]]] = Future(Right(Nil))
   }
 
   it should "decode from json" in {


### PR DESCRIPTION
Follow up to https://github.com/guardian/support-admin-console/pull/86
Adds 2 new archive endpoints - for getting the list of archived test names and for getting a single test's data by name.

Also a bit of a refactor of the S3 client:
- replace `put` method with `update`, as it's strictly for updating existing files.
- add new `create` method, which is now used to archive tests by the /archive POST endpoint (it was incorrectly using the old `put` method).