### PR TITLE
Restyle editable text field and remove button

### DIFF
--- a/public/src/components/epicTests/articlesViewedEditor.tsx
+++ b/public/src/components/epicTests/articlesViewedEditor.tsx
@@ -130,8 +130,8 @@ class ArticlesViewedEditor extends React.Component<Props, State> {
 
         { this.props.articlesViewedSettings &&
           <div className={classes.articlesViewsContainer}>
-            {this.buildField('minViews', 'Min articles viewed', this.props.articlesViewedSettings, false)}
-            {this.buildField('maxViews', 'Max articles viewed', this.props.articlesViewedSettings, false)}
+            {this.buildField('minViews', 'Minimum number of articles viewed', this.props.articlesViewedSettings, false)}
+            {this.buildField('maxViews', 'Maximum articles viewed', this.props.articlesViewedSettings, false)}
             {this.buildField('periodInWeeks', 'Time period in weeks', this.props.articlesViewedSettings, true)}
           </div>
         }

--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -53,10 +53,10 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   hasChanged: {
     color: 'orange'
   },
-  h4: {
-    fontSize: typography.pxToRem(24),
-    fontWeight: typography.fontWeightMedium,
-    margin: '20px 0 15px'
+  boldHeading: {
+    fontSize: typography.pxToRem(17),
+    fontWeight: typography.fontWeightBold,
+    margin: '20px 0 10px'
   },
   select: {
     minWidth: "460px",
@@ -65,8 +65,7 @@ const styles = ({ spacing, typography}: Theme) => createStyles({
   },
   selectLabel: {
     fontSize: typography.pxToRem(22),
-    fontWeight: typography.fontWeightMedium,
-    color: 'black'
+    color: 'black',
   },
   radio: {
     paddingTop: '20px',
@@ -252,7 +251,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
           {this.props.test && this.props.test.name}
           {statusText()}
         </Typography>
-        <Typography variant={'h4'} className={classes.h4}>{this.props.test && this.props.test.nickname}</Typography>
+        <Typography variant={'h4'} className={classes.boldHeading}>{this.props.test && this.props.test.nickname}</Typography>
 
         <div className={classes.switchWithIcon}>
           <Typography className={classes.switchLabel}>Live on theguardian.com</Typography>
@@ -272,7 +271,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
           onEpicTypeChange={this.onEpicTypeChange}
         />
 
-        <Typography variant={'h4'} className={classes.h4}>Variants</Typography>
+        <Typography variant={'h4'} className={classes.boldHeading}>Variants</Typography>
         <div>
           <EpicTestVariantsList
             variants={test.variants}
@@ -283,42 +282,42 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
           />
         </div>
 
-        <Typography variant={'h4'} className={classes.h4}>Editorial tags</Typography>
+        <Typography variant={'h4'} className={classes.boldHeading}>Target content</Typography>
 
         <div>
           <EditableTextField
             text={test.tagIds.join(",")}
             onSubmit={this.onListChange('tagIds')}
-            label="Display on tags:"
-            helperText="Separate each tag with a comma"
+            label="Target tags"
+            helperText="Format: environment/wildlife,business/economics"
             editEnabled={this.isEditable()}
           />
 
           <EditableTextField
             text={test.sections.join(",")}
             onSubmit={this.onListChange('sections')}
-            label="Display on sections:"
-            helperText="Separate each section with a comma"
+            label="Target sections"
+            helperText="Format: environment,business"
             editEnabled={this.isEditable()}
           />
 
           <EditableTextField
             text={test.excludedTagIds.join(",")}
             onSubmit={this.onListChange('excludedTagIds')}
-            label="Excluded tags:"
-            helperText="Separate each tag with a comma"
+            label="Excluded tags"
+            helperText="Format: environment/wildlife,business/economics"
             editEnabled={this.isEditable()}
           />
 
           <EditableTextField
             text={test.excludedSections.join(",")}
             onSubmit={this.onListChange('excludedSections')}
-            label="Excluded sections:"
-            helperText="Separate each section with a comma"
+            label="Excluded sections"
+            helperText="Format: environment,business"
             editEnabled={this.isEditable()}
           />
 
-          <Typography variant={'h4'} className={classes.h4}>Audience</Typography>
+          <Typography variant={'h4'} className={classes.boldHeading}>Target audience</Typography>
 
           <TargetRegionsSelector
             regions={test.locations}
@@ -326,14 +325,13 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             isEditable={this.isEditable()}
           />
 
-
           <FormControl
             className={classes.formControl}>
               <InputLabel
                 className={classes.selectLabel}
                 shrink
                 htmlFor="user-cohort">
-                  User cohort:
+                  Supporter status
               </InputLabel>
               <RadioGroup
                 className={classes.radio}
@@ -352,7 +350,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
               </RadioGroup>
           </FormControl>
 
-          <Typography variant={'h4'} className={this.props.classes.h4}>View frequency settings</Typography>
+          <Typography variant={'h4'} className={this.props.classes.boldHeading}>View frequency settings</Typography>
 
           <FormControlLabel
             control={
@@ -374,7 +372,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
             onValidationChange={onFieldValidationChange(this)('maxViews')}
           />
 
-          <Typography variant={'h4'} className={this.props.classes.h4}>Articles count settings</Typography>
+          <Typography variant={'h4'} className={this.props.classes.boldHeading}>Article count</Typography>
           <ArticlesViewedEditor
             articlesViewedSettings={test.articlesViewedSettings}
             editMode={this.isEditable()}

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {EpicVariant, Cta} from "./epicTestsForm";
-import {Theme, createStyles, WithStyles, withStyles, Typography} from "@material-ui/core";
+import {Theme, createStyles, WithStyles, withStyles} from "@material-ui/core";
 import EditableTextField from "../helpers/editableTextField";
 import CtaEditor from "./ctaEditor";
 import Switch from "@material-ui/core/Switch";
@@ -61,10 +61,6 @@ const styles = ({ palette, spacing, typography }: Theme) => createStyles({
     minWidth: "60%",
     maxWidth: "100%",
     display: "block",
-  },
-  h5: {
-    fontSize: typography.pxToRem(18),
-    margin: "20px 0 10px 0"
   },
   deleteButton: {
     marginTop: spacing(2),
@@ -152,10 +148,11 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
         <>
           <div className={classes.hook}>
             <EditableTextField
-              text={variant.heading || ""}
-              onSubmit={this.onOptionalTextChange("heading")}
-              label="Hook:"
+              text={variant.heading || ''}
+              onSubmit={this.onOptionalTextChange('heading')}
+              label="Hook"
               editEnabled={this.props.editMode}
+              helperText="e.g. Since you're here"
               validation={
                 {
                   getError: (value: string) => getInvalidTemplateError(value),
@@ -167,11 +164,13 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
 
           <EditableTextField
             required
+            textarea
+            height={10}
             text={variant.paragraphs.join("\n")}
-            textarea={true}
             onSubmit={this.onParagraphsChange("paragraphs")}
-            label="Paragraphs:"
+            label="Body copy"
             editEnabled={this.props.editMode}
+            helperText="Main Epic message, including paragraph breaks"
             validation={
               {
                 getError: (value: string) => {
@@ -183,8 +182,23 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
             }
           />
 
+          <EditableTextField
+            text={variant.highlightedText || ""}
+            onSubmit={this.onOptionalTextChange("highlightedText")}
+            label="Highlighted text"
+            helperText="Final sentence, highlighted in yellow"
+            editEnabled={this.props.editMode}
+            validation={
+              {
+                getError: (value: string) => getInvalidTemplateError(value),
+                onChange: onFieldValidationChange(this)("highlightedText")
+              }
+            }
+          />
+
+
           <div className={classes.ctaContainer}>
-            <span className={classes.label}>Buttons:</span>
+            <span className={classes.label}>Buttons</span>
             <CtaEditor
               cta={variant.cta}
               update={(cta?: Cta) =>
@@ -208,28 +222,6 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
             />
           </div>
 
-          <EditableTextField
-            text={variant.highlightedText || ""}
-            onSubmit={this.onOptionalTextChange("highlightedText")}
-            label="Highlighted text:"
-            helperText="This will appear as the last sentence"
-            editEnabled={this.props.editMode}
-            validation={
-              {
-                getError: (value: string) => getInvalidTemplateError(value),
-                onChange: onFieldValidationChange(this)("highlightedText")
-              }
-            }
-          />
-
-          <EditableTextField
-            text={variant.backgroundImageUrl || ""}
-            onSubmit={this.onOptionalTextChange(VariantFieldNames.backgroundImageUrl)}
-            label="Image URL:"
-            helperText="This will appear above everything except a ticker"
-            editEnabled={this.props.editMode}
-          />
-
           <div>
             <FormControlLabel
               control={
@@ -244,9 +236,17 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
           </div>
 
           <EditableTextField
+            text={variant.backgroundImageUrl || ""}
+            onSubmit={this.onOptionalTextChange(VariantFieldNames.backgroundImageUrl)}
+            label="Image URL"
+            helperText="This will appear above everything except a ticker"
+            editEnabled={this.props.editMode}
+          />
+
+          <EditableTextField
             text={variant.footer || ""}
             onSubmit={this.onOptionalTextChange("footer")}
-            label="Footer:"
+            label="Footer"
             helperText="Bold text that appears below the button"
             editEnabled={this.props.editMode}
           />

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -78,6 +78,9 @@ const styles = ({ palette, spacing, typography }: Theme) => createStyles({
   ctaContainer: {
     marginTop: "15px",
     marginBottom: "15px"
+  },
+  hook: {
+    maxWidth: '400px'
   }
 });
 
@@ -147,18 +150,20 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
     const {classes} = this.props;
     return (
         <>
-          <EditableTextField
-            text={variant.heading || ""}
-            onSubmit={this.onOptionalTextChange("heading")}
-            label="Hook:"
-            editEnabled={this.props.editMode}
-            validation={
-              {
-                getError: (value: string) => getInvalidTemplateError(value),
-                onChange: onFieldValidationChange(this)("heading")
+          <div className={classes.hook}>
+            <EditableTextField
+              text={variant.heading || ""}
+              onSubmit={this.onOptionalTextChange("heading")}
+              label="Hook:"
+              editEnabled={this.props.editMode}
+              validation={
+                {
+                  getError: (value: string) => getInvalidTemplateError(value),
+                  onChange: onFieldValidationChange(this)("heading")
+                }
               }
-            }
-          />
+            />
+          </div>
 
           <EditableTextField
             required

--- a/public/src/components/epicTests/epicTestVariantsList.tsx
+++ b/public/src/components/epicTests/epicTestVariantsList.tsx
@@ -10,7 +10,7 @@ import {defaultCta} from "./epicTestVariantEditor";
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
 
 
-const styles = ({ typography }: Theme) => createStyles({
+const styles = ({ typography, spacing }: Theme) => createStyles({
   h4: {
     fontSize: typography.pxToRem(20),
     fontWeight: typography.fontWeightMedium,
@@ -22,6 +22,9 @@ const styles = ({ typography }: Theme) => createStyles({
     fontSize: typography.pxToRem(14),
     fontWeight: 'normal',
     fontStyle: 'italic'
+  },
+  newVariantButton: {
+    marginTop: spacing(2)
   }
 });
 
@@ -102,7 +105,9 @@ class EpicTestVariantsList extends React.Component<EpicTestVariantsListProps, Ep
   };
 
   renderNewVariantButton = (): React.ReactNode => {
+    const {classes} = this.props;
     return this.props.editMode ? (
+      <div className={classes.newVariantButton}>
       <NewNameCreator
         type="variant"
         action="New"
@@ -111,6 +116,7 @@ class EpicTestVariantsList extends React.Component<EpicTestVariantsListProps, Ep
         onValidName={this.createVariant}
         editEnabled={this.props.editMode}
       />
+      </div>
     ) : null;
   }
 
@@ -162,11 +168,11 @@ class EpicTestVariantsList extends React.Component<EpicTestVariantsListProps, Ep
   render(): React.ReactNode {
    return(
     <>
+      {this.props.variants.length > 0 && this.renderVariantsList()}
+
       {this.props.variants.length < 1 && this.renderNoVariantMessage()}
 
       {this.renderNewVariantButton()}
-
-      {this.props.variants.length > 0 && this.renderVariantsList()}
     </>
    )
   };

--- a/public/src/components/epicTests/maxEpicViewsEditor.tsx
+++ b/public/src/components/epicTests/maxEpicViewsEditor.tsx
@@ -140,9 +140,9 @@ class MaxEpicViewsEditor extends React.Component<Props, State> {
 
         { !this.props.test.alwaysAsk &&
           <div className={classes.maxEpicViewsContainer}>
-            {this.buildField('maxViewsCount', 'Max views count')}
+            {this.buildField('maxViewsCount', 'Maximum view counts')}
             {this.buildField('maxViewsDays', 'Number of days')}
-            {this.buildField('minDaysBetweenViews', 'Min days between views')}
+            {this.buildField('minDaysBetweenViews', 'Minimum days between views')}
           </div>
         }
       </>

--- a/public/src/components/epicTests/targetRegionsSelector.tsx
+++ b/public/src/components/epicTests/targetRegionsSelector.tsx
@@ -14,8 +14,7 @@ import { Region } from '../../utils/models';
 
 const styles = ({ spacing, typography }: Theme) => createStyles({
   selectLabel: {
-    fontSize: typography.pxToRem(18),
-    fontWeight: typography.fontWeightMedium,
+    fontSize: typography.pxToRem(17),
     color: 'black',
   },
   indentedCheckbox: {
@@ -86,7 +85,7 @@ class TargetRegionsSelector extends React.Component<TargetRegionsSelectorProps, 
 
     return (
       <>
-        <Typography className={classes.selectLabel}>Target regions</Typography>
+        <Typography className={classes.selectLabel}>Region</Typography>
           <FormGroup>
             <FormControlLabel
               control={

--- a/public/src/components/helpers/editableTextField.tsx
+++ b/public/src/components/helpers/editableTextField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createStyles, Theme, withStyles, WithStyles, FormControl} from "@material-ui/core";
+import {createStyles, Theme, withStyles, WithStyles, Typography} from "@material-ui/core";
 import TextField from '@material-ui/core/TextField';
 
 const styles = ({ typography, spacing }: Theme) => createStyles({
@@ -42,7 +42,6 @@ interface EditableTextFieldProps extends WithStyles<typeof styles> {
   label: string,
   textarea?: boolean,
   onSubmit: (updatedText: string) => void,
-  startInEditMode?: boolean,
   errorMessage?: string,
   helperText?: string,
   autoFocus?: boolean,
@@ -58,7 +57,7 @@ interface EditableTextFieldState {
 
 class EditableTextField extends React.Component<EditableTextFieldProps, EditableTextFieldState> {
 
-  state: EditableTextFieldState =  {
+  state: EditableTextFieldState = {
     currentText: this.props.text
   };
 
@@ -100,17 +99,14 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
   render(): React.ReactNode {
     const {classes} = this.props;
 
-    const error = this.props.errorMessage ||
+    const error: string | null | undefined = this.props.errorMessage ||
       (this.props.validation && this.props.validation.getError(this.state.currentText));
 
     return (
       <>
         <div className={`${classes.container} ${this.props.isNumberField ? classes.numberContainer : classes.textContainer}`}>
-          <FormControl
-            required={this.props.required}
-            className={classes.formControl}
-          >
             <TextField
+              className={classes.formControl}
               label={this.props.label}
               variant={'outlined'}
               required={this.props.required}
@@ -120,16 +116,12 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
               disabled={!this.props.editEnabled}
               value={this.state.currentText}
               onChange={this.onChange}
-              helperText={this.props.helperText} // TODO: display error messages here
+              helperText={error ? error : this.props.helperText}
               autoFocus={this.props.autoFocus}
               error={this.props.validation ? !this.isValid() : false}
               onBlur={this.onExitField}
             />
-          </FormControl>
         </div>
-        {/* {error && (
-          <Typography color={'error'} variant={'body2'}>{error}</Typography>
-        )} */}
       </>
 
     )

--- a/public/src/components/helpers/editableTextField.tsx
+++ b/public/src/components/helpers/editableTextField.tsx
@@ -41,14 +41,15 @@ interface EditableTextFieldProps extends WithStyles<typeof styles> {
   text: string,
   label: string,
   textarea?: boolean,
+  height?: number,
   onSubmit: (updatedText: string) => void,
   errorMessage?: string,
   helperText?: string,
   autoFocus?: boolean,
   required?: boolean,
   editEnabled: boolean,
-  validation?: Validation
-  isNumberField?: boolean
+  validation?: Validation,
+  isNumberField?: boolean,
 }
 
 interface EditableTextFieldState {
@@ -111,6 +112,7 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
               variant={'outlined'}
               required={this.props.required}
               multiline={this.props.textarea}
+              rows={this.props.height}
               fullWidth
               name={this.props.label}
               disabled={!this.props.editEnabled}

--- a/public/src/components/helpers/editableTextField.tsx
+++ b/public/src/components/helpers/editableTextField.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import {createStyles, Theme, withStyles, WithStyles, Typography, FormControl, InputLabel} from "@material-ui/core";
-import Button from "@material-ui/core/Button";
+import {createStyles, Theme, withStyles, WithStyles, FormControl} from "@material-ui/core";
 import TextField from '@material-ui/core/TextField';
-import EditIcon from '@material-ui/icons/Edit';
-import SaveIcon from '@material-ui/icons/Save';
 
 const styles = ({ typography, spacing }: Theme) => createStyles({
   container: {
@@ -28,9 +25,6 @@ const styles = ({ typography, spacing }: Theme) => createStyles({
     fontSize: typography.pxToRem(22),
     fontWeight: typography.fontWeightMedium,
     color: "black"
-  },
-  textField: {
-    marginTop: "20px"
   },
   button: {
     marginTop: "30px",
@@ -59,14 +53,12 @@ interface EditableTextFieldProps extends WithStyles<typeof styles> {
 }
 
 interface EditableTextFieldState {
-  fieldEditMode: boolean,
   currentText: string
 }
 
 class EditableTextField extends React.Component<EditableTextFieldProps, EditableTextFieldState> {
 
   state: EditableTextFieldState =  {
-    fieldEditMode: this.props.startInEditMode || false,
     currentText: this.props.text
   };
 
@@ -80,7 +72,6 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
   componentDidUpdate(prevProps: EditableTextFieldProps) {
     if (prevProps.text !== this.props.text) {
       this.setState({
-        fieldEditMode: false,
         currentText: this.props.text
       })
     }
@@ -95,40 +86,16 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
 
     this.setState({
       currentText: newValue
-    })
+    });
   };
 
-  onClickButton = (): void => {
-    if (this.state.fieldEditMode) {
-      if (this.props.validation) {
-        this.props.validation.onChange(this.isValid());
-      }
-
-      this.props.onSubmit(this.state.currentText);
-
-      this.setState({
-        fieldEditMode: false
-      });
-    } else {
-      this.setState({
-        fieldEditMode: true
-      });
+  onExitField = (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+    if (this.props.validation) {
+      this.props.validation.onChange(this.isValid());
     }
-  };
 
-  showButton = (): React.ReactFragment | null => {
-    const {classes} = this.props;
-    return this.props.editEnabled && (
-      <Button
-      className={classes.button}
-      type="submit"
-      variant="contained"
-      color="primary"
-      onClick={this.onClickButton}>
-        {this.state.fieldEditMode ? <SaveIcon /> : <EditIcon />}
-      </Button>
-    )
-  }
+    this.props.onSubmit(this.state.currentText);
+  };
 
   render(): React.ReactNode {
     const {classes} = this.props;
@@ -143,30 +110,26 @@ class EditableTextField extends React.Component<EditableTextFieldProps, Editable
             required={this.props.required}
             className={classes.formControl}
           >
-            <InputLabel
-              className={classes.label}
-              shrink
-            >
-              {this.props.label}
-            </InputLabel>
             <TextField
-              className={classes.textField}
+              label={this.props.label}
+              variant={'outlined'}
+              required={this.props.required}
               multiline={this.props.textarea}
               fullWidth
               name={this.props.label}
-              disabled={!this.state.fieldEditMode}
+              disabled={!this.props.editEnabled}
               value={this.state.currentText}
               onChange={this.onChange}
-              helperText={this.props.helperText}
+              helperText={this.props.helperText} // TODO: display error messages here
               autoFocus={this.props.autoFocus}
               error={this.props.validation ? !this.isValid() : false}
+              onBlur={this.onExitField}
             />
           </FormControl>
-         {this.showButton()}
         </div>
-        {error && (
+        {/* {error && (
           <Typography color={'error'} variant={'body2'}>{error}</Typography>
-        )}
+        )} */}
       </>
 
     )


### PR DESCRIPTION
## Problem we're trying to solve
– it isn't intuitive to save or edit using the pencil / floppy disk icons in each text field. Users expect to be able to click into the field to edit. We'd like to add auto saving when you click out of a field
– we want to bring text field styles in-line with the new type we're using across the tool
– we'll improve/edit all labels and helper text

## Changes

* User can click in and out of fields to edit and auto save
* Edit/Save button removed
* Error messages added to textField component helperText attribute
* Labels updated
* Order of fields tweaked and 'add variant' button moved under variant list.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/15648334/77561217-50632700-6eb6-11ea-9718-e5aad9c69cc5.png)

![image](https://user-images.githubusercontent.com/15648334/77561335-7ab4e480-6eb6-11ea-934d-03e18b974782.png)

![image](https://user-images.githubusercontent.com/15648334/77561475-a768fc00-6eb6-11ea-9deb-4ba3e762a25c.png)


### After
![image](https://user-images.githubusercontent.com/15648334/77560591-979ce800-6eb5-11ea-8b39-b65d41d21a65.png)

![image](https://user-images.githubusercontent.com/15648334/77560848-dc288380-6eb5-11ea-91fa-720a1eb0519c.png)

![image](https://user-images.githubusercontent.com/15648334/77560887-e6e31880-6eb5-11ea-811f-cec3be8030a2.png)
