### PR TITLE
Update deploy date display

### DIFF
--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
@@ -31,13 +31,10 @@ const prettifiedRegion = (region: string): string =>
 const prettifiedTimestamp = (timestamp: number): string => {
   const date = new Date(timestamp);
   const day = date
-    .getUTCDay()
+    .getUTCDate()
     .toString()
     .padStart(2, '0');
-  const month = date
-    .getUTCMonth()
-    .toString()
-    .padStart(2, '0');
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
   const year = date.getUTCFullYear();
 
   const hour = date
@@ -50,7 +47,7 @@ const prettifiedTimestamp = (timestamp: number): string => {
     .toString()
     .padStart(2, '0');
 
-  return `${hour}:${minute} - ${day}/${month}/${year}`;
+  return `${year}/${month}/${day} - ${hour}:${minute}`;
 };
 
 const prettifiedUser = (email: string): string => {


### PR DESCRIPTION
## What does this change?
Fixes + updates the banner deploy date. 

There were a couple of bugs:
- we used `getUTCDay` (returns a number from 0-6 which is the current day of week) instead of `getUTCDate` (returns a number from 1-31)
- we didn't +1 to `getUTCMonth` (javascript months run from 0-11)

The update we made was to invert the order so now we have `year/month/day - hour:minute` instead of `hour: minute - year/month/day` to avoid any confusion with UK/US date formats

## Images

before:
<img width="695" alt="Screenshot 2020-10-23 at 16 13 27" src="https://user-images.githubusercontent.com/17720442/97022382-f578d780-154b-11eb-83e3-3ce71d43bb7b.png">

after:
<img width="695" alt="Screenshot 2020-10-23 at 16 15 23" src="https://user-images.githubusercontent.com/17720442/97022399-f873c800-154b-11eb-84c0-8021b5f0373d.png">

(the deploy date was Friday the 23rd October 2020)
