### PR TITLE
UI changes to support a new Payment Method switch for Single Contributions

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -28,6 +28,7 @@ case class ExperimentSwitch(name: String, description: String, state: SwitchStat
 case class PaymentMethodsSwitch(
   stripe: SwitchState,
   payPal: SwitchState,
+  amazonPay: Option[SwitchState],
   directDebit: Option[SwitchState],
   existingCard: Option[SwitchState],
   existingDirectDebit: Option[SwitchState]

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -64,6 +64,7 @@ function paymentMethodToHumanReadable(paymentMethod: string): string {
     case RecurringPaymentMethod.stripe: return 'Stripe';
     case RecurringPaymentMethod.existingCard: return 'Existing Card';
     case RecurringPaymentMethod.existingDirectDebit: return 'Existing Direct Debit';
+    case OneOffPaymentMethod.amazonPay: return 'Amazon Pay';
     default: return 'Unknown';
   }
 }

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -18,7 +18,7 @@ enum SwitchState {
 }
 
 enum OneOffPaymentMethod {
-  stripe = 'stripe', payPal = 'payPal'
+  stripe = 'stripe', payPal = 'payPal', amazonPay = 'amazonPay'
 }
 
 enum RecurringPaymentMethod {
@@ -99,6 +99,7 @@ class Switchboard extends React.Component<Props, Switches> {
       oneOffPaymentMethods: {
         stripe: SwitchState.Off,
         payPal: SwitchState.Off,
+        amazonPay: SwitchState.Off,
       },
       recurringPaymentMethods: {
         stripe: SwitchState.Off,

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -15,7 +15,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |{
       |      "oneOffPaymentMethods": {
       |        "stripe": "On",
-      |        "payPal": "On"
+      |        "payPal": "On",
+      |        "amazonPay": "On"
       |      },
       |      "recurringPaymentMethods": {
       |        "stripe": "On",
@@ -37,8 +38,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
 
   val expectedDecoded = VersionedS3Data(
     SupportFrontendSwitches(
-      PaymentMethodsSwitch(On,On,None, None, None),
-      PaymentMethodsSwitch(On,On,Some(On), Some(On), Some(On)),
+      PaymentMethodsSwitch(On, On, Some(On), None, None, None),
+      PaymentMethodsSwitch(On, On, None, Some(On), Some(On), Some(On)),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
       optimize = Off
     ),


### PR DESCRIPTION
This is my initial stab at creating a feature switch for Amazon Pay. It applies for Single Contributions only and the OFF mode will override any A/B tests.

**Checklist**

- [ ] Thalia to review and test Paul's initial stab at this
- [x] Tom and Thalia to coordinate on support-frontend changes
- [x] Test on CODE