### PR TITLE
Second banner tests list

### DIFF
--- a/app/controllers/BannerTestArchiveController2.scala
+++ b/app/controllers/BannerTestArchiveController2.scala
@@ -1,0 +1,24 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.BannerTest
+import models.BannerTests._
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, ControllerComponents}
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+class BannerTestArchiveController2(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  ws: WSClient, stage: String,
+  runtime: DefaultRuntime
+)(implicit ec: ExecutionContext) extends S3ObjectsController[BannerTest](
+  authAction,
+  components,
+  stage,
+  path = "archived-banner-tests2",
+  nameGenerator = _.name,
+  runtime
+)

--- a/app/controllers/BannerTestsController2.scala
+++ b/app/controllers/BannerTestsController2.scala
@@ -1,0 +1,37 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.BannerTests
+import play.api.libs.circe.Circe
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, ControllerComponents}
+import services.FastlyPurger
+import services.S3Client.S3ObjectSettings
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+object BannerTestsController2 {
+  val name = "banner-tests2"
+}
+
+class BannerTestsController2(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  ws: WSClient, stage: String,
+  runtime: DefaultRuntime
+)(implicit ec: ExecutionContext) extends LockableS3ObjectController[BannerTests](
+    authAction,
+    components,
+    stage,
+    name = BannerTestsController.name,
+    dataObjectSettings = S3ObjectSettings(
+      bucket = "gu-contributions-public",
+      key = s"banner/$stage/${BannerTestsController.name}.json",
+      publicRead = true,  // This data will be requested by dotcom
+      cacheControl = Some("max-age=30"),
+      surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
+    ),
+    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${BannerTestsController.name}.json", ws),
+    runtime = runtime
+  ) with Circe

