### PR TITLE
Fix empty lists in epic tool

### DIFF
--- a/public/src/components/epicTests/epicTestEditor.tsx
+++ b/public/src/components/epicTests/epicTestEditor.tsx
@@ -181,7 +181,8 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, EpicTestEditor
   }
 
   onListChange = (fieldName: string) => (updatedString: string): void => {
-    this.updateTest(test => ({...test, [fieldName]: updatedString.split(",")}));
+    const updatedList = updatedString === '' ? [] : updatedString.split(",");
+    this.updateTest(test => ({...test, [fieldName]: updatedList}));
   }
 
   onSwitchChange = (fieldName: string) => (event: React.ChangeEvent<HTMLInputElement>): void =>  {


### PR DESCRIPTION
This bug happens if:
1. a list field (e.g. tagIds) contains text
2. user deletes the contents of the field
3. user saves. The field is saved as `[""]` rather than `[]`

For some reason this breaks the test in frontend