### PR TITLE
Fix max views component

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -214,6 +214,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   const onMaxViewsChange = (updatedMaxViews?: MaxEpicViews): void => {
     updateTest(test => ({
       ...test,
+      alwaysAsk: !updatedMaxViews,
       maxViews: updatedMaxViews,
     }));
   };
@@ -311,7 +312,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         />
 
         <EpicTestMaxViewsEditor
-          maxEpicViews={test.maxViews}
+          maxEpicViews={test.alwaysAsk ? undefined : test.maxViews}
           isDisabled={!isEditable()}
           onMaxViewsChanged={onMaxViewsChange}
           onValidationChange={onMaxViewsValidationChange}

--- a/public/src/components/channelManagement/epicTests/epicTestMaxViewsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestMaxViewsEditor.tsx
@@ -47,7 +47,7 @@ interface TestEditorArticleCountEditorProps {
   isDisabled: boolean;
 }
 
-const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> = ({
+const EpicTestMaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
   maxEpicViews,
   onMaxViewsChanged,
   onValidationChange,
@@ -99,14 +99,14 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
             value="disabled"
             key="disabled"
             control={<Radio />}
-            label="Do not show user's article count"
+            label="Always ask"
             disabled={isDisabled}
           />
           <FormControlLabel
             value="enabled"
             key="enabled"
             control={<Radio />}
-            label="Show user's article count"
+            label="Use max views settings..."
             disabled={isDisabled}
           />
         </RadioGroup>
@@ -171,4 +171,4 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
   );
 };
 
-export default TestEditorArticleCountEditor;
+export default EpicTestMaxViewsEditor;


### PR DESCRIPTION
Now: if `maxEpicViews` is `undefined` then `alwaysAsk` is true


<img width="526" alt="Screen Shot 2020-11-02 at 09 13 06" src="https://user-images.githubusercontent.com/1513454/97850345-d288b900-1ceb-11eb-91c8-15a671ff7ba4.png">
<img width="526" alt="Screen Shot 2020-11-02 at 09 13 12" src="https://user-images.githubusercontent.com/1513454/97850348-d3b9e600-1ceb-11eb-9eb1-e7fb9a6e345a.png">
