### PR TITLE
Add a switch to control whether Digital Subs gifting is enabled

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -42,6 +42,7 @@ case class SupportFrontendSwitches(
   oneOffPaymentMethods: PaymentMethodSwitches,
   recurringPaymentMethods: PaymentMethodSwitches,
   experiments: Map[String, ExperimentSwitch],
+  enableDigitalSubGifting: SwitchState,
   useDotcomContactPage: SwitchState,
   enableRecaptchaBackend: SwitchState,
   enableRecaptchaFrontend: SwitchState

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "webpack-dev-server": "^3.8.1"
   },
   "dependencies": {
-    "@material-ui/core": "^4.9.0",
+    "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.5.1",
     "@types/react-beautiful-dnd": "^13.0.0",
     "immutability-helper": "^3.0.1",

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -47,6 +47,7 @@ interface Switches {
   recurringPaymentMethods: {
     [p in RecurringPaymentMethod]: SwitchState;
   };
+  enableDigitalSubGifting: SwitchState;
   useDotcomContactPage: SwitchState;
   enableRecaptchaBackend: SwitchState;
   enableRecaptchaFrontend: SwitchState;
@@ -146,6 +147,7 @@ class Switchboard extends React.Component<Props, Switches> {
         existingCard: SwitchState.Off,
         existingDirectDebit: SwitchState.Off,
       },
+      enableDigitalSubGifting: SwitchState.Off,
       useDotcomContactPage: SwitchState.Off,
       enableRecaptchaBackend: SwitchState.Off,
       enableRecaptchaFrontend: SwitchState.Off,
@@ -335,7 +337,21 @@ class Switchboard extends React.Component<Props, Switches> {
             />
           </FormControl>
           <FormControl component={'fieldset' as 'div'} className={classes.formControl}>
-            <FormLabel component={'legend' as 'label'}>Other Switches</FormLabel>
+            <FormLabel component={'legend' as 'label'}>Subscriptions Switches</FormLabel>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={switchStateToBoolean(this.state.enableDigitalSubGifting)}
+                  onChange={(event): void =>
+                    this.setState({
+                      enableDigitalSubGifting: booleanToSwitchState(event.target.checked),
+                    })
+                  }
+                  value={switchStateToBoolean(this.state.enableDigitalSubGifting)}
+                />
+              }
+              label="Enable Digital Subscriptions Gifting"
+            />
             <FormControlLabel
               control={
                 <Switch

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -40,6 +40,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |          "state": "On"
       |        }
       |      },
+      |      "enableDigitalSubGifting": "Off",
       |      "useDotcomContactPage": "Off",
       |      "enableRecaptchaBackend" : "On",
       |      "enableRecaptchaFrontend" : "On"
@@ -69,6 +70,7 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
         stripePaymentRequestButton = On
       ),
       experiments = Map("newFlow" -> ExperimentSwitch("newFlow","Redesign of the payment flow UI",On)),
+      enableDigitalSubGifting = Off,
       useDotcomContactPage = Off,
       enableRecaptchaBackend = On,
       enableRecaptchaFrontend = On


### PR DESCRIPTION
## What does this change?
This PR adds a switch to control whether Digital Subscriptions Gifting is enabled on the site

## How to test
Once deployed the switch should control whether you are able to go to `support.theguardian.com/digital/checkout/gift` or not

