### PR TITLE
Fix epic preview

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -223,6 +223,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
               variants={test.variants}
               createVariant={createVariant}
               testName={test.name}
+              testType="BANNER"
               editMode={isEditable()}
               renderVariantEditor={renderVariantEditor}
               onVariantDelete={onVariantDelete}

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -258,6 +258,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
           <TestVariantsEditor<EpicVariant>
             variants={test.variants}
             testName={test.name}
+            testType="EPIC"
             editMode={isEditable()}
             createVariant={createVariant}
             renderVariantEditor={renderVariantEditor}

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -4,6 +4,8 @@ export interface Variant {
   name: string;
 }
 
+export type TestType = 'EPIC' | 'BANNER';
+
 export interface Test {
   name: string;
   nickname?: string;

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -10,6 +10,7 @@ import {
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
 import TestEditorVariantSummaryPreviewButton from './testEditorVariantSummaryPreviewButton';
+import { TestType } from './helpers/shared';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>
@@ -43,6 +44,7 @@ const styles = ({ spacing, palette }: Theme) =>
 interface TestEditorVariantSummaryProps extends WithStyles<typeof styles> {
   name: string;
   testName: string;
+  testType: TestType;
   isInEditMode: boolean;
 }
 
@@ -50,6 +52,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
   classes,
   name,
   testName,
+  testType,
   isInEditMode,
 }: TestEditorVariantSummaryProps) => {
   return (
@@ -65,7 +68,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
         <TestEditorVariantSummaryPreviewButton
           name={name}
           testName={testName}
-          testType="BANNER" // will have to change this to make it more reusable
+          testType={testType}
           isDisabled={isInEditMode}
         />
       </div>

--- a/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
+import { TestType } from './helpers/shared';
 
-type TestType = 'EPIC' | 'BANNER';
 type Stage = 'DEV' | 'CODE' | 'PROD';
 
 declare global {

--- a/public/src/components/channelManagement/testVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/testVariantEditorsAccordion.tsx
@@ -6,7 +6,7 @@ import {
   AccordionDetails,
   AccordionActions,
 } from '@material-ui/core';
-import { Variant } from './helpers/shared';
+import { Variant, TestType } from './helpers/shared';
 import TestEditorVariantSummary from './testEditorVariantSummary';
 import VariantDeleteButton from './variantDeleteButton';
 
@@ -27,6 +27,7 @@ interface TestVariantEditorsAccordionProps<V extends Variant> {
   variants: V[];
   variantKeys: string[];
   testName: string;
+  testType: TestType;
   editMode: boolean;
   selectedVariantKey: string | null;
   onVariantSelected: (variantKey: string) => void;
@@ -38,6 +39,7 @@ function TestVariantEditorsAccordion<V extends Variant>({
   variants,
   variantKeys,
   testName,
+  testType,
   editMode,
   selectedVariantKey,
   onVariantSelected,
@@ -61,6 +63,7 @@ function TestVariantEditorsAccordion<V extends Variant>({
             <TestEditorVariantSummary
               name={variant.name}
               testName={testName}
+              testType={testType}
               isInEditMode={editMode}
             />
             <AccordionDetails>{renderVariantEditor(variant)}</AccordionDetails>

--- a/public/src/components/channelManagement/testVariantsEditor.tsx
+++ b/public/src/components/channelManagement/testVariantsEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { makeStyles, Theme } from '@material-ui/core';
-import { Variant } from './helpers/shared';
+import { Variant, TestType } from './helpers/shared';
 import TestNewVariantButton from './testNewVariantButton';
 import TestVariantEditorsAccordion from './testVariantEditorsAccordion';
 
@@ -15,6 +15,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 interface TestVariantsEditorProps<V extends Variant> {
   variants: V[];
   testName: string;
+  testType: TestType;
   editMode: boolean;
   createVariant: (name: string) => void;
   renderVariantEditor: (variant: V) => React.ReactElement;
@@ -24,6 +25,7 @@ interface TestVariantsEditorProps<V extends Variant> {
 function TestVariantsEditor<V extends Variant>({
   variants,
   testName,
+  testType,
   editMode,
   createVariant,
   renderVariantEditor,
@@ -48,6 +50,7 @@ function TestVariantsEditor<V extends Variant>({
         variants={variants}
         variantKeys={variantKeys}
         testName={testName}
+        testType={testType}
         editMode={editMode}
         selectedVariantKey={selectedVariantKey}
         onVariantSelected={onVariantSelected}


### PR DESCRIPTION
## What does this change?
Fix the epic preview feature. Before, the `TestEditorVariantSummary` component used the hard coded value `"BANNER"` as the `testType`. I didn't spot this when implementing the new components for the epic manager which means the preview links for epics have `force-banner` in the url, instead of `force-epic`. Now the `testType` is passed all the way down from the `EpicTestEditor`/`BannerTestEditor`.