### PR TITLE
Make CODE a little safer

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -12,9 +12,9 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="@routes.Assets.at("build/app.bundle.js")"></script>
     <script>
       window.guardian = { stage: "@stage"};
     </script>
+    <script src="@routes.Assets.at("build/app.bundle.js")"></script>
   </body>
 </html>

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -14,8 +14,8 @@ import TestEditorArticleCountEditor, {
 } from '../testEditorArticleCountEditor';
 import TestEditorActionButtons from '../testEditorActionButtons';
 import useValidation from '../hooks/useValidation';
-import { BannerTest, BannerVariant, BannerTemplate } from '../../../models/banner';
-import { defaultCta } from '../helpers/shared';
+import { BannerTest, BannerVariant } from '../../../models/banner';
+import { getDefaultVariant } from './utils/defaultBanner';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>
@@ -181,13 +181,8 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
 
   const createVariant = (name: string): void => {
     const newVariant: BannerVariant = {
+      ...getDefaultVariant(),
       name: name,
-      template: BannerTemplate.ContributionsBanner,
-      heading: undefined,
-      body: '',
-      highlightedText:
-        'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-      cta: defaultCta,
     };
     onVariantsChange([...test.variants, newVariant]);
   };

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -15,7 +15,7 @@ import TestEditorArticleCountEditor, {
 import TestEditorActionButtons from '../testEditorActionButtons';
 import useValidation from '../hooks/useValidation';
 import { BannerTest, BannerVariant } from '../../../models/banner';
-import { getDefaultVariant } from './utils/defaultBanner';
+import { getDefaultVariant } from './utils/defaults';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing, palette }: Theme) =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -4,21 +4,17 @@ import { FrontendSettingsType } from '../../../utils/requests';
 import Sidebar from '../sidebar';
 import BannerTestEditor from './bannerTestEditor';
 import TestsFormLayout from '../testsFormLayout';
-import { UserCohort } from '../helpers/shared';
 import { BannerTest } from '../../../models/banner';
+import { getDefaultBanner } from './utils/defaultBanner';
 
 type Props = InnerComponentProps<BannerTest>;
 
 const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
   const createDefaultBannerTest = (newTestName: string, newTestNickname: string): BannerTest => ({
+    ...getDefaultBanner(),
     name: newTestName,
     nickname: newTestNickname,
-    isOn: false,
     minArticlesBeforeShowingBanner: isFirstChannel ? 2 : 4,
-    userCohort: UserCohort.AllNonSupporters,
-    locations: [],
-    variants: [],
-    articlesViewedSettings: undefined,
   });
 
   const BannerTestsForm: React.FC<Props> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -5,13 +5,13 @@ import Sidebar from '../sidebar';
 import BannerTestEditor from './bannerTestEditor';
 import TestsFormLayout from '../testsFormLayout';
 import { BannerTest } from '../../../models/banner';
