### PR TITLE
Add banner deployment dashboard

### DIFF
--- a/app/controllers/BannerDeployController.scala
+++ b/app/controllers/BannerDeployController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.BannerDeploys
+import play.api.mvc.{AnyContent, ControllerComponents}
+import io.circe.generic.auto._
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+class BannerDeployController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+  extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel1.json", runtime) {
+}

--- a/app/controllers/BannerDeployController2.scala
+++ b/app/controllers/BannerDeployController2.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.BannerDeploys
+import play.api.mvc.{AnyContent, ControllerComponents}
+import io.circe.generic.auto._
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+class BannerDeployController2(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+  extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel2.json", runtime) {
+}

--- a/app/models/BannerDeploy.scala
+++ b/app/models/BannerDeploy.scala
@@ -1,0 +1,19 @@
+package models
+
+import io.circe.generic.extras.auto._
+import io.circe.{Decoder, Encoder}
+
+case class BannerDeployRegion(timestamp: Long, email: String)
+
+case class BannerDeploys(
+  Australia: BannerDeployRegion,
+  EuropeanUnion: BannerDeployRegion,
+  RestOfWorld: BannerDeployRegion,
+  UnitedKingdom: BannerDeployRegion,
+  UnitedStates: BannerDeployRegion
+)
+
+object BannerDeploys {
+  // implicit val encoder = Encoder[BannerDeploys]
+  // implicit val decoder = Decoder[BannerDeploys]
+}

--- a/app/models/BannerDeploy.scala
+++ b/app/models/BannerDeploy.scala
@@ -1,8 +1,5 @@
 package models
 
