### PR TITLE
Refactor testEditor 

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -91,10 +91,6 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   testNicknames,
   createTest,
 }: BannerTestEditorProps) => {
-  const isEditable = (): boolean => {
-    return editMode;
-  };
-
   const setValidationStatusForField = useValidation(onValidationChange);
 
   const onMinArticlesViewedValidationChanged = (isValid: boolean): void =>
@@ -204,7 +200,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
 
           <TestEditorLiveSwitch
             isChecked={test.isOn}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
             onChange={onLiveSwitchChange}
           />
         </div>
@@ -219,7 +215,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
               createVariant={createVariant}
               testName={test.name}
               testType="BANNER"
-              editMode={isEditable()}
+              editMode={editMode}
               renderVariantEditor={renderVariantEditor}
               onVariantDelete={onVariantDelete}
             />
@@ -233,7 +229,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
 
           <TestEditorMinArticlesViewedInput
             minArticles={test.minArticlesBeforeShowingBanner}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
             onValidationChange={onMinArticlesViewedValidationChanged}
             onUpdate={onMinArticlesViewedChange}
           />
@@ -249,7 +245,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
             onRegionsUpdate={onRegionsChange}
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
             showSupporterStatusSelector={true}
           />
         </div>
@@ -263,14 +259,14 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
             articlesViewedSettings={test.articlesViewedSettings}
             onArticlesViewedSettingsChanged={onArticlesViewedSettingsChange}
             onValidationChange={onArticlesViewedSettingsValidationChanged}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
           />
         </div>
         <div className={classes.buttonsContainer}>
           <TestEditorActionButtons
             existingNames={testNames}
             existingNicknames={testNicknames}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
             onArchive={onArchive}
             onDelete={onDelete}
             onCopy={onCopy}

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -71,7 +71,7 @@ interface BannerTestEditorProps extends WithStyles<typeof styles> {
   editMode: boolean;
   onDelete: () => void;
   onArchive: () => void;
-  onSelectedTestName: (testName: string) => void;
+  onTestSelected: (testName: string) => void;
   testNames: string[];
   testNicknames: string[];
   createTest: (newTest: BannerTest) => void;
@@ -86,7 +86,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   editMode,
   onArchive,
   onDelete,
-  onSelectedTestName,
+  onTestSelected,
   testNames,
   testNicknames,
   createTest,
@@ -162,7 +162,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   };
 
   const onCopy = (name: string, nickname: string): void => {
-    onSelectedTestName(name);
+    onTestSelected(name);
     createTest({ ...test, name: name, nickname: nickname, isOn: false });
   };
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -72,9 +72,6 @@ interface BannerTestEditorProps extends WithStyles<typeof styles> {
   onDelete: () => void;
   onArchive: () => void;
   onSelectedTestName: (testName: string) => void;
-  isDeleted: boolean;
-  isArchived: boolean;
-  isNew: boolean;
   testNames: string[];
   testNicknames: string[];
   createTest: (newTest: BannerTest) => void;
@@ -87,8 +84,6 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   onValidationChange,
   visible,
   editMode,
-  isDeleted,
-  isArchived,
   onArchive,
   onDelete,
   onSelectedTestName,
@@ -97,7 +92,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
   createTest,
 }: BannerTestEditorProps) => {
   const isEditable = (): boolean => {
-    return editMode && !isDeleted && !isArchived;
+    return editMode;
   };
 
   const setValidationStatusForField = useValidation(onValidationChange);

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -1,4 +1,4 @@
-import TestsForm, { InnerComponentProps, updateTest } from '../testEditor';
+import TestsForm, { InnerComponentProps } from '../testEditor';
 import React from 'react';
 import { FrontendSettingsType } from '../../../utils/requests';
 import Sidebar from '../sidebar';
@@ -25,15 +25,16 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
     tests,
     modifiedTests,
     selectedTestName,
+    onTestChange,
     onTestsChange,
     onSelectedTestName,
+    onTestSave,
     onTestDelete,
     onTestArchive,
     onTestErrorStatusChange,
     lockStatus,
     requestTakeControl,
     requestLock,
-    save,
     cancel,
     editMode,
   }: Props) => {
@@ -68,14 +69,12 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
             <BannerTestEditor
               test={selectedTest}
               hasChanged={!!modifiedTests[selectedTestName]}
-              onChange={(updatedTest): void =>
-                onTestsChange(updateTest(tests, updatedTest), updatedTest.name)
-              }
-              onValidationChange={onTestErrorStatusChange(selectedTestName)}
+              onChange={onTestChange}
+              onValidationChange={onTestErrorStatusChange}
               visible
               editMode={editMode}
-              onDelete={(): void => onTestDelete(selectedTestName)}
-              onArchive={(): void => onTestArchive(selectedTestName)}
+              onDelete={onTestDelete}
+              onArchive={onTestArchive}
               onSelectedTestName={onSelectedTestName}
               isDeleted={
                 modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted
@@ -99,7 +98,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
         lockStatus={lockStatus}
         requestTakeControl={requestTakeControl}
         requestLock={requestLock}
-        save={save}
+        save={onTestSave}
         cancel={cancel}
         editMode={editMode}
       />

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -27,7 +27,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
     selectedTestHasBeenModified,
     onTestChange,
     onTestPriorityChange,
-    onSelectedTestName,
+    onTestSelected,
     onTestSave,
     onTestDelete,
     onTestArchive,
@@ -56,7 +56,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
             tests={tests}
             selectedTestName={selectedTestName}
             onTestPriorityChange={onTestPriorityChange}
-            onSelectedTestName={onSelectedTestName}
+            onTestSelected={onTestSelected}
             createTest={createTest}
             isInEditMode={editMode}
           />
@@ -73,7 +73,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
               editMode={editMode}
               onDelete={onTestDelete}
               onArchive={onTestArchive}
-              onSelectedTestName={onSelectedTestName}
+              onTestSelected={onTestSelected}
               createTest={onTestCreate}
               testNames={tests.map(test => test.name)}
               testNicknames={

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -23,14 +23,15 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
 
   const BannerTestsForm: React.FC<Props> = ({
     tests,
-    modifiedTests,
     selectedTestName,
+    selectedTestHasBeenModified,
     onTestChange,
-    onTestsChange,
+    onTestPriorityChange,
     onSelectedTestName,
     onTestSave,
     onTestDelete,
     onTestArchive,
+    onTestCreate,
     onTestErrorStatusChange,
     lockStatus,
     requestTakeControl,
@@ -39,12 +40,10 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
     editMode,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
-      if (Object.keys(modifiedTests).length > 0) {
+      if (selectedTestHasBeenModified) {
         alert('Please either save or discard before creating a test.');
       } else {
-        const newTests = [...tests, createDefaultBannerTest(name, nickname)];
-        onSelectedTestName(name);
-        onTestsChange(newTests, name);
+        onTestCreate(createDefaultBannerTest(name, nickname));
       }
     };
 
@@ -55,9 +54,8 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
         sidebar={
           <Sidebar<BannerTest>
             tests={tests}
-            modifiedTests={modifiedTests}
             selectedTestName={selectedTestName}
-            onUpdate={onTestsChange}
+            onTestPriorityChange={onTestPriorityChange}
             onSelectedTestName={onSelectedTestName}
             createTest={createTest}
             isInEditMode={editMode}
@@ -68,7 +66,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
           selectedTestName && selectedTest ? (
             <BannerTestEditor
               test={selectedTest}
-              hasChanged={!!modifiedTests[selectedTestName]}
+              hasChanged={selectedTestHasBeenModified}
               onChange={onTestChange}
               onValidationChange={onTestErrorStatusChange}
               visible
@@ -76,17 +74,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
               onDelete={onTestDelete}
               onArchive={onTestArchive}
               onSelectedTestName={onSelectedTestName}
-              isDeleted={
-                modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted
-              }
-              isArchived={
-                modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isArchived
-              }
-              isNew={modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isNew}
-              createTest={(newTest: BannerTest): void => {
-                const newTests = [...tests, newTest];
-                onTestsChange(newTests, newTest.name);
-              }}
+              createTest={onTestCreate}
               testNames={tests.map(test => test.name)}
               testNicknames={
                 tests.map(test => test.nickname).filter(nickname => !!nickname) as string[]

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -71,7 +71,7 @@ interface EpicTestEditorProps {
   editMode: boolean;
   onDelete: () => void;
   onArchive: () => void;
-  onSelectedTestName: (testName: string) => void;
+  onTestSelected: (testName: string) => void;
   testNames: string[];
   testNicknames: string[];
   createTest: (newTest: EpicTest) => void;
@@ -84,7 +84,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   editMode,
   onDelete,
   onArchive,
-  onSelectedTestName,
+  onTestSelected,
   testNames,
   testNicknames,
   createTest,
@@ -213,7 +213,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   };
 
   const onCopy = (name: string, nickname: string): void => {
-    onSelectedTestName(name);
+    onTestSelected(name);
     createTest({ ...test, name: name, nickname: nickname, isOn: false });
   };
 

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -102,10 +102,6 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   const onArticlesViewedSettingsValidationChanged = (isValid: boolean): void =>
     setValidationStatusForField('articlesViewedSettings', isValid);
 
-  const isEditable = (): boolean => {
-    return editMode;
-  };
-
   const getArticlesViewedSettings = (test: EpicTest): ArticlesViewedSettings | undefined => {
     if (!!test.articlesViewedSettings) {
       return test.articlesViewedSettings;
@@ -242,7 +238,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
 
         <TestEditorLiveSwitch
           isChecked={test.isOn}
-          isDisabled={!isEditable()}
+          isDisabled={!editMode}
           onChange={onLiveSwitchChange}
         />
       </div>
@@ -257,7 +253,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
               variants={test.variants}
               testName={test.name}
               testType="EPIC"
-              editMode={isEditable()}
+              editMode={editMode}
               createVariant={createVariant}
               renderVariantEditor={renderVariantEditor}
               onVariantDelete={onVariantDelete}
@@ -299,7 +295,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             sections={test.sections}
             excludeTagIds={test.excludedTagIds}
             excludeSections={test.excludedSections}
-            editMode={isEditable()}
+            editMode={editMode}
             updateTargetContent={updateTargetSections}
           />
         </div>
@@ -316,7 +312,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             onRegionsUpdate={onRegionsChange}
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
             showSupporterStatusSelector={epicType !== 'AMP'}
           />
         </div>
@@ -333,7 +329,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
               <Switch
                 checked={test.useLocalViewLog}
                 onChange={onSwitchChange('useLocalViewLog')}
-                disabled={!isEditable()}
+                disabled={!editMode}
               />
             }
             label={`Use private view counter for this test (instead of the global one)`}
@@ -341,7 +337,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
 
           <EpicTestMaxViewsEditor
             maxEpicViews={test.alwaysAsk ? undefined : test.maxViews}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
             onMaxViewsChanged={onMaxViewsChange}
             onValidationChange={onMaxViewsValidationChange}
           />
@@ -358,7 +354,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             articlesViewedSettings={test.articlesViewedSettings}
             onArticlesViewedSettingsChanged={onArticlesViewedSettingsChange}
             onValidationChange={onArticlesViewedSettingsValidationChanged}
-            isDisabled={!isEditable()}
+            isDisabled={!editMode}
           />
         </div>
       )}
@@ -367,7 +363,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         <TestEditorActionButtons
           existingNames={testNames}
           existingNicknames={testNicknames}
-          isDisabled={!isEditable()}
+          isDisabled={!editMode}
           onArchive={onArchive}
           onDelete={onDelete}
           onCopy={onCopy}

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -72,9 +72,6 @@ interface EpicTestEditorProps {
   onDelete: () => void;
   onArchive: () => void;
   onSelectedTestName: (testName: string) => void;
-  isDeleted: boolean;
-  isArchived: boolean;
-  isNew: boolean;
   testNames: string[];
   testNicknames: string[];
   createTest: (newTest: EpicTest) => void;
@@ -88,8 +85,6 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   onDelete,
   onArchive,
   onSelectedTestName,
-  isDeleted,
-  isArchived,
   testNames,
   testNicknames,
   createTest,
@@ -108,7 +103,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
     setValidationStatusForField('articlesViewedSettings', isValid);
 
   const isEditable = (): boolean => {
-    return editMode && !isDeleted && !isArchived;
+    return editMode;
   };
 
   const getArticlesViewedSettings = (test: EpicTest): ArticlesViewedSettings | undefined => {

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -118,13 +118,13 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
     selectedTestName,
     onTestsChange,
     onSelectedTestName,
+    onTestSave,
     onTestDelete,
     onTestArchive,
     onTestErrorStatusChange,
     lockStatus,
     requestTakeControl,
     requestLock,
-    save,
     cancel,
     editMode,
   }: Props) => {
@@ -162,11 +162,11 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
               onChange={(updatedTest): void =>
                 onTestsChange(updateTest(tests, updatedTest), updatedTest.name)
               }
-              onValidationChange={onTestErrorStatusChange(selectedTestName)}
+              onValidationChange={onTestErrorStatusChange}
               visible
               editMode={editMode}
-              onDelete={(): void => onTestDelete(selectedTestName)}
-              onArchive={(): void => onTestArchive(selectedTestName)}
+              onDelete={onTestDelete}
+              onArchive={onTestArchive}
               onSelectedTestName={onSelectedTestName}
               isDeleted={
                 modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted
@@ -190,7 +190,7 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
         lockStatus={lockStatus}
         requestTakeControl={requestTakeControl}
         requestLock={requestLock}
-        save={save}
+        save={onTestSave}
         cancel={cancel}
         editMode={editMode}
       />

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -116,7 +116,7 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
     tests,
     selectedTestName,
     selectedTestHasBeenModified,
-    onSelectedTestName,
+    onTestSelected,
     onTestSave,
     onTestDelete,
     onTestArchive,
@@ -147,7 +147,7 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
             tests={tests}
             selectedTestName={selectedTestName}
             onTestPriorityChange={onTestPriorityChange}
-            onSelectedTestName={onSelectedTestName}
+            onTestSelected={onTestSelected}
             createTest={createTest}
             isInEditMode={editMode}
           />
@@ -164,7 +164,7 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
               editMode={editMode}
               onDelete={onTestDelete}
               onArchive={onTestArchive}
-              onSelectedTestName={onSelectedTestName}
+              onTestSelected={onTestSelected}
               createTest={onTestCreate}
               testNames={tests.map(test => test.name)}
               testNicknames={

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -11,7 +11,7 @@ import {
   EpicType,
   defaultCta,
 } from '../helpers/shared';
-import { InnerComponentProps, updateTest } from '../testEditor';
+import { InnerComponentProps } from '../testEditor';
 import TestsForm from '../testEditor';
 import TestsFormLayout from '../testsFormLayout';
 import Sidebar from '../sidebar';
@@ -114,14 +114,16 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
 
   const EpicTestsForm: React.FC<Props> = ({
     tests,
-    modifiedTests,
     selectedTestName,
-    onTestsChange,
+    selectedTestHasBeenModified,
     onSelectedTestName,
     onTestSave,
     onTestDelete,
     onTestArchive,
     onTestErrorStatusChange,
+    onTestChange,
+    onTestCreate,
+    onTestPriorityChange,
     lockStatus,
     requestTakeControl,
     requestLock,
@@ -129,12 +131,10 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
     editMode,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
-      if (Object.keys(modifiedTests).length > 0) {
+      if (selectedTestHasBeenModified) {
         alert('Please either save or discard before creating a test.');
       } else {
-        const newTests = [...tests, createDefaultEpicTest(name, nickname)];
-        onSelectedTestName(name);
-        onTestsChange(newTests, name);
+        onTestCreate(createDefaultEpicTest(name, nickname));
       }
     };
 
@@ -145,9 +145,8 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
         sidebar={
           <Sidebar<EpicTest>
             tests={tests}
-            modifiedTests={modifiedTests}
             selectedTestName={selectedTestName}
-            onUpdate={onTestsChange}
+            onTestPriorityChange={onTestPriorityChange}
             onSelectedTestName={onSelectedTestName}
             createTest={createTest}
             isInEditMode={editMode}
@@ -157,28 +156,16 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
           selectedTestName && selectedTest ? (
             <EpicTestEditor
               test={selectedTest}
-              hasChanged={!!modifiedTests[selectedTestName]}
+              hasChanged={selectedTestHasBeenModified}
               epicType={epicType}
-              onChange={(updatedTest): void =>
-                onTestsChange(updateTest(tests, updatedTest), updatedTest.name)
-              }
+              onChange={onTestChange}
               onValidationChange={onTestErrorStatusChange}
               visible
               editMode={editMode}
               onDelete={onTestDelete}
               onArchive={onTestArchive}
               onSelectedTestName={onSelectedTestName}
-              isDeleted={
-                modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isDeleted
-              }
-              isArchived={
-                modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isArchived
-              }
-              isNew={modifiedTests[selectedTestName] && modifiedTests[selectedTestName].isNew}
-              createTest={(newTest: EpicTest): void => {
-                const newTests = [...tests, newTest];
-                onTestsChange(newTests, newTest.name);
-              }}
+              createTest={onTestCreate}
               testNames={tests.map(test => test.name)}
               testNicknames={
                 tests.map(test => test.nickname).filter(nickname => !!nickname) as string[]

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createStyles, Typography, withStyles, WithStyles } from '@material-ui/core';
-import { ModifiedTests } from './helpers/shared';
 import { Test } from './helpers/shared';
 import TestList from './testList';
 import TestPriorityLabelList from './testPriorityLabelList';
@@ -29,9 +28,8 @@ const styles = createStyles({
 
 interface SidebarProps<T extends Test> {
   tests: T[];
-  modifiedTests: ModifiedTests;
   selectedTestName?: string;
-  onUpdate: (tests: T[], modifiedTestName?: string) => void;
+  onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onSelectedTestName: (testName: string) => void;
   createTest: (name: string, nickname: string) => void;
   isInEditMode: boolean;
@@ -42,7 +40,7 @@ function Sidebar<T extends Test>({
   tests,
   isInEditMode,
   selectedTestName,
-  onUpdate,
+  onTestPriorityChange,
   onSelectedTestName,
   createTest,
 }: SidebarProps<T> & WithStyles<typeof styles>): React.ReactElement<SidebarProps<T>> {
@@ -64,7 +62,7 @@ function Sidebar<T extends Test>({
           tests={tests}
           isInEditMode={isInEditMode}
           selectedTestName={selectedTestName}
-          onUpdate={onUpdate}
+          onTestPriorityChange={onTestPriorityChange}
           onTestSelected={onSelectedTestName}
         />
       </div>

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -28,7 +28,7 @@ const styles = createStyles({
 
 interface SidebarProps<T extends Test> {
   tests: T[];
-  selectedTestName?: string;
+  selectedTestName: string | null;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
   createTest: (name: string, nickname: string) => void;

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -30,7 +30,7 @@ interface SidebarProps<T extends Test> {
   tests: T[];
   selectedTestName?: string;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
-  onSelectedTestName: (testName: string) => void;
+  onTestSelected: (testName: string) => void;
   createTest: (name: string, nickname: string) => void;
   isInEditMode: boolean;
 }
@@ -41,7 +41,7 @@ function Sidebar<T extends Test>({
   isInEditMode,
   selectedTestName,
   onTestPriorityChange,
-  onSelectedTestName,
+  onTestSelected,
   createTest,
 }: SidebarProps<T> & WithStyles<typeof styles>): React.ReactElement<SidebarProps<T>> {
   return (
@@ -63,7 +63,7 @@ function Sidebar<T extends Test>({
           isInEditMode={isInEditMode}
           selectedTestName={selectedTestName}
           onTestPriorityChange={onTestPriorityChange}
-          onTestSelected={onSelectedTestName}
+          onTestSelected={onTestSelected}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -48,7 +48,7 @@ const styles = ({ palette, spacing }: Theme) =>
 
 interface StickyBottomBarProps extends WithStyles<typeof styles> {
   isInEditMode: boolean;
-  selectedTestName?: string;
+  selectedTestName: string | null;
   lockStatus: LockStatus;
   requestTakeControl: () => void;
   requestLock: () => void;

--- a/public/src/components/channelManagement/stickyBottomBarDetail.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarDetail.tsx
@@ -13,7 +13,7 @@ const styles = createStyles({
 
 interface StickyBottomBarDetailProps extends WithStyles<typeof styles> {
   isInEditMode: boolean;
-  selectedTestName?: string;
+  selectedTestName: string | null;
   lockStatus: LockStatus;
 }
 

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -103,7 +103,7 @@ const TestEditor = <T extends Test>(
       fetchStateFromServer();
     }, []);
 
-    const save = (updatedTests: T[]): Promise<void> => {
+    const save = async (updatedTests: T[]): Promise<void> => {
       const postData = {
         version: version,
         value: {
@@ -111,7 +111,7 @@ const TestEditor = <T extends Test>(
         },
       };
 
-      return saveFrontendSettings(settingsType, postData)
+      saveFrontendSettings(settingsType, postData)
         .then(resp => {
           if (!resp.ok) {
             resp.text().then(msg => alert(msg));

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -22,7 +22,7 @@ export interface InnerComponentProps<T extends Test> {
   onTestArchive: () => void;
   onTestCreate: (newTest: T) => void;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
-  onSelectedTestName: (testName: string) => void;
+  onTestSelected: (testName: string) => void;
   onTestErrorStatusChange: (isValid: boolean) => void;
   cancel: () => void;
   requestTakeControl: () => void;
@@ -258,7 +258,7 @@ const TestEditor = <T extends Test>(
               onTestDelete={onTestDelete}
               onTestArchive={onTestArchive}
               onTestCreate={onTestCreate}
-              onSelectedTestName={onSelectedTestName}
+              onTestSelected={onSelectedTestName}
               requestTakeControl={requestTestsTakeControl}
               requestLock={requestTestsLock}
               lockStatus={lockStatus}

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -103,7 +103,7 @@ const TestEditor = <T extends Test>(
       fetchStateFromServer();
     }, []);
 
-    const save = async (updatedTests: T[]): Promise<void> => {
+    const save = (updatedTests: T[]): Promise<void> => {
       const postData = {
         version: version,
         value: {
@@ -111,7 +111,7 @@ const TestEditor = <T extends Test>(
         },
       };
 
-      saveFrontendSettings(settingsType, postData)
+      return saveFrontendSettings(settingsType, postData)
         .then(resp => {
           if (!resp.ok) {
             resp.text().then(msg => alert(msg));

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -14,7 +14,7 @@ import { LockStatus, Test } from './helpers/shared';
 // The inner component's props must extend this type
 export interface InnerComponentProps<T extends Test> {
   tests: T[];
-  selectedTestName?: string;
+  selectedTestName: string | null;
   selectedTestHasBeenModified: boolean;
   onTestChange: (updatedTest: T) => void;
   onTestSave: () => void;
@@ -79,7 +79,7 @@ const TestEditor = <T extends Test>(
     const [tests, setTests] = useState<T[] | null>(null);
     const [version, setVersion] = useState<string | null>(null);
     const [editMode, setEditMode] = useState<boolean>(false);
-    const [selectedTestName, setSelectedTestName] = useState<string>('');
+    const [selectedTestName, setSelectedTestName] = useState<string | null>(null);
     const [selectedTestIsValid, setSelectedTestIsValid] = useState<boolean>(true);
     const [selectedTestHasBeenModified, setSelectedTestHasBeenModified] = useState<boolean>(true);
     const [lockStatus, setLockStatus] = useState<LockStatus>({ locked: false });
@@ -154,7 +154,7 @@ const TestEditor = <T extends Test>(
       const updatedTests = tests.filter(test => test.name !== selectedTestName);
 
       save(updatedTests).then(() => {
-        setSelectedTestName('');
+        setSelectedTestName(null);
         setSelectedTestIsValid(true);
         setSelectedTestHasBeenModified(false);
       });
@@ -178,7 +178,7 @@ const TestEditor = <T extends Test>(
           const updatedTests = tests.filter(test => test.name !== selectedTestName);
 
           save(updatedTests).then(() => {
-            setSelectedTestName('');
+            setSelectedTestName(null);
             setSelectedTestIsValid(true);
             setSelectedTestHasBeenModified(false);
           });

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -19,7 +19,7 @@ const styles = createStyles({
 interface TestListProps<T extends Test> {
   tests: T[];
   isInEditMode: boolean;
-  selectedTestName?: string;
+  selectedTestName: string | null;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
 }

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -20,7 +20,7 @@ interface TestListProps<T extends Test> {
   tests: T[];
   isInEditMode: boolean;
   selectedTestName?: string;
-  onUpdate: (tests: T[], modifiedTestName?: string) => void;
+  onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
 }
 
@@ -29,17 +29,12 @@ const TestList = <T extends Test>({
   tests,
   isInEditMode,
   selectedTestName,
-  onUpdate,
+  onTestPriorityChange,
   onTestSelected,
 }: TestListProps<T> & WithStyles<typeof styles>): React.ReactElement => {
   const onDragEnd = ({ destination, source }: DropResult): void => {
     if (destination) {
-      const newTests = [...tests];
-      const movedTest = { ...tests[source.index] };
-      newTests.splice(source.index, 1);
-      newTests.splice(destination.index, 0, movedTest);
-
-      onUpdate(newTests, movedTest.name);
+      onTestPriorityChange(destination.index, source.index);
     }
   };
 

--- a/public/src/components/channelManagement/testsFormLayout.tsx
+++ b/public/src/components/channelManagement/testsFormLayout.tsx
@@ -43,7 +43,7 @@ const styles = ({ spacing, typography }: Theme) =>
 interface Props extends WithStyles<typeof styles> {
   sidebar: JSX.Element;
   testEditor: JSX.Element | null;
-  selectedTestName?: string;
+  selectedTestName: string | null;
   editMode: boolean;
   lockStatus: LockStatus;
   requestTakeControl: () => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "exclude": [
     "node_modules",
+    "target",
     "config",
     "scripts",
     "**/*.spec.tsx"


### PR DESCRIPTION
## What does this change?

Refactor the `testEditor` higher order component. This started out as [this card](https://trello.com/c/NZACHuoB/2405-epic-banner-tool-prevent-save-if-there-are-invalid-fields) but ended up being a little more!

The initial bug was caused by legacy logic in `testEditor` that allowed for editing multiple tests in one session before saving. To fix this I removed all that logic - we now just use the flags `selectedTestIsValid` and `selectedTestHasBeenModified` to keep track of the selected test status.

I also took this as an opportunity to refactor `testEditor` to return a functional component that uses hooks instead of a class component. 