### PR TITLE
Increase play.http.parser.maxMemoryBuffer

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,3 +3,6 @@ play.application.loader = "wiring.AppLoader"
 googleAuth.domain = "guardian.co.uk"
 
 pidfile.path="/dev/null"
+
+play.http.parser.maxMemoryBuffer=4MB
+


### PR DESCRIPTION
We've started getting `413 Payload Too Large` error responses on the epic tests page.
The default `maxMemoryBuffer` is 100kb, which is too small.