### PR TITLE
Fix scroll on amounts page

### DIFF
--- a/public/src/components/amounts/amounts.tsx
+++ b/public/src/components/amounts/amounts.tsx
@@ -47,6 +47,8 @@ const styles = ({ palette, spacing }: Theme) =>
     form: {
       display: 'flex',
       flexDirection: 'row',
+      overflow: 'auto',
+      marginTop: '20px',
     },
     button: {
       marginRight: spacing(2),


### PR DESCRIPTION
The main container now has `overflow: 'hidden'`, which breaks the amounts page.