-import { getDefaultBanner } from './utils/defaultBanner';
+import { getDefaultTest } from './utils/defaults';
 
 type Props = InnerComponentProps<BannerTest>;
 
 const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
   const createDefaultBannerTest = (newTestName: string, newTestNickname: string): BannerTest => ({
-    ...getDefaultBanner(),
+    ...getDefaultTest(),
     name: newTestName,
     nickname: newTestNickname,
     minArticlesBeforeShowingBanner: isFirstChannel ? 2 : 4,

--- a/public/src/components/channelManagement/bannerTests/utils/defaultBanner.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaultBanner.ts
@@ -1,29 +1,48 @@
 import { UserCohort } from '../../helpers/shared';
-import { BannerTest, BannerTemplate } from '../../../../models/banner';
+import { BannerTest, BannerVariant, BannerTemplate } from '../../../../models/banner';
 
 import { getStage } from '../../../../utils/stage';
 
+const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
+  name: 'CONTROL',
+  template: BannerTemplate.ContributionsBanner,
+  heading: 'We chose a different approach. Will you support it?',
+  body:
+    'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+  highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+  cta: {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+  },
+};
+
+const PROD_DEFAULT_VARIANT: BannerVariant = {
+  name: 'CONTROL',
+  template: BannerTemplate.ContributionsBanner,
+  body: '',
+  highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+  cta: {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+  },
+};
+
+export const getDefaultVariant = (): BannerVariant => {
+  const stage = getStage();
+  if (stage === 'DEV' || stage === 'CODE') {
+    return DEV_AND_CODE_DEFAULT_VARIANT;
+  }
+  return PROD_DEFAULT_VARIANT;
+};
+
 const DEV_AND_CODE_DEFAULT_BANNER_TEST: BannerTest = {
-  name: '',
-  nickname: '',
+  name: 'TEST',
+  nickname: 'TEST',
   isOn: false,
   minArticlesBeforeShowingBanner: 0,
   userCohort: UserCohort.AllNonSupporters,
   locations: [],
-  variants: [
-    {
-      name: 'CONTROL',
-      template: BannerTemplate.ContributionsBanner,
-      heading: 'We chose a different approach. Will you support it?',
-      body:
-        'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
-      highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
-      cta: {
-        text: 'Support the Guardian',
-        baseUrl: 'https://support.theguardian.com/contribute',
-      },
-    },
-  ],
+  variants: [DEV_AND_CODE_DEFAULT_VARIANT],
   articlesViewedSettings: undefined,
 };
 

--- a/public/src/components/channelManagement/bannerTests/utils/defaultBanner.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaultBanner.ts
@@ -1,0 +1,47 @@
+import { UserCohort } from '../../helpers/shared';
+import { BannerTest, BannerTemplate } from '../../../../models/banner';
+
+import { getStage } from '../../../../utils/stage';
+
+const DEV_AND_CODE_DEFAULT_BANNER_TEST: BannerTest = {
+  name: '',
+  nickname: '',
+  isOn: false,
+  minArticlesBeforeShowingBanner: 0,
+  userCohort: UserCohort.AllNonSupporters,
+  locations: [],
+  variants: [
+    {
+      name: 'CONTROL',
+      template: BannerTemplate.ContributionsBanner,
+      heading: 'We chose a different approach. Will you support it?',
+      body:
+        'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+      highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+      cta: {
+        text: 'Support the Guardian',
+        baseUrl: 'https://support.theguardian.com/contribute',
+      },
+    },
+  ],
+  articlesViewedSettings: undefined,
+};
+
+const PROD_DEFAULT_BANNER: BannerTest = {
+  name: '',
+  nickname: '',
+  isOn: false,
+  minArticlesBeforeShowingBanner: 0,
+  userCohort: UserCohort.AllNonSupporters,
+  locations: [],
+  variants: [],
+  articlesViewedSettings: undefined,
+};
+
+export const getDefaultBanner = (): BannerTest => {
+  const stage = getStage();
+  if (stage === 'DEV' || stage === 'CODE') {
+    return DEV_AND_CODE_DEFAULT_BANNER_TEST;
+  }
+  return PROD_DEFAULT_BANNER;
+};

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -57,7 +57,7 @@ const PROD_DEFAULT_BANNER: BannerTest = {
   articlesViewedSettings: undefined,
 };
 
