### PR TITLE
Increase article count period to 8 weeks

### DIFF
--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -101,7 +101,7 @@ const copyHasTemplate = (test: EpicTest, template: string): boolean => test.vari
 
 const defaultArticlesViewedSettings: ArticlesViewedSettings = {
   minViews: 5,
-  periodInWeeks: 4
+  periodInWeeks: 8
 };
 
 interface EpicTestEditorProps extends WithStyles<typeof styles> {


### PR DESCRIPTION
as it's making a lot more money than 4 weeks.
Still no requirement to make these params configurable from the tool.

Note - the copy will need to be updated to reflect this change, but that can happen after it has been deployed