-import io.circe.generic.extras.auto._
-import io.circe.{Decoder, Encoder}
-
 case class BannerDeployRegion(timestamp: Long, email: String)
 
 case class BannerDeploys(
@@ -12,8 +9,3 @@ case class BannerDeploys(
   UnitedKingdom: BannerDeployRegion,
   UnitedStates: BannerDeployRegion
 )
-
-object BannerDeploys {
-  // implicit val encoder = Encoder[BannerDeploys]
-  // implicit val decoder = Decoder[BannerDeploys]
-}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -63,6 +63,8 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new BannerTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestsController2(authAction, controllerComponents, wsClient, stage, runtime),
     new BannerTestArchiveController2(authAction, controllerComponents, wsClient, stage, runtime),
+    new BannerDeployController(authAction, controllerComponents, stage, runtime),
+    new BannerDeployController2(authAction, controllerComponents, stage, runtime),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -9,6 +9,7 @@ GET /amounts                                        controllers.Application.inde
 GET /epic-tests                                     controllers.Application.index
 GET /banner-tests                                   controllers.Application.index
 GET /banner-tests2                                  controllers.Application.index
+GET /banner-deploy                                  controllers.Application.index
 
 # ----- Authentication ----- #
 GET  /login                                         controllers.Login.login
@@ -57,6 +58,14 @@ POST  /frontend/banner-tests2/takecontrol              controllers.BannerTestsCo
 POST  /frontend/banner-tests2/archive                  controllers.BannerTestArchiveController2.set
 GET   /frontend/banner-tests2/archive/:testName        controllers.BannerTestArchiveController2.get(testName: String)
 GET   /frontend/banner-tests2/archived-test-names      controllers.BannerTestArchiveController2.list
+
+# ----- banner deploys ----- #
+GET   /frontend/banner-deploy                          controllers.BannerDeployController.get
+POST  /frontend/banner-deploy/update                   controllers.BannerDeployController.set
+
+# ----- banner deploys ----- #
+GET   /frontend/banner-deploy2                         controllers.BannerDeployController2.get
+POST  /frontend/banner-deploy2/update                  controllers.BannerDeployController2.set
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
@@ -30,7 +30,15 @@ export interface BannerDeploys {
   EuropeanUnion: BannerDeployRegion;
   RestOfWorld: BannerDeployRegion;
   UnitedStates: BannerDeployRegion;
-  UnitedKingom: BannerDeployRegion;
+  UnitedKingdom: BannerDeployRegion;
+}
+
+export interface BannersToRedeploy {
+  Australia: boolean;
+  EuropeanUnion: boolean;
+  RestOfWorld: boolean;
+  UnitedStates: boolean;
+  UnitedKingdom: boolean;
 }
 
 type BannerDeployChannelDeployerProps = WithStyles<typeof styles> & {
@@ -47,6 +55,30 @@ const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = 
     : FrontendSettingsType.bannerDeploy2;
 
   const [bannerDeploys, setBannerDeploys] = useState<BannerDeploys | null>(null);
+  const [bannersToRedeploy, setBannersToRedeploy] = useState<BannersToRedeploy>({
+    Australia: false,
+    EuropeanUnion: false,
+    RestOfWorld: false,
+    UnitedStates: false,
+    UnitedKingdom: false,
+  });
+
+  const onRedeployAllClick = (shouldRedeploy: boolean): void => {
+    setBannersToRedeploy({
+      Australia: shouldRedeploy,
+      EuropeanUnion: shouldRedeploy,
+      RestOfWorld: shouldRedeploy,
+      UnitedStates: shouldRedeploy,
+      UnitedKingdom: shouldRedeploy,
+    });
+  };
+
+  const onRedeployClick = (region: string, shouldRedeploy: boolean): void => {
+    setBannersToRedeploy({
+      ...bannersToRedeploy,
+      [region as keyof BannersToRedeploy]: shouldRedeploy,
+    });
+  };
 
   useEffect(() => {
     fetchFrontendSettings(settingsType)
@@ -56,7 +88,13 @@ const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = 
 
   return (
     <div className={classes.container}>
-      <BannerChannelDeployerTable channel={channel} bannerDeploys={bannerDeploys} />
+      <BannerChannelDeployerTable
+        channel={channel}
+        bannerDeploys={bannerDeploys}
+        bannersToRedeploy={bannersToRedeploy}
+        onRedeployAllClick={onRedeployAllClick}
+        onRedeployClick={onRedeployClick}
+      />
 
       <Button color="primary" variant="contained" size="large">
         {isChannel1 ? 'Redeploy channel 1' : 'Redeploy channel 2'}

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from 'react';
+
+import { Button, Theme, withStyles, createStyles, WithStyles } from '@material-ui/core';
+import { BannerChannel } from './bannerDeployDashboard';
+import BannerChannelDeployerTable from './bannerDeployChannelDeployerTable';
+
+import {
+  fetchFrontendSettings,
+  saveFrontendSettings,
+  FrontendSettingsType,
+} from '../../../utils/requests';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const styles = ({ spacing }: Theme) =>
+  createStyles({
+    container: {
+      '& > * + *': {
+        marginTop: spacing(2),
+      },
+    },
+  });
+
+export interface BannerDeployRegion {
+  timestamp: number;
+  email: string;
+}
+
+export interface BannerDeploys {
+  Australia: BannerDeployRegion;
+  EuropeanUnion: BannerDeployRegion;
+  RestOfWorld: BannerDeployRegion;
+  UnitedStates: BannerDeployRegion;
+  UnitedKingom: BannerDeployRegion;
+}
+
+type BannerDeployChannelDeployerProps = WithStyles<typeof styles> & {
+  channel: BannerChannel;
+};
+
+const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = ({
+  classes,
+  channel,
+}: BannerDeployChannelDeployerProps) => {
+  const isChannel1 = channel === 'CHANNEL1';
+  const settingsType = isChannel1
+    ? FrontendSettingsType.bannerDeploy
+    : FrontendSettingsType.bannerDeploy2;
+
+  const [bannerDeploys, setBannerDeploys] = useState<BannerDeploys | null>(null);
+
+  useEffect(() => {
+    fetchFrontendSettings(settingsType)
+      .then(data => setBannerDeploys(data.value))
+      .catch(err => alert(err));
+  });
+
+  return (
+    <div className={classes.container}>
+      <BannerChannelDeployerTable channel={channel} bannerDeploys={bannerDeploys} />
+
+      <Button color="primary" variant="contained" size="large">
+        {isChannel1 ? 'Redeploy channel 1' : 'Redeploy channel 2'}
+      </Button>
+    </div>
+  );
+};
+
+// class Switchboard extends React.Component<Props, Switches> {
+//   state: Switches;
+//   previousStateFromServer: DataFromServer | null;
+
+//   UNSAFE_componentWillMount(): void {
+//     this.fetchStateFromServer();
+//   }
+
+//   fetchStateFromServer(): void {
+//     fetchSupportFrontendSettings(SupportFrontendSettingsType.switches).then(serverData => {
+//       this.previousStateFromServer = serverData;
+//       this.setState({
+//         ...serverData.value,
+//       });
+//     });
+//   }
+
+//   updateOneOffPaymentMethodSwitch(paymentMethod: string, switchState: SwitchState): void {
+//     this.setState(prevState =>
+//       update(prevState, {
+//         oneOffPaymentMethods: {
+//           [paymentMethod]: { $set: switchState },
+//         },
+//       }),
+//     );
+//   }
+
+//   updateRecurringPaymentMethodSwitch(paymentMethod: string, switchState: SwitchState): void {
+//     this.setState(prevState =>
+//       update(prevState, {
+//         recurringPaymentMethods: {
+//           [paymentMethod]: { $set: switchState },
+//         },
+//       }),
+//     );
+//   }
+
+//   updateFeatureSwitch(switchName: string, switchState: SwitchState): void {
+//     this.setState(prevState =>
+//       update(prevState, {
+//         experiments: {
+//           [switchName]: {
+//             state: { $set: switchState },
+//           },
+//         },
+//       }),
+//     );
+//   }
+
+//   saveSwitches = (): void => {
+//     const newState = update(this.previousStateFromServer, {
+//       value: { $set: this.state },
+//     });
+
+//     saveSupportFrontendSettings(SupportFrontendSettingsType.switches, newState)
+//       .then(resp => {
+//         if (!resp.ok) {
+//           resp.text().then(msg => alert(msg));
+//         }
+//         this.fetchStateFromServer();
+//       })
+//       .catch(resp => {
+//         alert(`Error while saving: ${resp}`);
+//         this.fetchStateFromServer();
+//       });
+//   };
+//   }
+// }
+
+export default withStyles(styles)(BannerDeployChannelDeployer);

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
@@ -143,7 +143,7 @@ const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = 
       />
 
       <Button onClick={redeploy} color="primary" variant="contained" size="large">
-        {isChannel1 ? 'Redeploy channel 1' : 'Redeploy channel 2'}
+        Redeploy channel {isChannel1 ? ' 1 ' : ' 2 '} in selected regions
       </Button>
     </div>
   );

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import {
+  Checkbox,
+  Paper,
+  Theme,
+  Table,
+  TableContainer,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Toolbar,
+  Typography,
+  withStyles,
+  createStyles,
+  WithStyles,
+} from '@material-ui/core';
+import { BannerChannel } from './bannerDeployDashboard';
+import { BannerDeploys } from './bannerDeployChannelDeployer';
+import BannerDeployChannelDeployerTableRow from './bannerDeployChannelDeployerTableRow';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const styles = ({ spacing }: Theme) =>
+  createStyles({
+    container: {
+      '& > * + *': {
+        marginTop: spacing(2),
+      },
+    },
+  });
+
+type BannerDeployChannelDeployerTableProps = WithStyles<typeof styles> & {
+  channel: BannerChannel;
+  bannerDeploys: BannerDeploys | null;
+};
+
+const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTableProps> = ({
+  channel,
+  bannerDeploys,
+}: BannerDeployChannelDeployerTableProps) => {
+  const isChannel1 = channel === 'CHANNEL1';
+
+  return (
+    <TableContainer component={Paper}>
+      <Toolbar>
+        <Typography variant="h6" id="tableTitle" component="div">
+          {isChannel1 ? 'Banner 1' : 'Banner 2'}
+        </Typography>
+      </Toolbar>
+      <Table aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell padding="checkbox">
+              <Checkbox />
+            </TableCell>
+            <TableCell>Region</TableCell>
+            <TableCell>Last Deploy (UTC)</TableCell>
+            <TableCell>User</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {bannerDeploys &&
+            Object.keys(bannerDeploys).map(region => (
+              <BannerDeployChannelDeployerTableRow
+                key={region}
+                region={region}
+                timestamp={bannerDeploys[region as keyof BannerDeploys].timestamp}
+                email={bannerDeploys[region as keyof BannerDeploys].email}
+              />
+            ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default withStyles(styles)(BannerDeployChannelDeployerTable);

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -32,7 +32,7 @@ const styles = ({ spacing }: Theme) =>
 
 type BannerDeployChannelDeployerTableProps = WithStyles<typeof styles> & {
   channel: BannerChannel;
-  bannerDeploys: BannerDeploys | null;
+  bannerDeploys?: BannerDeploys;
   bannersToRedeploy: BannersToRedeploy;
   onRedeployAllClick: (shouldRedeploy: boolean) => void;
   onRedeployClick: (region: string, shouldRedeploy: boolean) => void;

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -17,7 +17,7 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { BannerChannel } from './bannerDeployDashboard';
-import { BannerDeploys } from './bannerDeployChannelDeployer';
+import { BannerDeploys, BannersToRedeploy } from './bannerDeployChannelDeployer';
 import BannerDeployChannelDeployerTableRow from './bannerDeployChannelDeployerTableRow';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -33,13 +33,22 @@ const styles = ({ spacing }: Theme) =>
 type BannerDeployChannelDeployerTableProps = WithStyles<typeof styles> & {
   channel: BannerChannel;
   bannerDeploys: BannerDeploys | null;
+  bannersToRedeploy: BannersToRedeploy;
+  onRedeployAllClick: (shouldRedeploy: boolean) => void;
+  onRedeployClick: (region: string, shouldRedeploy: boolean) => void;
 };
 
 const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTableProps> = ({
   channel,
   bannerDeploys,
+  bannersToRedeploy,
+  onRedeployAllClick,
+  onRedeployClick,
 }: BannerDeployChannelDeployerTableProps) => {
   const isChannel1 = channel === 'CHANNEL1';
+  const shouldRedeployAllBanners = Object.values(bannersToRedeploy).every(
+    shouldRedeploy => shouldRedeploy,
+  );
 
   return (
     <TableContainer component={Paper}>
@@ -52,7 +61,10 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
         <TableHead>
           <TableRow>
             <TableCell padding="checkbox">
-              <Checkbox />
+              <Checkbox
+                checked={shouldRedeployAllBanners}
+                onChange={(event): void => onRedeployAllClick(event.target.checked)}
+              />
             </TableCell>
             <TableCell>Region</TableCell>
             <TableCell>Last Deploy (UTC)</TableCell>
@@ -67,6 +79,10 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
                 region={region}
                 timestamp={bannerDeploys[region as keyof BannerDeploys].timestamp}
                 email={bannerDeploys[region as keyof BannerDeploys].email}
+                shouldRedeploy={bannersToRedeploy[region as keyof BannersToRedeploy]}
+                onRedeployClick={(shouldRedeploy: boolean): void =>
+                  onRedeployClick(region, shouldRedeploy)
+                }
               />
             ))}
         </TableBody>

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
@@ -6,6 +6,8 @@ type BannerDeployChannelDeployerTableRowProps = {
   region: string;
   timestamp: number;
   email: string;
+  shouldRedeploy: boolean;
+  onRedeployClick: (shouldRedeploy: boolean) => void;
 };
 
 interface PrettifiedRegions {
@@ -64,11 +66,16 @@ const BannerDeployChannelDeployerTableRow: React.FC<BannerDeployChannelDeployerT
   region,
   timestamp,
   email,
+  shouldRedeploy,
+  onRedeployClick,
 }: BannerDeployChannelDeployerTableRowProps) => {
   return (
     <TableRow key={region}>
       <TableCell padding="checkbox">
-        <Checkbox />
+        <Checkbox
+          checked={shouldRedeploy}
+          onChange={(event): void => onRedeployClick(event.target.checked)}
+        />
       </TableCell>
       <TableCell>{prettifiedRegion(region)}</TableCell>
       <TableCell>{prettifiedTimestamp(timestamp)}</TableCell>

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { Checkbox, TableRow, TableCell } from '@material-ui/core';
+
+type BannerDeployChannelDeployerTableRowProps = {
+  region: string;
+  timestamp: number;
+  email: string;
+};
+
+interface PrettifiedRegions {
+  Australia: string;
+  EuropeanUnion: string;
+  RestOfWorld: string;
+  UnitedStates: string;
+  UnitedKingdom: string;
+}
+
+const REGION_TO_PRETTIFIED_STRING: PrettifiedRegions = {
+  Australia: 'Australia',
+  EuropeanUnion: 'European Union',
+  RestOfWorld: 'Rest of World',
+  UnitedStates: 'United States',
+  UnitedKingdom: 'United Kingdom',
+};
+const prettifiedRegion = (region: string): string =>
+  REGION_TO_PRETTIFIED_STRING[region as keyof PrettifiedRegions];
+
+const prettifiedTimestamp = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  const day = date
+    .getUTCDay()
+    .toString()
+    .padStart(2, '0');
+  const month = date
+    .getUTCMonth()
+    .toString()
+    .padStart(2, '0');
+  const year = date.getUTCFullYear();
+
+  const hour = date
+    .getUTCHours()
+    .toString()
+    .padStart(2, '0');
+
+  const minute = date
+    .getUTCMinutes()
+    .toString()
+    .padStart(2, '0');
+
+  return `${hour}:${minute} - ${day}/${month}/${year}`;
+};
+
+const prettifiedUser = (email: string): string => {
+  const nameArr: RegExpMatchArray | null = email.match(/^([a-z]*)\.([a-z]*).*@.*/);
+  return nameArr
+    ? `${nameArr[1][0].toUpperCase()}${nameArr[1].slice(
+        1,
+      )} ${nameArr[2][0].toUpperCase()}${nameArr[2].slice(1)}`
+    : email;
+};
+
+const BannerDeployChannelDeployerTableRow: React.FC<BannerDeployChannelDeployerTableRowProps> = ({
+  region,
+  timestamp,
+  email,
+}: BannerDeployChannelDeployerTableRowProps) => {
+  return (
+    <TableRow key={region}>
+      <TableCell padding="checkbox">
+        <Checkbox />
+      </TableCell>
+      <TableCell>{prettifiedRegion(region)}</TableCell>
+      <TableCell>{prettifiedTimestamp(timestamp)}</TableCell>
+      <TableCell>{prettifiedUser(email)}</TableCell>
+    </TableRow>
+  );
+};
+
+export default BannerDeployChannelDeployerTableRow;

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { Theme, withStyles, createStyles, WithStyles } from '@material-ui/core';
+
+import BannerDeployeChannelDeployer from './bannerDeployChannelDeployer';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const styles = ({ spacing }: Theme) =>
+  createStyles({
+    scrollableContainer: {
+      overflow: 'auto',
+    },
+    container: {
+      padding: `${spacing(6)}px ${spacing(9)}px`,
+
+      '& > * + *': {
+        marginTop: spacing(4),
+      },
+    },
+    tableContainer: {
+      width: '45%',
+    },
+  });
+
+export type BannerChannel = 'CHANNEL1' | 'CHANNEL2';
+
+type BannerDeployDashboardProps = WithStyles<typeof styles>;
+
+const BannerDeployDashboard: React.FC<BannerDeployDashboardProps> = ({
+  classes,
+}: BannerDeployDashboardProps) => {
+  return (
+    <div className={classes.scrollableContainer}>
+      <div className={classes.container}>
+        <div className={classes.tableContainer}>
+          <BannerDeployeChannelDeployer channel="CHANNEL1" />
+        </div>
+        <div className={classes.tableContainer}>
+          <BannerDeployeChannelDeployer channel="CHANNEL2" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default withStyles(styles)(BannerDeployDashboard);

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -136,6 +136,11 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Banner 2" />
           </ListItem>
         </Link>
+        <Link key="Banner Deploy" to="/banner-deploy" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Banner Deploy">
+            <ListItemText primary="Banner Deploy" />
+          </ListItem>
+        </Link>
       </div>
 
       <div>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Switchboard from './components/switchboard';
+import BannerDeployDashboard from './components/channelManagement/bannerDeploy/bannerDeployDashboard';
 import ContributionTypesForm from './components/contributionTypes';
 import AmountsForm from './components/amounts/amounts';
 import EpicTestsForm from './components/channelManagement/epicTests/epicTestsForm';
@@ -102,6 +103,12 @@ const AppRouter = withStyles(styles)(({ classes }: Props) => {
         <Route
           path="/banner-tests2"
           render={(): React.ReactElement => createComponent(<BannerTestsForm2 />, 'Banner Tests 2')}
+        />
+        <Route
+          path="/banner-deploy"
+          render={(): React.ReactElement =>
+            createComponent(<BannerDeployDashboard />, 'Banner Deploy')
+          }
         />
       </div>
     </Router>

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -10,6 +10,8 @@ export enum FrontendSettingsType {
   epicTests = 'epic-tests',
   bannerTests = 'banner-tests',
   bannerTests2 = 'banner-tests2',
+  bannerDeploy = 'banner-deploy',
+  bannerDeploy2 = 'banner-deploy2',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What does this change?
Add the banner redeploy dashboard to the admin console, as per [this card](https://trello.com/c/DU1qFTro/2326-new-banner-redeploy-tool)

## Images
<img width="859" alt="Screenshot 2020-10-08 at 15 34 32" src="https://user-images.githubusercontent.com/17720442/95473299-dee35580-097b-11eb-9c13-cfced36845fd.png">

