### PR TITLE
Add preview to epic and refactor to get stage from server

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,12 +3,12 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc._
 
-class Application(authAction: AuthAction[AnyContent], components: ControllerComponents) extends AbstractController(components) {
+class Application(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String) extends AbstractController(components) {
   def healthcheck = Action {
     Ok("healthy")
   }
 
   def index = authAction {
-    Ok(views.html.index())
+    Ok(views.html.index(stage))
   }
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,3 +1,4 @@
+@(stage: String)
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,5 +11,8 @@
   <body>
     <div id="root"></div>
     <script src="@routes.Assets.at("build/app.bundle.js")"></script>
+    <script>
+      window.guardian = { stage: "@stage"};
+    </script>
   </body>
 </html>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -52,7 +52,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
 
   override lazy val router: Router = new Routes(
     httpErrorHandler,
-    new Application(authAction, controllerComponents),
+    new Application(authAction, controllerComponents, stage),
     new Login(authConfig, wsClient, requiredGoogleGroups, googleGroupChecker, controllerComponents),
     new SwitchesController(authAction, controllerComponents, stage, runtime),
     new ContributionTypesController(authAction, controllerComponents, stage, runtime),

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsList.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsList.tsx
@@ -15,6 +15,7 @@ import { EpicVariant } from './epicTestsForm';
 import NewNameCreator from '../newNameCreator';
 import { onFieldValidationChange, ValidationStatus } from '../helpers/validation';
 import { defaultCta } from '../helpers/shared';
+import TestEditorVariantSummaryPreviewButton from '../testEditorVariantSummaryPreviewButton';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ typography, spacing }: Theme) =>
@@ -33,6 +34,12 @@ const styles = ({ typography, spacing }: Theme) =>
     },
     newVariantButton: {
       marginTop: spacing(2),
+    },
+    summary: {
+      display: 'flex',
+      width: '100%',
+      justifyContent: 'space-between',
+      alignItems: 'center',
     },
   });
 
@@ -160,12 +167,21 @@ class EpicTestVariantsList extends React.Component<
                 aria-controls="variant-control"
                 id="variant-header"
               >
-                <Typography variant={'h4'} className={classes.h4}>
-                  {variant.name}{' '}
-                  {variant.heading && (
-                    <span className={classes.heading}>- &quot;{variant.heading}&quot;</span>
-                  )}
-                </Typography>
+                <div className={classes.summary}>
+                  <Typography variant={'h4'} className={classes.h4}>
+                    {variant.name}{' '}
+                    {variant.heading && (
+                      <span className={classes.heading}>- &quot;{variant.heading}&quot;</span>
+                    )}
+                  </Typography>
+
+                  <TestEditorVariantSummaryPreviewButton
+                    name={variant.name}
+                    testName={this.props.testName}
+                    testType="EPIC" // will have to change this to make it more reusable
+                    isDisabled={this.props.editMode}
+                  />
+                </div>
               </ExpansionPanelSummary>
               <ExpansionPanelDetails>
                 <EpicTestVariantEditor

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -65,6 +65,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
         <TestEditorVariantSummaryPreviewButton
           name={name}
           testName={testName}
+          testType="BANNER" // will have to change this to make it more reusable
           isDisabled={isInEditMode}
         />
       </div>

--- a/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
@@ -2,20 +2,17 @@ import React from 'react';
 import { Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 
-// TODO: Do this properly at some point!
+type TestType = 'EPIC' | 'BANNER';
 type Stage = 'DEV' | 'CODE' | 'PROD';
 
-const CODE_URL_REGEX = /support.code.dev-gutools/;
-const PROD_URL_REGEX = /support.gutools/;
+declare global {
+  interface Window {
+    guardian: { stage: Stage };
+  }
+}
 
 const getStage = (): Stage => {
-  const url = window.location.href;
-  if (url.match(CODE_URL_REGEX)) {
-    return 'CODE';
-  } else if (url.match(PROD_URL_REGEX)) {
-    return 'PROD';
-  }
-  return 'DEV';
+  return window.guardian.stage;
 };
 
 const PROD_BASE_ARTICLE_URL =
@@ -24,25 +21,30 @@ const PROD_BASE_ARTICLE_URL =
 const CODE_BASE_ARTICLE_URL =
   'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder';
 
-const getPreviewUrl = (testName: string, variantName: string): string => {
+const getPreviewUrl = (testName: string, variantName: string, testType: TestType): string => {
   const stage = getStage();
+
+  const queryString = `?drc&force-${testType.toLowerCase()}=${testName}:${variantName}`;
   if (stage === 'CODE') {
-    return `${CODE_BASE_ARTICLE_URL}?dcr&force-banner=${testName}:${variantName}`;
+    return `${CODE_BASE_ARTICLE_URL}${queryString}`;
   } else if (stage == 'PROD') {
-    return `${PROD_BASE_ARTICLE_URL}?dcr&force-banner=${testName}:${variantName}`;
+    return `${PROD_BASE_ARTICLE_URL}${queryString}`;
   }
   // placeholder for dev
   return '/';
 };
+
 interface TestEditorVariantSummaryPreviewButtonProps {
   name: string;
   testName: string;
+  testType: TestType;
   isDisabled: boolean;
 }
 
 const TestEditorVariantSummaryPreviewButton: React.FC<TestEditorVariantSummaryPreviewButtonProps> = ({
   name,
   testName,
+  testType,
   isDisabled,
 }: TestEditorVariantSummaryPreviewButtonProps) => {
   return (
@@ -51,7 +53,7 @@ const TestEditorVariantSummaryPreviewButton: React.FC<TestEditorVariantSummaryPr
       size="small"
       onClick={(event): void => event.stopPropagation()}
       onFocus={(event): void => event.stopPropagation()}
-      href={getPreviewUrl(testName, name)}
+      href={getPreviewUrl(testName, name, testType)}
       target="_blank"
       rel="noopener noreferrer"
       disabled={isDisabled}


### PR DESCRIPTION
## What does this change?
Add preview link to epic variants. Additionally refactor the logic to get the current stage from the server instead of the url.

## Images
<img width="1265" alt="Screenshot 2020-09-09 at 16 17 57" src="https://user-images.githubusercontent.com/17720442/92618387-36789d80-f2b8-11ea-8558-a2436933287b.png">
