### PR TITLE
Update sticky bottom bar when lock is taken

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -57,6 +57,8 @@ const BannerTestsForm: React.FC<Props> = ({
   onTestDelete,
   onTestArchive,
   onTestErrorStatusChange,
+  lockStatus,
+  requestTakeControl,
   requestLock,
   save,
   cancel,
@@ -119,6 +121,8 @@ const BannerTestsForm: React.FC<Props> = ({
         ) : null
       }
       selectedTestName={selectedTestName}
+      lockStatus={lockStatus}
+      requestTakeControl={requestTakeControl}
       requestLock={requestLock}
       save={save}
       cancel={cancel}

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -106,6 +106,8 @@ const EpicTestsForm: React.FC<Props> = ({
   onTestDelete,
   onTestArchive,
   onTestErrorStatusChange,
+  lockStatus,
+  requestTakeControl,
   requestLock,
   save,
   cancel,
@@ -167,6 +169,8 @@ const EpicTestsForm: React.FC<Props> = ({
         ) : null
       }
       selectedTestName={selectedTestName}
+      lockStatus={lockStatus}
+      requestTakeControl={requestTakeControl}
       requestLock={requestLock}
       save={save}
       cancel={cancel}

--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -8,6 +8,8 @@ import {
   withStyles,
 } from "@material-ui/core";
 import AppBar from "@material-ui/core/AppBar";
+import { LockStatus } from "./helpers/shared";
+
 import StickyBottomBarStatus from "./stickyBottomBarStatus";
 import StickyBottomBarDetail from "./stickyBottomBarDetail";
 import StickyBottomBarActionButtons from "./stickyBottomBarActionButtons";
@@ -47,6 +49,8 @@ const styles = ({ palette, spacing, mixins, typography, transitions }: Theme) =>
 interface StickyBottomBarProps {
   isInEditMode: boolean;
   selectedTestName?: string;
+  lockStatus: LockStatus;
+  requestTakeControl: () => void;
   requestLock: () => void;
   save: () => void;
   cancel: () => void;
@@ -58,6 +62,8 @@ const StickyBottomBar: React.FC<
   classes,
   isInEditMode,
   selectedTestName,
+  lockStatus,
+  requestTakeControl,
   requestLock,
   save,
   cancel,
@@ -70,10 +76,14 @@ const StickyBottomBar: React.FC<
   return (
     <AppBar position="relative" className={classes.appBar}>
       <div className={containerClasses}>
-        <StickyBottomBarStatus isInEditMode={isInEditMode} />
+        <StickyBottomBarStatus
+          isInEditMode={isInEditMode}
+          isLocked={lockStatus.locked}
+        />
         <StickyBottomBarDetail
           isInEditMode={isInEditMode}
           selectedTestName={selectedTestName}
+          lockStatus={lockStatus}
         />
       </div>
 
@@ -81,6 +91,8 @@ const StickyBottomBar: React.FC<
         <StickyBottomBarActionButtons
           isInEditMode={isInEditMode}
           hasTestSelected={selectedTestName !== undefined}
+          isLocked={lockStatus.locked}
+          requestTakeControl={requestTakeControl}
           requestLock={requestLock}
           save={save}
           cancel={cancel}

--- a/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
@@ -17,6 +17,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import VisibilityIcon from "@material-ui/icons/Visibility";
 import SaveIcon from "@material-ui/icons/Save";
 import EditIcon from "@material-ui/icons/Edit";
+import LockIcon from "@material-ui/icons/Lock";
 
 const styles = ({ spacing }: Theme) =>
   createStyles({
@@ -50,6 +51,8 @@ const SAVE_BUTTON_TEST_NOT_SELECTED_TEXT = "Save changes";
 interface StickyBottomBarActionButtonsProps {
   isInEditMode: boolean;
   hasTestSelected: boolean;
+  isLocked: boolean;
+  requestTakeControl: () => void;
   requestLock: () => void;
   save: () => void;
   cancel: () => void;
@@ -57,7 +60,16 @@ interface StickyBottomBarActionButtonsProps {
 
 const StickyBottomBarActionButtons: React.FC<
   StickyBottomBarActionButtonsProps & WithStyles<typeof styles>
-> = ({ classes, isInEditMode, hasTestSelected, requestLock, save, cancel }) => {
+> = ({
+  classes,
+  isInEditMode,
+  hasTestSelected,
+  isLocked,
+  requestTakeControl,
+  requestLock,
+  save,
+  cancel,
+}) => {
   const CancelButton = () => {
     const [isOpen, setIsOpen] = useState(false);
     return (
@@ -132,6 +144,17 @@ const StickyBottomBarActionButtons: React.FC<
       <Typography className={classes.buttonText}>Enter edit mode</Typography>
     </Button>
   );
+
+  const TakeControlButton = () => (
+    <Button
+      variant="outlined"
+      className={classes.button}
+      startIcon={<LockIcon />}
+      onClick={requestTakeControl}
+    >
+      <Typography className={classes.buttonText}>Take control</Typography>
+    </Button>
+  );
   return (
     <div className={classes.container}>
       <div className={classes.leftContainer}>
@@ -150,8 +173,11 @@ const StickyBottomBarActionButtons: React.FC<
             // Edit mode + no test selected
             <SaveButton />
           )
+        ) : isLocked ? (
+          // Read only mode + locked
+          <TakeControlButton />
         ) : (
-          // Read only mode
+          // Read only mode + not locked
           <EditButton />
         )}
       </div>

--- a/public/src/components/channelManagement/stickyBottomBarDetail.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarDetail.tsx
@@ -6,6 +6,7 @@ import {
   WithStyles,
   withStyles,
 } from "@material-ui/core";
+import { LockStatus } from "./helpers/shared";
 
 const styles = ({}: Theme) =>
   createStyles({
@@ -20,22 +21,70 @@ const styles = ({}: Theme) =>
 interface StickyBottomBarDetailProps {
   isInEditMode: boolean;
   selectedTestName?: string;
+  lockStatus: LockStatus;
 }
+
+const formattedName = (email: string) => {
+  const nameArr: RegExpMatchArray | null = email.match(
+    /^([a-z]*)\.([a-z]*).*@.*/
+  );
+  return nameArr
+    ? `${nameArr[1][0].toUpperCase()}${nameArr[1].slice(
+        1
+      )} ${nameArr[2][0].toUpperCase()}${nameArr[2].slice(1)}`
+    : email;
+};
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const formattedTimestamp = (timestamp: string) => {
+  const date = new Date(timestamp);
+
+  const hours = date.getHours();
+  const paddedhours = String(hours).padStart(2, "0");
+  const minutes = date.getMinutes();
+  const paddedMinutes = String(minutes).padStart(2, "0");
+  const day = date.getDay();
+  const paddedDay = String(day).padStart(2, "0");
+  const month_name = MONTH_NAMES[date.getMonth()];
+
+  return `${month_name} ${paddedDay} - ${paddedhours}:${paddedMinutes}`;
+};
 
 const READ_ONLY_MODE_DEFAULT_TEXT =
   "— View live and draft tests using the left-hand menu";
 
 const StickyBottomBarDetail: React.FC<
   StickyBottomBarDetailProps & WithStyles<typeof styles>
-> = ({ classes, isInEditMode, selectedTestName }) => {
-  const editModeText =
-    selectedTestName === undefined ? "" : `- ${selectedTestName}`;
+> = ({ classes, isInEditMode, selectedTestName, lockStatus }) => {
+  let text = "";
+  if (isInEditMode) {
+    text = selectedTestName === undefined ? "" : `- ${selectedTestName}`;
+  } else if (lockStatus.locked && lockStatus.email && lockStatus.timestamp) {
+    const name = formattedName(lockStatus.email);
+    const timestamp = formattedTimestamp(lockStatus.timestamp);
+
+    text = `- By ${name}, last live ${timestamp}`;
+  } else {
+    text = READ_ONLY_MODE_DEFAULT_TEXT;
+  }
 
   return (
     <div>
-      <Typography className={classes.text}>
-        {isInEditMode ? editModeText : READ_ONLY_MODE_DEFAULT_TEXT}
-      </Typography>
+      <Typography className={classes.text}>{text}</Typography>
     </div>
   );
 };

--- a/public/src/components/channelManagement/stickyBottomBarStatus.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarStatus.tsx
@@ -19,19 +19,28 @@ const styles = ({}: Theme) =>
 
 interface StickyBottomBarStatusProps {
   isInEditMode: boolean;
+  isLocked: boolean;
 }
 
+const LOCKED_TEXT = "Locked for editing";
 const READ_ONLY_MODE_TEXT = "Read only mode";
 const EDIT_MODE_TEXT = "Edit mode";
 
 const StickyBottomBarStatus: React.FC<
   StickyBottomBarStatusProps & WithStyles<typeof styles>
-> = ({ classes, isInEditMode }) => {
+> = ({ classes, isInEditMode, isLocked }) => {
+  let text = "";
+  if (isInEditMode) {
+    text = EDIT_MODE_TEXT;
+  } else if (isLocked) {
+    text = LOCKED_TEXT;
+  } else {
+    text = READ_ONLY_MODE_TEXT;
+  }
+
   return (
     <div>
-      <Typography className={classes.text}>
-        {isInEditMode ? EDIT_MODE_TEXT : READ_ONLY_MODE_TEXT}
-      </Typography>
+      <Typography className={classes.text}>{text}</Typography>
     </div>
   );
 };

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -32,7 +32,9 @@ export interface InnerComponentProps<T extends Test> {
   onTestErrorStatusChange: (testName: string) => (isValid: boolean) => void;
   cancel: () => void;
   save: () => void;
+  requestTakeControl: () => void;
   requestLock: () => void;
+  lockStatus: LockStatus;
   editMode: boolean;
 }
 
@@ -287,7 +289,9 @@ const TestEditor = <T extends Test>(
                 onTestArchive={this.onTestArchive}
                 onSelectedTestName={this.onSelectedTestName}
                 onTestErrorStatusChange={this.onTestErrorStatusChange}
+                requestTakeControl={this.requestTestsTakeControl}
                 requestLock={this.requestTestsLock}
+                lockStatus={this.state.lockStatus}
                 save={this.save(this.state.tests)}
                 cancel={this.cancel}
                 editMode={this.state.editMode}

--- a/public/src/components/channelManagement/testsFormLayout.tsx
+++ b/public/src/components/channelManagement/testsFormLayout.tsx
@@ -7,6 +7,7 @@ import {
   WithStyles,
 } from "@material-ui/core";
 import StickyBottomBar from "./stickyBottomBar";
+import { LockStatus } from "./helpers/shared";
 
 const styles = ({ spacing, typography }: Theme) =>
   createStyles({
@@ -48,6 +49,8 @@ interface Props {
   testEditor: JSX.Element | null;
   selectedTestName?: string;
   editMode: boolean;
+  lockStatus: LockStatus;
+  requestTakeControl: () => void;
   requestLock: () => void;
   save: () => void;
   cancel: () => void;
@@ -61,7 +64,9 @@ const TestsFormLayout: React.FC<Props & WithStyles<typeof styles>> = ({
   save,
   cancel,
   editMode,
+  requestTakeControl,
   requestLock,
+  lockStatus,
 }) => {
   return (
     <>
@@ -87,6 +92,8 @@ const TestsFormLayout: React.FC<Props & WithStyles<typeof styles>> = ({
       <StickyBottomBar
         isInEditMode={editMode}
         selectedTestName={selectedTestName}
+        lockStatus={lockStatus}
+        requestTakeControl={requestTakeControl}
         requestLock={requestLock}
         save={save}
         cancel={cancel}


### PR DESCRIPTION
## What does this change?
Status bar now refects when another user has locked the tests for editing. They are also provided with a 'Take Control' button.

## Images
<img width="1680" alt="Screenshot 2020-08-14 at 08 50 02" src="https://user-images.githubusercontent.com/17720442/90226812-7c525b00-de0b-11ea-980f-4b4424d4bda2.png">

