### PR TITLE
Update template validation 

### DIFF
--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -95,7 +95,7 @@ export const ARTICLE_COUNT_TEMPLATE = '%%ARTICLE_COUNT%%';
 const validTemplates = [CURRENCY_TEMPLATE, COUNTRY_NAME_TEMPLATE, ARTICLE_COUNT_TEMPLATE];
 
 export const invalidTemplateValidator = (text: string): string | boolean => {
-  const templates = text.match(/%%[A-Za-z_]*%%/g);
+  const templates = text.match(/%%.*%%/g);
 
   if (templates !== null) {
     const invalidTemplate = templates.find(template => !validTemplates.includes(template));


### PR DESCRIPTION
## What does this change?
Iona ran into an issue this morning that turned out to be due to accidently using`%%ARTICLE COUNT%%` instead of `%%ARTICLE_COUNT%%`. I figured the easiest thing to do would be to just match on anything between two sets of `%%`s. 

I very briefly played around with the [string-similarity](https://www.npmjs.com/package/string-similarity) npm package to figure out the closest match to provide a `did you mean...` type error message. It was neat, but as it was running on every character input it made the editing experience really laggy. I think we could maybe solve this with a simpler algorithm/debouncing the input to avoid accessive calls (which shouldn't be too difficult with react-hook-form), but didn't seem worth the effort for now! 