### PR TITLE
Default cta has lowercase 'the'

### DIFF
--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -26,7 +26,7 @@ export interface Cta {
 }
 
 export const defaultCta = {
-  text: "Support The Guardian",
+  text: "Support the Guardian",
   baseUrl: "https://support.theguardian.com/contribute",
 };
 


### PR DESCRIPTION
`Support The Guardian`
becomes
`Support the Guardian`

@ionamckendrick 