### PR TITLE
Warning if user has epic tests open for edit for too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@types/jest": "24.0.18"
   },
   "dependencies": {
-    "@material-ui/core": "^4.4.3",
-    "@material-ui/icons": "^4.4.3",
+    "@material-ui/core": "^4.9.0",
+    "@material-ui/icons": "^4.5.1",
     "immutability-helper": "^3.0.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -170,6 +170,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       });
   };
 
+  // Maintains an alert if tool is left open for edit for 20 minutes
   updateWarningTimeout = (editMode: boolean): void => {
     if (editMode) {
       if (this.state.timeoutAlertId) {
@@ -179,7 +180,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       const timeoutAlertId = window.setTimeout(() => {
         alert("You've had this editing session open for 20 minutes - if you leave it much longer then you may lose any unsaved work!\nIf you've finished then please click 'Cancel'.");
         this.setState({ timeoutAlertId: null });
-      }, 10000);
+      }, 60 * 20 * 1000);
 
       this.setState({ timeoutAlertId });
 

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -178,7 +178,7 @@ class EpicTestsForm extends React.Component<EpicTestFormProps, EpicTestsFormStat
       }
 
       const timeoutAlertId = window.setTimeout(() => {
-        alert("You've had this editing session open for 20 minutes - if you leave it much longer then you may lose any unsaved work!\nIf you've finished then please click 'Cancel'.");
+        alert("You've had this editing session open for 20 minutes - if you leave it much longer then you may lose any unsaved work!\nIf you've finished then please either save or cancel.");
         this.setState({ timeoutAlertId: null });
       }, 60 * 20 * 1000);
 

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -16,7 +16,7 @@ import Divider from '@material-ui/core/Divider';
 import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import ListItem from '@material-ui/core/ListItem';
-import {CreateCSSProperties} from "@material-ui/core/styles/withStyles";
+import {CSSProperties} from "@material-ui/core/styles/withStyles";
 
 const drawerWidth = 240;
 
@@ -35,7 +35,7 @@ const styles = ({ palette, spacing, mixins, typography }: Theme) => createStyles
   drawerPaper: {
     width: drawerWidth,
   },
-  toolbar: mixins.toolbar as CreateCSSProperties<{}>,
+  toolbar: mixins.toolbar as CSSProperties, // createStyles expects material-ui's CSSProperties type, not react's
   content: {
     flexGrow: 1,
     backgroundColor: palette.background.default,

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -6,7 +6,7 @@ import Switchboard from './components/switchboard';
 import ContributionTypesForm from './components/contributionTypes';
 import AmountsForm from './components/amounts/amounts';
 import EpicTestsForm from './components/epicTests/epicTestsForm';
-import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -16,6 +16,7 @@ import Divider from '@material-ui/core/Divider';
 import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import ListItem from '@material-ui/core/ListItem';
+import {CreateCSSProperties} from "@material-ui/core/styles/withStyles";
 
 const drawerWidth = 240;
 
@@ -34,7 +35,7 @@ const styles = ({ palette, spacing, mixins, typography }: Theme) => createStyles
   drawerPaper: {
     width: drawerWidth,
   },
-  toolbar: mixins.toolbar,
+  toolbar: mixins.toolbar as CreateCSSProperties<{}>,
   content: {
     flexGrow: 1,
     backgroundColor: palette.background.default,


### PR DESCRIPTION
This is because the google auth currently silently times out if the user leaves it open for too long. When this happens, any unsaved changes are lost because it cannot send them to the server.
There is a trello card for a proper solution to this, but it's not trivial.

We're expanding the number of users so this is likely to happen more. For now the simplest solution is to show an alert if they leave it open for edit for 20 minutes (which they shouldn't be anyway).

<img width="1395" alt="Screen Shot 2020-01-27 at 10 42 33" src="https://user-images.githubusercontent.com/1513454/73168445-bf5c1380-40f1-11ea-9e0a-58f1ce72fbe5.png">

