### PR TITLE
Add liveblog epic channel

### DIFF
--- a/app/controllers/LiveblogEpicTestArchiveController.scala
+++ b/app/controllers/LiveblogEpicTestArchiveController.scala
@@ -1,0 +1,24 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.EpicTest
+import models.EpicTests._
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, ControllerComponents}
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+class LiveblogEpicTestArchiveController(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  ws: WSClient, stage: String,
+  runtime: DefaultRuntime
+)(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
+  authAction,
+  components,
+  stage,
+  path = "archived-liveblog-epic-tests",
+  nameGenerator = _.name,
+  runtime
+)

--- a/app/controllers/LiveblogEpicTestsController.scala
+++ b/app/controllers/LiveblogEpicTestsController.scala
@@ -33,6 +33,6 @@ class LiveblogEpicTestsController(
       cacheControl = Some("max-age=30"),
       surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
     ),
-    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${EpicTestsController.name}.json", ws),
+    fastlyPurger = None,
     runtime = runtime
   ) with Circe

--- a/app/controllers/LiveblogEpicTestsController.scala
+++ b/app/controllers/LiveblogEpicTestsController.scala
@@ -33,6 +33,6 @@ class LiveblogEpicTestsController(
       cacheControl = Some("max-age=30"),
       surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
     ),
-    fastlyPurger = None,
+    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${LiveblogEpicTestsController.name}.json", ws),
     runtime = runtime
   ) with Circe

--- a/app/controllers/LiveblogEpicTestsController.scala
+++ b/app/controllers/LiveblogEpicTestsController.scala
@@ -1,0 +1,38 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import play.api.mvc._
+import models.EpicTests
+import play.api.libs.ws.WSClient
+import services.FastlyPurger
+import services.S3Client.S3ObjectSettings
+
+import play.api.libs.circe.Circe
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+object LiveblogEpicTestsController {
+  val name = "liveblog-epic-tests"
+}
+
+class LiveblogEpicTestsController(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  ws: WSClient, stage: String,
+  runtime: DefaultRuntime
+)(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
+    authAction,
+    components,
+    stage,
+    name = LiveblogEpicTestsController.name,
+    dataObjectSettings = S3ObjectSettings(
+      bucket = "gu-contributions-public",
+      key = s"epic/$stage/${LiveblogEpicTestsController.name}.json",
+      publicRead = true,  // This data will be requested by dotcom
+      cacheControl = Some("max-age=30"),
+      surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
+    ),
+    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${EpicTestsController.name}.json", ws),
+    runtime = runtime
+  ) with Circe

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -59,6 +59,8 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new AmountsController(authAction, controllerComponents, stage, runtime),
     new EpicTestsController(authAction, controllerComponents, wsClient, stage, runtime),
     new EpicTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
