### PR TITLE
make ticker configurable

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -1,10 +1,41 @@
 package models
 
+import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import io.circe.{Decoder, Encoder}
+import scala.collection.immutable.IndexedSeq
 
 case class Cta(text: Option[String], baseUrl: Option[String])
+
+sealed trait TickerEndType extends EnumEntry
+object TickerEndType extends Enum[TickerEndType] with CirceEnum[TickerEndType] {
+  override val values: IndexedSeq[TickerEndType] = findValues
+
+  case object unlimited extends TickerEndType
+  case object hardstop extends TickerEndType
+}
+
+sealed trait TickerCountType extends EnumEntry
+object TickerCountType extends Enum[TickerCountType] with CirceEnum[TickerCountType] {
+  override val values: IndexedSeq[TickerCountType] = findValues
+
+  case object money extends TickerCountType
+  case object people extends TickerCountType
+}
+
+case class TickerCopy(
+  countLabel: String,
+  goalReachedPrimary: String,
+  goalReachedSecondary: String
+)
+
+case class TickerSettings(
+  endType: TickerEndType,
+  countType: TickerCountType,
+  currencySymbol: String,
+  copy: TickerCopy
+)
 
 case class EpicVariant(
   name: String,
@@ -12,7 +43,8 @@ case class EpicVariant(
   paragraphs: List[String],
   highlightedText: Option[String] = None,
   footer: Option[String] = None,
-  showTicker: Boolean = false,
+  showTicker: Boolean = false,  // Deprecated - use tickerSettings instead
+  tickerSettings: Option[TickerSettings] = None,
   backgroundImageUrl: Option[String] = None,
   cta: Option[Cta],
   secondaryCta: Option[Cta]

--- a/public/src/components/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/epicTests/epicTestVariantEditor.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import {EpicVariant, Cta} from "./epicTestsForm";
+import {EpicVariant, Cta, TickerSettings} from "./epicTestsForm";
 import {Theme, createStyles, WithStyles, withStyles} from "@material-ui/core";
 import EditableTextField from "../helpers/editableTextField";
 import CtaEditor from "./ctaEditor";
-import Switch from "@material-ui/core/Switch";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
+import TickerEditor from './tickerEditor';
 import ButtonWithConfirmationPopup from '../helpers/buttonWithConfirmationPopup';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import {onFieldValidationChange, ValidationStatus} from '../helpers/validation';
@@ -223,15 +222,11 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
           </div>
 
           <div>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={variant.showTicker}
-                  onChange={this.onVariantSwitchChange("showTicker")}
-                  disabled={!this.props.editMode}
-                />
-              }
-              label={`Ticker is ${variant.showTicker ? "on" : "off"}`}
+            <TickerEditor
+              editMode={this.props.editMode}
+              tickerSettings={variant.tickerSettings}
+              onChange={(tickerSettings) => this.updateVariant(variant => ({...variant, tickerSettings}))}
+              onValidationChange={onFieldValidationChange(this)('tickerSettings')}
             />
           </div>
 

--- a/public/src/components/epicTests/epicTestsForm.tsx
+++ b/public/src/components/epicTests/epicTestsForm.tsx
@@ -28,6 +28,27 @@ export interface Cta {
   baseUrl?: string
 }
 
+export enum TickerEndType {
+  unlimited = 'unlimited',
+  hardstop = 'hardstop'
+}
+export enum TickerCountType {
+  money = 'money',
+  people = 'people'
+}
+interface TickerCopy {
+  countLabel: string,
+  goalReachedPrimary: string,
+  goalReachedSecondary: string
+}
+
+export interface TickerSettings {
+  endType: TickerEndType,
+  countType: TickerCountType,
+  currencySymbol: string,
+  copy: TickerCopy
+}
+
 export interface EpicVariant {
   name: string,
   heading?: string,
@@ -35,6 +56,7 @@ export interface EpicVariant {
   highlightedText?: string,
   footer?: string,
   showTicker: boolean,
+  tickerSettings?: TickerSettings,
   backgroundImageUrl?: string,
   cta?: Cta,
   secondaryCta?: Cta,

--- a/public/src/components/epicTests/tickerEditor.tsx
+++ b/public/src/components/epicTests/tickerEditor.tsx
@@ -69,9 +69,8 @@ class TickerEditor extends React.Component<Props, State> {
   renderFields(tickerSettings: TickerSettings) {
     const classes = this.props.classes;
 
-    const onChange = (updatedTickerSettings: TickerSettings) => this.props.onChange(updatedTickerSettings);
     const onCopyFieldChange = (fieldName: string) => (value: string) =>
-      onChange({
+      this.props.onChange({
         ...tickerSettings,
         copy: {
           ...tickerSettings.copy,
@@ -110,7 +109,7 @@ class TickerEditor extends React.Component<Props, State> {
           <EditableTextField
             text={tickerSettings.currencySymbol}
             label="Currency"
-            onSubmit={value => onChange({
+            onSubmit={value => this.props.onChange({
               ...tickerSettings,
               currencySymbol: value
             })}
@@ -137,7 +136,7 @@ class TickerEditor extends React.Component<Props, State> {
             className={classes.radio}
             value={tickerSettings.countType}
             onChange={(event, value: string) =>
-              onChange({
+              this.props.onChange({
                 ...tickerSettings,
                 countType: (value as TickerCountType)
               })
@@ -167,7 +166,7 @@ class TickerEditor extends React.Component<Props, State> {
             className={classes.radio}
             value={tickerSettings.endType}
             onChange={(event, value: string) =>
-              onChange({
+              this.props.onChange({
                 ...tickerSettings,
                 endType: (value as TickerEndType)
               })

--- a/public/src/components/epicTests/tickerEditor.tsx
+++ b/public/src/components/epicTests/tickerEditor.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import {
+  createStyles,
+  FormControl,
+  InputLabel,
+  Radio,
+  RadioGroup,
+  Theme,
+  withStyles,
+  WithStyles
+} from "@material-ui/core";
+import Switch from "@material-ui/core/Switch";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import {TickerCountType, TickerEndType, TickerSettings} from "./epicTestsForm";
+import EditableTextField from "../helpers/editableTextField"
+import {onFieldValidationChange, ValidationStatus} from "../helpers/validation";
+import {getInvalidTemplateError} from "./epicTestVariantEditor";
+
+const styles = ({ spacing, typography}: Theme) => createStyles({
+  formControl: {
+    marginTop: spacing(2),
+    marginBottom: spacing(1),
+    display: 'block',
+  },
+  selectLabel: {
+    fontSize: typography.pxToRem(22),
+    color: 'black',
+  },
+  radio: {
+    paddingTop: '20px',
+    marginBottom: '10px'
+  },
+  fieldsContainer: {
+    marginLeft: '30px',
+    marginBottom: '20px',
+    borderRadius: '4px',
+    border: '1px solid #dcdcdc',
+    padding: '2px 2px 0px 10px',
+  }
+});
+
+interface Props extends WithStyles<typeof styles> {
+  editMode: boolean,
+  tickerSettings?: TickerSettings,
+  onChange: (tickerSettings: TickerSettings | undefined) => void,
+  onValidationChange: (isValid: boolean) => void
+}
+
+interface State {
+  validationStatus: ValidationStatus
+}
+
+class TickerEditor extends React.Component<Props, State> {
+
+  state: State = {
+    validationStatus: {}
+  };
+
+  defaultTickerSettings: TickerSettings = {
+    endType: TickerEndType.unlimited,
+    countType: TickerCountType.money,
+    copy: {
+      countLabel: 'contributors',
+      goalReachedPrimary: 'We\'ve hit our goal!',
+      goalReachedSecondary: 'but you can still support us',
+    },
+    currencySymbol: '$',
+  };
+
+  renderFields(tickerSettings: TickerSettings) {
+    const classes = this.props.classes;
+
+    const onChange = (updatedTickerSettings: TickerSettings) => this.props.onChange(updatedTickerSettings);
+    const onCopyFieldChange = (fieldName: string) => (value: string) =>
+      onChange({
+        ...tickerSettings,
+        copy: {
+          ...tickerSettings.copy,
+          [fieldName]: value
+        }
+      });
+
+    const renderTextField = (value: string, fieldName: string, label: string) => (
+      <EditableTextField
+        text={value}
+        label={label}
+        onSubmit={onCopyFieldChange(fieldName)}
+        editEnabled={this.props.editMode}
+        required={true}
+        validation={
+          {
+            getError: (value: string) => {
+              if (value.trim() === '') return "Field must not be empty";
+              else return getInvalidTemplateError(value);
+            },
+            onChange: onFieldValidationChange(this)(fieldName)
+          }
+        }
+      />
+    );
+
+    return (
+      <div className={classes.fieldsContainer}>
+        {renderTextField(tickerSettings.copy.countLabel, 'countLabel', 'Count label')}
+        {renderTextField(tickerSettings.copy.goalReachedPrimary, 'goalReachedPrimary', 'Goal reached primary text')}
+        {renderTextField(tickerSettings.copy.goalReachedSecondary, 'goalReachedSecondary', 'Goal reached secondary text')}
+
+        { tickerSettings.countType === 'money' &&
+          <EditableTextField
+            text={tickerSettings.currencySymbol}
+            label="Currency"
+            onSubmit={value => onChange({
+              ...tickerSettings,
+              currencySymbol: value
+            })}
+            editEnabled={this.props.editMode}
+            required={true}
+            validation={
+              {
+                getError: (value: string) => {
+                  if (value.trim() === '') return "Field must not be empty";
+                  else return getInvalidTemplateError(value);
+                },
+                onChange: onFieldValidationChange(this)('currencySymbol')
+              }
+            }
+          />
+        }
+
+        <FormControl
+          className={classes.formControl}>
+          <InputLabel
+            className={classes.selectLabel}
+            shrink
+            htmlFor="count-type">
+            Ticker count type - are we fund-raising or accumulating supporters?
+          </InputLabel>
+          <RadioGroup
+            className={classes.radio}
+            value={tickerSettings.countType}
+            onChange={(event, value: string) =>
+              onChange({
+                ...tickerSettings,
+                countType: (value as TickerCountType)
+              })
+            }
+          >
+            {Object.values(TickerCountType).map(countType =>
+              <FormControlLabel
+                value={countType}
+                key={countType}
+                control={<Radio />}
+                label={countType}
+                disabled={!this.props.editMode}
+              />
+            )}
+          </RadioGroup>
+        </FormControl>
+
+        <FormControl
+          className={classes.formControl}>
+          <InputLabel
+            className={classes.selectLabel}
+            shrink
+            htmlFor="end-type">
+            Ticker end type - the behaviour when the goal is reached
+          </InputLabel>
+          <RadioGroup
+            className={classes.radio}
+            value={tickerSettings.endType}
+            onChange={(event, value: string) =>
+              onChange({
+                ...tickerSettings,
+                endType: (value as TickerEndType)
+              })
+            }
+          >
+            {Object.values(TickerEndType).map(endType =>
+              <FormControlLabel
+                value={endType}
+                key={endType}
+                control={<Radio />}
+                label={endType}
+                disabled={!this.props.editMode}
+              />
+            )}
+          </RadioGroup>
+        </FormControl>
+      </div>
+    )
+  }
+
+  render() {
+    return (
+      <>
+        <FormControl>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!this.props.tickerSettings}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  this.props.onChange(event.target.checked ? this.defaultTickerSettings : undefined)
+                }
+                disabled={!this.props.editMode}
+              />
+            }
+            label={`Ticker is ${!!this.props.tickerSettings ? "on" : "off"}`}
+          />
+        </FormControl>
+
+        {
+          !!this.props.tickerSettings && this.renderFields(this.props.tickerSettings)
+        }
+      </>
+    )
+  }
+}
+
+export default withStyles(styles)(TickerEditor);

--- a/public/src/components/epicTests/tickerEditor.tsx
+++ b/public/src/components/epicTests/tickerEditor.tsx
@@ -60,7 +60,7 @@ class TickerEditor extends React.Component<Props, State> {
     endType: TickerEndType.unlimited,
     countType: TickerCountType.money,
     copy: {
-      countLabel: 'contributors',
+      countLabel: 'contributions',
       goalReachedPrimary: 'We\'ve hit our goal!',
       goalReachedSecondary: 'but you can still support us',
     },

--- a/public/src/components/epicTests/tickerEditor.tsx
+++ b/public/src/components/epicTests/tickerEditor.tsx
@@ -14,7 +14,6 @@ import FormControlLabel from "@material-ui/core/FormControlLabel";
 import {TickerCountType, TickerEndType, TickerSettings} from "./epicTestsForm";
 import EditableTextField from "../helpers/editableTextField"
 import {onFieldValidationChange, ValidationStatus} from "../helpers/validation";
-import {getInvalidTemplateError} from "./epicTestVariantEditor";
 
 const styles = ({ spacing, typography}: Theme) => createStyles({
   formControl: {
@@ -80,6 +79,11 @@ class TickerEditor extends React.Component<Props, State> {
         }
       });
 
+    const emptyFieldCheck = (value: string): string | null => {
+      if (value.trim() === '') return "Field must not be empty";
+      else return null;
+    };
+
     const renderTextField = (value: string, fieldName: string, label: string) => (
       <EditableTextField
         text={value}
@@ -89,10 +93,7 @@ class TickerEditor extends React.Component<Props, State> {
         required={true}
         validation={
           {
-            getError: (value: string) => {
-              if (value.trim() === '') return "Field must not be empty";
-              else return getInvalidTemplateError(value);
-            },
+            getError: emptyFieldCheck,
             onChange: onFieldValidationChange(this)(fieldName)
           }
         }
@@ -117,10 +118,7 @@ class TickerEditor extends React.Component<Props, State> {
             required={true}
             validation={
               {
-                getError: (value: string) => {
-                  if (value.trim() === '') return "Field must not be empty";
-                  else return getInvalidTemplateError(value);
-                },
+                getError: emptyFieldCheck,
                 onChange: onFieldValidationChange(this)('currencySymbol')
               }
             }


### PR DESCRIPTION
We now have 2 types of ticker:
- `money` tickers, for fund-raising
- `people` tickers, for counting supporters

To support this we also need to configure the copy. So when you enable the ticker, additional fields become visible.
This will be used by both `frontend` and `DCR`.

The old `showTicker` boolean field is now deprecated.
See frontend PR here https://github.com/guardian/frontend/pull/22642

### No ticker
![Screen Shot 2020-06-05 at 14 12 43](https://user-images.githubusercontent.com/1513454/83880310-da413300-a736-11ea-9515-4b05b233fb13.png)

### money ticker
![Screen Shot 2020-06-05 at 14 13 05](https://user-images.githubusercontent.com/1513454/83880315-db726000-a736-11ea-974b-0fed95aca68a.png)

### people ticker
![Screen Shot 2020-06-05 at 14 19 29](https://user-images.githubusercontent.com/1513454/83880773-9864bc80-a737-11ea-85d0-56dbb94978d6.png)

E.g.
<img width="628" alt="Screen Shot 2020-06-04 at 12 10 03" src="https://user-images.githubusercontent.com/1513454/83751525-e5c12b00-a65e-11ea-9e2d-05e61111665a.png">
