### PR TITLE
Remove logic that caused bug in epic manager

### DIFF
--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -211,18 +211,6 @@ const TestEditor = <T extends Test>(
             },
           },
         });
-      } else {
-        this.setState({
-          modifiedTests: {
-            ...this.state.modifiedTests,
-            [testName]: {
-              isValid,
-              isDeleted: false,
-              isArchived: false,
-              isNew: false,
-            },
-          },
-        });
       }
     };
 


### PR DESCRIPTION

## What does this change?
Removes some logic that was causing a bug in the epic manager. The current version in prod considers a test modified as soon as it has been selected (even though you're in read-only mode). This leads to a really bad UX!  The logic was added initially to catch an edge case that allowed an invalid test to be saved. I think it's best to remove it for now, and re-add/re-write it after we overhaul the epic manager

## Images
<img width="1792" alt="Screenshot 2020-09-10 at 08 25 13" src="https://user-images.githubusercontent.com/17720442/92695039-cb72a980-f33f-11ea-93d6-f527db961769.png">
