### PR TITLE
Epic manager fix

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -1,16 +1,9 @@
 import TestsForm, { InnerComponentProps, updateTest } from "../testEditor";
 import React from "react";
 import { FrontendSettingsType } from "../../../utils/requests";
-import {
-  createStyles,
-  Theme,
-  Typography,
-  withStyles,
-  WithStyles,
-} from "@material-ui/core";
 import Sidebar from "../sidebar";
 import BannerTestEditor from "./bannerTestEditor";
-import StickyBottomBar from "../stickyBottomBar";
+import TestsFormLayout from "../testsFormLayout";
 import {
   ArticlesViewedSettings,
   Cta,
@@ -53,56 +46,9 @@ const createDefaultBannerTest = (
   articlesViewedSettings: undefined,
 });
 
-const styles = ({ spacing, typography }: Theme) =>
-  createStyles({
-    testListAndEditor: {
-      display: "flex",
-      padding: spacing(1),
-    },
-    viewTextContainer: {
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "center",
-      alignItems: "center",
-      marginTop: "-50px",
-    },
-    viewText: {
-      fontSize: typography.pxToRem(16),
-    },
-    editModeBorder: {
-      border: "none",
-    },
-    h2: {
-      fontSize: "3rem",
-    },
-    body: {
-      display: "flex",
-      overflow: "hidden",
-      flexGrow: 1,
-      width: "100%",
-      height: "100%",
-    },
-    leftCol: {
-      height: "100%",
-      background: "white",
-      paddingTop: spacing(6),
-      paddingLeft: spacing(6),
-      paddingRight: spacing(6),
-    },
-    rightCol: {
-      overflowY: "auto",
-      flexGrow: 1,
-      display: "flex",
-      justifyContent: "center",
-    },
-  });
-
-interface Props
-  extends InnerComponentProps<BannerTest>,
-    WithStyles<typeof styles> {}
+type Props = InnerComponentProps<BannerTest>;
 
 const BannerTestsForm: React.FC<Props> = ({
-  classes,
   tests,
   modifiedTests,
   selectedTestName,
@@ -122,83 +68,63 @@ const BannerTestsForm: React.FC<Props> = ({
   };
 
   return (
-    <>
-      <div className={classes.body}>
-        <div className={classes.leftCol}>
-          <Sidebar<BannerTest>
-            tests={tests}
-            modifiedTests={modifiedTests}
-            selectedTestName={selectedTestName}
-            onUpdate={onTestsChange}
-            onSelectedTestName={onSelectedTestName}
-            createTest={createTest}
-            isInEditMode={editMode}
+    <TestsFormLayout
+      sidebar={
+        <Sidebar<BannerTest>
+          tests={tests}
+          modifiedTests={modifiedTests}
+          selectedTestName={selectedTestName}
+          onUpdate={onTestsChange}
+          onSelectedTestName={onSelectedTestName}
+          createTest={createTest}
+          isInEditMode={editMode}
+        />
+      }
+      testEditor={
+        selectedTestName ? (
+          <BannerTestEditor
+            test={tests.find((test) => test.name === selectedTestName)}
+            hasChanged={!!modifiedTests[selectedTestName]}
+            onChange={(updatedTest) =>
+              onTestsChange(updateTest(tests, updatedTest), updatedTest.name)
+            }
+            onValidationChange={onTestErrorStatusChange(selectedTestName)}
+            visible
+            editMode={editMode}
+            onDelete={onTestDelete}
+            onArchive={onTestArchive}
+            isDeleted={
+              modifiedTests[selectedTestName] &&
+              modifiedTests[selectedTestName].isDeleted
+            }
+            isArchived={
+              modifiedTests[selectedTestName] &&
+              modifiedTests[selectedTestName].isArchived
+            }
+            isNew={
+              modifiedTests[selectedTestName] &&
+              modifiedTests[selectedTestName].isNew
+            }
+            createTest={(newTest: BannerTest) => {
+              const newTests = [...tests, newTest];
+              onTestsChange(newTests, newTest.name);
+            }}
+            testNames={tests.map((test) => test.name)}
+            testNicknames={
+              tests
+                .map((test) => test.nickname)
+                .filter((nickname) => !!nickname) as string[]
+            }
           />
-        </div>
-
-        <div className={classes.rightCol}>
-          {selectedTestName ? (
-            tests.map((test) => (
-              <BannerTestEditor
-                test={tests.find((test) => test.name === selectedTestName)}
-                hasChanged={!!modifiedTests[test.name]}
-                onChange={(updatedTest) =>
-                  onTestsChange(
-                    updateTest(tests, updatedTest),
-                    updatedTest.name
-                  )
-                }
-                onValidationChange={onTestErrorStatusChange(test.name)}
-                visible={test.name === selectedTestName}
-                key={test.name}
-                editMode={editMode}
-                onDelete={onTestDelete}
-                onArchive={onTestArchive}
-                isDeleted={
-                  modifiedTests[test.name] && modifiedTests[test.name].isDeleted
-                }
-                isArchived={
-                  modifiedTests[test.name] &&
-                  modifiedTests[test.name].isArchived
-                }
-                isNew={
-                  modifiedTests[test.name] && modifiedTests[test.name].isNew
-                }
-                createTest={(newTest: BannerTest) => {
-                  const newTests = [...tests, newTest];
-                  onTestsChange(newTests, newTest.name);
-                }}
-                testNames={tests.map((test) => test.name)}
-                testNicknames={
-                  tests
-                    .map((test) => test.nickname)
-                    .filter((nickname) => !!nickname) as string[]
-                }
-              />
-            ))
-          ) : (
-            <div className={classes.viewTextContainer}>
-              <Typography className={classes.viewText}>
-                Select an existing test from the menu,
-              </Typography>
-              <Typography className={classes.viewText}>
-                or create a new one
-              </Typography>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <StickyBottomBar
-        isInEditMode={editMode}
-        selectedTestName={selectedTestName}
-        requestLock={requestLock}
-        save={save}
-        cancel={cancel}
-      />
-    </>
+        ) : null
+      }
+      selectedTestName={selectedTestName}
+      requestLock={requestLock}
+      save={save}
+      cancel={cancel}
+      editMode={editMode}
+    />
   );
 };
 
-const styled = withStyles(styles)(BannerTestsForm);
-export default TestsForm(styled, FrontendSettingsType.bannerTests);
+export default TestsForm(BannerTestsForm, FrontendSettingsType.bannerTests);

--- a/public/src/components/channelManagement/testsFormLayout.tsx
+++ b/public/src/components/channelManagement/testsFormLayout.tsx
@@ -1,0 +1,97 @@
+import * as React from "react";
+import {
+  createStyles,
+  Theme,
+  Typography,
+  withStyles,
+  WithStyles,
+} from "@material-ui/core";
+import StickyBottomBar from "./stickyBottomBar";
+
+const styles = ({ spacing, typography }: Theme) =>
+  createStyles({
+    viewTextContainer: {
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      marginTop: "-50px",
+    },
+    viewText: {
+      fontSize: typography.pxToRem(16),
+    },
+    body: {
+      display: "flex",
+      overflow: "hidden",
+      flexGrow: 1,
+      width: "100%",
+      height: "100%",
+    },
+    leftCol: {
+      height: "100%",
+      background: "white",
+      paddingTop: spacing(6),
+      paddingLeft: spacing(6),
+      paddingRight: spacing(6),
+    },
+    rightCol: {
+      overflowY: "auto",
+      flexGrow: 1,
+      display: "flex",
+      justifyContent: "center",
+    },
+  });
+
+interface Props {
+  sidebar: JSX.Element;
+  testEditor: JSX.Element | null;
+  selectedTestName?: string;
+  editMode: boolean;
+  requestLock: () => void;
+  save: () => void;
+  cancel: () => void;
+}
+
+const TestsFormLayout: React.FC<Props & WithStyles<typeof styles>> = ({
+  classes,
+  sidebar,
+  testEditor,
+  selectedTestName,
+  save,
+  cancel,
+  editMode,
+  requestLock,
+}) => {
+  return (
+    <>
+      <div className={classes.body}>
+        <div className={classes.leftCol}>{sidebar}</div>
+
+        <div className={classes.rightCol}>
+          {testEditor ? (
+            testEditor
+          ) : (
+            <div className={classes.viewTextContainer}>
+              <Typography className={classes.viewText}>
+                Select an existing test from the menu,
+              </Typography>
+              <Typography className={classes.viewText}>
+                or create a new one
+              </Typography>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <StickyBottomBar
+        isInEditMode={editMode}
+        selectedTestName={selectedTestName}
+        requestLock={requestLock}
+        save={save}
+        cancel={cancel}
+      />
+    </>
+  );
+};
+
+export default withStyles(styles)(TestsFormLayout);


### PR DESCRIPTION
## What does this change?
Makes the epic manager useable. It's now at the same level of implementation as the banner manger. It's still WIP but basic editing now works.

To increase reuse I've factored out a layout component that both the epic and banner managers now use. I think it's probably possible to share even more code, but this solution works and allows us to fix PROD asap. 

## Images

<img width="1792" alt="Screenshot 2020-08-12 at 10 54 04" src="https://user-images.githubusercontent.com/17720442/90002151-315d0a00-dc8a-11ea-82a9-f8f8770d84f7.png">
