### PR TITLE
fix name in home page copy

### DIFF
--- a/public/src/components/bannerToolPlaceholder.tsx
+++ b/public/src/components/bannerToolPlaceholder.tsx
@@ -32,7 +32,7 @@ export default function BannerToolPlaceHolder() {
         🚧 Apologies, our Banner Tool is still under construction. 🚧
       </p>
       <p className={classes.content}>
-        Please select a tool from the menu.
+        Please select another tool from the menu.
       </p>
     </div>
   )

--- a/public/src/components/indexPage.tsx
+++ b/public/src/components/indexPage.tsx
@@ -29,7 +29,7 @@ export default function IndexPage() {
   return (
     <div className={classes.body}>
       <p className={classes.content}>
-        Welcome to the Guardian's Support Station.
+        Welcome to the Reader Revenue Control Panel.
       </p>
       <p className={classes.content}>
         To begin, select a tool from the menu.


### PR DESCRIPTION
Uses correct name (Reader Revenue Control Panel) in the home page. See screenshot below:
<br>
<img width="1440" alt="Screenshot 2020-05-14 at 17 00 38" src="https://user-images.githubusercontent.com/25020231/81957527-9ad66980-9604-11ea-8d78-fae2f37b949d.png">

