### PR TITLE
Banner manager update

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -77,6 +77,8 @@ const styles = ({ spacing, typography }: Theme) =>
     },
     body: {
       display: "flex",
+      overflow: "hidden",
+      flexGrow: 1,
       width: "100%",
       height: "100%",
     },
@@ -88,6 +90,7 @@ const styles = ({ spacing, typography }: Theme) =>
       paddingRight: spacing(6),
     },
     rightCol: {
+      overflowY: "auto",
       flexGrow: 1,
       display: "flex",
       justifyContent: "center",

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -49,6 +49,7 @@ const Sidebar = <T extends Test>({
   classes,
   tests,
   isInEditMode,
+  selectedTestName,
   onUpdate,
   onSelectedTestName,
   createTest,
@@ -72,6 +73,7 @@ const Sidebar = <T extends Test>({
         <TestList
           tests={tests}
           isInEditMode={isInEditMode}
+          selectedTestName={selectedTestName}
           onUpdate={onUpdate}
           onTestSelected={onSelectedTestName}
         />

--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -68,7 +68,7 @@ const StickyBottomBar: React.FC<
   ].join(" ");
 
   return (
-    <AppBar position="fixed" className={classes.appBar}>
+    <AppBar position="relative" className={classes.appBar}>
       <div className={containerClasses}>
         <StickyBottomBarStatus isInEditMode={isInEditMode} />
         <StickyBottomBarDetail

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -31,6 +31,7 @@ const styles = ({}: Theme) =>
 interface TestListProps<T extends Test> {
   tests: T[];
   isInEditMode: boolean;
+  selectedTestName?: string;
   onUpdate: (tests: T[], modifiedTestName?: string) => void;
   onTestSelected: (testName: string) => void;
 }
@@ -39,6 +40,7 @@ const TestList = <T extends Test>({
   classes,
   tests,
   isInEditMode,
+  selectedTestName,
   onUpdate,
   onTestSelected,
 }: TestListProps<T> & WithStyles<typeof styles>) => {
@@ -78,6 +80,7 @@ const TestList = <T extends Test>({
                       >
                         <TestListTest
                           test={test}
+                          isSelected={test.name === selectedTestName}
                           onClick={() => onTestSelected(test.name)}
                         />
                       </div>
@@ -87,6 +90,7 @@ const TestList = <T extends Test>({
                   <TestListTest
                     key={test.name}
                     test={test}
+                    isSelected={test.name === selectedTestName}
                     onClick={() => onTestSelected(test.name)}
                   />
                 )

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   ListItem,
   createStyles,
@@ -6,12 +6,14 @@ import {
   WithStyles,
   Theme,
 } from "@material-ui/core";
+import { red } from "@material-ui/core/colors";
 import { Test } from "./helpers/shared";
 import TestListTestLiveLabel from "./testListTestLiveLabel";
 import TestListTestName from "./testListTestName";
 import TestListTestArticleCountLabel from "./testListTestArticleCountLabel";
+import useHover from "../../hooks/useHover";
 
-const styles = ({ spacing, palette }: Theme) =>
+const styles = ({ palette }: Theme) =>
   createStyles({
     test: {
       position: "relative",
@@ -24,11 +26,25 @@ const styles = ({ spacing, palette }: Theme) =>
       borderRadius: "4px",
       padding: "0 12px",
     },
-    testLive: {
-      border: `1px solid #f2453d`,
+    live: {
+      border: `1px solid ${red[500]}`,
+
+      "&:hover": {
+        background: `${red[500]}`,
+      },
     },
-    testDraft: {
+    liveInverted: {
+      background: `${red[500]}`,
+    },
+    draft: {
       border: `1px solid ${palette.grey[700]}`,
+
+      "&:hover": {
+        background: `${palette.grey[700]}`,
+      },
+    },
+    draftInverted: {
+      background: `${palette.grey[700]}`,
     },
     priorityLabelContainer: {
       position: "absolute",
@@ -47,26 +63,47 @@ const styles = ({ spacing, palette }: Theme) =>
 
 interface TestListTestProps extends WithStyles<typeof styles> {
   test: Test;
+  isSelected: boolean;
   onClick: () => void;
 }
 
 const TestListTest: React.FC<TestListTestProps> = ({
   classes,
   test,
+  isSelected,
   onClick,
 }: TestListTestProps) => {
   const hasArticleCount = test.articlesViewedSettings !== undefined;
 
-  const testClasses = [
-    classes.test,
-    test.isOn ? classes.testLive : classes.testDraft,
-  ].join(" ");
+  const [ref, isHovered] = useHover<HTMLDivElement>();
+
+  const shouldInvertColor = isHovered || isSelected;
+
+  const containerClasses = [classes.test];
+  containerClasses.push(test.isOn ? classes.live : classes.draft);
+  if (shouldInvertColor) {
+    containerClasses.push(
+      test.isOn ? classes.liveInverted : classes.draftInverted
+    );
+  }
 
   return (
-    <ListItem className={testClasses} button={true} onClick={onClick}>
+    <ListItem
+      className={containerClasses.join(" ")}
+      button={true}
+      onClick={onClick}
+      ref={ref}
+    >
       <div className={classes.labelAndNameContainer}>
-        <TestListTestLiveLabel isLive={test.isOn} />
-        <TestListTestName name={test.name} nickname={test.nickname} />
+        <TestListTestLiveLabel
+          isLive={test.isOn}
+          shouldInvertColor={shouldInvertColor}
+        />
+        <TestListTestName
+          name={test.name}
+          nickname={test.nickname}
+          shouldInverColor={shouldInvertColor}
+        />
       </div>
 
       {hasArticleCount && <TestListTestArticleCountLabel />}

--- a/public/src/components/channelManagement/testListTestLiveLabel.tsx
+++ b/public/src/components/channelManagement/testListTestLiveLabel.tsx
@@ -6,10 +6,11 @@ import {
   WithStyles,
   Theme,
 } from "@material-ui/core";
+import { red } from "@material-ui/core/colors";
 
-const styles = ({ typography, spacing, palette }: Theme) =>
+const styles = ({ palette }: Theme) =>
   createStyles({
-    label: {
+    container: {
       display: "flex",
       justifyContent: "center",
       width: "35px",
@@ -17,35 +18,53 @@ const styles = ({ typography, spacing, palette }: Theme) =>
       borderRadius: "2px",
       backgroundColor: "#F2453D",
     },
-    labelLive: {
-      backgroundColor: "#F2453D",
+    live: {
+      color: "#FFFFFF",
+      backgroundColor: `${red[500]}`,
     },
-    labelDraft: {
+    liveInverted: {
+      color: `${red[500]}`,
+      backgroundColor: "#FFFFFF",
+    },
+    draft: {
+      color: "#FFFFFF",
       backgroundColor: `${palette.grey[700]}`,
     },
-    labelText: {
+    draftInverted: {
+      color: `${palette.grey[700]}`,
+      backgroundColor: "#FFFFFF",
+    },
+    text: {
       fontSize: "9px",
       fontWeight: 500,
       textTransform: "uppercase",
-      color: "white",
     },
   });
 
 interface TestListTestLiveLabelProps extends WithStyles<typeof styles> {
   isLive: boolean;
+  shouldInvertColor: boolean;
 }
 
 const TestListTestLiveLabel: React.FC<TestListTestLiveLabelProps> = ({
   isLive,
+  shouldInvertColor,
   classes,
 }: TestListTestLiveLabelProps) => {
+  const containerClasses = [classes.container];
+  if (isLive) {
+    containerClasses.push(
+      shouldInvertColor ? classes.liveInverted : classes.live
+    );
+  } else {
+    containerClasses.push(
+      shouldInvertColor ? classes.draftInverted : classes.draft
+    );
+  }
+
   return (
-    <div
-      className={`${classes.label} ${
-        isLive ? classes.labelLive : classes.labelDraft
-      }`}
-    >
-      <Typography className={classes.labelText}>
+    <div className={containerClasses.join(" ")}>
+      <Typography className={classes.text}>
         {isLive ? "Live" : "Draft"}
       </Typography>
     </div>

--- a/public/src/components/channelManagement/testListTestName.tsx
+++ b/public/src/components/channelManagement/testListTestName.tsx
@@ -9,18 +9,22 @@ import {
 
 const styles = ({}: Theme) =>
   createStyles({
-    testName: {
+    text: {
       maxWidth: "190px",
       fontSize: "12px",
       fontWeight: 500,
       lineHeight: "24px",
       textTransform: "uppercase",
     },
+    textInverted: {
+      color: "#FFFFFF",
+    },
   });
 
 interface TestListTestNameProps extends WithStyles<typeof styles> {
   name: string;
   nickname?: string;
+  shouldInverColor: boolean;
 }
 
 const TEST_NAME_CHARACTERS_TO_STRIP_REGEX = /^\d{4}-\d{2}-\d{2}_(contribs*_|moment_)*/;
@@ -29,9 +33,15 @@ const TestListTestName: React.FC<TestListTestNameProps> = ({
   classes,
   name,
   nickname,
+  shouldInverColor,
 }: TestListTestNameProps) => {
+  const textClasses = [classes.text];
+  if (shouldInverColor) {
+    textClasses.push(classes.textInverted);
+  }
+
   return (
-    <Typography className={classes.testName} noWrap={true}>
+    <Typography className={textClasses.join(" ")} noWrap={true}>
       {nickname
         ? nickname
         : name.replace(TEST_NAME_CHARACTERS_TO_STRIP_REGEX, "")}

--- a/public/src/hooks/useHover.ts
+++ b/public/src/hooks/useHover.ts
@@ -1,0 +1,31 @@
+import { useState, useRef, useEffect, RefObject } from "react";
+
+const useHover = <Element extends HTMLElement>(): [
+  RefObject<Element>,
+  boolean
+] => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleMouseOver = () => setIsHovered(true);
+  const handleMouseOut = () => setIsHovered(false);
+
+  const ref = useRef<Element>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.addEventListener("mouseover", handleMouseOver);
+      ref.current.addEventListener("mouseout", handleMouseOut);
+
+      return () => {
+        if (ref.current) {
+          ref.current.removeEventListener("mouseover", handleMouseOver);
+          ref.current.removeEventListener("mouseout", handleMouseOut);
+        }
+      };
+    }
+  }, [ref.current]);
+
+  return [ref, isHovered];
+};
+
+export default useHover;

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -39,6 +39,9 @@ const styles = ({ palette, spacing, mixins, typography, transitions }: Theme) =>
       }),
     },
     appContent: {
+      display: "flex",
+      flexDirection: "column",
+      overflow: "hidden",
       flexGrow: 1,
       backgroundColor: palette.grey[100],
     },


### PR DESCRIPTION
## What does this change?
Add two new features to the banner manager:
- add hover/select states for the tests
- make the main body scrollable

## Images
 live:
<img width="338" alt="Screenshot 2020-08-12 at 08 49 01" src="https://user-images.githubusercontent.com/17720442/89990436-4893fb80-dc7a-11ea-9240-b64b97e07d28.png">

live hovered/selected:
<img width="338" alt="Screenshot 2020-08-12 at 08 49 05" src="https://user-images.githubusercontent.com/17720442/89990441-4a5dbf00-dc7a-11ea-9aeb-0ed6729c7a5e.png">

draft:
<img width="338" alt="Screenshot 2020-08-12 at 08 49 19" src="https://user-images.githubusercontent.com/17720442/89990447-4df14600-dc7a-11ea-8040-7cbefd50784a.png">

draft hovered/selected:
<img width="338" alt="Screenshot 2020-08-12 at 08 49 23" src="https://user-images.githubusercontent.com/17720442/89990455-5053a000-dc7a-11ea-942a-cb1e3935c486.png">

scroll:
![banner-manager-ui-scroll](https://user-images.githubusercontent.com/17720442/89990464-53e72700-dc7a-11ea-983c-8811db696c18.gif)





