### PR TITLE
Epic test 'copy' button

### DIFF
--- a/public/src/components/epicTests/epicTestActionBar.tsx
+++ b/public/src/components/epicTests/epicTestActionBar.tsx
@@ -24,7 +24,10 @@ const styles = ({ spacing, typography }: Theme) => createStyles({
   },
   actionBarButtons: {
     marginLeft: spacing(2),
-    marginRight: spacing(2)
+    marginRight: spacing(2),
+    '& button': {
+      marginLeft: spacing(2)
+    }
   },
   editModeColour: {
     backgroundColor: "#ffe500"

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -88,7 +88,6 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   button: {
     marginTop: spacing(2),
     marginLeft: spacing(2),
-    float: 'right'
   },
   isDeleted: {
     color: '#ab0613'

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -30,6 +30,7 @@ import ArchiveIcon from '@material-ui/icons/Archive';
 import {articleCountTemplate, countryNameTemplate} from "./epicTestVariantEditor";
 import ArticlesViewedEditor, {defaultArticlesViewedSettings} from "./articlesViewedEditor";
 import articlesViewedEditor from "./articlesViewedEditor";
+import NewNameCreator from "./newNameCreator";
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
   container: {
@@ -86,6 +87,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   },
   button: {
     marginTop: spacing(2),
+    marginLeft: spacing(2),
     float: 'right'
   },
   isDeleted: {
@@ -112,7 +114,9 @@ interface EpicTestEditorProps extends WithStyles<typeof styles> {
   onArchive: (testName: string) => void,
   isDeleted: boolean,
   isArchived: boolean,
-  isNew: boolean
+  isNew: boolean,
+  testNames: string[],
+  createTest: (newTest: EpicTest) => void
 }
 
 interface EpicTestEditorState {
@@ -154,6 +158,16 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     }
   }
 
+  copyTest = (newTestName: string): void => {
+    if (this.props.test) {
+      const newTest: EpicTest = {
+        ...this.props.test,
+        name: newTestName
+      };
+      this.props.createTest(newTest)
+    }
+  }
+
   onVariantsChange = (updatedVariantList: EpicVariant[]): void => {
     if (this.props.test) {
       this.updateTest(test => ({...test, "variants": updatedVariantList}));
@@ -179,27 +193,36 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
     this.updateTest(test => ({...test, "locations": selectedLocations}));
   }
 
-  renderDeleteTestButton = (testName: string) => {
-    return this.isEditable() && (
-      <ButtonWithConfirmationPopup
-        buttonText="Delete test"
-        confirmationText={areYouSure}
-        onConfirm={() => this.props.onDelete(testName)}
-        icon={<DeleteSweepIcon />}
-      />
-    );
-  };
-
-  renderArchiveButton = (testName: string) => {
-    return this.isEditable() && (
-      <ButtonWithConfirmationPopup
-        buttonText="Archive test"
-        confirmationText={areYouSure}
-        onConfirm={() => this.props.onArchive(testName)}
-        icon={<ArchiveIcon />}
-      />
-    )
-  }
+  renderBottomButtons = () => (
+    <div className={this.props.classes.buttons}>
+      <div className={this.props.classes.button}>
+        <ButtonWithConfirmationPopup
+          buttonText="Archive test"
+          confirmationText={areYouSure}
+          onConfirm={() => this.props.onArchive(test.name)}
+          icon={<ArchiveIcon />}
+        />
+      </div>
+      <div className={this.props.classes.button}>
+        <ButtonWithConfirmationPopup
+          buttonText="Delete test"
+          confirmationText={areYouSure}
+          onConfirm={() => this.props.onDelete(test.name)}
+          icon={<DeleteSweepIcon />}
+        />
+      </div>
+      <div className={this.props.classes.button}>
+        <NewNameCreator
+          type="test"
+          action="Copy"
+          existingNames={ this.props.testNames }
+          onValidName={this.copyTest}
+          editEnabled={this.props.editMode}
+          initialValue={this.props.test ? this.props.test.name : undefined }
+        />
+      </div>
+    </div>
+  )
 
   renderEditor = (test: EpicTest): React.ReactNode => {
     const {classes} = this.props;
@@ -396,10 +419,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             onValidationChange={onFieldValidationChange(this)('articlesViewedEditor')}
           />
 
-          <div className={classes.buttons}>
-            <div className={classes.button}>{this.renderArchiveButton(test.name)}</div>
-            <div className={classes.button}>{this.renderDeleteTestButton(test.name)}</div>
-          </div>
+          { this.isEditable() && this.renderBottomButtons() }
 
         </div>
       </div>

--- a/public/src/components/epicTests/epicTestVariantsList.tsx
+++ b/public/src/components/epicTests/epicTestVariantsList.tsx
@@ -104,7 +104,8 @@ class EpicTestVariantsList extends React.Component<EpicTestVariantsListProps, Ep
   renderNewVariantButton = (): React.ReactNode => {
     return this.props.editMode ? (
       <NewNameCreator
-        text="variant"
+        type="variant"
+        action="New"
         existingNames={this.props.variants.map(variant => variant.name)}
         onValidName={this.createVariant}
         editEnabled={this.props.editMode}

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -347,6 +347,11 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
                       isDeleted={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isDeleted}
                       isArchived={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isArchived}
                       isNew={this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isNew}
+                      createTest={(newTest: EpicTest) => {
+                        const newTests = [...this.state.tests, newTest];
+                        this.onTestsChange(newTests, newTest.name)
+                      }}
+                      testNames={this.state.tests.map(test => test.name)}
                     />)
                   ) : (<Typography className={classes.viewText}>Click on a test on the left to view contents.</Typography>)}
                 </div>

--- a/public/src/components/epicTests/epicTestsList.tsx
+++ b/public/src/components/epicTests/epicTestsList.tsx
@@ -234,7 +234,8 @@ class EpicTestsList extends React.Component<EpicTestListProps> {
         <div className={classes.root}>
           {this.props.editMode ? (
             <NewNameCreator
-              text="test"
+              type="test"
+              action="New"
               existingNames={ this.props.tests.map(test => test.name) }
               onValidName={this.createTest}
               editEnabled={this.props.editMode}

--- a/public/src/components/epicTests/newNameCreator.tsx
+++ b/public/src/components/epicTests/newNameCreator.tsx
@@ -19,9 +19,11 @@ const styles = ({ spacing }: Theme) => createStyles({
 
 interface NewNameCreatorProps extends WithStyles<typeof styles> {
   existingNames: string[],
-  text: string,
+  type: 'test' | 'variant',
+  action: 'New' | 'Copy',
   onValidName: (name: string) => void,
-  editEnabled: boolean
+  editEnabled: boolean,
+  initialValue?: string
 }
 
 interface NewNameCreatorState {
@@ -94,7 +96,7 @@ class NewNameCreator extends React.Component<NewNameCreatorProps, NewNameCreator
       <div>
         <Button variant="contained" color="primary" onClick={this.onNewNameButtonClick} className={classes.button}>
             <AddIcon />
-            New {this.props.text}
+            {this.props.action} {this.props.type}
         </Button>
         <Popover
           open={this.state.newNamePopoverOpen}
@@ -112,9 +114,9 @@ class NewNameCreator extends React.Component<NewNameCreatorProps, NewNameCreator
       <div className={classes.popover}>
         <EditableTextField
           required
-          text=""
+          text={this.props.initialValue ? this.props.initialValue : ""}
           onSubmit={this.handleName}
-          label={this.props.text[0].toUpperCase() + this.props.text.substr(1,) + " name:"}
+          label={this.props.type[0].toUpperCase() + this.props.type.substr(1,) + " name:"}
           startInEditMode
           autoFocus
           errorMessage={this.state.errorMessage}

--- a/public/src/components/helpers/buttonWithConfirmationPopup.tsx
+++ b/public/src/components/helpers/buttonWithConfirmationPopup.tsx
@@ -5,7 +5,6 @@ import { SvgIconProps } from '@material-ui/core/SvgIcon';
 
 const styles = ({ spacing, typography }: Theme) => createStyles({
   button: {
-    marginLeft: spacing(2),
     marginBottom: spacing(2)
   },
   popover: {


### PR DESCRIPTION
Adds a new 'copy test' button to the bottom of the epic test editor component.
This behaves the same as the 'new test' button, except it copies everything but the name.
The name input field is pre-populated with the name of the existing test, as it's likely to be similar.
<img width="548" alt="Screenshot 2019-12-13 at 04 01 19" src="https://user-images.githubusercontent.com/1513454/70768657-08cceb00-1d5e-11ea-9515-0da1f746e0ae.png">

This is useful because we are often running very similar tests, e.g. with and without article view count