### PR TITLE
Tp banner manager bug fixes

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorsAccordion.tsx
@@ -71,7 +71,7 @@ const BannerTestVariantEditorsAccordion: React.FC<BannerTestVariantEditorsAccord
         const variantKey = variantKeys[index];
         return (
           <Accordion
-            key={variant.name}
+            key={variantKey}
             expanded={variantKey === selectedVariantKey}
             onChange={(): void => onVariantSelected(variantKey)}
             className={classes.expansionPanel}

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -62,7 +62,14 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
     periodInWeeks: articlesViewedSettings?.periodInWeeks.toString() || '',
   };
 
-  const { register, errors, handleSubmit } = useForm<FormData>({ mode: 'onChange', defaultValues });
+  const { register, errors, handleSubmit, reset } = useForm<FormData>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues.minViews, defaultValues.maxViews, defaultValues.periodInWeeks]);
 
   const onSubmit = ({ minViews, maxViews, periodInWeeks }: FormData): void => {
     onArticlesViewedSettingsChanged({

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -126,6 +126,7 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               onBlur={handleSubmit(onSubmit)}
               name="minViews"
               label="Minimum page views"
+              InputLabelProps={{ shrink: true }}
               variant="filled"
               disabled={isDisabled}
             />
@@ -138,6 +139,7 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               onBlur={handleSubmit(onSubmit)}
               name="maxViews"
               label="Maximum page views"
+              InputLabelProps={{ shrink: true }}
               variant="filled"
               disabled={isDisabled}
             />
@@ -153,6 +155,7 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               onBlur={handleSubmit(onSubmit)}
               name="periodInWeeks"
               label="Time period in weeks"
+              InputLabelProps={{ shrink: true }}
               variant="filled"
               disabled={isDisabled}
             />


### PR DESCRIPTION
## What does this change?
Fixes a couple of bugs with the banner manager.

### Variant editor

The variant editor wouldn't update if a new test was selected, but the variant had the same name. This has been fixed by scoping the key by the testName (which is unique).

### Article count editor

The article count editor wouldn't update when selecting a new test. This was because the defaultValues is cached by react-hook-form. Now whenever any of those values change, we reset the form to the new values inside a useEffect hook.

Also, always shrink the label to avoid and issue where the label was overlapping the text

<img width="477" alt="Screenshot 2020-09-22 at 09 30 35" src="https://user-images.githubusercontent.com/17720442/93861439-6c565280-fcb8-11ea-9936-e84830b3ad81.png">

