### PR TITLE
Disable test selection when editing and rename 'Cancel' to 'Discard' for clarity

### DIFF
--- a/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
@@ -80,7 +80,7 @@ const StickyBottomBarActionButtons: React.FC<
           startIcon={<CloseIcon />}
           onClick={() => setIsOpen(true)}
         >
-          <Typography className={classes.buttonText}>Cancel</Typography>
+          <Typography className={classes.buttonText}>Discard</Typography>
         </Button>
         <Dialog
           open={isOpen}
@@ -88,7 +88,7 @@ const StickyBottomBarActionButtons: React.FC<
           aria-labelledby="cancel-dialog-title"
           aria-describedby="cancel-dialog-description"
         >
-          <DialogTitle id="cancel-dialog-title">Cancel changes?</DialogTitle>
+          <DialogTitle id="cancel-dialog-title">Discard changes?</DialogTitle>
           <DialogContent>
             <DialogContentText id="cancel-dialog-description">
               You have unsaved changes - these will be lost if you move on.
@@ -97,10 +97,13 @@ const StickyBottomBarActionButtons: React.FC<
           </DialogContent>
           <DialogActions>
             <Button onClick={cancel} color="primary">
-              Cancel
+              Discard changes
             </Button>
             <Button onClick={save} color="primary" autoFocus>
               Save changes
+            </Button>
+            <Button onClick={() => setIsOpen(false)} color="primary" autoFocus>
+              Cancel
             </Button>
           </DialogActions>
         </Dialog>

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -255,7 +255,7 @@ const TestEditor = <T extends Test>(
 
     onSelectedTestName = (testName: string): void => {
       if (this.state.selectedTestName && this.state.editMode) {
-        alert("Please either save or cancel before selecting another test.")
+        alert("Please either save or discard before selecting another test.")
       } else {
         this.setState({
           selectedTestName: testName,

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -254,9 +254,13 @@ const TestEditor = <T extends Test>(
     };
 
     onSelectedTestName = (testName: string): void => {
-      this.setState({
-        selectedTestName: testName,
-      });
+      if (this.state.selectedTestName && this.state.editMode) {
+        alert("Please either save or cancel before selecting another test.")
+      } else {
+        this.setState({
+          selectedTestName: testName,
+        });
+      }
     };
 
     requestTestsLock = () => {


### PR DESCRIPTION
1. If in edit mode, display an alert if the user tries to select another test (we can revisit this design later):
![Screen Shot 2020-08-26 at 15 02 20](https://user-images.githubusercontent.com/1513454/91313321-27b8c380-e7ad-11ea-9f13-433be2cccea9.png)

2. Say 'discard' instead of 'cancel', to make it clear it's going to lose changes:
![Screen Shot 2020-08-26 at 14 58 02](https://user-images.githubusercontent.com/1513454/91312974-bf69e200-e7ac-11ea-80bd-ab7de88d847b.png)
