### PR TITLE
Do not set default 'articles viewed' settings

### DIFF
--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -16,8 +16,8 @@ const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
 
 export const defaultArticlesViewedSettings: ArticlesViewedSettings = {
   maxViews: null,
-  minViews: 5,
-  periodInWeeks: 8,
+  minViews: null,
+  periodInWeeks: null, //By initialising this to null we require the user to enter a value before the test can be valid
 };
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
@@ -83,7 +83,15 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
       editEnabled={this.props.editMode}
       validation={
         {
-          getError: (value: string) => isNumber(value) ? null : 'Must be a number',
+          getError: (value: string) => {
+            if (isRequired && !value) {
+              return 'This field is required'
+            }
+            else if (!isNumber(value)) {
+              return 'Must be a number';
+            }
+            else return null;
+          },
           onChange: onFieldValidationChange(this)(fieldName)
         }
       }

--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -16,8 +16,8 @@ const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
 
 export const defaultArticlesViewedSettings: ArticlesViewedSettings = {
   maxViews: null,
-  minViews: null,
-  periodInWeeks: null, //By initialising this to null we require the user to enter a value before the test can be valid
+  minViews: 5,
+  periodInWeeks: 52,
 };
 
 const styles = ({ spacing, typography}: Theme) => createStyles({

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -410,10 +410,8 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
           <ArticlesViewedEditor
             articlesViewedSettings={test.articlesViewedSettings}
             editMode={this.isEditable()}
-            onChange={(articlesViewedSettings?: ArticlesViewedSettings) => {
+            onChange={(articlesViewedSettings?: ArticlesViewedSettings) =>
               this.updateTest(test => ({ ...test, articlesViewedSettings }))
-            }
-
             }
             onValidationChange={onFieldValidationChange(this)('articlesViewedEditor')}
           />

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -49,7 +49,10 @@ export interface MaxEpicViews {
 export interface ArticlesViewedSettings {
   minViews: number | null,
   maxViews: number | null,
-  periodInWeeks: number
+  // periodInWeeks is required in server-side model, but optional here because we have to automatically add
+  // a blank ArticlesViewedSettings when the %%ARTICLE_COUNT%% template is detected. Validation in the
+  // articlesViewedEditor will immediately report the error, preventing use of the save button.
+  periodInWeeks: number | null,
 }
 
 export interface EpicTest {

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -49,10 +49,7 @@ export interface MaxEpicViews {
 export interface ArticlesViewedSettings {
   minViews: number | null,
   maxViews: number | null,
-  // periodInWeeks is required in server-side model, but optional here because we have to automatically add
-  // a blank ArticlesViewedSettings when the %%ARTICLE_COUNT%% template is detected. Validation in the
-  // articlesViewedEditor will immediately report the error, preventing use of the save button.
-  periodInWeeks: number | null,
+  periodInWeeks: number,
 }
 
 export interface EpicTest {


### PR DESCRIPTION
Edit: after discussion, we decided just to set the default to 52 weeks. The stuff below is now incorrect...

because it's easy to forget to adjust them to match what's in the copy.
The 'default' is now all nulls, and so the form now immediately fails validation until you set it yourself.

So, as soon as you add the `%%ARTICLE_COUNT%%` template to the copy it adds this:
<img width="529" alt="Screen Shot 2020-01-30 at 11 52 33" src="https://user-images.githubusercontent.com/1513454/73447636-1282d000-4357-11ea-87ce-cf3e8bb1a8bc.png">
