### PR TITLE
Add a switch to enable use of the dotcom contacts page

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -40,5 +40,5 @@ case class SupportFrontendSwitches(
   oneOffPaymentMethods: PaymentMethodSwitches,
   recurringPaymentMethods: PaymentMethodSwitches,
   experiments: Map[String, ExperimentSwitch],
-  optimize: SwitchState
+  useDotcomContactPage: SwitchState
 )

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -32,7 +32,7 @@ interface Switches {
   recurringPaymentMethods: {
     [p in RecurringPaymentMethod]: SwitchState
   },
-  optimize: SwitchState,
+  useDotcomContactPage: SwitchState,
   experiments: {
     [featureSwitch: string]: {
       name: string,
@@ -116,7 +116,7 @@ class Switchboard extends React.Component<Props, Switches> {
         existingCard: SwitchState.Off,
         existingDirectDebit: SwitchState.Off,
       },
-      optimize: SwitchState.Off,
+      useDotcomContactPage: SwitchState.Off,
       experiments: {},
     };
     this.previousStateFromServer = null;
@@ -255,12 +255,12 @@ class Switchboard extends React.Component<Props, Switches> {
               <FormControlLabel
                 control={
                   <Switch
-                    checked={switchStateToBoolean(this.state.optimize)}
-                    onChange={(event) => this.setState({optimize: booleanToSwitchState(event.target.checked)})}
-                    value={switchStateToBoolean(this.state.optimize)}
+                    checked={switchStateToBoolean(this.state.useDotcomContactPage)}
+                    onChange={(event) => this.setState({useDotcomContactPage: booleanToSwitchState(event.target.checked)})}
+                    value={switchStateToBoolean(this.state.useDotcomContactPage)}
                   />
                 }
-                label="Google Optimize"
+                label="Use emergency contact page on dotcom"
               />
             </FormControl>
           </div>

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -36,7 +36,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |          "state": "On"
       |        }
       |      },
-      |      "optimize": "Off"
+      |      "useDotcomContactPage": "Off"
       |}
     """.stripMargin
 
@@ -63,7 +63,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
         stripePaymentRequestButton = On
       ),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
-      optimize = Off
+      useDotcomContactPage = Off
     ),
     version = "v1"
   )


### PR DESCRIPTION
During the Corona virus period we want to update all the contact us information on support-frontend to point to the contact us page on dotcom so that it can be easily updated by central production.

This PR adds a switch which will toggle that behaviour. It also removes the old `optimize` switch as this is no longer used by support-frontend.