### PR TITLE
Open ELB

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -210,7 +210,7 @@ Resources:
       - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
-        CidrIp: !Ref KingsPlaceIP
+        CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
       - IpProtocol: tcp
         FromPort: 9000


### PR DESCRIPTION
currently it requires VPN to access, which causes a lot of pain, particularly for US colleagues.
Composer does not have this restriction, so I think it's reasonable to trust google auth here as well.