### PR TITLE
Enable configuration of epic control audience proportion

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -6,6 +6,8 @@ import io.circe.generic.extras.auto._
 import io.circe.{Decoder, Encoder}
 import scala.collection.immutable.IndexedSeq
 
+case class ControlProportionSettings(proportion: Float, offset: Int)
+
 case class Cta(text: Option[String], baseUrl: Option[String])
 
 sealed trait TickerEndType extends EnumEntry
@@ -66,7 +68,8 @@ case class EpicTest(
   variants: List[EpicVariant],
   highPriority: Boolean = false, // has been removed from form, but might be used in future
   useLocalViewLog: Boolean = false,
-  articlesViewedSettings: Option[ArticlesViewedSettings] = None
+  articlesViewedSettings: Option[ArticlesViewedSettings] = None,
+  controlProportionSettings: Option[ControlProportionSettings] = None
 )
 
 case class EpicTests(tests: List[EpicTest])

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -270,7 +270,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {!isOffPlatform && (
+      {!isOffPlatform && test.variants.length > 0 && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants split

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
-import { EpicTest, EpicVariant, MaxEpicViews } from './epicTestsForm';
+import { ControlProportionSettings, EpicTest, EpicVariant, MaxEpicViews } from './epicTestsForm';
 import { ArticlesViewedSettings, UserCohort, defaultCta, EpicType } from '../helpers/shared';
 import { makeStyles, FormControlLabel, Switch, Theme, Typography } from '@material-ui/core';
 import TestEditorHeader from '../testEditorHeader';
@@ -16,6 +16,7 @@ import EpicTestTargetContentEditor from './epicTestTargetContentEditor';
 import EpicTestMaxViewsEditor from './epicTestMaxViewsEditor';
 import useValidation from '../hooks/useValidation';
 import { articleCountTemplate, countryNameTemplate } from '../helpers/copyTemplates';
+import EpicTestVariantsSplitEditor from './epicTestVariantsSplitEditor';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
@@ -101,6 +102,9 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
 
   const onArticlesViewedSettingsValidationChanged = (isValid: boolean): void =>
     setValidationStatusForField('articlesViewedSettings', isValid);
+
+  const onVariantsSplitSettingsValidationChanged = (isValid: boolean): void =>
+    setValidationStatusForField('variantsSplitSettings', isValid);
 
   const getArticlesViewedSettings = (test: EpicTest): ArticlesViewedSettings | undefined => {
     if (!!test.articlesViewedSettings) {
@@ -212,6 +216,10 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
     }));
   };
 
+  const onControlProportionSettingsChange = (
+    controlProportionSettings?: ControlProportionSettings,
+  ): void => updateTest(test => ({ ...test, controlProportionSettings }));
+
   const onCopy = (name: string, nickname: string): void => {
     onTestSelected(name);
     createTest({ ...test, name: name, nickname: nickname, isOn: false });
@@ -257,6 +265,23 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
               createVariant={createVariant}
               renderVariantEditor={renderVariantEditor}
               onVariantDelete={onVariantDelete}
+            />
+          </div>
+        </div>
+      )}
+
+      {!isOffPlatform && (
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Variants split
+          </Typography>
+          <div>
+            <EpicTestVariantsSplitEditor
+              variants={test.variants}
+              controlProportionSettings={test.controlProportionSettings}
+              onControlProportionSettingsChange={onControlProportionSettingsChange}
+              onValidationChange={onVariantsSplitSettingsValidationChanged}
+              isDisabled={!editMode}
             />
           </div>
         </div>

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -140,10 +140,6 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
       ));
   };
 
-  if (variants.length === 0) {
-    return null;
-  }
-
   return (
     <div>
       <FormControl>

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -70,7 +70,7 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
   // clears error if necessary
   useEffect(() => {
     trigger();
-  }, [variants]);
+  }, []);
 
   // display initial value when switching to manual
   useEffect(() => {
@@ -78,7 +78,7 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
   }, [defaultValues.percentage]);
 
   useEffect(() => {
-    const isValid = Object.keys(errors).length === 0 || !getValues().percentage;
+    const isValid = Object.keys(errors).length === 0 || !controlProportionSettings;
     onValidationChange(isValid);
   }, [errors.percentage]);
 

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -12,10 +12,15 @@ import { ControlProportionSettings, EpicVariant } from './epicTestsForm';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
 
+const MAX_MVT = 1000000;
+
 const hasControl = (variants: EpicVariant[]): boolean =>
   !!variants.find(v => v.name.toLowerCase() === 'control');
 
