### PR TITLE
Swap from ExpansionPanel to Accordion

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
@@ -4,9 +4,9 @@ import {
   createStyles,
   WithStyles,
   withStyles,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelActions,
+  Accordion,
+  AccordionDetails,
+  AccordionActions,
 } from '@material-ui/core';
 import { BannerVariant } from './bannerTestsForm';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
@@ -70,7 +70,7 @@ const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccord
       {variants.map((variant, index) => {
         const variantKey = variantKeys[index];
         return (
-          <ExpansionPanel
+          <Accordion
             key={variant.name}
             expanded={variantKey === selectedVariantKey}
             onChange={(): void => onVariantSelected(variantKey)}
@@ -81,7 +81,7 @@ const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccord
               testName={testName}
               isInEditMode={editMode}
             />
-            <ExpansionPanelDetails>
+            <AccordionDetails>
               <BannerTestVariantEditor
                 variant={variant}
                 onVariantChange={onVariantChange}
@@ -94,14 +94,14 @@ const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccord
                   setValidationStatusForField(variant.name, isValid)
                 }
               />
-            </ExpansionPanelDetails>
-            <ExpansionPanelActions>
+            </AccordionDetails>
+            <AccordionActions>
               <VariantDeleteButton
                 isDisabled={!editMode}
                 onConfirm={(): void => onVariantDelete(variant.name)}
               />
-            </ExpansionPanelActions>
-          </ExpansionPanel>
+            </AccordionActions>
+          </Accordion>
         );
       })}
     </div>

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -5,7 +5,7 @@ import {
   WithStyles,
   Theme,
   Typography,
-  ExpansionPanelSummary,
+  AccordionSummary,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
@@ -53,7 +53,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
   isInEditMode,
 }: TestEditorVariantSummaryProps) => {
   return (
-    <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
       <div className={classes.container}>
         <div className={classes.nameContainer}>
           <InsertDriveFileIcon className={classes.icon} />
@@ -68,7 +68,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
           isDisabled={isInEditMode}
         />
       </div>
-    </ExpansionPanelSummary>
+    </AccordionSummary>
   );
 };
 


### PR DESCRIPTION
## What does this change?
Material UI renamed ExpansionPanel to Accordion. This PR migrates all ExpansionPanel components over to Accordions