### PR TITLE
Tp banner manager fixes

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Theme,
   createStyles,
@@ -31,22 +31,24 @@ const styles = ({ spacing, palette }: Theme) =>
 
 interface BannerTestVariantEditorsAccordionProps extends WithStyles<typeof styles> {
   variants: BannerVariant[];
+  variantKeys: string[];
   onVariantsListChange: (variantList: BannerVariant[]) => void;
-  testName: string;
   editMode: boolean;
   onValidationChange: (isValid: boolean) => void;
+  selectedVariantKey: string | null;
+  onVariantSelected: (variantKey: string) => void;
 }
 
 const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccordionProps> = ({
   classes,
   variants,
+  variantKeys,
   onVariantsListChange,
-  testName,
   editMode,
   onValidationChange,
+  selectedVariantKey,
+  onVariantSelected,
 }: BannerTestVariantEditorsAccordionProps) => {
-  const [expandedVariantKey, setExpandedVariantKey] = useState<string | undefined>(undefined);
-
   const setValidationStatusForField = useValidation(onValidationChange);
 
   const onVariantChange = (updatedVariant: BannerVariant): void => {
@@ -61,24 +63,15 @@ const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccord
     onVariantsListChange(updatedVariantList);
   };
 
-  const onExpansionPanelChange = (key: string) => (): void => {
-    expandedVariantKey === key ? setExpandedVariantKey(undefined) : setExpandedVariantKey(key);
-  };
-
-  const createVariantKey = (variantName: string): string => {
-    return `${testName}${variantName}`;
-  };
-
   return (
     <div className={classes.expansionPanelsContainer}>
       {variants.map((variant, index) => {
-        const key = createVariantKey(variant.name);
-
+        const variantKey = variantKeys[index];
         return (
           <ExpansionPanel
-            key={index}
-            expanded={expandedVariantKey === key}
-            onChange={onExpansionPanelChange(key)}
+            key={variant.name}
+            expanded={variantKey === selectedVariantKey}
+            onChange={(): void => onVariantSelected(variantKey)}
             className={classes.expansionPanel}
           >
             <TestEditorVariantSummary name={variant.name} />

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Theme, createStyles, WithStyles, withStyles } from '@material-ui/core';
 import { BannerVariant } from './bannerTestsForm';
 import BannerTestVariantEditorsAccordion from './bannerTestVariantEditorsAccordion';
@@ -31,6 +31,16 @@ const BannerTestVariantsEditor: React.FC<BannerTestVariantsEditorProps> = ({
   editMode,
   onValidationChange,
 }: BannerTestVariantsEditorProps) => {
+  const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>(null);
+
+  // unselect a variant if the test changes
+  useEffect(() => {
+    setSelectedVariantKey(null);
+  }, [testName]);
+
+  const onVariantSelected = (variantKey: string): void =>
+    setSelectedVariantKey(variantKey === selectedVariantKey ? null : variantKey);
+
   const createVariant = (name: string): void => {
     const newVariant: BannerVariant = {
       name: name,
@@ -42,16 +52,21 @@ const BannerTestVariantsEditor: React.FC<BannerTestVariantsEditorProps> = ({
     };
 
     onVariantsListChange([...variants, newVariant]);
+    onVariantSelected(name);
   };
+
+  const variantKeys = variants.map(variant => `${testName}-${variant.name}`);
 
   return (
     <div className={classes.container}>
       <BannerTestVariantEditorsAccordion
         variants={variants}
+        variantKeys={variantKeys}
         onVariantsListChange={onVariantsListChange}
-        testName={testName}
         editMode={editMode}
         onValidationChange={onValidationChange}
+        selectedVariantKey={selectedVariantKey}
+        onVariantSelected={onVariantSelected}
       />
 
       <BannerTestNewVariantButton

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -57,8 +57,13 @@ const BannerTestsForm: React.FC<Props> = ({
   editMode,
 }: Props) => {
   const createTest = (name: string, nickname: string): void => {
-    const newTests = [...tests, createDefaultBannerTest(name, nickname)];
-    onTestsChange(newTests, name);
+    if (Object.keys(modifiedTests).length > 0) {
+      alert('Please either save or discard before creating a test.');
+    } else {
+      const newTests = [...tests, createDefaultBannerTest(name, nickname)];
+      onTestsChange(newTests, name);
+      onSelectedTestName(name);
+    }
   };
 
   const selectedTest = tests.find(t => t.name === selectedTestName);

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -61,8 +61,9 @@ export const getNotNumberError = (text: string): string | null =>
 const DUPLICATE_ERROR_HELPER_TEXT = 'Name already exists - please try another';
 
 export const createGetDuplicateError = (existing: string[]): ((text: string) => string | null) => {
+  const existingLowerCased = existing.map(value => value.toLowerCase());
   const getDuplicateError = (text: string): string | null => {
-    if (existing.includes(text)) {
+    if (existingLowerCased.includes(text.toLowerCase())) {
       return DUPLICATE_ERROR_HELPER_TEXT;
     }
     return null;

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -265,7 +265,7 @@ const TestEditor = <T extends Test>(
     };
 
     onSelectedTestName = (testName: string): void => {
-      if (this.state.selectedTestName && this.state.editMode) {
+      if (Object.keys(this.state.modifiedTests).length > 0) {
         alert('Please either save or discard before selecting another test.');
       } else {
         this.setState({

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -118,8 +118,13 @@ const TestEditor = <T extends Test>(
       );
     };
 
-    save = (tests: T[]) => (): void => {
+    save = (): void => {
+      // TODO - remove the concept of modifiedTests and simplify
       // TODO - implement dialog in StickyBottomBar?
+      if (this.state.tests == null) {
+        return;
+      }
+
       if (
         Object.keys(this.state.modifiedTests).some(
           testName => !this.state.modifiedTests[testName].isValid,
@@ -129,7 +134,7 @@ const TestEditor = <T extends Test>(
         return;
       }
 
-      const testsToArchive: T[] = tests.filter(
+      const testsToArchive: T[] = this.state.tests.filter(
         test =>
           this.state.modifiedTests[test.name] && this.state.modifiedTests[test.name].isArchived,
       );
@@ -140,7 +145,10 @@ const TestEditor = <T extends Test>(
         if (notOk) {
           alert(`Failed to archive ${numTestsToArchive} test${numTestsToArchive !== 1 ? 's' : ''}`);
         } else {
-          const updatedTests: T[] = tests.filter(test => {
+          if (this.state.tests == null) {
+            return;
+          }
+          const updatedTests: T[] = this.state.tests.filter(test => {
             const modifiedTestData = this.state.modifiedTests[test.name];
             return !(
               modifiedTestData &&
@@ -225,7 +233,7 @@ const TestEditor = <T extends Test>(
         },
         () => {
           if (this.state.tests !== null) {
-            this.save(this.state.tests)();
+            this.save();
           }
         },
       );
@@ -250,7 +258,7 @@ const TestEditor = <T extends Test>(
         },
         () => {
           if (this.state.tests !== null) {
-            this.save(this.state.tests)();
+            this.save();
           }
         },
       );
@@ -295,7 +303,7 @@ const TestEditor = <T extends Test>(
                 requestTakeControl={this.requestTestsTakeControl}
                 requestLock={this.requestTestsLock}
                 lockStatus={this.state.lockStatus}
-                save={this.save(this.state.tests)}
+                save={this.save}
                 cancel={this.cancel}
                 editMode={this.state.editMode}
               />

--- a/public/src/components/channelManagement/variantDeleteButton.tsx
+++ b/public/src/components/channelManagement/variantDeleteButton.tsx
@@ -22,6 +22,12 @@ const VariantEditorButtonsEditor: React.FC<VariantEditorButtonsEditorProps> = ({
   onConfirm,
 }: VariantEditorButtonsEditorProps) => {
   const [isOpen, open, close] = useOpenable();
+
+  const submit = (): void => {
+    onConfirm();
+    close();
+  };
+
   return (
     <>
       <IconButton onClick={open} disabled={isDisabled}>
@@ -43,7 +49,7 @@ const VariantEditorButtonsEditor: React.FC<VariantEditorButtonsEditorProps> = ({
           <Button color="primary" onClick={close}>
             Cancel
           </Button>
-          <Button color="primary" onClick={onConfirm}>
+          <Button color="primary" onClick={submit}>
             Delete variant
           </Button>
         </DialogActions>


### PR DESCRIPTION
## What does this change?
A handfull of useability fixes and improvements:
- stop saving tests with erros
- select tests on creation
- select variants on creation
- close delete dialog
- names are now case insensitive
- allow swapping to a new test if nothing has been modified 