+    new LiveblogEpicTestsController(authAction, controllerComponents, wsClient, stage, runtime),
+    new LiveblogEpicTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestsController(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestsController2(authAction, controllerComponents, wsClient, stage, runtime),

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET /switches                                       controllers.Application.inde
 GET /contribution-types                             controllers.Application.index
 GET /amounts                                        controllers.Application.index
 GET /epic-tests                                     controllers.Application.index
+GET /liveblog-epic-tests                            controllers.Application.index
 GET /banner-tests                                   controllers.Application.index
 GET /banner-tests2                                  controllers.Application.index
 
@@ -37,6 +38,16 @@ POST  /frontend/epic-tests/takecontrol              controllers.EpicTestsControl
 POST  /frontend/epic-tests/archive                  controllers.EpicTestArchiveController.set
 GET   /frontend/epic-tests/archive/:testName        controllers.EpicTestArchiveController.get(testName: String)
 GET   /frontend/epic-tests/archived-test-names      controllers.EpicTestArchiveController.list
+
+# ----- liveblog epic tests ----- #
+GET   /frontend/liveblog-epic-tests                          controllers.LiveblogEpicTestsController.get
+POST  /frontend/liveblog-epic-tests/update                   controllers.LiveblogEpicTestsController.set
+POST  /frontend/liveblog-epic-tests/lock                     controllers.LiveblogEpicTestsController.lock
+POST  /frontend/liveblog-epic-tests/unlock                   controllers.LiveblogEpicTestsController.unlock
+POST  /frontend/liveblog-epic-tests/takecontrol              controllers.LiveblogEpicTestsController.takecontrol
+POST  /frontend/liveblog-epic-tests/archive                  controllers.LiveblogEpicTestArchiveController.set
+GET   /frontend/liveblog-epic-tests/archive/:testName        controllers.LiveblogEpicTestArchiveController.get(testName: String)
+GET   /frontend/liveblog-epic-tests/archived-test-names      controllers.LiveblogEpicTestArchiveController.list
 
 # ----- banner tests ----- #
 GET   /frontend/banner-tests                          controllers.BannerTestsController.get

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -24,7 +24,6 @@ import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import ArchiveIcon from '@material-ui/icons/Archive';
 import ArticlesViewedEditor, { defaultArticlesViewedSettings } from '../articlesViewedEditor';
 import NewNameCreator from '../newNameCreator';
-import EpicTypeComponent, { EpicType } from './epicTypeComponent';
 import TargetRegionsSelector from '../targetRegionsSelector';
 import { articleCountTemplate, countryNameTemplate } from '../helpers/copyTemplates';
 
@@ -114,6 +113,7 @@ const copyHasTemplate = (test: EpicTest, template: string): boolean =>
 interface EpicTestEditorProps extends WithStyles<typeof styles> {
   test?: EpicTest;
   hasChanged: boolean;
+  isLiveblog: boolean;
   onChange: (updatedTest: EpicTest) => void;
   onValidationChange: (isValid: boolean) => void;
   visible: boolean;
@@ -197,11 +197,6 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, TestEditorStat
     this.updateTest(test => ({ ...test, userCohort: selectedCohort }));
   };
 
-  onEpicTypeChange = (epicType: EpicType): void => {
-    const isLiveBlog = epicType === 'LiveBlog';
-    this.updateTest(test => ({ ...test, isLiveBlog: isLiveBlog }));
-  };
-
   onTargetRegionsChange = (selectedRegions: Region[]): void => {
     this.updateTest(test => ({ ...test, locations: selectedRegions }));
   };
@@ -274,12 +269,6 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, TestEditorStat
 
         <hr />
 
-        <EpicTypeComponent
-          epicType={test.isLiveBlog ? 'LiveBlog' : 'Standard'}
-          isEditable={this.isEditable()}
-          onEpicTypeChange={this.onEpicTypeChange}
-        />
-
         <Typography variant={'h4'} className={classes.boldHeading}>
           Variants
         </Typography>
@@ -289,6 +278,7 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, TestEditorStat
             onVariantsListChange={this.onVariantsChange}
             testName={test.name}
             editMode={this.isEditable()}
+            isLiveblog={this.props.isLiveblog}
             onValidationChange={onFieldValidationChange(this)('variantsList')}
           />
         </div>

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -24,6 +24,7 @@ import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import ArchiveIcon from '@material-ui/icons/Archive';
 import ArticlesViewedEditor, { defaultArticlesViewedSettings } from '../articlesViewedEditor';
 import NewNameCreator from '../newNameCreator';
+import EpicTypeComponent, { EpicType } from './epicTypeComponent';
 import TargetRegionsSelector from '../targetRegionsSelector';
 import { articleCountTemplate, countryNameTemplate } from '../helpers/copyTemplates';
 
@@ -197,6 +198,11 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, TestEditorStat
     this.updateTest(test => ({ ...test, userCohort: selectedCohort }));
   };
 
+  onEpicTypeChange = (epicType: EpicType): void => {
+    const isLiveBlog = epicType === 'LiveBlog';
+    this.updateTest(test => ({ ...test, isLiveBlog: isLiveBlog }));
+  };
+
   onTargetRegionsChange = (selectedRegions: Region[]): void => {
     this.updateTest(test => ({ ...test, locations: selectedRegions }));
   };
