### PR TITLE
2nd CTA url helper text about campaign code

### DIFF
--- a/public/src/components/epicTests/ctaEditor.tsx
+++ b/public/src/components/epicTests/ctaEditor.tsx
@@ -17,6 +17,7 @@ interface Props extends WithStyles<typeof styles> {
   label: string,
   defaultText?: string,
   defaultBaseUrl?: string,
+  manualCampaignCode: boolean
 }
 
 class CtaEditor extends React.Component<Props> {
@@ -42,6 +43,10 @@ class CtaEditor extends React.Component<Props> {
           }
           label="Button destination:"
           editEnabled={this.props.editMode}
+          helperText={ this.props.manualCampaignCode ?
+            'Note - tracking code must be added manually to this url, e.g. theguardian.com/article?INTCMP=my-campaign-code' :
+            undefined
+          }
         />
       </div>
     )

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -189,6 +189,7 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
               label="Has a button linking to the landing page"
               defaultText={defaultCta.text}
               defaultBaseUrl={defaultCta.baseUrl}
+              manualCampaignCode={false}
             />
 
             <CtaEditor
@@ -198,6 +199,7 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
               }
               editMode={this.props.editMode}
               label={"Has a secondary button"}
+              manualCampaignCode={true}
             />
           </div>
 


### PR DESCRIPTION
dotcom automatically adds tracking params to the primary cta, but not the 2nd cta.

<img width="1037" alt="Screenshot 2019-12-13 at 00 21 53" src="https://user-images.githubusercontent.com/1513454/70759571-c1833200-1d3e-11ea-8917-44ca5528b8c5.png">