--- a/app/controllers/BannerTestsController2.scala
+++ b/app/controllers/BannerTestsController2.scala
@@ -24,14 +24,14 @@ class BannerTestsController2(
     authAction,
     components,
     stage,
-    name = BannerTestsController.name,
+    name = BannerTestsController2.name,
     dataObjectSettings = S3ObjectSettings(
       bucket = "gu-contributions-public",
-      key = s"banner/$stage/${BannerTestsController.name}.json",
+      key = s"banner/$stage/${BannerTestsController2.name}.json",
       publicRead = true,  // This data will be requested by dotcom
       cacheControl = Some("max-age=30"),
       surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
     ),
-    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${BannerTestsController.name}.json", ws),
+    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${BannerTestsController2.name}.json", ws),
     runtime = runtime
   ) with Circe

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -61,6 +61,8 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new EpicTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestsController(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
+    new BannerTestsController2(authAction, controllerComponents, wsClient, stage, runtime),
+    new BannerTestArchiveController2(authAction, controllerComponents, wsClient, stage, runtime),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -47,5 +47,15 @@ POST  /frontend/banner-tests/archive                  controllers.BannerTestArch
 GET   /frontend/banner-tests/archive/:testName        controllers.BannerTestArchiveController.get(testName: String)
 GET   /frontend/banner-tests/archived-test-names      controllers.BannerTestArchiveController.list
 
+# ----- banner tests ----- #
+GET   /frontend/banner-tests2                          controllers.BannerTestsController2.get
+POST  /frontend/banner-tests2/update                   controllers.BannerTestsController2.set
+POST  /frontend/banner-tests2/lock                     controllers.BannerTestsController2.lock
+POST  /frontend/banner-tests2/unlock                   controllers.BannerTestsController2.unlock
+POST  /frontend/banner-tests2/takecontrol              controllers.BannerTestsController2.takecontrol
+POST  /frontend/banner-tests2/archive                  controllers.BannerTestArchiveController2.set
+GET   /frontend/banner-tests2/archive/:testName        controllers.BannerTestArchiveController2.get(testName: String)
+GET   /frontend/banner-tests2/archived-test-names      controllers.BannerTestArchiveController2.list
+
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/conf/routes
+++ b/conf/routes
@@ -8,6 +8,7 @@ GET /contribution-types                             controllers.Application.inde
 GET /amounts                                        controllers.Application.index
 GET /epic-tests                                     controllers.Application.index
 GET /banner-tests                                   controllers.Application.index
+GET /banner-tests2                                  controllers.Application.index
 
 # ----- Authentication ----- #
 GET  /login                                         controllers.Login.login

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -123,4 +123,5 @@ const BannerTestsForm: React.FC<Props> = ({
   );
 };
 
-export default TestsForm(BannerTestsForm, FrontendSettingsType.bannerTests);
+export const BannerTestsForm1 = TestsForm(BannerTestsForm, FrontendSettingsType.bannerTests);
+export const BannerTestsForm2 = TestsForm(BannerTestsForm, FrontendSettingsType.bannerTests2);

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -126,9 +126,14 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Epic" />
           </ListItem>
         </Link>
-        <Link key="Banner" to="/banner-tests" className={classes.link}>
-          <ListItem className={classes.listItem} button key="Banner">
-            <ListItemText primary="Banner" />
+        <Link key="Banner1" to="/banner-tests" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Banner1">
+            <ListItemText primary="Banner 1" />
+          </ListItem>
+        </Link>
+        <Link key="Banner2" to="/banner-tests2" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Banner2">
+            <ListItemText primary="Banner 2" />
           </ListItem>
         </Link>
       </div>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -8,7 +8,7 @@ import AmountsForm from './components/amounts/amounts';
 import EpicTestsForm from './components/channelManagement/epicTests/epicTestsForm';
 import {
   BannerTestsForm1,
-  BannerTestsForm2
+  BannerTestsForm2,
 } from './components/channelManagement/bannerTests/bannerTestsForm';
 import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -6,7 +6,10 @@ import Switchboard from './components/switchboard';
 import ContributionTypesForm from './components/contributionTypes';
 import AmountsForm from './components/amounts/amounts';
 import EpicTestsForm from './components/channelManagement/epicTests/epicTestsForm';
-import BannerTestsForm from './components/channelManagement/bannerTests/bannerTestsForm';
+import {
+  BannerTestsForm1,
+  BannerTestsForm2
+} from './components/channelManagement/bannerTests/bannerTestsForm';
 import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
@@ -94,7 +97,11 @@ const AppRouter = withStyles(styles)(({ classes }: Props) => {
         />
         <Route
           path="/banner-tests"
-          render={(): React.ReactElement => createComponent(<BannerTestsForm />, 'Banner Tests')}
+          render={(): React.ReactElement => createComponent(<BannerTestsForm1 />, 'Banner Tests 1')}
+        />
+        <Route
+          path="/banner-tests2"
+          render={(): React.ReactElement => createComponent(<BannerTestsForm2 />, 'Banner Tests 2')}
         />
       </div>
     </Router>

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -9,6 +9,7 @@ export enum SupportFrontendSettingsType {
 export enum FrontendSettingsType {
   epicTests = 'epic-tests',
   bannerTests = 'banner-tests',
+  bannerTests2 = 'banner-tests2',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
We are adding support for the subscriptions banner in the tool.
For the initial implementation we are temporarily having 2 banner lists.
This is because we currently have the ability to dismiss the contributions banner and the subscriptions banner separately (the client stores 2 separate timestamps when these banners are dismissed).
Having 2 separate banner test lists allows us to continue doing this, for now.

So, in the code `banner-tests2` is identical to `banner-tests`, except it writes to a new file in S3.
`support-dotcom-components` can then poll both S3 files, to get both banner test lists.

![Screen Shot 2020-09-11 at 15 39 29](https://user-images.githubusercontent.com/1513454/93061117-07bd4700-f66b-11ea-811c-b2aba791b443.png)

Before deploying to CODE + PROD:

- [x] create `support-admin-console/<STAGE>/locks/banner-tests2.lock` in S3
- [x] create `gu-contributions-public/banner/<STAGE>/banner-tests2.json` in S3