### PR TITLE
Make label always at the top

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestTargetContentEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestTargetContentEditor.tsx
@@ -78,6 +78,7 @@ const EpicTestTargetContentEditor: React.FC<EpicTestTargetContentEditorProps> = 
         helperText="Format: environment/wildlife,business/economics"
         onBlur={handleSubmit(onSubmit)}
         margin="normal"
+        InputLabelProps={{ shrink: true }}
         variant="outlined"
         disabled={!editMode}
         fullWidth
@@ -90,6 +91,7 @@ const EpicTestTargetContentEditor: React.FC<EpicTestTargetContentEditorProps> = 
         helperText="Format: environment,business"
         onBlur={handleSubmit(onSubmit)}
         margin="normal"
+        InputLabelProps={{ shrink: true }}
         variant="outlined"
         disabled={!editMode}
         fullWidth
@@ -102,6 +104,7 @@ const EpicTestTargetContentEditor: React.FC<EpicTestTargetContentEditorProps> = 
         helperText="Format: environment/wildlife,business/economics"
         onBlur={handleSubmit(onSubmit)}
         margin="normal"
+        InputLabelProps={{ shrink: true }}
         variant="outlined"
         disabled={!editMode}
         fullWidth
@@ -114,6 +117,7 @@ const EpicTestTargetContentEditor: React.FC<EpicTestTargetContentEditorProps> = 
         helperText="Format: environment,business"
         onBlur={handleSubmit(onSubmit)}
         margin="normal"
+        InputLabelProps={{ shrink: true }}
         variant="outlined"
         disabled={!editMode}
         fullWidth


### PR DESCRIPTION
## What does this change?
Follow up fix for #170. After that fix, if you have a test selected that doesn't have any target tags (so that the field label is in the middle of the field) and then swap to a test that does have some, the label doesn't move, and gets in the way of the content.

<img width="355" alt="Screenshot 2020-10-27 at 08 44 26" src="https://user-images.githubusercontent.com/17720442/97278621-eb97f280-1831-11eb-9a4f-4c9634f7291c.png">

As a quick fix, we now just always force the label to be in the top corner. 