### PR TITLE
Support 2nd cta in epic

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -42,7 +42,8 @@ case class EpicVariant(
   footer: Option[String] = None,
   showTicker: Boolean = false,
   backgroundImageUrl: Option[String] = None,
-  cta: Option[Cta]
+  cta: Option[Cta],
+  secondaryCta: Option[Cta]
 )
 
 case class MaxViews(

--- a/public/src/components/epicTests/ctaEditor.tsx
+++ b/public/src/components/epicTests/ctaEditor.tsx
@@ -10,18 +10,13 @@ const styles = ({ palette, spacing, typography }: Theme) => createStyles({
   }
 });
 
-const defaultText = "Support The Guardian";
-const defaultBaseUrl = "https://support.theguardian.com/contribute";
-
-export const defaultCta = {
-  text: defaultText,
-  baseUrl: defaultBaseUrl
-};
-
 interface Props extends WithStyles<typeof styles> {
   cta?: Cta,
   update: (cta?: Cta) => void,
-  editMode: boolean
+  editMode: boolean,
+  label: string,
+  defaultText?: string,
+  defaultBaseUrl?: string,
 }
 
 class CtaEditor extends React.Component<Props> {
@@ -31,7 +26,7 @@ class CtaEditor extends React.Component<Props> {
       <div className={this.props.classes.fields}>
         <EditableTextField
           required
-          text={cta.text || defaultText}
+          text={cta.text || this.props.defaultText || ""}
           onSubmit={(value) =>
             this.props.update({...cta, text: value})
           }
@@ -41,7 +36,7 @@ class CtaEditor extends React.Component<Props> {
 
         <EditableTextField
           required
-          text={cta.baseUrl || defaultBaseUrl}
+          text={cta.baseUrl || this.props.defaultBaseUrl || ""}
           onSubmit={(value) =>
             this.props.update({...cta, baseUrl: value})
           }
@@ -55,7 +50,10 @@ class CtaEditor extends React.Component<Props> {
   toggleCta = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const ctaEnabled = event.target.checked;
     if (ctaEnabled) {
-      this.props.update(defaultCta)
+      this.props.update({
+        text: this.props.defaultText || "",
+        baseUrl: this.props.defaultBaseUrl || ""
+      })
     } else {
       this.props.update(undefined)
     }
@@ -72,7 +70,7 @@ class CtaEditor extends React.Component<Props> {
               disabled={!this.props.editMode}
             />
           }
-          label="Has CTA button"
+          label={this.props.label}
         />
         { this.props.cta && this.renderFields(this.props.cta) }
       </div>

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -28,6 +28,11 @@ export const getInvalidTemplateError = (text: string): string | null => {
   }
 };
 
+export const defaultCta = {
+  text: "Support The Guardian",
+  baseUrl: "https://support.theguardian.com/contribute"
+};
+
 const styles = ({ palette, spacing, typography }: Theme) => createStyles({
   container: {
     width: "100%",
@@ -64,6 +69,15 @@ const styles = ({ palette, spacing, typography }: Theme) => createStyles({
   deleteButton: {
     marginTop: spacing(2),
     float: "right"
+  },
+  label: {
+    fontSize: typography.pxToRem(16),
+    fontWeight: typography.fontWeightMedium,
+    color: "black"
+  },
+  ctaContainer: {
+    marginTop: "15px",
+    marginBottom: "15px"
   }
 });
 
@@ -99,10 +113,6 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
     if (this.props.variant) {
       this.props.onVariantChange(update(this.props.variant));
     }
-  };
-
-  onCtaUpdate = (cta?: Cta): void => {
-    this.updateVariant(variant => ({...variant, cta}));
   };
 
   onOptionalTextChange = (fieldName: string) => (updatedString: string): void => {
@@ -168,11 +178,28 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
             }
           />
 
-          <CtaEditor
-            cta={variant.cta}
-            update={this.onCtaUpdate}
-            editMode={this.props.editMode}
-          />
+          <div className={classes.ctaContainer}>
+            <span className={classes.label}>Buttons:</span>
+            <CtaEditor
+              cta={variant.cta}
+              update={(cta?: Cta) =>
+                this.updateVariant(variant => ({...variant, cta}))
+              }
+              editMode={this.props.editMode}
+              label="Has a button linking to the landing page"
+              defaultText={defaultCta.text}
+              defaultBaseUrl={defaultCta.baseUrl}
+            />
+
+            <CtaEditor
+              cta={variant.secondaryCta}
+              update={(cta?: Cta) =>
+                this.updateVariant(variant => ({...variant, secondaryCta: cta}))
+              }
+              editMode={this.props.editMode}
+              label={"Has a secondary button"}
+            />
+          </div>
 
           <EditableTextField
             text={variant.highlightedText || ""}

--- a/public/src/components/epicTests/epicTestVariantsList.tsx
+++ b/public/src/components/epicTests/epicTestVariantsList.tsx
@@ -6,7 +6,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import EpicTestVariantEditor from './epicTestVariantEditor';
 import { EpicVariant } from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
-import {defaultCta} from "./ctaEditor";
+import {defaultCta} from "./epicTestVariantEditor";
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 
 

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -36,7 +36,8 @@ export interface EpicVariant {
   footer?: string,
   showTicker: boolean,
   backgroundImageUrl?: string,
-  cta?: Cta
+  cta?: Cta,
+  secondaryCta?: Cta,
 }
 
 export interface MaxViews {


### PR DESCRIPTION
https://github.com/guardian/frontend/pull/22021 adds support for an optional 2nd cta in the epic.

This PR adds it to the epic tool. Each variant may have a 2nd button.

#### No buttons:
<img width="1023" alt="Screenshot 2019-11-19 at 11 49 52" src="https://user-images.githubusercontent.com/1513454/69144259-cc8dce00-0ac2-11ea-82ef-2f95c6d83534.png">

#### Only the primary button:
<img width="1023" alt="Screenshot 2019-11-19 at 11 49 59" src="https://user-images.githubusercontent.com/1513454/69144261-cdbefb00-0ac2-11ea-97bf-b3d3a5647451.png">

#### Both buttons:
<img width="1023" alt="Screenshot 2019-11-19 at 11 50 20" src="https://user-images.githubusercontent.com/1513454/69144265-d0215500-0ac2-11ea-8a8b-3260326ef7fa.png">
