### PR TITLE
Fix EpicTestTargetContentEditor

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestTargetContentEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestTargetContentEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { Theme, makeStyles, TextField } from '@material-ui/core';
 
@@ -49,7 +49,16 @@ const EpicTestTargetContentEditor: React.FC<EpicTestTargetContentEditorProps> = 
     excludeSections: excludeSections.join(','),
   };
 
-  const { register, handleSubmit } = useForm<FormData>({ defaultValues });
+  const { register, handleSubmit, reset } = useForm<FormData>({ defaultValues });
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [
+    defaultValues.tagIds,
+    defaultValues.sections,
+    defaultValues.excludeTagIds,
+    defaultValues.excludeSections,
+  ]);
 
   const onSubmit = ({ tagIds, sections, excludeTagIds, excludeSections }: FormData): void => {
     updateTargetContent(


### PR DESCRIPTION
## What does this change?
Fix the `EpicTestTargetContentEditor`. `react-hook-form` caches the `defaultValues` field, which means when a new test is selected, it still displays the old data. We had this same issue with the article count editor too.