### PR TITLE
Do not save if form has errors

### DIFF
--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -130,6 +130,12 @@ const TestEditor = <T extends Test>(
     };
 
     save = (tests: T[]) => (): void => {
+      // TODO - implement dialog in StickyBottomBar?
+      if (Object.keys(this.state.modifiedTests).some(testName => !this.state.modifiedTests[testName].isValid)) {
+        alert("Test contains errors. Please fix any errors before saving.");
+        return;
+      }
+
       const testsToArchive: T[] = tests.filter(
         (test) =>
           this.state.modifiedTests[test.name] &&


### PR DESCRIPTION
I think we used to disable the Save button if there were any errors, but since the redesign that has been lost.
The quick fix for now is to alert if the user clicks save but there are errors.
In future we may want to implement something that fits with the design, possibly in `StickyBottomBar`.