### PR TITLE
Articles viewed settings

### DIFF
--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -72,7 +72,7 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
           this.props.onChange(
             {
               ...articlesViewedSettings || defaultArticlesViewedSettings,
-              [fieldName]: value !== null ? Number(value) : null;
+              [fieldName]: value !== null ? Number(value) : null,
             }
           )
         }

--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -68,11 +68,11 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
     return (<EditableTextField
       text={ setting ? setting.toString() : ''}
       onSubmit={ (value: string) => {
-        if (isNumber(value)) {
+        if (value === null || isNumber(value)) {
           this.props.onChange(
             {
               ...articlesViewedSettings || defaultArticlesViewedSettings,
-              [fieldName]: Number(value)
+              [fieldName]: value !== null ? Number(value) : null;
             }
           )
         }

--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import {
+  createStyles, FormControl,
+  FormControlLabel,
+  InputLabel,
+  Switch,
+  Theme, Typography,
+  withStyles,
+  WithStyles
+} from "@material-ui/core";
+import EditableTextField from "../helpers/editableTextField"
+import {onFieldValidationChange, ValidationStatus} from "../helpers/validation";
+import {ArticlesViewedSettings, EpicTest} from "./epicTestsForm";
+
+const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
+
+export const defaultArticlesViewedSettings: ArticlesViewedSettings = {
+  maxViews: null,
+  minViews: 5,
+  periodInWeeks: 8,
+};
+
+const styles = ({ spacing, typography}: Theme) => createStyles({
+  button: {
+    marginTop: '20px'
+  },
+  formControl: {
+    marginTop: spacing(2),
+    marginBottom: spacing(1),
+    display: "block",
+  },
+  selectLabel: {
+    fontSize: typography.pxToRem(22),
+    fontWeight: typography.fontWeightMedium,
+    color: "black"
+  },
+  radio: {
+    paddingTop: "20px",
+    marginBottom: "10px"
+  },
+  articlesViewsContainer: {
+    marginTop: '10px',
+    marginLeft: '20px'
+  }
+});
+
+type ArticleViewsFieldName = 'minArticleViews' | 'maxArticleViews' | 'periodInWeeks';
+
+interface Props extends WithStyles<typeof styles> {
+  articlesViewedSettings?: ArticlesViewedSettings,
+  editMode: boolean,
+  onChange: (articlesViewedSettings?: ArticlesViewedSettings) => void,
+  onValidationChange: (isValid: boolean) => void
+}
+
+interface State {
+  validationStatus: ValidationStatus
+}
+
+class ArticlesViewedEditor extends React.Component<Props, State> {
+  state: State = {
+    validationStatus: {}
+  };
+
+  buildField = (fieldName: ArticleViewsFieldName, label: string, articlesViewedSettings: ArticlesViewedSettings) => {
+    const setting: number | null = articlesViewedSettings[fieldName];
+
+    return (<EditableTextField
+      text={ setting ? setting.toString() : ''}
+      onSubmit={ (value: string) => {
+        if (isNumber(value)) {
+          this.props.onChange(
+            {
+              ...articlesViewedSettings || defaultArticlesViewedSettings,
+              [fieldName]: Number(value)
+            }
+          )
+        }
+      }}
+      label={label}
+      helperText="Must be a number"
+      editEnabled={this.props.editMode}
+      validation={
+        {
+          getError: (value: string) => isNumber(value) ? null : 'Must be a number',
+          onChange: onFieldValidationChange(this)(fieldName)
+        }
+      }
+      isNumberField
+    />)
+  };
+
+  onArticlesViewedEditorSwitchChange = (enabled: boolean) => {
+    if (enabled) {
+      this.props.onChange(defaultArticlesViewedSettings);
+    } else {
+      this.props.onChange(undefined);
+    }
+  }
+
+  render(): React.ReactNode {
+    const classes = this.props.classes;
+
+    return (
+      <>
+        <FormControl
+          className={classes.formControl}>
+          <FormControlLabel
+              control={
+                <Switch
+                  disabled={!this.props.editMode}
+                  onChange={(event) => {
+                    this.onArticlesViewedEditorSwitchChange(event.target.checked);
+                  }}
+                />
+              }
+              label={`Enable article count conditions`}
+            />
+        </FormControl>
+
+        { this.props.articlesViewedSettings &&
+          <div className={classes.articlesViewsContainer}>
+            {this.buildField('minArticleViews', 'Min articles viewed', this.props.articlesViewedSettings)}
+            {this.buildField('maxArticleViews', 'Max articles viewed', this.props.articlesViewedSettings)}
+            {this.buildField('periodInWeeks', 'Time period in weeks', this.props.articlesViewedSettings)}
+          </div>
+        }
+      </>
+    )
+  }
+}
+
+export default withStyles(styles)(ArticlesViewedEditor);

--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -62,7 +62,7 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
     validationStatus: {}
   };
 
-  buildField = (fieldName: ArticleViewsFieldName, label: string, articlesViewedSettings: ArticlesViewedSettings) => {
+  buildField = (fieldName: ArticleViewsFieldName, label: string, articlesViewedSettings: ArticlesViewedSettings, isRequired: boolean) => {
     const setting: number | null = articlesViewedSettings[fieldName];
 
     return (<EditableTextField
@@ -77,6 +77,7 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
           )
         }
       }}
+      required={isRequired}
       label={label}
       helperText="Must be a number"
       editEnabled={this.props.editMode}
@@ -121,9 +122,9 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
 
         { this.props.articlesViewedSettings &&
           <div className={classes.articlesViewsContainer}>
-            {this.buildField('minViews', 'Min articles viewed', this.props.articlesViewedSettings)}
-            {this.buildField('maxViews', 'Max articles viewed', this.props.articlesViewedSettings)}
-            {this.buildField('periodInWeeks', 'Time period in weeks', this.props.articlesViewedSettings)}
+            {this.buildField('minViews', 'Min articles viewed', this.props.articlesViewedSettings, false)}
+            {this.buildField('maxViews', 'Max articles viewed', this.props.articlesViewedSettings, false)}
+            {this.buildField('periodInWeeks', 'Time period in weeks', this.props.articlesViewedSettings, true)}
           </div>
         }
       </>

--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -44,7 +44,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   }
 });
 
