### PR TITLE
Adding recaptcha control switches

### DIFF
--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -3,7 +3,8 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.SupportFrontendSwitches
 import play.api.mvc.{AnyContent, ControllerComponents}
-import io.circe.generic.auto._
+import models.SupportFrontendSwitches.SupportFrontendSwitchesDecoder
+import models.SupportFrontendSwitches.SupportFrontendSwitchesEncoder
 import zio.DefaultRuntime
 
 import scala.concurrent.ExecutionContext

--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -1,5 +1,7 @@
 package models
 
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.auto._
 import io.circe.{Decoder, Encoder}
 import utils.Circe.decodeStringAndCollect
 
@@ -44,3 +46,9 @@ case class SupportFrontendSwitches(
   enableRecaptchaBackend: SwitchState,
   enableRecaptchaFrontend: SwitchState
 )
+
+object SupportFrontendSwitches {
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val SupportFrontendSwitchesDecoder = Decoder[SupportFrontendSwitches]
+  implicit val SupportFrontendSwitchesEncoder = Encoder[SupportFrontendSwitches]
+}

--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -40,5 +40,7 @@ case class SupportFrontendSwitches(
   oneOffPaymentMethods: PaymentMethodSwitches,
   recurringPaymentMethods: PaymentMethodSwitches,
   experiments: Map[String, ExperimentSwitch],
-  useDotcomContactPage: SwitchState
+  useDotcomContactPage: SwitchState,
+  enableRecaptchaBackend: SwitchState,
+  enableRecaptchaFrontend: SwitchState
 )

--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -6,7 +6,7 @@ import io.circe.{Decoder, Encoder}
 import utils.Circe.decodeStringAndCollect
 
 /**
-  * Based on https://github.com/guardian/support-frontend/blob/master/app/admin/Settings.scala
+  * Based on https://github.com/guardian/support-frontend/blob/master/support-frontend/app/admin/settings/
   */
 
 sealed trait SwitchState

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -266,6 +266,8 @@ class Switchboard extends React.Component<Props, Switches> {
                 }
                 label="Enable recaptcha on backend"
               />
+              <FormControlLabel
+              control={
               <Switch
                 checked={switchStateToBoolean(this.state.enableRecaptchaFrontend)}
                 onChange={(event) => this.setState({enableRecaptchaFrontend: booleanToSwitchState(event.target.checked)})}

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -33,6 +33,8 @@ interface Switches {
     [p in RecurringPaymentMethod]: SwitchState
   },
   useDotcomContactPage: SwitchState,
+  enableRecaptchaBackend: SwitchState,
+  enableRecaptchaFrontend: SwitchState,
   experiments: {
     [featureSwitch: string]: {
       name: string,
@@ -117,6 +119,8 @@ class Switchboard extends React.Component<Props, Switches> {
         existingDirectDebit: SwitchState.Off,
       },
       useDotcomContactPage: SwitchState.Off,
+      enableRecaptchaBackend: SwitchState.Off,
+      enableRecaptchaFrontend: SwitchState.Off,
       experiments: {},
     };
     this.previousStateFromServer = null;
@@ -249,6 +253,27 @@ class Switchboard extends React.Component<Props, Switches> {
                   label={`${switchData.name}: ${switchData.description}`}
                 />
               )}
+            </FormControl>
+            <FormControl component={'fieldset' as 'div'} className={classes.formControl}>
+              <FormLabel component={'legend' as 'label'}>Recaptcha Switches</FormLabel>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={switchStateToBoolean(this.state.enableRecaptchaBackend)}
+                    onChange={(event) => this.setState({enableRecaptchaBackend: booleanToSwitchState(event.target.checked)})}
+                    value={switchStateToBoolean(this.state.enableRecaptchaBackend)}
+                  />
+                }
+                label="Enable recaptcha on backend"
+              />
+              <Switch
+                checked={switchStateToBoolean(this.state.enableRecaptchaFrontend)}
+                onChange={(event) => this.setState({enableRecaptchaFrontend: booleanToSwitchState(event.target.checked)})}
+                value={switchStateToBoolean(this.state.enableRecaptchaFrontend)}
+              />
+              }
+              label="Enable recaptcha on frontend"
+              />
             </FormControl>
             <FormControl component={'fieldset' as 'div'} className={classes.formControl}>
               <FormLabel component={'legend' as 'label'}>Other Switches</FormLabel>

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -264,7 +264,7 @@ class Switchboard extends React.Component<Props, Switches> {
                     value={switchStateToBoolean(this.state.enableRecaptchaBackend)}
                   />
                 }
-                label="Enable recaptcha on backend"
+                label="Enable recaptcha on backend [Always Disable First then wait 2 mins]"
               />
               <FormControlLabel
               control={
@@ -274,7 +274,7 @@ class Switchboard extends React.Component<Props, Switches> {
                 value={switchStateToBoolean(this.state.enableRecaptchaFrontend)}
               />
               }
-              label="Enable recaptcha on frontend"
+              label="Enable recaptcha on frontend [Always Enable First then wait 2 mins]"
               />
             </FormControl>
             <FormControl component={'fieldset' as 'div'} className={classes.formControl}>

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -40,7 +40,9 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |          "state": "On"
       |        }
       |      },
-      |      "useDotcomContactPage": "Off"
+      |      "useDotcomContactPage": "Off",
+      |      "enableRecaptchaBackend" : "On",
+      |      "enableRecaptchaFrontend" : "On"
       |}
     """.stripMargin
 
@@ -67,7 +69,9 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
         stripePaymentRequestButton = On
       ),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
-      useDotcomContactPage = Off
+      useDotcomContactPage = Off,
+      enableRecaptchaBackend = On,
+      enableRecaptchaFrontend = On
     ),
     version = "v1"
   )


### PR DESCRIPTION
Adding recaptcha control switches

- We want to be able to turn recaptcha off in support-frontend and payment-api.

![image](https://user-images.githubusercontent.com/30600967/80958910-b15b1480-8dfd-11ea-827b-36a053eb8fa4.png)