@@ -268,6 +274,12 @@ class EpicTestEditor extends React.Component<EpicTestEditorProps, TestEditorStat
         </div>
 
         <hr />
+
+        <EpicTypeComponent
+          epicType={test.isLiveBlog ? 'LiveBlog' : 'Standard'}
+          isEditable={this.isEditable()}
+          onEpicTypeChange={this.onEpicTypeChange}
+        />
 
         <Typography variant={'h4'} className={classes.boldHeading}>
           Variants

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -162,20 +162,18 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
           fullWidth
         />
 
-        {!this.props.isLiveblog && (
-          <EditableTextField
-            text={variant.highlightedText || ''}
-            onSubmit={this.onOptionalTextChange('highlightedText')}
-            label="Highlighted text"
-            helperText="Final sentence, highlighted in yellow"
-            editEnabled={this.props.editMode}
-            validation={{
-              getError: (value: string): string | null => getInvalidTemplateError(value),
-              onChange: onFieldValidationChange(this)('highlightedText'),
-            }}
-            fullWidth
-          />
-        )}
+        <EditableTextField
+          text={variant.highlightedText || ''}
+          onSubmit={this.onOptionalTextChange('highlightedText')}
+          label="Highlighted text"
+          helperText="Final sentence, highlighted in yellow"
+          editEnabled={this.props.editMode}
+          validation={{
+            getError: (value: string): string | null => getInvalidTemplateError(value),
+            onChange: onFieldValidationChange(this)('highlightedText'),
+          }}
+          fullWidth
+        />
         <div className={classes.ctaContainer}>
           <span className={classes.label}>Buttons</span>
           <CtaEditor

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -162,18 +162,20 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
           fullWidth
         />
 
-        <EditableTextField
-          text={variant.highlightedText || ''}
-          onSubmit={this.onOptionalTextChange('highlightedText')}
-          label="Highlighted text"
-          helperText="Final sentence, highlighted in yellow"
-          editEnabled={this.props.editMode}
-          validation={{
-            getError: (value: string): string | null => getInvalidTemplateError(value),
-            onChange: onFieldValidationChange(this)('highlightedText'),
-          }}
-          fullWidth
-        />
+        {!this.props.isLiveblog && (
+          <EditableTextField
+            text={variant.highlightedText || ''}
+            onSubmit={this.onOptionalTextChange('highlightedText')}
+            label="Highlighted text"
+            helperText="Final sentence, highlighted in yellow"
+            editEnabled={this.props.editMode}
+            validation={{
+              getError: (value: string): string | null => getInvalidTemplateError(value),
+              onChange: onFieldValidationChange(this)('highlightedText'),
+            }}
+            fullWidth
+          />
+        )}
         <div className={classes.ctaContainer}>
           <span className={classes.label}>Buttons</span>
           <CtaEditor

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -68,6 +68,7 @@ interface Props extends WithStyles<typeof styles> {
   variant?: EpicVariant;
   onVariantChange: (updatedVariant: EpicVariant) => void;
   editMode: boolean;
+  isLiveblog: boolean;
   onDelete: () => void;
   onValidationChange: (isValid: boolean) => void;
 }
@@ -123,20 +124,22 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
     const { classes } = this.props;
     return (
       <div className={classes.fieldsContainer}>
-        <div className={classes.hook}>
-          <EditableTextField
-            text={variant.heading || ''}
-            onSubmit={this.onOptionalTextChange('heading')}
-            label="Hook"
-            editEnabled={this.props.editMode}
-            helperText="e.g. Since you're here"
-            validation={{
-              getError: (value: string): string | null => getInvalidTemplateError(value),
-              onChange: onFieldValidationChange(this)('heading'),
-            }}
-            fullWidth
-          />
-        </div>
+        {!this.props.isLiveblog && (
+          <div className={classes.hook}>
+            <EditableTextField
+              text={variant.heading || ''}
+              onSubmit={this.onOptionalTextChange('heading')}
+              label="Hook"
+              editEnabled={this.props.editMode}
+              helperText="e.g. Since you're here"
+              validation={{
+                getError: (value: string): string | null => getInvalidTemplateError(value),
+                onChange: onFieldValidationChange(this)('heading'),
+              }}
+              fullWidth
+            />
+          </div>
+        )}
         <EditableTextField
           required
           textarea
@@ -158,18 +161,21 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
           }}
           fullWidth
         />
