### PR TITLE
Add BannerTemplate field

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -1,12 +1,25 @@
 package models
 
+import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import io.circe.{Decoder, Encoder}
 
+import scala.collection.immutable.IndexedSeq
+
+
+sealed trait BannerTemplate extends EnumEntry
+object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate] {
+  override val values: IndexedSeq[BannerTemplate] = findValues
+
+  case object ContributionsBanner extends BannerTemplate
+  case object DigitalSubscriptionsBanner extends BannerTemplate
+  case object GuardianWeeklyBanner extends BannerTemplate
+}
 
 case class BannerVariant(
   name: String,
+  template: BannerTemplate,
   heading: Option[String],
   body: String,
   highlightedText: Option[String],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build-dev": "webpack --config webpack.dev.js",
     "watch": "webpack --config webpack.dev.js --watch",
     "lint": "eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx",
+    "fix": "npm run lint -- --fix",
     "test": "echo 'Running JS tests' && jest"
   },
   "jest": {

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -3,7 +3,7 @@ import { createStyles, withStyles, WithStyles } from '@material-ui/core';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { BannerTemplate, BannerVariant } from './bannerTestsForm';
+import { BannerTemplate, BannerVariant } from '../../../models/banner';
 
 function isBannerTemplate(s: string): s is BannerTemplate {
   return Object.values(BannerTemplate).includes(s as BannerTemplate);

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { createStyles, withStyles, WithStyles } from '@material-ui/core';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Radio from '@material-ui/core/Radio';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { BannerTemplate, BannerVariant } from './bannerTestsForm';
+
+function isBannerTemplate(s: string): s is BannerTemplate {
+  return Object.values(BannerTemplate).includes(s as BannerTemplate);
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const styles = () =>
+  createStyles({
+    templates: {
+      marginTop: '15px',
+    },
+  });
+
+interface BannerTemplateSelectorProps extends WithStyles<typeof styles> {
+  variant: BannerVariant;
+  onVariantChange: (updatedVariant: BannerVariant) => void;
+  editMode: boolean;
+}
+
+const templatesWithLabels = [
+  { template: BannerTemplate.ContributionsBanner, label: 'Contributions' },
+  { template: BannerTemplate.DigitalSubscriptionsBanner, label: 'Digital subscriptions' },
+  { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
+];
+
+const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({
+  classes,
+  variant,
+  onVariantChange,
+  editMode,
+}: BannerTemplateSelectorProps) => (
+  <RadioGroup
+    aria-label="Default"
+    name="default"
+    className={classes.templates}
+    value={variant.template}
+    onChange={(event, value): void => {
+      if (isBannerTemplate(value)) {
+        onVariantChange({
+          ...variant,
+          template: value,
+        });
+      }
+    }}
+  >
+    {templatesWithLabels.map(withLabel => (
+      <FormControlLabel
+        key={withLabel.template}
+        value={withLabel.template}
+        control={<Radio disabled={!editMode} />}
+        label={withLabel.label}
+      />
+    ))}
+  </RadioGroup>
+);
+
+export default withStyles(styles)(BannerTemplateSelector);

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -3,7 +3,6 @@ import { Region } from '../../../utils/models';
 import { ArticlesViewedSettings, UserCohort } from '../helpers/shared';
 import { articleCountTemplate } from '../helpers/copyTemplates';
 import { createStyles, Theme, Typography, WithStyles, withStyles } from '@material-ui/core';
-import { BannerTest, BannerVariant } from './bannerTestsForm';
 import { defaultArticlesViewedSettings } from '../articlesViewedEditor';
 import BannerTestVariantsEditor from './bannerTestVariantsEditor';
 import TestEditorHeader from '../testEditorHeader';
@@ -13,6 +12,7 @@ import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelecto
 import TestEditorArticleCountEditor from '../testEditorArticleCountEditor';
 import TestEditorActionButtons from '../testEditorActionButtons';
 import useValidation from '../hooks/useValidation';
+import { BannerTest, BannerVariant } from '../../../models/banner';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -9,9 +9,12 @@ import {
   withStyles,
 } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
-import { BannerVariant } from './bannerTestsForm';
+import {BannerTemplate, BannerVariant} from './bannerTestsForm';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
+import RadioGroup from "@material-ui/core/RadioGroup";
+import Radio from "@material-ui/core/Radio";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, spacing }: Theme) =>
@@ -35,10 +38,19 @@ const styles = ({ palette, spacing }: Theme) =>
         marginTop: spacing(3),
       },
     },
