### PR TITLE
Set articlesViewedSettings in the epic tool

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -51,6 +51,12 @@ case class MaxViews(
   minDaysBetweenViews: Int
 )
 
+case class ArticlesViewedSettings(
+  minViews: Option[Int],
+  maxViews: Option[Int],
+  periodInWeeks: Int
+)
+
 case class EpicTest(
   name: String,
   isOn: Boolean,
@@ -66,7 +72,8 @@ case class EpicTest(
   hasCountryName: Boolean = false,
   variants: List[EpicVariant],
   highPriority: Boolean = false,
-  useLocalViewLog: Boolean = false
+  useLocalViewLog: Boolean = false,
+  articlesViewedSettings: Option[ArticlesViewedSettings] = None
 )
 
 case class EpicTests(tests: List[EpicTest])

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -27,6 +27,7 @@ import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import ArchiveIcon from '@material-ui/icons/Archive';
+import {articleCountTemplate, countryNameTemplate} from "./epicTestVariantEditor";
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
   container: {
@@ -140,9 +141,9 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
       this.props.onChange({
         ...updatedTest,
         // To save dotcom from having to work this out
-        hasCountryName: copyHasTemplate(updatedTest, "%%COUNTRY_NAME%%"),
+        hasCountryName: copyHasTemplate(updatedTest, countryNameTemplate),
         // Temporarily hardcode a default articlesViewedSettings. We can add a UI for configuring this later
-        articlesViewedSettings: copyHasTemplate(updatedTest, "%%ARTICLE_COUNT%%") ? defaultArticlesViewedSettings : undefined
+        articlesViewedSettings: copyHasTemplate(updatedTest, articleCountTemplate) ? defaultArticlesViewedSettings : undefined
       })
     }
   }

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, ChangeEvent } from 'react';
-import { EpicTest, EpicVariant, UserCohort, MaxViews } from "./epicTestsForm";
+import {EpicTest, EpicVariant, UserCohort, MaxViews, ArticlesViewedSettings} from "./epicTestsForm";
 import {
   Checkbox,
   FormControl,
@@ -93,7 +93,15 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   }
 });
 
-const countryNameTemplate = '%%COUNTRY_NAME%%';
+const copyHasTemplate = (test: EpicTest, template: string): boolean => test.variants.some(variant =>
+  variant.heading && variant.heading.includes(template) ||
+  variant.paragraphs.some(para => para.includes(template))
+);
+
+const defaultArticlesViewedSettings: ArticlesViewedSettings = {
+  minViews: 5,
+  periodInWeeks: 4
+};
 
 interface EpicTestEditorProps extends WithStyles<typeof styles> {
   test?: EpicTest,
@@ -125,19 +133,16 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     return this.props.editMode && !this.props.isDeleted && !this.props.isArchived;
   }
 
-  // To save dotcom from having to work this out
-  hasCountryName = (test: EpicTest): boolean => test.variants.some(variant =>
-    variant.heading && variant.heading.includes(countryNameTemplate) ||
-      variant.paragraphs.some(para => para.includes(countryNameTemplate))
-  )
-
   updateTest = (update: (test: EpicTest) => EpicTest) => {
     if (this.props.test) {
       const updatedTest = update(this.props.test);
 
       this.props.onChange({
         ...updatedTest,
-        hasCountryName: this.hasCountryName(updatedTest)
+        // To save dotcom from having to work this out
+        hasCountryName: copyHasTemplate(updatedTest, "%%COUNTRY_NAME%%"),
+        // Temporarily hardcode a default articlesViewedSettings. We can add a UI for configuring this later
+        articlesViewedSettings: copyHasTemplate(updatedTest, "%%ARTICLE_COUNT%%") ? defaultArticlesViewedSettings : undefined
       })
     }
   }

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -10,7 +10,10 @@ import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 
 
-const validTemplates = ["%%CURRENCY_SYMBOL%%", "%%COUNTRY_NAME%%", "%%ARTICLE_COUNT%%"];
+const currencyTemplate = "%%CURRENCY_SYMBOL%%";
+export const countryNameTemplate = "%%COUNTRY_NAME%%";
+export const articleCountTemplate = "%%ARTICLE_COUNT%%";
+const validTemplates = [currencyTemplate, countryNameTemplate, articleCountTemplate];
 
 export const getInvalidTemplateError = (text: string): string | null => {
   const templates: string[] | null = text.match(/%%[A-Z_]*%%/g);

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -10,7 +10,7 @@ import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 
 
-const validTemplates = ["%%CURRENCY_SYMBOL%%", "%%COUNTRY_NAME%%"];
+const validTemplates = ["%%CURRENCY_SYMBOL%%", "%%COUNTRY_NAME%%", "%%ARTICLE_COUNT%%"];
 
 export const getInvalidTemplateError = (text: string): string | null => {
   const templates: string[] | null = text.match(/%%[A-Z_]*%%/g);

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -45,6 +45,12 @@ export interface MaxViews {
   minDaysBetweenViews: number
 }
 
+export interface ArticlesViewedSettings {
+  minViews?: number,
+  maxViewed?: number,
+  periodInWeeks: number
+}
+
 export interface EpicTest {
   name: string,
   isOn: boolean,
@@ -60,7 +66,8 @@ export interface EpicTest {
   hasCountryName: boolean,
   variants: EpicVariant[],
   highPriority: boolean,
-  useLocalViewLog: boolean
+  useLocalViewLog: boolean,
+  articlesViewedSettings?: ArticlesViewedSettings
 }
 
 interface EpicTests {

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -152,10 +152,6 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
       variants: [],
       highPriority: false,
       useLocalViewLog: false,
-      articlesViewedSettings: {
-        minViews: 5,
-        periodInWeeks: 4
-      }
     }
     const newTestList = [...this.props.tests, newTest];
 

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -151,7 +151,11 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
       hasCountryName: false,
       variants: [],
       highPriority: false,
-      useLocalViewLog: false
+      useLocalViewLog: false,
+      articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 4
+      }
     }
     const newTestList = [...this.props.tests, newTest];
 


### PR DESCRIPTION
[Corresponding frontend PR](https://github.com/guardian/frontend/pull/21991).

This change means:
1. Allows users to add the `%%ARTICLE_COUNT%%` template in the copy, which frontend replaces with a count of articles viewed over a period of time
2. If this template is present then the test configuration must also include an `articlesViewedSettings` field, which has the period in weeks and optional max/min counts. The max/min counts are for limiting who sees the test based on the count.

For now I have hardcoded the `articlesViewedSettings` to min 5 articles per 4 weeks. We'll probably need a UI change to make this configurable later, but just having 5/month is a big leap forward by enabling non-devs to include article counts in epic tests.

E.g. the POST to server contains `articlesViewedSettings` when paragraphs contains the template:
<img width="360" alt="Screenshot 2019-11-13 at 08 20 25" src="https://user-images.githubusercontent.com/1513454/68745378-7e725980-05ee-11ea-8c5d-e5396b5cb78f.png">
