### PR TITLE
Add basic preview feature

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
@@ -81,7 +81,11 @@ const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccord
             onChange={onExpansionPanelChange(key)}
             className={classes.expansionPanel}
           >
-            <TestEditorVariantSummary name={variant.name} />
+            <TestEditorVariantSummary
+              name={variant.name}
+              testName={testName}
+              isInEditMode={editMode}
+            />
             <ExpansionPanelDetails>
               <BannerTestVariantEditor
                 variant={variant}

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Button,
   createStyles,
   withStyles,
   WithStyles,
@@ -9,11 +10,18 @@ import {
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
+import VisibilityIcon from '@material-ui/icons/Visibility';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>
   createStyles({
     container: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      width: '100%',
+    },
+    nameContainer: {
       display: 'flex',
       alignItems: 'center',
 
@@ -33,22 +41,46 @@ const styles = ({ spacing, palette }: Theme) =>
     },
   });
 
+const BASE_ARTICLE_URL =
+  'https://www.theguardian.com/politics/2020/jun/18/dominic-raab-taking-the-knee-feels-like-symbol-of-subjugation?dcr';
+
+const getPreviewUrl = (testName: string, variantName: string): string =>
+  `${BASE_ARTICLE_URL}?dcr&force=${testName}:${variantName}`;
+
 interface TestEditorVariantSummaryProps extends WithStyles<typeof styles> {
   name: string;
+  testName: string;
+  isInEditMode: boolean;
 }
 
 const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
   classes,
   name,
+  testName,
+  isInEditMode,
 }: TestEditorVariantSummaryProps) => {
   return (
     <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
       <div className={classes.container}>
-        <InsertDriveFileIcon className={classes.icon} />
+        <div className={classes.nameContainer}>
+          <InsertDriveFileIcon className={classes.icon} />
 
-        <Typography variant="h4" className={classes.text}>
-          {name}
-        </Typography>
+          <Typography variant="h4" className={classes.text}>
+            {name}
+          </Typography>
+        </div>
+        <Button
+          startIcon={<VisibilityIcon />}
+          size="small"
+          onClick={(event): void => event.stopPropagation()}
+          onFocus={(event): void => event.stopPropagation()}
+          href={getPreviewUrl(testName, name)}
+          target="_blank"
+          rel="noopener noreferrer"
+          disabled={isInEditMode}
+        >
+          Preview
+        </Button>
       </div>
     </ExpansionPanelSummary>
   );

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Button,
   createStyles,
   withStyles,
   WithStyles,
@@ -10,7 +9,7 @@ import {
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
-import VisibilityIcon from '@material-ui/icons/Visibility';
+import TestEditorVariantSummaryPreviewButton from './testEditorVariantSummaryPreviewButton';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>
@@ -41,12 +40,6 @@ const styles = ({ spacing, palette }: Theme) =>
     },
   });
 
-const BASE_ARTICLE_URL =
-  'https://www.theguardian.com/politics/2020/jun/18/dominic-raab-taking-the-knee-feels-like-symbol-of-subjugation?dcr';
-
-const getPreviewUrl = (testName: string, variantName: string): string =>
-  `${BASE_ARTICLE_URL}?dcr&force=${testName}:${variantName}`;
-
 interface TestEditorVariantSummaryProps extends WithStyles<typeof styles> {
   name: string;
   testName: string;
@@ -69,18 +62,11 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
             {name}
           </Typography>
         </div>
-        <Button
-          startIcon={<VisibilityIcon />}
-          size="small"
-          onClick={(event): void => event.stopPropagation()}
-          onFocus={(event): void => event.stopPropagation()}
-          href={getPreviewUrl(testName, name)}
-          target="_blank"
-          rel="noopener noreferrer"
-          disabled={isInEditMode}
-        >
-          Preview
-        </Button>
+        <TestEditorVariantSummaryPreviewButton
+          name={name}
+          testName={testName}
+          isDisabled={isInEditMode}
+        />
       </div>
     </ExpansionPanelSummary>
   );

--- a/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
@@ -24,7 +24,8 @@ const PROD_BASE_ARTICLE_URL =
 const CODE_BASE_ARTICLE_URL =
   'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder';
 