-type ArticleViewsFieldName = 'minArticleViews' | 'maxArticleViews' | 'periodInWeeks';
+type ArticleViewsFieldName = 'minViews' | 'maxViews' | 'periodInWeeks';
 
 interface Props extends WithStyles<typeof styles> {
   articlesViewedSettings?: ArticlesViewedSettings,
@@ -108,6 +108,7 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
           <FormControlLabel
               control={
                 <Switch
+                  checked={!!this.props.articlesViewedSettings}
                   disabled={!this.props.editMode}
                   onChange={(event) => {
                     this.onArticlesViewedEditorSwitchChange(event.target.checked);
@@ -120,8 +121,8 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
 
         { this.props.articlesViewedSettings &&
           <div className={classes.articlesViewsContainer}>
-            {this.buildField('minArticleViews', 'Min articles viewed', this.props.articlesViewedSettings)}
-            {this.buildField('maxArticleViews', 'Max articles viewed', this.props.articlesViewedSettings)}
+            {this.buildField('minViews', 'Min articles viewed', this.props.articlesViewedSettings)}
+            {this.buildField('maxViews', 'Max articles viewed', this.props.articlesViewedSettings)}
             {this.buildField('periodInWeeks', 'Time period in weeks', this.props.articlesViewedSettings)}
           </div>
         }

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, ChangeEvent } from 'react';
-import {EpicTest, EpicVariant, UserCohort, MaxViews, ArticlesViewedSettings} from "./epicTestsForm";
+import {EpicTest, EpicVariant, UserCohort, MaxEpicViews, ArticlesViewedSettings} from "./epicTestsForm";
 import {
   Checkbox,
   FormControl,
@@ -21,15 +21,17 @@ import {
 import EditableTextField from "../helpers/editableTextField"
 import { Region } from '../../utils/models';
 import EpicTestVariantsList from './epicTestVariantsList';
-import MaxViewsEditor from './maxViewsEditor';
+import MaxEpicViewsEditor from './maxEpicViewsEditor';
 import { renderVisibilityIcons, renderVisibilityHelpText } from './utilities';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import ArchiveIcon from '@material-ui/icons/Archive';
 import {articleCountTemplate, countryNameTemplate} from "./epicTestVariantEditor";
+import ArticlesViewedEditor, {defaultArticlesViewedSettings} from "./articlesViewedEditor";
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
+
   container: {
     width: '100%',
     borderTop: `2px solid #999999`,
@@ -99,11 +101,6 @@ const copyHasTemplate = (test: EpicTest, template: string): boolean => test.vari
   variant.paragraphs.some(para => para.includes(template))
 );
 
-const defaultArticlesViewedSettings: ArticlesViewedSettings = {
-  minViews: 5,
-  periodInWeeks: 8
-};
-
 interface EpicTestEditorProps extends WithStyles<typeof styles> {
   test?: EpicTest,
   hasChanged: boolean,
@@ -143,7 +140,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
         // To save dotcom from having to work this out
         hasCountryName: copyHasTemplate(updatedTest, countryNameTemplate),
         // Temporarily hardcode a default articlesViewedSettings. We can add a UI for configuring this later
-        articlesViewedSettings: copyHasTemplate(updatedTest, articleCountTemplate) ? defaultArticlesViewedSettings : undefined
+        // articlesViewedSettings: copyHasTemplate(updatedTest, articleCountTemplate) ? defaultArticlesViewedSettings : undefined
       })
     }
   }
@@ -369,13 +366,23 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             label={`Use private view counter for this test (instead of the global one)`}
           />
 
-          <MaxViewsEditor
+          <MaxEpicViewsEditor
             test={test}
             editMode={this.isEditable()}
-            onChange={(alwaysAsk: boolean, maxViews: MaxViews) =>
-              this.updateTest(test => ({ ...test, alwaysAsk, maxViews }))
+            onChange={(alwaysAsk: boolean, maxEpicViews: MaxEpicViews) =>
+              this.updateTest(test => ({ ...test, alwaysAsk, maxViews: maxEpicViews }))
             }
             onValidationChange={onFieldValidationChange(this)('maxViews')}
+          />
+
+          <Typography variant={'h4'} className={this.props.classes.h4}>Articles count settings</Typography>
+          <ArticlesViewedEditor
+            articlesViewedSettings={test.articlesViewedSettings}
+            editMode={this.isEditable()}
+            onChange={(articlesViewedSettings?: ArticlesViewedSettings) =>
+              this.updateTest(test => ({ ...test, articlesViewedSettings }))
+            }
+            onValidationChange={onFieldValidationChange(this)('articlesViewedEditor')}
           />
 
           <div className={classes.buttons}>

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -29,6 +29,7 @@ import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import ArchiveIcon from '@material-ui/icons/Archive';
 import {articleCountTemplate, countryNameTemplate} from "./epicTestVariantEditor";
 import ArticlesViewedEditor, {defaultArticlesViewedSettings} from "./articlesViewedEditor";
+import articlesViewedEditor from "./articlesViewedEditor";
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
   container: {
@@ -130,6 +131,16 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     return this.props.editMode && !this.props.isDeleted && !this.props.isArchived;
   }
 
+  getArticlesViewedSettings = (test: EpicTest): ArticlesViewedSettings | undefined => {
+    if (!!test.articlesViewedSettings) {
+      return test.articlesViewedSettings;
+    }
+    if (copyHasTemplate(test, articleCountTemplate)) {
+      return defaultArticlesViewedSettings
+    }
+    return undefined;
+  }
+
   updateTest = (update: (test: EpicTest) => EpicTest) => {
     if (this.props.test) {
       const updatedTest = update(this.props.test);
@@ -138,8 +149,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
         ...updatedTest,
         // To save dotcom from having to work this out
         hasCountryName: copyHasTemplate(updatedTest, countryNameTemplate),
-        // Temporarily hardcode a default articlesViewedSettings. We can add a UI for configuring this later
-        // articlesViewedSettings: copyHasTemplate(updatedTest, articleCountTemplate) ? defaultArticlesViewedSettings : undefined
+        articlesViewedSettings: this.getArticlesViewedSettings(updatedTest),
       })
     }
   }
@@ -378,8 +388,10 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
           <ArticlesViewedEditor
             articlesViewedSettings={test.articlesViewedSettings}
             editMode={this.isEditable()}
-            onChange={(articlesViewedSettings?: ArticlesViewedSettings) =>
+            onChange={(articlesViewedSettings?: ArticlesViewedSettings) => {
               this.updateTest(test => ({ ...test, articlesViewedSettings }))
+            }
+
             }
             onValidationChange={onFieldValidationChange(this)('articlesViewedEditor')}
           />

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -31,7 +31,6 @@ import {articleCountTemplate, countryNameTemplate} from "./epicTestVariantEditor
 import ArticlesViewedEditor, {defaultArticlesViewedSettings} from "./articlesViewedEditor";
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
-
   container: {
     width: '100%',
     borderTop: `2px solid #999999`,

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -40,15 +40,15 @@ export interface EpicVariant {
   secondaryCta?: Cta,
 }
 
-export interface MaxViews {
+export interface MaxEpicViews {
   maxViewsCount: number,
   maxViewsDays: number,
   minDaysBetweenViews: number
 }
 
 export interface ArticlesViewedSettings {
-  minViews?: number,
-  maxViewed?: number,
+  minViews: number | null,
+  maxViews: number | null,
   periodInWeeks: number
 }
 
@@ -61,7 +61,7 @@ export interface EpicTest {
   excludedTagIds: string[],
   excludedSections: string[],
   alwaysAsk: boolean,
-  maxViews?: MaxViews,
+  maxViews?: MaxEpicViews,
   userCohort?: UserCohort,
   isLiveBlog: boolean,
   hasCountryName: boolean,

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -7,7 +7,7 @@ import ArchiveIcon from '@material-ui/icons/Archive';
 import { renderVisibilityIcons } from './utilities';
 import {EpicTest, ModifiedTests, UserCohort, TestStatus} from './epicTestsForm';
 import NewNameCreator from './newNameCreator';
-import { MaxViewsDefaults } from './maxViewsEditor';
+import { MaxEpicViewsDefaults } from './maxEpicViewsEditor';
 
 
 const styles = ( { typography, spacing }: Theme ) => createStyles({
@@ -145,7 +145,7 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
       excludedTagIds: [],
       excludedSections: [],
       alwaysAsk: false,
-      maxViews: MaxViewsDefaults,
+      maxViews: MaxEpicViewsDefaults,
       userCohort: UserCohort.AllNonSupporters,  // matches the default in dotcom
       isLiveBlog: false,
       hasCountryName: false,

--- a/public/src/components/epicTests/maxEpicViewsEditor.tsx
+++ b/public/src/components/epicTests/maxEpicViewsEditor.tsx
@@ -10,11 +10,11 @@ import {
 } from "@material-ui/core";
 import EditableTextField from "../helpers/editableTextField"
 import {onFieldValidationChange, ValidationStatus} from "../helpers/validation";
-import {EpicTest, MaxViews} from "./epicTestsForm";
+import {EpicTest, MaxEpicViews} from "./epicTestsForm";
 
 const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
 
-export const MaxViewsDefaults: MaxViews = {
+export const MaxEpicViewsDefaults: MaxEpicViews = {
   maxViewsCount: 4,
   maxViewsDays: 30,
   minDaysBetweenViews: 0
@@ -38,20 +38,20 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
     paddingTop: "20px",
     marginBottom: "10px"
   },
-  maxViewsContainer: {
+  maxEpicViewsContainer: {
     marginTop: '10px',
     marginLeft: '20px'
   }
 });
 
-type AskStrategy = 'AlwaysAsk' | 'MaxViews';
+type AskStrategy = 'AlwaysAsk' | 'MaxEpicViews';
 
-type MaxViewsFieldName = 'maxViewsCount' | 'maxViewsDays' | 'minDaysBetweenViews';
+type MaxEpicViewsFieldName = 'maxViewsCount' | 'maxViewsDays' | 'minDaysBetweenViews';
 
 interface Props extends WithStyles<typeof styles> {
   test: EpicTest,
   editMode: boolean,
-  onChange: (alwaysAsk: boolean, maxViews: MaxViews) => void,
+  onChange: (alwaysAsk: boolean, maxEpicViews: MaxEpicViews) => void,
   onValidationChange: (isValid: boolean) => void
 }
 
@@ -59,22 +59,22 @@ interface State {
   validationStatus: ValidationStatus
 }
 
-class MaxViewsEditor extends React.Component<Props, State> {
+class MaxEpicViewsEditor extends React.Component<Props, State> {
   state: State = {
     validationStatus: {}
   };
 
-  buildField = (fieldName: MaxViewsFieldName, label: string) => {
+  buildField = (fieldName: MaxEpicViewsFieldName, label: string) => {
     const test = this.props.test;
 
     return (<EditableTextField
-      text={test.maxViews ? test.maxViews[fieldName].toString() : MaxViewsDefaults[fieldName].toString()}
+      text={test.maxViews ? test.maxViews[fieldName].toString() : MaxEpicViewsDefaults[fieldName].toString()}
       onSubmit={ (value: string) => {
         if (isNumber(value)) {
           this.props.onChange(
             this.props.test.alwaysAsk,
             {
-              ...this.props.test.maxViews || MaxViewsDefaults,
+              ...this.props.test.maxViews || MaxEpicViewsDefaults,
               [fieldName]: Number(value)
             }
           )
@@ -96,7 +96,7 @@ class MaxViewsEditor extends React.Component<Props, State> {
   onRadioChange(askStrategy: AskStrategy) {
     this.props.onChange(
       askStrategy === 'AlwaysAsk',
-      this.props.test.maxViews || MaxViewsDefaults
+      this.props.test.maxViews || MaxEpicViewsDefaults
     )
   }
 
@@ -116,9 +116,9 @@ class MaxViewsEditor extends React.Component<Props, State> {
 
           <RadioGroup
             className={classes.radio}
-            value={this.props.test.alwaysAsk ? 'AlwaysAsk' : 'MaxViews'}
+            value={this.props.test.alwaysAsk ? 'AlwaysAsk' : 'MaxEpicViews'}
             onChange={(event, value) => {
-              if (value === 'AlwaysAsk' || value === 'MaxViews') this.onRadioChange(value)
+              if (value === 'AlwaysAsk' || value === 'MaxEpicViews') this.onRadioChange(value)
             }}
           >
             <FormControlLabel
@@ -129,8 +129,8 @@ class MaxViewsEditor extends React.Component<Props, State> {
               disabled={!this.props.editMode}
             />
             <FormControlLabel
-              value={'MaxViews'}
-              key={'MaxViews'}
+              value={'MaxEpicViews'}
+              key={'MaxEpicViews'}
               control={<Radio />}
               label={'Use max views settings...'}
               disabled={!this.props.editMode}
@@ -139,7 +139,7 @@ class MaxViewsEditor extends React.Component<Props, State> {
         </FormControl>
 
         { !this.props.test.alwaysAsk &&
-          <div className={classes.maxViewsContainer}>
+          <div className={classes.maxEpicViewsContainer}>
             {this.buildField('maxViewsCount', 'Max views count')}
             {this.buildField('maxViewsDays', 'Number of days')}
             {this.buildField('minDaysBetweenViews', 'Min days between views')}
@@ -150,4 +150,4 @@ class MaxViewsEditor extends React.Component<Props, State> {
   }
 }
 
-export default withStyles(styles)(MaxViewsEditor);
+export default withStyles(styles)(MaxEpicViewsEditor);

--- a/public/src/components/helpers/editableTextField.tsx
+++ b/public/src/components/helpers/editableTextField.tsx
@@ -155,7 +155,7 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
               fullWidth
               name={this.props.label}
               disabled={!this.state.fieldEditMode}
-              value={this.state.currentText || ''}
+              value={this.state.currentText}
               onChange={this.onChange}
               helperText={this.props.helperText}
               autoFocus={this.props.autoFocus}

--- a/public/src/components/helpers/editableTextField.tsx
+++ b/public/src/components/helpers/editableTextField.tsx
@@ -155,7 +155,7 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
               fullWidth
               name={this.props.label}
               disabled={!this.state.fieldEditMode}
-              value={this.state.currentText}
+              value={this.state.currentText || ''}
               onChange={this.onChange}
               helperText={this.props.helperText}
               autoFocus={this.props.autoFocus}


### PR DESCRIPTION
This change allows for test editors to configure custom settings for who sees an article based on how many or how few articles they've looked at in the past X weeks