-        <EditableTextField
-          text={variant.highlightedText || ''}
-          onSubmit={this.onOptionalTextChange('highlightedText')}
-          label="Highlighted text"
-          helperText="Final sentence, highlighted in yellow"
-          editEnabled={this.props.editMode}
-          validation={{
-            getError: (value: string): string | null => getInvalidTemplateError(value),
-            onChange: onFieldValidationChange(this)('highlightedText'),
-          }}
-          fullWidth
-        />
+
+        {!this.props.isLiveblog && (
+          <EditableTextField
+            text={variant.highlightedText || ''}
+            onSubmit={this.onOptionalTextChange('highlightedText')}
+            label="Highlighted text"
+            helperText="Final sentence, highlighted in yellow"
+            editEnabled={this.props.editMode}
+            validation={{
+              getError: (value: string): string | null => getInvalidTemplateError(value),
+              onChange: onFieldValidationChange(this)('highlightedText'),
+            }}
+            fullWidth
+          />
+        )}
         <div className={classes.ctaContainer}>
           <span className={classes.label}>Buttons</span>
           <CtaEditor
@@ -182,45 +188,53 @@ class EpicTestVariantEditor extends React.Component<Props, State> {
             manualCampaignCode={false}
           />
 
-          <CtaEditor
-            cta={variant.secondaryCta}
-            update={(cta?: Cta): void =>
-              this.updateVariant(variant => ({
-                ...variant,
-                secondaryCta: cta,
-              }))
-            }
-            editMode={this.props.editMode}
-            label={'Has a secondary button'}
-            manualCampaignCode={true}
-          />
+          {!this.props.isLiveblog && (
+            <CtaEditor
+              cta={variant.secondaryCta}
+              update={(cta?: Cta): void =>
+                this.updateVariant(variant => ({
+                  ...variant,
+                  secondaryCta: cta,
+                }))
+              }
+              editMode={this.props.editMode}
+              label={'Has a secondary button'}
+              manualCampaignCode={true}
+            />
+          )}
         </div>
-        <div>
-          <TickerEditor
-            editMode={this.props.editMode}
-            tickerSettings={variant.tickerSettings}
-            onChange={(tickerSettings): void =>
-              this.updateVariant(variant => ({ ...variant, tickerSettings }))
-            }
-            onValidationChange={onFieldValidationChange(this)('tickerSettings')}
+        {!this.props.isLiveblog && (
+          <div>
+            <TickerEditor
+              editMode={this.props.editMode}
+              tickerSettings={variant.tickerSettings}
+              onChange={(tickerSettings): void =>
+                this.updateVariant(variant => ({ ...variant, tickerSettings }))
+              }
+              onValidationChange={onFieldValidationChange(this)('tickerSettings')}
+            />
+          </div>
+        )}
+        {!this.props.isLiveblog && (
+          <EditableTextField
+            text={variant.backgroundImageUrl || ''}
+            onSubmit={this.onOptionalTextChange(VariantFieldNames.backgroundImageUrl)}
+            label="Image URL"
+            helperText="Image ratio should be 2.5:1. This will appear above everything except a ticker"
+            editEnabled={this.props.editMode}
+            fullWidth
           />
-        </div>
-        <EditableTextField
-          text={variant.backgroundImageUrl || ''}
-          onSubmit={this.onOptionalTextChange(VariantFieldNames.backgroundImageUrl)}
-          label="Image URL"
-          helperText="Image ratio should be 2.5:1. This will appear above everything except a ticker"
-          editEnabled={this.props.editMode}
-          fullWidth
-        />
-        <EditableTextField
-          text={variant.footer || ''}
-          onSubmit={this.onOptionalTextChange('footer')}
-          label="Footer"
-          helperText="Bold text that appears below the button"
-          editEnabled={this.props.editMode}
-          fullWidth
-        />
+        )}
+        {!this.props.isLiveblog && (
+          <EditableTextField
+            text={variant.footer || ''}
+            onSubmit={this.onOptionalTextChange('footer')}
+            label="Footer"
+            helperText="Bold text that appears below the button"
+            editEnabled={this.props.editMode}
+            fullWidth
+          />
+        )}
         <div className={classes.deleteButton}>
           {this.props.editMode && (
             <ButtonWithConfirmationPopup

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsList.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsList.tsx
@@ -48,6 +48,7 @@ interface EpicTestVariantsListProps extends WithStyles<typeof styles> {
   onVariantsListChange: (variantList: EpicVariant[]) => void;
   testName: string;
   editMode: boolean;
+  isLiveblog: boolean;
   onValidationChange: (isValid: boolean) => void;
 }
 
@@ -188,6 +189,7 @@ class EpicTestVariantsList extends React.Component<
                   variant={variant}
                   onVariantChange={this.onVariantChange}
                   editMode={this.props.editMode}
+                  isLiveblog={this.props.isLiveblog}
                   onDelete={(): void => {
                     this.onVariantDelete(variant.name);
                     onFieldValidationChange(this)(variant.name)(true);

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -68,103 +68,122 @@ export interface EpicTest extends Test {
   articlesViewedSettings?: ArticlesViewedSettings;
 }
 
-const createDefaultEpicTest = (newTestName: string, newTestNickname: string): EpicTest => ({
-  name: newTestName,
-  nickname: newTestNickname,
-  isOn: false,
-  locations: [],
-  tagIds: [],
-  sections: [],
-  excludedTagIds: [],
-  excludedSections: [],
-  alwaysAsk: false,
-  maxViews: MaxEpicViewsDefaults,
-  userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
-  isLiveBlog: false,
-  hasCountryName: false,
-  variants: [],
-  highPriority: false, // has been removed from form, but might be used in future
-  useLocalViewLog: false,
-});
+export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
 type Props = InnerComponentProps<EpicTest>;
 
-const EpicTestsForm: React.FC<Props> = ({
-  tests,
-  modifiedTests,
-  selectedTestName,
-  onTestsChange,
-  onSelectedTestName,
-  onTestDelete,
-  onTestArchive,
-  onTestErrorStatusChange,
-  lockStatus,
-  requestTakeControl,
-  requestLock,
-  save,
-  cancel,
-  editMode,
-}: Props) => {
-  const createTest = (name: string, nickname: string): void => {
-    const newTests = [...tests, createDefaultEpicTest(name, nickname)];
-    onTestsChange(newTests, name);
-  };
-  return (
-    <TestsFormLayout
-      sidebar={
-        <Sidebar<EpicTest>
-          tests={tests}
-          modifiedTests={modifiedTests}
-          selectedTestName={selectedTestName}
-          onUpdate={onTestsChange}
-          onSelectedTestName={onSelectedTestName}
-          createTest={createTest}
-          isInEditMode={editMode}
-        />
+const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
+  const isLiveBlog = epicType === 'LIVEBLOG';
+
+  const createDefaultEpicTest = (newTestName: string, newTestNickname: string): EpicTest => ({
+    name: newTestName,
+    nickname: newTestNickname,
+    isOn: false,
+    locations: [],
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: MaxEpicViewsDefaults,
+    userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
+    isLiveBlog: isLiveBlog,
+    hasCountryName: false,
+    variants: [],
+    highPriority: false, // has been removed from form, but might be used in future
+    useLocalViewLog: false,
+  });
+
+  const EpicTestsForm: React.FC<Props> = ({
+    tests,
+    modifiedTests,
+    selectedTestName,
+    onTestsChange,
+    onSelectedTestName,
+    onTestDelete,
+    onTestArchive,
+    onTestErrorStatusChange,
+    lockStatus,
+    requestTakeControl,
+    requestLock,
+    save,
+    cancel,
+    editMode,
+  }: Props) => {
+    const createTest = (name: string, nickname: string): void => {
+      if (Object.keys(modifiedTests).length > 0) {
+        alert('Please either save or discard before creating a test.');
+      } else {
+        const newTests = [...tests, createDefaultEpicTest(name, nickname)];
+        onSelectedTestName(name);
+        onTestsChange(newTests, name);
       }
-      testEditor={
-        selectedTestName ? (
-          <EpicTestEditor
-            test={tests.find(test => test.name === selectedTestName)}
-            hasChanged={!!modifiedTests[selectedTestName]}
-            onChange={(updatedTest): void =>
-              onTestsChange(updateTest(tests, updatedTest), updatedTest.name)
-            }
-            onValidationChange={onTestErrorStatusChange(selectedTestName)}
-            visible
-            editMode={editMode}
-            onDelete={onTestDelete}
-            onArchive={onTestArchive}
+    };
+    return (
+      <TestsFormLayout
+        sidebar={
+          <Sidebar<EpicTest>
+            tests={tests}
+            modifiedTests={modifiedTests}
+            selectedTestName={selectedTestName}
+            onUpdate={onTestsChange}
             onSelectedTestName={onSelectedTestName}
-            isDeleted={modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted}
-            isArchived={
-              modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isArchived
-            }
-            isNew={modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isNew}
-            createTest={(newTest: EpicTest): void => {
-              const newTests = [...tests, newTest];
-              onTestsChange(newTests, newTest.name);
-            }}
-            testNames={tests.map(test => test.name)}
-            testNicknames={
-              tests.map(test => test.nickname).filter(nickname => !!nickname) as string[]
-            }
+            createTest={createTest}
+            isInEditMode={editMode}
           />
-        ) : null
-      }
-      selectedTestName={selectedTestName}
-      lockStatus={lockStatus}
-      requestTakeControl={requestTakeControl}
-      requestLock={requestLock}
-      save={save}
-      cancel={cancel}
-      editMode={editMode}
-    />
-  );
+        }
+        testEditor={
+          selectedTestName ? (
+            <EpicTestEditor
+              test={tests.find(test => test.name === selectedTestName)}
+              hasChanged={!!modifiedTests[selectedTestName]}
+              isLiveblog={isLiveBlog}
+              onChange={(updatedTest): void =>
+                onTestsChange(updateTest(tests, updatedTest), updatedTest.name)
+              }
+              onValidationChange={onTestErrorStatusChange(selectedTestName)}
+              visible
+              editMode={editMode}
+              onDelete={onTestDelete}
+              onArchive={onTestArchive}
+              onSelectedTestName={onSelectedTestName}
+              isDeleted={
+                modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted
+              }
+              isArchived={
+                modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isArchived
+              }
+              isNew={modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isNew}
+              createTest={(newTest: EpicTest): void => {
+                const newTests = [...tests, newTest];
+                onTestsChange(newTests, newTest.name);
+              }}
+              testNames={tests.map(test => test.name)}
+              testNicknames={
+                tests.map(test => test.nickname).filter(nickname => !!nickname) as string[]
+              }
+            />
+          ) : null
+        }
+        selectedTestName={selectedTestName}
+        lockStatus={lockStatus}
+        requestTakeControl={requestTakeControl}
+        requestLock={requestLock}
+        save={save}
+        cancel={cancel}
+        editMode={editMode}
+      />
+    );
+  };
+
+  return EpicTestsForm;
 };
 
-export const ArticleEpicTestsForm = TestsForm(EpicTestsForm, FrontendSettingsType.epicTests);
+export const ArticleEpicTestsForm = TestsForm(
+  getEpicTestForm('ARTICLE'),
+  FrontendSettingsType.epicTests,
+);
 export const LiveblogEpicTestsForm = TestsForm(
-  EpicTestsForm,
+  getEpicTestForm('LIVEBLOG'),
   FrontendSettingsType.liveblogEpicTests,
 );

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -163,4 +163,8 @@ const EpicTestsForm: React.FC<Props> = ({
   );
 };
 
-export default TestsForm(EpicTestsForm, FrontendSettingsType.epicTests);
+export const ArticleEpicTestsForm = TestsForm(EpicTestsForm, FrontendSettingsType.epicTests);
+export const LiveblogEpicTestsForm = TestsForm(
+  EpicTestsForm,
+  FrontendSettingsType.liveblogEpicTests,
+);

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -126,11 +126,12 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Epic" />
           </ListItem>
         </Link>
-        <Link key="Liveblog Epic" to="/liveblog-epic-tests" className={classes.link}>
+        {/* TODO: add this back once we've migrated over the liveblog tests */}
+        {/* <Link key="Liveblog Epic" to="/liveblog-epic-tests" className={classes.link}>
           <ListItem className={classes.listItem} button key="Liveblog Epic">
             <ListItemText primary="Liveblog Epic" />
           </ListItem>
-        </Link>
+        </Link> */}
         <Link key="Banner1" to="/banner-tests" className={classes.link}>
           <ListItem className={classes.listItem} button key="Banner1">
             <ListItemText primary="Banner 1" />

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -126,6 +126,11 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Epic" />
           </ListItem>
         </Link>
+        <Link key="Liveblog Epic" to="/liveblog-epic-tests" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Liveblog Epic">
+            <ListItemText primary="Liveblog Epic" />
+          </ListItem>
+        </Link>
         <Link key="Banner1" to="/banner-tests" className={classes.link}>
           <ListItem className={classes.listItem} button key="Banner1">
             <ListItemText primary="Banner 1" />

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -5,7 +5,10 @@ import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Switchboard from './components/switchboard';
 import ContributionTypesForm from './components/contributionTypes';
 import AmountsForm from './components/amounts/amounts';
-import EpicTestsForm from './components/channelManagement/epicTests/epicTestsForm';
+import {
+  ArticleEpicTestsForm,
+  LiveblogEpicTestsForm,
+} from './components/channelManagement/epicTests/epicTestsForm';
 import {
   BannerTestsForm1,
   BannerTestsForm2,
@@ -93,7 +96,13 @@ const AppRouter = withStyles(styles)(({ classes }: Props) => {
         />
         <Route
           path="/epic-tests"
-          render={(): React.ReactElement => createComponent(<EpicTestsForm />, 'Epic Tests')}
+          render={(): React.ReactElement => createComponent(<ArticleEpicTestsForm />, 'Epic Tests')}
+        />
+        <Route
+          path="/liveblog-epic-tests"
+          render={(): React.ReactElement =>
+            createComponent(<LiveblogEpicTestsForm />, 'Liveblog Epic Tests')
+          }
         />
         <Route
           path="/banner-tests"

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -8,6 +8,7 @@ export enum SupportFrontendSettingsType {
 
 export enum FrontendSettingsType {
   epicTests = 'epic-tests',
+  liveblogEpicTests = 'liveblog-epic-tests',
   bannerTests = 'banner-tests',
   bannerTests2 = 'banner-tests2',
 }


### PR DESCRIPTION
## What does this change?
Create a new liveblog epic channel. As liveblog epics don't compete with regular epics and have slightly different config it makes sense to split them out. Currently the liveblog channel is hidden in the drawer. This is so we can deploy and test by going directly to the endpoint before anybody starts using it

## Follow up work

- migrate over liveblog epics (manually updating the json files in s3)
- re-enable the the channel in the drawer
- remove epic type editor