-const getPreviewUrlForStage = (stage: Stage, testName: string, variantName: string): string => {
+const getPreviewUrl = (testName: string, variantName: string): string => {
+  const stage = getStage();
   if (stage === 'CODE') {
     return `${CODE_BASE_ARTICLE_URL}?dcr&force-banner=${testName}:${variantName}`;
   } else if (stage == 'PROD') {
@@ -33,11 +34,6 @@ const getPreviewUrlForStage = (stage: Stage, testName: string, variantName: stri
   // placeholder for dev
   return '/';
 };
-
-const getPreviewUrl = (testName: string, variantName: string): string => {
-  return getPreviewUrlForStage(getStage(), testName, variantName);
-};
-
 interface TestEditorVariantSummaryPreviewButtonProps {
   name: string;
   testName: string;
@@ -49,7 +45,6 @@ const TestEditorVariantSummaryPreviewButton: React.FC<TestEditorVariantSummaryPr
   testName,
   isDisabled,
 }: TestEditorVariantSummaryPreviewButtonProps) => {
-  console.log(getStage());
   return (
     <Button
       startIcon={<VisibilityIcon />}

--- a/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+
+// TODO: Do this properly at some point!
+type Stage = 'DEV' | 'CODE' | 'PROD';
+
+const CODE_URL_REGEX = /support.code.dev-gutools/;
+const PROD_URL_REGEX = /support.gutools/;
+
+const getStage = (): Stage => {
+  const url = window.location.href;
+  if (url.match(CODE_URL_REGEX)) {
+    return 'CODE';
+  } else if (url.match(PROD_URL_REGEX)) {
+    return 'PROD';
+  }
+  return 'DEV';
+};
+
+const PROD_BASE_ARTICLE_URL =
+  'https://theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder';
+
+const CODE_BASE_ARTICLE_URL =
+  'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder';
+
+const getPreviewUrlForStage = (stage: Stage, testName: string, variantName: string): string => {
+  if (stage === 'CODE') {
+    return `${CODE_BASE_ARTICLE_URL}?dcr&force-banner=${testName}:${variantName}`;
+  } else if (stage == 'PROD') {
+    return `${PROD_BASE_ARTICLE_URL}?dcr&force-banner=${testName}:${variantName}`;
+  }
+  // placeholder for dev
+  return '/';
+};
+
+const getPreviewUrl = (testName: string, variantName: string): string => {
+  return getPreviewUrlForStage(getStage(), testName, variantName);
+};
+
+interface TestEditorVariantSummaryPreviewButtonProps {
+  name: string;
+  testName: string;
+  isDisabled: boolean;
+}
+
+const TestEditorVariantSummaryPreviewButton: React.FC<TestEditorVariantSummaryPreviewButtonProps> = ({
+  name,
+  testName,
+  isDisabled,
+}: TestEditorVariantSummaryPreviewButtonProps) => {
+  console.log(getStage());
+  return (
+    <Button
+      startIcon={<VisibilityIcon />}
+      size="small"
+      onClick={(event): void => event.stopPropagation()}
+      onFocus={(event): void => event.stopPropagation()}
+      href={getPreviewUrl(testName, name)}
+      target="_blank"
+      rel="noopener noreferrer"
+      disabled={isDisabled}
+    >
+      Preview
+    </Button>
+  );
+};
+export default TestEditorVariantSummaryPreviewButton;


### PR DESCRIPTION
## What does this change?
Add the ability to preview variants. There are a few things to note here:

- doesn't work in DEV
- the button is disabled in edit mode, as you can't view a test until it's been saved

The current implementation is a bit of a hack. It looks at the current url to figure out if it's running in dev/code/prod. We can refactor to have a backend endpoint e.g. `/banner-preview-url` and do the url construction on the server instead (which already has access to the stage). 
## Images

<img width="1193" alt="Screenshot 2020-09-03 at 12 01 23" src="https://user-images.githubusercontent.com/17720442/92107400-9e714480-eddd-11ea-98ce-1afcd9d28491.png">

