### PR TITLE
Show apple news in drawer

### DIFF
--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -135,12 +135,12 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Liveblog Epic" />
           </ListItem>
         </Link>
-        {/*<Link key="Apple News Epic" to="/apple-news-epic-tests" className={classes.link}>*/}
-        {/*<ListItem className={classes.listItem} button key="Apple News Epic">*/}
-        {/*<ListItemText primary="Apple News Epic" />*/}
-        {/*<img className={classes.icon} src="assets/images/apple-news-icon.png" />*/}
-        {/*</ListItem>*/}
-        {/*</Link>*/}
+        <Link key="Apple News Epic" to="/apple-news-epic-tests" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Apple News Epic">
+            <ListItemText primary="Apple News Epic" />
+            <img className={classes.icon} src="assets/images/apple-news-icon.png" />
+          </ListItem>
+        </Link>
         <Link key="AMP Epic" to="/amp-epic-tests" className={classes.link}>
           <ListItem className={classes.listItem} button key="AMP Epic">
             <ListItemText primary="AMP Epic" />


### PR DESCRIPTION
## What does this change?
Unhide the apple news link in the drawer!

## Images
<img width="352" alt="Screenshot 2020-11-13 at 09 49 58" src="https://user-images.githubusercontent.com/17720442/99059279-45205100-2596-11eb-8dc0-bffc42225773.png">