-const randomMvt = (): number => Math.round(Math.random() * 1000000);
+const randomMvt = (): number => Math.round(Math.random() * MAX_MVT);
+
+// adapted from https://stackoverflow.com/a/11832950
+const round = (n: number): number => Math.round((n + Number.EPSILON) * MAX_MVT) / MAX_MVT;
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   variantsContainer: {
@@ -80,7 +85,7 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
   const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     if (event.target.value === 'manual') {
       onControlProportionSettingsChange({
-        proportion: 1 / variants.length,
+        proportion: round(1 / variants.length),
         offset: randomMvt(),
       });
     } else {
@@ -93,7 +98,7 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
   }: FormState): void => {
     if (percentage) {
       onControlProportionSettingsChange({
-        proportion: percentage / 100,
+        proportion: round(percentage / 100),
         offset: controlProportionSettings.offset,
       });
     }

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -1,0 +1,186 @@
+import React, { ReactElement, useEffect } from 'react';
+import {
+  FormControl,
+  makeStyles,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  TextField,
+  Theme,
+} from '@material-ui/core';
+import { ControlProportionSettings, EpicVariant } from './epicTestsForm';
+import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import { useForm } from 'react-hook-form';
+
+const hasControl = (variants: EpicVariant[]): boolean =>
+  !!variants.find(v => v.name.toLowerCase() === 'control');
+
+const randomMvt = (): number => Math.round(Math.random() * 1000000);
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  variantsContainer: {
+    display: 'flex',
+    margin: '15px 30px 0 30px',
+    '& > * + *': {
+      marginLeft: spacing(3),
+    },
+  },
+  variant: {},
+}));
+
+interface FormState {
+  proportion?: number;
+}
+
+interface EpicTestVariantsSplitEditorProps {
+  variants: EpicVariant[];
+  controlProportionSettings?: ControlProportionSettings;
+  onControlProportionSettingsChange: (
+    controlProportionSettings?: ControlProportionSettings,
+  ) => void;
+  onValidationChange: (isValid: boolean) => void;
+  isDisabled: boolean;
+}
+
+const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = ({
+  variants,
+  controlProportionSettings,
+  onControlProportionSettingsChange,
+  onValidationChange,
+  isDisabled,
+}: EpicTestVariantsSplitEditorProps) => {
+  const classes = useStyles();
+
+  const defaultValues = { proportion: controlProportionSettings?.proportion };
+
+  const { register, errors, handleSubmit, trigger, getValues, reset } = useForm<FormState>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  // clears error if necessary
+  useEffect(() => {
+    trigger();
+  }, [variants]);
+
+  // display initial value when switching to manual
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues.proportion]);
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0 || !getValues().proportion;
+    onValidationChange(isValid);
+  }, [errors.proportion]);
+
+  const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.value === 'manual') {
+      onControlProportionSettingsChange({
+        proportion: 1 / variants.length,
+        offset: randomMvt(),
+      });
+    } else {
+      onControlProportionSettingsChange(undefined);
+    }
+  };
+
+  const onSubmit = (controlProportionSettings: ControlProportionSettings) => ({
+    proportion,
+  }: FormState): void => {
+    if (proportion) {
+      onControlProportionSettingsChange({
+        proportion,
+        offset: controlProportionSettings.offset,
+      });
+    }
+  };
+
+  const validate = (text: string): string | boolean => {
+    const value = Number(text);
+    if (!Number.isNaN(value)) {
+      const controlExists = hasControl(variants);
+      if (controlExists) {
+        const max = 1 / variants.length;
+        if (value <= max) {
+          return true;
+        } else {
+          return `Control cannot be greater than ${+max.toFixed(2)}`;
+        }
+      } else {
+        return 'No control variant exists';
+      }
+    } else {
+      return 'Must be a number';
+    }
+  };
+
+  const renderVariants = (controlProportion: number): ReactElement[] => {
+    const proportion = (1 - controlProportion) / (variants.length - 1);
+    return variants
+      .filter(v => v.name.toLowerCase() !== 'control')
+      .map(variant => (
+        <div className={classes.variant} key={`${variant.name}_proportion`}>
+          <TextField
+            value={+proportion.toFixed(2)}
+            label={variant.name}
+            InputLabelProps={{ shrink: true }}
+            variant="filled"
+            fullWidth
+            disabled={true}
+          />
+        </div>
+      ));
+  };
+
+  return (
+    <div>
+      <FormControl>
+        <RadioGroup
+          value={controlProportionSettings ? 'manual' : 'auto'}
+          onChange={onRadioGroupChange}
+        >
+          <FormControlLabel
+            value="auto"
+            key="auto"
+            control={<Radio />}
+            label="Auto split"
+            disabled={isDisabled}
+          />
+          <FormControlLabel
+            value="manual"
+            key="manual"
+            control={<Radio />}
+            label="Manual split"
+            disabled={isDisabled}
+          />
+        </RadioGroup>
+
+        {controlProportionSettings && hasControl(variants) && (
+          <div className={classes.variantsContainer}>
+            <div className={classes.variant}>
+              <TextField
+                inputRef={register({
+                  required: EMPTY_ERROR_HELPER_TEXT,
+                  validate: validate,
+                })}
+                error={errors.proportion !== undefined}
+                helperText={errors.proportion?.message}
+                onBlur={handleSubmit(onSubmit(controlProportionSettings))}
+                name="proportion"
+                label="CONTROL"
+                InputLabelProps={{ shrink: true }}
+                variant="outlined"
+                fullWidth
+                disabled={isDisabled}
+              />
+            </div>
+
+            {renderVariants(controlProportionSettings.proportion)}
+          </div>
+        )}
+      </FormControl>
+    </div>
+  );
+};
+
+export default EpicTestVariantsSplitEditor;

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -119,13 +119,13 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
   };
 
   const renderVariants = (controlProportion: number): ReactElement[] => {
-    const percentage = +((1 - controlProportion) / (variants.length - 1)) * 100;
+    const percentage = ((1 - controlProportion) / (variants.length - 1)) * 100;
     return variants
       .filter(v => v.name.toLowerCase() !== 'control')
       .map(variant => (
         <div key={`${variant.name}_proportion`}>
           <TextField
-            value={percentage.toFixed(2)}
+            value={+percentage.toFixed(2)}
             label={variant.name}
             helperText="This value cannot be edited"
             InputLabelProps={{ shrink: true }}

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -62,7 +62,7 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
     percentage: controlProportionSettings ? controlProportionSettings.proportion * 100 : undefined,
   };
 
-  const { register, errors, handleSubmit, trigger, getValues, reset } = useForm<FormState>({
+  const { register, errors, handleSubmit, trigger, reset } = useForm<FormState>({
     mode: 'onChange',
     defaultValues,
   });

--- a/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantsSplitEditor.tsx
@@ -140,6 +140,10 @@ const EpicTestVariantsSplitEditor: React.FC<EpicTestVariantsSplitEditorProps> = 
       ));
   };
 
+  if (variants.length === 0) {
+    return null;
+  }
+
   return (
     <div>
       <FormControl>

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -55,6 +55,11 @@ export interface MaxEpicViews {
   minDaysBetweenViews: number;
 }
 
+export interface ControlProportionSettings {
+  proportion: number;
+  offset: number;
+}
+
 export interface EpicTest extends Test {
   name: string;
   nickname?: string;
@@ -73,6 +78,7 @@ export interface EpicTest extends Test {
   highPriority: boolean; // has been removed from form, but might be used in future
   useLocalViewLog: boolean;
   articlesViewedSettings?: ArticlesViewedSettings;
+  controlProportionSettings?: ControlProportionSettings;
 }
 
 type Props = InnerComponentProps<EpicTest>;


### PR DESCRIPTION
See also https://github.com/guardian/support-dotcom-components/pull/304

By default the audience is split evenly across the variants.
This PR allows the user to configure the proportion for the control only.
The control must always be the smallest/joint-smallest variant.
The %s for the other variants is displayed in disabled text inputs, as these cannot be modified.

### Even split (default):
![Screen Shot 2020-11-27 at 08 42 20](https://user-images.githubusercontent.com/1513454/100428932-87648a80-308c-11eb-9734-61e6ac52b640.png)

### Manual split:
![Screen Shot 2020-11-27 at 08 42 25](https://user-images.githubusercontent.com/1513454/100428940-89c6e480-308c-11eb-9f59-5e752384b303.png)

### Invalid manual split:
![Screen Shot 2020-11-27 at 08 42 31](https://user-images.githubusercontent.com/1513454/100428945-8c293e80-308c-11eb-932c-69fce63fe738.png)

### rounding...
![Screen Shot 2020-11-27 at 09 27 57](https://user-images.githubusercontent.com/1513454/100433366-e2997b80-3092-11eb-8234-44bf6aa94dba.png)

