### PR TITLE
Added 2 new switches: stripeApplePay and stripePaymentRequestButton

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -25,8 +25,10 @@ case object SwitchState {
 
 case class ExperimentSwitch(name: String, description: String, state: SwitchState)
 
-case class PaymentMethodsSwitch(
+case class PaymentMethodSwitches(
   stripe: SwitchState,
+  stripeApplePay: SwitchState,
+  stripePaymentRequestButton: SwitchState,
   payPal: SwitchState,
   amazonPay: Option[SwitchState],
   directDebit: Option[SwitchState],
@@ -35,8 +37,8 @@ case class PaymentMethodsSwitch(
 )
 
 case class SupportFrontendSwitches(
-  oneOffPaymentMethods: PaymentMethodsSwitch,
-  recurringPaymentMethods: PaymentMethodsSwitch,
+  oneOffPaymentMethods: PaymentMethodSwitches,
+  recurringPaymentMethods: PaymentMethodSwitches,
   experiments: Map[String, ExperimentSwitch],
   optimize: SwitchState
 )

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -10,16 +10,20 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
 class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
-  val expectedJson =
+  val expectedJson: String =
     """
       |{
       |      "oneOffPaymentMethods": {
       |        "stripe": "On",
+      |        "stripeApplePay": "On",
+      |        "stripePaymentRequestButton": "On",
       |        "payPal": "On",
       |        "amazonPay": "On"
       |      },
       |      "recurringPaymentMethods": {
       |        "stripe": "On",
+      |        "stripeApplePay": "On",
+      |        "stripePaymentRequestButton": "On",
       |        "payPal": "On",
       |        "directDebit": "On",
       |        "existingCard": "On",
@@ -36,24 +40,42 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |}
     """.stripMargin
 
-  val expectedDecoded = VersionedS3Data(
+  val expectedDecoded: VersionedS3Data[SupportFrontendSwitches] = VersionedS3Data(
     SupportFrontendSwitches(
-      PaymentMethodsSwitch(On, On, Some(On), None, None, None),
-      PaymentMethodsSwitch(On, On, None, Some(On), Some(On), Some(On)),
+      PaymentMethodSwitches(
+        stripe = On,
+        payPal = On,
+        amazonPay = Some(On),
+        directDebit = None,
+        existingCard = None,
+        existingDirectDebit = None,
+        stripeApplePay = On,
+        stripePaymentRequestButton = On
+      ),
+      PaymentMethodSwitches(
+        stripe = On,
+        payPal = On,
+        amazonPay = None,
+        directDebit = Some(On),
+        existingCard = Some(On),
+        existingDirectDebit = Some(On),
+        stripeApplePay = On,
+        stripePaymentRequestButton = On
+      ),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
       optimize = Off
     ),
     version = "v1"
   )
 
-  val objectSettings = S3ObjectSettings(
+  val objectSettings: S3ObjectSettings = S3ObjectSettings(
     bucket = "bucket",
     key = "key",
     publicRead = false,
     cacheControl = None
   )
 
-  val dummyS3Client = new S3Client {
+  val dummyS3Client: S3Client = new S3Client {
     def get(objectSettings: S3ObjectSettings)(implicit ec: ExecutionContext): Future[Either[String,RawVersionedS3Data]] = Future {
       Right {
         VersionedS3Data[String](
@@ -90,7 +112,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       S3Json.updateAsJson[SupportFrontendSwitches](objectSettings, expectedDecoded)(dummyS3Client),
       1.second
     )
-    val diff = JsonDiff.diff(expectedJson, result.right.value.value, false)
+    val diff = JsonDiff.diff(expectedJson, result.right.value.value, remember = false)
 
     diff should be(JsonPatch(Nil))
   }


### PR DESCRIPTION
Adding 2 new switches: stripeApplePay and stripePaymentRequestButton to both Single and Recurring switchboards. The first means we can roll out Apple Pay to 100 of eligible audience, as the test showed a 300% increase! Also added a second means we can turn off the ugly purple button as it showed little boost in conversion.

I also made a change to alphabetically sort the switch ordering, and renamed the case class PaymentMethodsSwitch to PaymentMethodSwitches as I feel it's a better name - it also fixed a bizarre compile issue.

Finally, I fixed some code analysis issues that IntelliJ complained about.

<img width="763" alt="Screen Shot 2019-12-24 at 10 26 13" src="https://user-images.githubusercontent.com/1515970/71408964-d95c8f00-2637-11ea-989e-f862537d6b6f.png">
