### PR TITLE
Add react-hook-form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^16.9.0",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.9.0",
+    "react-hook-form": "^6.7.2",
     "react-router-dom": "^5.0.1"
   },
   "scripts": {

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -68,6 +68,7 @@ interface BannerTestEditorProps extends WithStyles<typeof styles> {
   editMode: boolean;
   onDelete: () => void;
   onArchive: () => void;
+  onSelectedTestName: (testName: string) => void;
   isDeleted: boolean;
   isArchived: boolean;
   isNew: boolean;
@@ -87,6 +88,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   isArchived,
   onArchive,
   onDelete,
+  onSelectedTestName,
   testNames,
   testNicknames,
   createTest,
@@ -157,6 +159,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   };
 
   const onCopy = (name: string, nickname: string): void => {
+    onSelectedTestName(name);
     createTest({ ...test, name: name, nickname: nickname });
   };
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -151,6 +151,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           updatePrimaryCta={updatePrimaryCta}
           updateSecondaryCta={updateSecondaryCta}
           isDisabled={!editMode}
+          onValidationChange={onValidationChange}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
@@ -50,9 +50,10 @@ const BannerTestVariantsEditor: React.FC<BannerTestVariantsEditorProps> = ({
         'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
       cta: defaultCta,
     };
+    console.log('here');
 
     onVariantsListChange([...variants, newVariant]);
-    onVariantSelected(name);
+    onVariantSelected(`${testName}-${name}`);
   };
 
   const variantKeys = variants.map(variant => `${testName}-${variant.name}`);

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -61,8 +61,8 @@ const BannerTestsForm: React.FC<Props> = ({
       alert('Please either save or discard before creating a test.');
     } else {
       const newTests = [...tests, createDefaultBannerTest(name, nickname)];
-      onTestsChange(newTests, name);
       onSelectedTestName(name);
+      onTestsChange(newTests, name);
     }
   };
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -95,6 +95,7 @@ const BannerTestsForm: React.FC<Props> = ({
             editMode={editMode}
             onDelete={(): void => onTestDelete(selectedTestName)}
             onArchive={(): void => onTestArchive(selectedTestName)}
+            onSelectedTestName={onSelectedTestName}
             isDeleted={modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted}
             isArchived={
               modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isArchived

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -33,9 +33,10 @@ export type ValidationStatus = {
   [fieldName: string]: boolean;
 };
 
-const INVALID_CHARACTERS_ERROR_HELPER_TEXT =
+export const INVALID_CHARACTERS_ERROR_HELPER_TEXT =
   'Only letters, numbers, underscores and hyphens are allowed';
 const INVALID_CHARACTERS_REGEX = /[^\w-]/;
+export const VALID_CHARACTERS_REGEX = /^[\w-]+$/;
 
 export const getInvalidCharactersError = (text: string): string | null => {
   if (INVALID_CHARACTERS_REGEX.test(text)) {
@@ -44,7 +45,7 @@ export const getInvalidCharactersError = (text: string): string | null => {
   return null;
 };
 
-const EMPTY_ERROR_HELPER_TEXT = 'Field cannot be empty - please enter some text';
+export const EMPTY_ERROR_HELPER_TEXT = 'Field cannot be empty - please enter some text';
 
 export const getEmptyError = (text: string): string | null => {
   if (text.trim() === '') {
@@ -58,7 +59,7 @@ const NOT_NUMBER_ERROR_HELPER_TEXT = 'Must be a number';
 export const getNotNumberError = (text: string): string | null =>
   Number.isNaN(Number(text)) ? NOT_NUMBER_ERROR_HELPER_TEXT : null;
 
-const DUPLICATE_ERROR_HELPER_TEXT = 'Name already exists - please try another';
+export const DUPLICATE_ERROR_HELPER_TEXT = 'Name already exists - please try another';
 
 export const createGetDuplicateError = (existing: string[]): ((text: string) => string | null) => {
   const existingLowerCased = existing.map(value => value.toLowerCase());
@@ -69,6 +70,19 @@ export const createGetDuplicateError = (existing: string[]): ((text: string) => 
     return null;
   };
   return getDuplicateError;
+};
+
+export const createDuplicateValidator = (
+  existing: string[],
+): ((text: string) => string | boolean) => {
+  const existingLowerCased = existing.map(value => value.toLowerCase());
+  const duplicateValidator = (text: string): string | boolean => {
+    if (existingLowerCased.includes(text.toLowerCase())) {
+      return DUPLICATE_ERROR_HELPER_TEXT;
+    }
+    return true;
+  };
+  return duplicateValidator;
 };
 
 export interface ValidationComponentState {

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -59,6 +59,9 @@ const NOT_NUMBER_ERROR_HELPER_TEXT = 'Must be a number';
 export const getNotNumberError = (text: string): string | null =>
   Number.isNaN(Number(text)) ? NOT_NUMBER_ERROR_HELPER_TEXT : null;
 
+export const notNumberValidator = (text: string): string | boolean =>
+  Number.isNaN(Number(text)) ? NOT_NUMBER_ERROR_HELPER_TEXT : true;
+
 export const DUPLICATE_ERROR_HELPER_TEXT = 'Name already exists - please try another';
 
 export const createGetDuplicateError = (existing: string[]): ((text: string) => string | null) => {

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -85,6 +85,24 @@ export const createDuplicateValidator = (
   return duplicateValidator;
 };
 
+export const CURRENCY_TEMPLATE = '%%CURRENCY_SYMBOL%%';
+export const COUNTRY_NAME_TEMPLATE = '%%COUNTRY_NAME%%';
+export const ARTICLE_COUNT_TEMPLATE = '%%ARTICLE_COUNT%%';
+
+const validTemplates = [CURRENCY_TEMPLATE, COUNTRY_NAME_TEMPLATE, ARTICLE_COUNT_TEMPLATE];
+
+export const invalidTemplateValidator = (text: string): string | boolean => {
+  const templates = text.match(/%%[A-Za-z_]*%%/g);
+
+  if (templates !== null) {
+    const invalidTemplate = templates.find(template => !validTemplates.includes(template));
+    if (invalidTemplate) {
+      return `Invalid template: ${invalidTemplate}`;
+    }
+  }
+  return true;
+};
+
 export interface ValidationComponentState {
   validationStatus: ValidationStatus;
 }

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -211,6 +211,18 @@ const TestEditor = <T extends Test>(
             },
           },
         });
+      } else {
+        this.setState({
+          modifiedTests: {
+            ...this.state.modifiedTests,
+            [testName]: {
+              isValid,
+              isDeleted: false,
+              isArchived: false,
+              isNew: false,
+            },
+          },
+        });
       }
     };
 

--- a/public/src/components/channelManagement/variantEditorButtonEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorButtonEditor.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import {
   Checkbox,
   createStyles,
   FormControlLabel,
+  TextField,
   Theme,
   WithStyles,
   withStyles,
 } from '@material-ui/core';
-import EditableTextField from './editableTextField';
 import { Cta } from './helpers/shared';
+import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
@@ -25,10 +27,16 @@ const styles = ({ spacing }: Theme) =>
     },
   });
 
+interface FormData {
+  text: string;
+  baseUrl: string;
+}
+
 interface VariantEditorButtonEditorProps extends WithStyles<typeof styles> {
   label: string;
   cta?: Cta;
   updateCta: (updatedCta?: Cta) => void;
+  onValidationChange: (isValid: boolean) => void;
   defaultCta: Cta;
   isDisabled: boolean;
 }
@@ -38,6 +46,7 @@ const VariantEditorButtonEditor: React.FC<VariantEditorButtonEditorProps> = ({
   label,
   cta,
   updateCta,
+  onValidationChange,
   defaultCta,
   isDisabled,
 }: VariantEditorButtonEditorProps) => {
@@ -45,19 +54,23 @@ const VariantEditorButtonEditor: React.FC<VariantEditorButtonEditorProps> = ({
 
   const onCheckboxChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const isChecked = event.target.checked;
-    if (isChecked) {
-      updateCta(defaultCta);
-    } else {
-      updateCta(undefined);
-    }
+    updateCta(isChecked ? defaultCta : undefined);
   };
 
-  const onTextChanged = (updatedText: string): void => {
-    updateCta({ ...cta, text: updatedText });
+  const defaultValues: FormData = {
+    text: cta?.text || '',
+    baseUrl: cta?.baseUrl || '',
   };
 
-  const onBaseUrlChanged = (updatedBaseUrl: string): void => {
-    updateCta({ ...cta, baseUrl: updatedBaseUrl });
+  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange(isValid);
+  }, [errors.text, errors.baseUrl]);
+
+  const onSubmit = ({ text, baseUrl }: FormData): void => {
+    updateCta({ text, baseUrl });
   };
 
   return (
@@ -76,18 +89,32 @@ const VariantEditorButtonEditor: React.FC<VariantEditorButtonEditorProps> = ({
 
       {isChecked && (
         <div className={classes.fieldsContainer}>
-          <EditableTextField
-            text={cta?.text || ''}
-            onSubmit={onTextChanged}
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors.text !== undefined}
+            helperText={errors.text?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="text"
             label="Button copy"
-            editEnabled={!isDisabled}
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
             fullWidth
           />
-          <EditableTextField
-            text={cta?.baseUrl || ''}
-            onSubmit={onBaseUrlChanged}
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors.baseUrl !== undefined}
+            helperText={errors.baseUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="baseUrl"
             label="Button destination"
-            editEnabled={!isDisabled}
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
             fullWidth
           />
         </div>

--- a/public/src/components/channelManagement/variantEditorButtonsEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorButtonsEditor.tsx
@@ -28,6 +28,7 @@ interface VariantEditorButtonsEditorProps extends WithStyles<typeof styles> {
   secondaryCta?: Cta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
   updateSecondaryCta: (updatedCta?: Cta) => void;
+  onValidationChange: (isValid: boolean) => void;
   isDisabled: boolean;
 }
 
@@ -37,6 +38,7 @@ const VariantEditorButtonsEditor: React.FC<VariantEditorButtonsEditorProps> = ({
   secondaryCta,
   updatePrimaryCta,
   updateSecondaryCta,
+  onValidationChange,
   isDisabled,
 }: VariantEditorButtonsEditorProps) => {
   return (
@@ -47,6 +49,7 @@ const VariantEditorButtonsEditor: React.FC<VariantEditorButtonsEditorProps> = ({
         cta={primaryCta}
         updateCta={updatePrimaryCta}
         defaultCta={DEFAULT_PRIMARY_CTA}
+        onValidationChange={onValidationChange}
       />
       <VariantEditorButtonEditor
         label="Secondary button"
@@ -54,6 +57,7 @@ const VariantEditorButtonsEditor: React.FC<VariantEditorButtonsEditorProps> = ({
         cta={secondaryCta}
         updateCta={updateSecondaryCta}
         defaultCta={DEFAULT_SECONDARY_CTA}
+        onValidationChange={onValidationChange}
       />
     </div>
   );


### PR DESCRIPTION
## What does this change?
Use `react-hook-form` for validation. This allows us to remove boilerplate and eventually remove some components like `EditableTextField`. This PR also lays the groundwork for changing how validation works in the app and removing the concept of `modifiedTests` (will be addressed in a follow up PR). 