-    buttonsSectionHeader: {
+    sectionHeader: {
       fontSize: 16,
       color: palette.grey[900],
+      fontWeight: 500,
     },
+    sectionContainer: {
+      paddingTop: spacing(1),
+      paddingBottom: spacing(2),
+      borderBottom: `1px solid ${palette.grey[500]}`,
+    },
+    templates: {
+      marginTop: '15px',
+    }
   });
 
 const HEADER_DEFAULT_HELPER_TEXT = 'Assitive text';
@@ -90,8 +102,43 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
     onVariantChange({ ...variant, secondaryCta: updatedCta });
   };
 
+  function isBannerTemplate(s: string): s is BannerTemplate {
+    return Object.values(BannerTemplate).includes(s as BannerTemplate);
+  }
+
   return (
     <div className={classes.container}>
+
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.sectionHeader} variant="h4">
+          Banner template
+        </Typography>
+        <RadioGroup
+          aria-label="Default"
+          name="default"
+          className={classes.templates}
+          value={variant.template}
+          onChange={(event, value): void => {
+            if (isBannerTemplate(value)) {
+              onVariantChange({
+                ...variant,
+                template: value,
+              })
+            }
+          }}
+        >
+          { Object.values(BannerTemplate).map(bannerTemplate => (
+              <FormControlLabel
+                key={bannerTemplate}
+                value={bannerTemplate}
+                control={<Radio />}
+                label={bannerTemplate}
+              />
+            ))
+          }
+        </RadioGroup>
+      </div>
+
       <TextField
         inputRef={register({ validate: invalidTemplateValidator })}
         error={errors.heading !== undefined}
@@ -141,7 +188,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
       />
 
       <div className={classes.buttonsSectionContainer}>
-        <Typography className={classes.buttonsSectionHeader} variant="h4">
+        <Typography className={classes.sectionHeader} variant="h4">
           Buttons
         </Typography>
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -12,7 +12,7 @@ import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
-import { BannerTemplate, BannerVariant } from './bannerTestsForm';
+import { BannerTemplate, BannerVariant } from '../../../models/banner';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, spacing }: Theme) =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -30,12 +30,6 @@ const styles = ({ palette, spacing }: Theme) =>
     hook: {
       maxWidth: '400px',
     },
-    buttonsSectionContainer: {
-      marginTop: spacing(5),
-      '& > * + *': {
-        marginTop: spacing(3),
-      },
-    },
     sectionHeader: {
       fontSize: 16,
       color: palette.grey[900],
@@ -45,6 +39,9 @@ const styles = ({ palette, spacing }: Theme) =>
       paddingTop: spacing(1),
       paddingBottom: spacing(2),
       borderBottom: `1px solid ${palette.grey[500]}`,
+      '& > * + *': {
+        marginTop: spacing(3),
+      },
     },
   });
 
@@ -160,7 +157,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
         />
       )}
 
-      <div className={classes.buttonsSectionContainer}>
+      <div className={classes.sectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">
           Buttons
         </Typography>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -131,7 +131,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
               <FormControlLabel
                 key={bannerTemplate}
                 value={bannerTemplate}
-                control={<Radio />}
+                control={<Radio disabled={!editMode}/>}
                 label={bannerTemplate}
               />
             ))
@@ -170,22 +170,24 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
         fullWidth
       />
 
-      <TextField
-        inputRef={register({
-          validate: invalidTemplateValidator,
-        })}
-        error={errors.highlightedText !== undefined}
-        helperText={
-          errors.highlightedText ? errors.highlightedText.message : HIGHTLIGHTED_TEXT_HELPER_TEXT
-        }
-        onBlur={handleSubmit(onSubmit)}
-        name="highlightedText"
-        label="Hightlighted text"
-        margin="normal"
-        variant="outlined"
-        disabled={!editMode}
-        fullWidth
-      />
+      { variant.template === BannerTemplate.ContributionsBanner &&
+        <TextField
+          inputRef={register({
+            validate: invalidTemplateValidator,
+          })}
+          error={errors.highlightedText !== undefined}
+          helperText={
+            errors.highlightedText ? errors.highlightedText.message : HIGHTLIGHTED_TEXT_HELPER_TEXT
+          }
+          onBlur={handleSubmit(onSubmit)}
+          name="highlightedText"
+          label="Hightlighted text"
+          margin="normal"
+          variant="outlined"
+          disabled={!editMode}
+          fullWidth
+        />
+      }
 
       <div className={classes.buttonsSectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -9,12 +9,10 @@ import {
   withStyles,
 } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
-import { BannerTemplate, BannerVariant } from './bannerTestsForm';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
-import RadioGroup from '@material-ui/core/RadioGroup';
-import Radio from '@material-ui/core/Radio';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import BannerTemplateSelector from './bannerTemplateSelector';
+import { BannerTemplate, BannerVariant } from './bannerTestsForm';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, spacing }: Theme) =>
@@ -47,9 +45,6 @@ const styles = ({ palette, spacing }: Theme) =>
       paddingTop: spacing(1),
       paddingBottom: spacing(2),
       borderBottom: `1px solid ${palette.grey[500]}`,
