### PR TITLE
Fix parsing of list fields

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestTargetContentEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestTargetContentEditor.tsx
@@ -18,6 +18,8 @@ interface FormData {
   excludeSections: string;
 }
 
+const parseList = (list: string): string[] => list.split(',').filter(item => !!item);
+
 interface EpicTestTargetContentEditorProps {
   tagIds: string[];
   sections: string[];
@@ -62,10 +64,10 @@ const EpicTestTargetContentEditor: React.FC<EpicTestTargetContentEditorProps> = 
 
   const onSubmit = ({ tagIds, sections, excludeTagIds, excludeSections }: FormData): void => {
     updateTargetContent(
-      tagIds.split(','),
-      sections.split(','),
-      excludeTagIds.split(','),
-      excludeSections.split(','),
+      parseList(tagIds),
+      parseList(sections),
+      parseList(excludeTagIds),
+      parseList(excludeSections),
     );
   };
 


### PR DESCRIPTION
## What does this change?
Before list fields were parsed just using `.split(',')`, which meant an empty string was parsed as `['']`. Now we filter that list to remove an blank entries. 

TODO
- manually fix the affected tests