### PR TITLE
Truncate epic test names in list

### DIFF
--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -53,7 +53,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
     margin: "20px 0 15px 0"
   },
   select: {
-    minWidth: "300px",
+    minWidth: "460px",
     paddingTop: "10px",
     marginBottom: "20px"
   },

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -53,7 +53,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
     margin: "20px 0 15px 0"
   },
   select: {
-    minWidth: "500px",
+    minWidth: "300px",
     paddingTop: "10px",
     marginBottom: "20px"
   },

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -224,7 +224,10 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
               ].join(' ');
 
               return (
-                <MuiThemeProvider theme={theme}>
+                <MuiThemeProvider
+                  theme={theme} 
+                  key={index}
+                >
                   <Tooltip
                     title={test.name}
                     aria-label="test name"
@@ -233,7 +236,6 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                     <ListItem
                       className={classNames}
                       onClick={this.onTestSelected(test.name)}
-                      key={index}
                       button={true}
                     >
                       { this.props.editMode ? this.renderReorderButtons(test.name, index) : <div className={classes.buttonsContainer}></div>}

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -213,6 +213,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
             {this.props.tests.map((test, index) => {
 
               const testStatus = this.props.modifiedTests[test.name];
+              const toStrip = /^\d{4}-\d{2}-\d{2}_(contribs*_|moment_)*/;
 
               const classNames = [
                 classes.test,
@@ -237,7 +238,8 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
                     >
                       { this.props.editMode ? this.renderReorderButtons(test.name, index) : <div className={classes.buttonsContainer}></div>}
                       <div className={classes.testText}>
-                        <Typography className={classes.testName}noWrap={true}>{test.name}</Typography>
+                        <Typography className={classes.testName}noWrap={true}>{test.name.replace(toStrip, '')}</Typography>
+
                         {(testStatus && testStatus.isDeleted) && (<div><Typography className={classes.toBeDeleted}>To be deleted</Typography></div>)}
                       </div>
                       {testStatus && testStatus.isDeleted ? renderDeleteIcon() : renderVisibilityIcons(test.isOn)}

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -10,7 +10,7 @@ import {MaxViewsDefaults} from "./maxViewsEditor";
 
 const styles = ( { typography, spacing }: Theme ) => createStyles({
   root: {
-    width: "250px",
+    width: "300px",
   },
   testsList: {
     padding: 0
@@ -53,8 +53,8 @@ const styles = ( { typography, spacing }: Theme ) => createStyles({
   },
   testText: {
     textAlign: "left",
-    minWidth: "160px",
-    maxWidth: "160px",
+    minWidth: "200px",
+    maxWidth: "200px",
     marginRight: "10px"
   },
   testIndicator: {


### PR DESCRIPTION
This removes the date and the word 'moment' or 'contrib/s' from the epic test name in the list, and makes the list wider for easier viewing at a glance.

The test name remains unchanged and the tooltip and editor are unaffected by this change.