-    },
-    templates: {
-      marginTop: '15px',
     },
   });
 
@@ -102,39 +97,17 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
     onVariantChange({ ...variant, secondaryCta: updatedCta });
   };
 
-  function isBannerTemplate(s: string): s is BannerTemplate {
-    return Object.values(BannerTemplate).includes(s as BannerTemplate);
-  }
-
   return (
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">
           Banner template
         </Typography>
-        <RadioGroup
-          aria-label="Default"
-          name="default"
-          className={classes.templates}
-          value={variant.template}
-          onChange={(event, value): void => {
-            if (isBannerTemplate(value)) {
-              onVariantChange({
-                ...variant,
-                template: value,
-              });
-            }
-          }}
-        >
-          {Object.values(BannerTemplate).map(bannerTemplate => (
-            <FormControlLabel
-              key={bannerTemplate}
-              value={bannerTemplate}
-              control={<Radio disabled={!editMode} />}
-              label={bannerTemplate}
-            />
-          ))}
-        </RadioGroup>
+        <BannerTemplateSelector
+          variant={variant}
+          onVariantChange={onVariantChange}
+          editMode={editMode}
+        />
       </div>
 
       <TextField

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -9,12 +9,12 @@ import {
   withStyles,
 } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
-import {BannerTemplate, BannerVariant} from './bannerTestsForm';
+import { BannerTemplate, BannerVariant } from './bannerTestsForm';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
-import RadioGroup from "@material-ui/core/RadioGroup";
-import Radio from "@material-ui/core/Radio";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Radio from '@material-ui/core/Radio';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, spacing }: Theme) =>
@@ -50,7 +50,7 @@ const styles = ({ palette, spacing }: Theme) =>
     },
     templates: {
       marginTop: '15px',
-    }
+    },
   });
 
 const HEADER_DEFAULT_HELPER_TEXT = 'Assitive text';
@@ -108,7 +108,6 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
 
   return (
     <div className={classes.container}>
-
       <div className={classes.sectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">
           Banner template
@@ -123,19 +122,18 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
               onVariantChange({
                 ...variant,
                 template: value,
-              })
+              });
             }
           }}
         >
-          { Object.values(BannerTemplate).map(bannerTemplate => (
-              <FormControlLabel
-                key={bannerTemplate}
-                value={bannerTemplate}
-                control={<Radio disabled={!editMode}/>}
-                label={bannerTemplate}
-              />
-            ))
-          }
+          {Object.values(BannerTemplate).map(bannerTemplate => (
+            <FormControlLabel
+              key={bannerTemplate}
+              value={bannerTemplate}
+              control={<Radio disabled={!editMode} />}
+              label={bannerTemplate}
+            />
+          ))}
         </RadioGroup>
       </div>
 
@@ -170,7 +168,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
         fullWidth
       />
 