-export const getDefaultBanner = (): BannerTest => {
+export const getDefaultTest = (): BannerTest => {
   const stage = getStage();
   if (stage === 'DEV' || stage === 'CODE') {
     return DEV_AND_CODE_DEFAULT_BANNER_TEST;

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 import { ControlProportionSettings, EpicTest, EpicVariant, MaxEpicViews } from './epicTestsForm';
-import { ArticlesViewedSettings, UserCohort, defaultCta, EpicType } from '../helpers/shared';
+import { ArticlesViewedSettings, UserCohort, EpicType } from '../helpers/shared';
 import { makeStyles, FormControlLabel, Switch, Theme, Typography } from '@material-ui/core';
 import TestEditorHeader from '../testEditorHeader';
 import TestEditorLiveSwitch from '../testEditorLiveSwitch';
@@ -17,6 +17,7 @@ import EpicTestMaxViewsEditor from './epicTestMaxViewsEditor';
 import useValidation from '../hooks/useValidation';
 import { articleCountTemplate, countryNameTemplate } from '../helpers/copyTemplates';
 import EpicTestVariantsSplitEditor from './epicTestVariantsSplitEditor';
+import { getDefaultVariant } from './utils/defaults';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
@@ -155,15 +156,8 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
 
   const createVariant = (name: string): void => {
     const newVariant: EpicVariant = {
+      ...getDefaultVariant(),
       name: name,
-      heading: undefined,
-      paragraphs: [],
-      highlightedText:
-        'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-      footer: undefined,
-      showTicker: false,
-      backgroundImageUrl: undefined,
-      cta: defaultCta,
     };
 
     if (test) {

--- a/public/src/components/channelManagement/epicTests/epicTestMaxViewsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestMaxViewsEditor.tsx
@@ -12,6 +12,7 @@ import {
 } from '@material-ui/core';
 import { MaxEpicViews } from './epicTestsForm';
 import { notNumberValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import { DEFAULT_MAX_EPIC_VIEWS } from './utils/defaults';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -27,12 +28,6 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
     },
   },
 }));
-
-export const DEFAULT_MAX_EPIC_VIEWS: MaxEpicViews = {
-  maxViewsCount: 4,
-  maxViewsDays: 30,
-  minDaysBetweenViews: 0,
-};
 
 interface FormData {
   maxViewsCount: string;

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -9,14 +9,13 @@ import {
   Test,
   Variant,
   EpicType,
-  defaultCta,
 } from '../helpers/shared';
 import { InnerComponentProps } from '../testEditor';
 import TestsForm from '../testEditor';
 import TestsFormLayout from '../testsFormLayout';
 import Sidebar from '../sidebar';
 import { FrontendSettingsType } from '../../../utils/requests';
-import { DEFAULT_MAX_EPIC_VIEWS } from './epicTestMaxViewsEditor';
+import { getDefaultTest, getDefaultVariant } from './utils/defaults';
 
 export enum TickerEndType {
   unlimited = 'unlimited',
@@ -87,35 +86,12 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
   const isLiveBlog = epicType === 'LIVEBLOG';
   const isOffPlatform = epicType === 'APPLE_NEWS' || epicType === 'AMP';
 
-  const createDefaultEpicVariant = (): EpicVariant => ({
-    name: 'CONTROL',
-    heading: undefined,
-    paragraphs: [],
-    highlightedText:
-      'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-    footer: undefined,
-    showTicker: false,
-    backgroundImageUrl: undefined,
-    cta: defaultCta,
-  });
-
   const createDefaultEpicTest = (newTestName: string, newTestNickname: string): EpicTest => ({
+    ...getDefaultTest(),
     name: newTestName,
     nickname: newTestNickname,
-    isOn: false,
-    locations: [],
-    tagIds: [],
-    sections: [],
-    excludedTagIds: [],
-    excludedSections: [],
-    alwaysAsk: false,
-    maxViews: DEFAULT_MAX_EPIC_VIEWS,
-    userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
     isLiveBlog: isLiveBlog,
-    hasCountryName: false,
-    variants: isOffPlatform ? [createDefaultEpicVariant()] : [],
-    highPriority: false, // has been removed from form, but might be used in future
-    useLocalViewLog: false,
+    variants: isOffPlatform ? [{ ...getDefaultVariant() }] : [],
   });
 
   const EpicTestsForm: React.FC<Props> = ({

--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -1,0 +1,94 @@
+import { UserCohort } from '../../helpers/shared';
+import { EpicVariant, EpicTest, MaxEpicViews } from '../epicTestsForm';
+
+import { getStage } from '../../../../utils/stage';
+
+export const DEFAULT_MAX_EPIC_VIEWS: MaxEpicViews = {
+  maxViewsCount: 4,
+  maxViewsDays: 30,
+  minDaysBetweenViews: 0,
+};
+
+const DEV_AND_CODE_DEFAULT_VARIANT: EpicVariant = {
+  name: 'CONTROL',
+  heading: "Since you're here ...",
+  paragraphs: [
+    "… we have a small favour to ask. You've read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; millions are flocking to the Guardian for quality news every day. We believe everyone deserves access to factual information, and analysis that has authority and integrity. That’s why, unlike many others, we made a choice: to keep Guardian reporting open for all, regardless of where they live or what they can afford to pay.",
+    'As an open, independent news organisation we investigate, interrogate and expose the actions of those in power, without fear. With no shareholders or billionaire owner, our journalism is free from political and commercial bias – this makes us different. We can give a voice to the oppressed and neglected, and stand in solidarity with those who are calling for a fairer future. With your help we can make a difference.',
+    'We’re determined to provide journalism that helps each of us better understand the world, and take actions that challenge, unite, and inspire change – in times of crisis and beyond. Our work would not be possible without our readers, who now support our work from 180 countries around the world.',
+    'Every reader contribution, however big or small, is so valuable for our future.',
+  ],
+  highlightedText:
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+  showTicker: false,
+  cta: {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+  },
+};
+
+const PROD_DEFAULT_VARIANT: EpicVariant = {
+  name: 'CONTROL',
+  paragraphs: [],
+  highlightedText:
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+  showTicker: false,
+  cta: {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+  },
+};
+
+export const getDefaultVariant = (): EpicVariant => {
+  const stage = getStage();
+  if (stage === 'DEV' || stage === 'CODE') {
+    return DEV_AND_CODE_DEFAULT_VARIANT;
+  }
+  return PROD_DEFAULT_VARIANT;
+};
+
+const DEV_AND_CODE_DEFAULT_TEST: EpicTest = {
+  name: 'TEST',
+  nickname: 'TEST',
+  isOn: false,
+  locations: [],
+  tagIds: [],
+  sections: [],
+  excludedTagIds: [],
+  excludedSections: [],
+  alwaysAsk: false,
+  maxViews: DEFAULT_MAX_EPIC_VIEWS,
+  userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
+  isLiveBlog: false,
+  hasCountryName: false,
+  variants: [DEV_AND_CODE_DEFAULT_VARIANT],
+  highPriority: false, // has been removed from form, but might be used in future
+  useLocalViewLog: false,
+};
+
+const PROD_DEFAULT_TEST: EpicTest = {
+  name: 'TEST',
+  nickname: 'TEST',
+  isOn: false,
+  locations: [],
+  tagIds: [],
+  sections: [],
+  excludedTagIds: [],
+  excludedSections: [],
+  alwaysAsk: false,
+  maxViews: DEFAULT_MAX_EPIC_VIEWS,
+  userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
+  isLiveBlog: false,
+  hasCountryName: false,
+  variants: [],
+  highPriority: false, // has been removed from form, but might be used in future
+  useLocalViewLog: false,
+};
+
+export const getDefaultTest = (): EpicTest => {
+  const stage = getStage();
+  if (stage === 'DEV' || stage === 'CODE') {
+    return DEV_AND_CODE_DEFAULT_TEST;
+  }
+  return PROD_DEFAULT_TEST;
+};

--- a/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryPreviewButton.tsx
@@ -2,18 +2,7 @@ import React from 'react';
 import { Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import { TestType } from './helpers/shared';
-
-type Stage = 'DEV' | 'CODE' | 'PROD';
-
-declare global {
-  interface Window {
-    guardian: { stage: Stage };
-  }
-}
-
-const getStage = (): Stage => {
-  return window.guardian.stage;
-};
+import { getStage } from '../../utils/stage';
 
 const PROD_BASE_ARTICLE_URL =
   'https://theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder';

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -16,7 +16,13 @@ import {
   BannerTestsForm1,
   BannerTestsForm2,
 } from './components/channelManagement/bannerTests/bannerTestsForm';
-import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
+import {
+  createStyles,
+  Theme,
+  ThemeProvider,
+  WithStyles,
+  withStyles,
+} from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
@@ -24,6 +30,7 @@ import NavDrawer from './components/drawer';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import IndexPage from './components/indexPage';
+import { getTheme } from './utils/theme';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, mixins, typography, transitions }: Theme) =>
@@ -75,64 +82,72 @@ const AppRouter = withStyles(styles)(({ classes }: Props) => {
   );
 
   return (
-    <Router>
-      <div className={classes.root}>
-        <CssBaseline />
-        <Route
-          exact
-          path="/"
-          render={(): React.ReactElement => createComponent(<IndexPage />, 'Home Page')}
-        />
-        <Route
-          path="/switches"
-          render={(): React.ReactElement => createComponent(<Switchboard />, 'Switches')}
-        />
-        <Route
-          path="/contribution-types"
-          render={(): React.ReactElement =>
-            createComponent(<ContributionTypesForm />, 'Contribution Types')
-          }
-        />
-        <Route
-          path="/amounts"
-          render={(): React.ReactElement => createComponent(<AmountsForm />, 'Amounts')}
-        />
-        <Route
-          path="/epic-tests"
-          render={(): React.ReactElement => createComponent(<ArticleEpicTestsForm />, 'Epic Tests')}
-        />
-        <Route
-          path="/liveblog-epic-tests"
-          render={(): React.ReactElement =>
-            createComponent(<LiveblogEpicTestsForm />, 'Liveblog Epic Tests')
-          }
-        />
-        <Route
-          path="/apple-news-epic-tests"
-          render={(): React.ReactElement =>
-            createComponent(<AppleNewsEpicTestsForm />, 'Apple News Epics')
-          }
-        />
-        <Route
-          path="/amp-epic-tests"
-          render={(): React.ReactElement => createComponent(<AMPEpicTestsForm />, 'AMP Epics')}
-        />
-        <Route
-          path="/banner-tests"
-          render={(): React.ReactElement => createComponent(<BannerTestsForm1 />, 'Banner Tests 1')}
-        />
-        <Route
-          path="/banner-tests2"
-          render={(): React.ReactElement => createComponent(<BannerTestsForm2 />, 'Banner Tests 2')}
-        />
-        <Route
-          path="/banner-deploy"
-          render={(): React.ReactElement =>
-            createComponent(<BannerDeployDashboard />, 'Banner Deploy')
-          }
-        />
-      </div>
-    </Router>
+    <ThemeProvider theme={getTheme()}>
+      <Router>
+        <div className={classes.root}>
+          <CssBaseline />
+          <Route
+            exact
+            path="/"
+            render={(): React.ReactElement => createComponent(<IndexPage />, 'Home Page')}
+          />
+          <Route
+            path="/switches"
+            render={(): React.ReactElement => createComponent(<Switchboard />, 'Switches')}
+          />
+          <Route
+            path="/contribution-types"
+            render={(): React.ReactElement =>
+              createComponent(<ContributionTypesForm />, 'Contribution Types')
+            }
+          />
+          <Route
+            path="/amounts"
+            render={(): React.ReactElement => createComponent(<AmountsForm />, 'Amounts')}
+          />
+          <Route
+            path="/epic-tests"
+            render={(): React.ReactElement =>
+              createComponent(<ArticleEpicTestsForm />, 'Epic Tests')
+            }
+          />
+          <Route
+            path="/liveblog-epic-tests"
+            render={(): React.ReactElement =>
+              createComponent(<LiveblogEpicTestsForm />, 'Liveblog Epic Tests')
+            }
+          />
+          <Route
+            path="/apple-news-epic-tests"
+            render={(): React.ReactElement =>
+              createComponent(<AppleNewsEpicTestsForm />, 'Apple News Epics')
+            }
+          />
+          <Route
+            path="/amp-epic-tests"
+            render={(): React.ReactElement => createComponent(<AMPEpicTestsForm />, 'AMP Epics')}
+          />
+          <Route
+            path="/banner-tests"
+            render={(): React.ReactElement =>
+              createComponent(<BannerTestsForm1 />, 'Banner Tests 1')
+            }
+          />
+          <Route
+            path="/banner-tests2"
+            render={(): React.ReactElement =>
+              createComponent(<BannerTestsForm2 />, 'Banner Tests 2')
+            }
+          />
+          <Route
+            path="/banner-deploy"
+            render={(): React.ReactElement =>
+              createComponent(<BannerDeployDashboard />, 'Banner Deploy')
+            }
+          />
+        </div>
+      </Router>
+    </ThemeProvider>
   );
 });
 

--- a/public/src/utils/stage.ts
+++ b/public/src/utils/stage.ts
@@ -1,0 +1,11 @@
+type Stage = 'DEV' | 'CODE' | 'PROD';
+
+declare global {
+  interface Window {
+    guardian: { stage: Stage };
+  }
+}
+
+export const getStage = (): Stage => {
+  return window.guardian.stage;
+};

--- a/public/src/utils/theme.ts
+++ b/public/src/utils/theme.ts
@@ -1,0 +1,25 @@
+import { createMuiTheme, Theme } from '@material-ui/core/styles';
+import purple from '@material-ui/core/colors/purple';
+import green from '@material-ui/core/colors/green';
+import { getStage } from './stage';
+
+const DEV_AND_CODE_THEME = createMuiTheme({
+  palette: {
+    primary: {
+      main: purple[500],
+    },
+    secondary: {
+      main: green[500],
+    },
+  },
+});
+
+const PROD_THEME = createMuiTheme({});
+
+export const getTheme = (): Theme => {
+  const stage = getStage();
+  if (stage == 'DEV' || stage === 'CODE') {
+    return DEV_AND_CODE_THEME;
+  }
+  return PROD_THEME;
+};


### PR DESCRIPTION
## What does this change?
It was pointed out that we should maybe make out CODE tests a little more realistic, just incase they ever slip into production. There are two things in this PR to hopefully make things a little safer:

- custom colour scheme in DEV/CODE to make it more distinct from PROD
- default tests/variants in DEV/CODE to allow devs to quickly save realistic looking tests whilst testing

TODO:
- After merging, delete the existing DEV/CODE tests and replace them with out more realistic placeholders

## Images
<img width="1792" alt="Screenshot 2020-12-11 at 11 51 07" src="https://user-images.githubusercontent.com/17720442/101911959-0394bd00-3bb9-11eb-81c7-de357ff51a2a.png">