### PR TITLE
Add help cta

### DIFF
--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -6,6 +6,7 @@ import { LockStatus } from './helpers/shared';
 import StickyBottomBarStatus from './stickyBottomBarStatus';
 import StickyBottomBarDetail from './stickyBottomBarDetail';
 import StickyBottomBarActionButtons from './stickyBottomBarActionButtons';
+import StickyBottomBarHelpButton from './stickyBottomBarHelpButton';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, spacing }: Theme) =>
@@ -37,6 +38,11 @@ const styles = ({ palette, spacing }: Theme) =>
       right: '100px',
       display: 'flex',
       alignItems: 'center',
+    },
+    helpButtonContainer: {
+      position: 'absolute',
+      top: '-62px',
+      right: '24px',
     },
   });
 
@@ -87,6 +93,12 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
           cancel={cancel}
         />
       </div>
+
+      {isInEditMode && (
+        <div className={classes.helpButtonContainer}>
+          <StickyBottomBarHelpButton />
+        </div>
+      )}
     </AppBar>
   );
 };

--- a/public/src/components/channelManagement/stickyBottomBarHelpButton.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarHelpButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { createStyles, Link, Theme, Tooltip, WithStyles, withStyles } from '@material-ui/core';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const styles = ({ palette }: Theme) =>
+  createStyles({
+    container: {
+      postion: 'relative',
+    },
+    link: {
+      width: '40px',
+      height: '40px',
+      background: palette.grey[900],
+      borderRadius: '50%',
+      textAlign: 'center',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: '18px',
+      fontWeight: 500,
+      color: 'white',
+      cursor: 'pointer',
+      filter: 'drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.25))',
+
+      '&:hover': {
+        textDecoration: 'none',
+      },
+    },
+  });
+
+const HELP_GUIDE_URL =
+  'https://docs.google.com/document/d/1jgc8nK7fognfXan9OB_g5EOQywOPF4roNKP_3T4Na8Y/edit';
+
+type StickyBottomBarHelpButtonProps = WithStyles<typeof styles>;
+
+const StickyBottomBarHelpButton: React.FC<StickyBottomBarHelpButtonProps> = ({
+  classes,
+}: StickyBottomBarHelpButtonProps) => {
+  return (
+    <Tooltip title="View help guide" placement="top-end">
+      <Link
+        className={classes.link}
+        href={HELP_GUIDE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <div>?</div>
+      </Link>
+    </Tooltip>
+  );
+};
+
+export default withStyles(styles)(StickyBottomBarHelpButton);


### PR DESCRIPTION
## What does this change?
Add the help cta to the banner manager, as per [this card](https://trello.com/c/C1QmCpZy/2096-banner-manager-implement-the-help-cta-on-the-test-sheet).

## Images
<img width="1792" alt="Screenshot 2020-09-30 at 09 26 56" src="https://user-images.githubusercontent.com/17720442/94662982-0c3b5e00-0301-11eb-82c2-9d7944f910d5.png">
<img width="1792" alt="Screenshot 2020-09-30 at 09 27 33" src="https://user-images.githubusercontent.com/17720442/94663001-10677b80-0301-11eb-8537-21b83fc507dc.png">