-      { variant.template === BannerTemplate.ContributionsBanner &&
+      {variant.template === BannerTemplate.ContributionsBanner && (
         <TextField
           inputRef={register({
             validate: invalidTemplateValidator,
@@ -187,7 +185,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           disabled={!editMode}
           fullWidth
         />
-      }
+      )}
 
       <div className={classes.buttonsSectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
@@ -8,11 +8,11 @@ import {
   AccordionDetails,
   AccordionActions,
 } from '@material-ui/core';
-import { BannerVariant } from './bannerTestsForm';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
 import TestEditorVariantSummary from '../testEditorVariantSummary';
 import VariantDeleteButton from '../variantDeleteButton';
 import useValidation from '../hooks/useValidation';
+import { BannerVariant } from '../../../models/banner';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
@@ -1,9 +1,9 @@
-import React, {useEffect, useState} from 'react';
-import {createStyles, Theme, WithStyles, withStyles} from '@material-ui/core';
-import {BannerTemplate, BannerVariant} from './bannerTestsForm';
+import React, { useEffect, useState } from 'react';
+import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { BannerTemplate, BannerVariant } from './bannerTestsForm';
 import BannerTestVariantEditorsAccordion from './bannerTestVariantEditorsAccordion';
 import BannerTestNewVariantButton from './bannerTestNewVariantButton';
-import {defaultCta} from '../helpers/shared';
+import { defaultCta } from '../helpers/shared';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
-import { BannerTemplate, BannerVariant } from './bannerTestsForm';
 import BannerTestVariantEditorsAccordion from './bannerTestVariantEditorsAccordion';
 import BannerTestNewVariantButton from './bannerTestNewVariantButton';
 import { defaultCta } from '../helpers/shared';
+import { BannerTemplate, BannerVariant } from '../../../models/banner';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantsEditor.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { Theme, createStyles, WithStyles, withStyles } from '@material-ui/core';
-import { BannerVariant } from './bannerTestsForm';
+import React, {useEffect, useState} from 'react';
+import {createStyles, Theme, WithStyles, withStyles} from '@material-ui/core';
+import {BannerTemplate, BannerVariant} from './bannerTestsForm';
 import BannerTestVariantEditorsAccordion from './bannerTestVariantEditorsAccordion';
 import BannerTestNewVariantButton from './bannerTestNewVariantButton';
-import { defaultCta } from '../helpers/shared';
+import {defaultCta} from '../helpers/shared';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
@@ -44,13 +44,13 @@ const BannerTestVariantsEditor: React.FC<BannerTestVariantsEditorProps> = ({
   const createVariant = (name: string): void => {
     const newVariant: BannerVariant = {
       name: name,
+      template: BannerTemplate.ContributionsBanner,
       heading: undefined,
       body: '',
       highlightedText:
         'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
       cta: defaultCta,
     };
-    console.log('here');
 
     onVariantsListChange([...variants, newVariant]);
     onVariantSelected(`${testName}-${name}`);

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -14,7 +14,7 @@ export enum BannerTemplate {
 }
 export interface BannerVariant {
   name: string;
-  template: BannerTemplate,
+  template: BannerTemplate;
   heading?: string;
   body: string;
   highlightedText?: string;

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -4,34 +4,8 @@ import { FrontendSettingsType } from '../../../utils/requests';
 import Sidebar from '../sidebar';
 import BannerTestEditor from './bannerTestEditor';
 import TestsFormLayout from '../testsFormLayout';
-import { ArticlesViewedSettings, Cta, Test, UserCohort } from '../helpers/shared';
-import { Region } from '../../../utils/models';
-
-export enum BannerTemplate {
-  ContributionsBanner = 'ContributionsBanner',
-  DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
-  GuardianWeeklyBanner = 'GuardianWeeklyBanner',
-}
-export interface BannerVariant {
-  name: string;
-  template: BannerTemplate;
-  heading?: string;
-  body: string;
-  highlightedText?: string;
-  cta?: Cta;
-  secondaryCta?: Cta;
-}
-
-export interface BannerTest extends Test {
-  name: string;
-  nickname?: string;
-  isOn: boolean;
-  minArticlesBeforeShowingBanner: number;
-  userCohort: UserCohort;
-  locations: Region[];
-  variants: BannerVariant[];
-  articlesViewedSettings?: ArticlesViewedSettings;
-}
+import { UserCohort } from '../helpers/shared';
+import { BannerTest } from '../../../models/banner';
 
 const createDefaultBannerTest = (newTestName: string, newTestNickname: string): BannerTest => ({
   name: newTestName,

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -7,8 +7,14 @@ import TestsFormLayout from '../testsFormLayout';
 import { ArticlesViewedSettings, Cta, Test, UserCohort } from '../helpers/shared';
 import { Region } from '../../../utils/models';
 
+export enum BannerTemplate {
+  ContributionsBanner = 'ContributionsBanner',
+  DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
+  GuardianWeeklyBanner = 'GuardianWeeklyBanner',
+}
 export interface BannerVariant {
   name: string;
+  template: BannerTemplate,
   heading?: string;
   body: string;
   highlightedText?: string;

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -1,0 +1,33 @@
+import {
+  ArticlesViewedSettings,
+  Cta,
+  Test,
+  UserCohort,
+} from '../components/channelManagement/helpers/shared';
+import { Region } from '../utils/models';
+
+export enum BannerTemplate {
+  ContributionsBanner = 'ContributionsBanner',
+  DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
+  GuardianWeeklyBanner = 'GuardianWeeklyBanner',
+}
+export interface BannerVariant {
+  name: string;
+  template: BannerTemplate;
+  heading?: string;
+  body: string;
+  highlightedText?: string;
+  cta?: Cta;
+  secondaryCta?: Cta;
+}
+
+export interface BannerTest extends Test {
+  name: string;
+  nickname?: string;
+  isOn: boolean;
+  minArticlesBeforeShowingBanner: number;
+  userCohort: UserCohort;
+  locations: Region[];
+  variants: BannerVariant[];
+  articlesViewedSettings?: ArticlesViewedSettings;
+}


### PR DESCRIPTION
The banner tool will soon be used for Subscriptions banners as well as contributions.
This change adds a radio group for each variant for setting a new `template` field.
Also, the highlightedText field is hidden for subscriptions banners.
<img width="802" alt="Screen Shot 2020-09-14 at 10 48 41" src="https://user-images.githubusercontent.com/1513454/93071292-e2830580-f677-11ea-8eb2-b969ee8eef7f.png">

