### PR TITLE
Add Epic Holdback Tests

### DIFF
--- a/app/controllers/epic/EpicHoldbackTestArchiveController.scala
+++ b/app/controllers/epic/EpicHoldbackTestArchiveController.scala
@@ -1,0 +1,25 @@
+package controllers.epic
+
+import com.gu.googleauth.AuthAction
+import controllers.S3ObjectsController
+import models.EpicTest
+import models.EpicTests._
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, ControllerComponents}
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+class EpicHoldbackTestArchiveController(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  ws: WSClient, stage: String,
+  runtime: DefaultRuntime
+)(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
+  authAction,
+  components,
+  stage,
+  path = "archived-epic-holdback-tests",
+  nameGenerator = _.name,
+  runtime
+)

--- a/app/controllers/epic/EpicHoldbackTestsController.scala
+++ b/app/controllers/epic/EpicHoldbackTestsController.scala
@@ -1,0 +1,38 @@
+package controllers.epic
+
+import com.gu.googleauth.AuthAction
+import controllers.LockableS3ObjectController
+import models.EpicTests
+import play.api.libs.circe.Circe
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+import services.FastlyPurger
+import services.S3Client.S3ObjectSettings
+import zio.DefaultRuntime
+
+import scala.concurrent.ExecutionContext
+
+object EpicHoldbackTestsController {
+  val name = "epic-holdback-tests"
+}
+
+class EpicHoldbackTestsController(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  ws: WSClient, stage: String,
+  runtime: DefaultRuntime
+)(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
+    authAction,
+    components,
+    stage,
+    name = EpicHoldbackTestsController.name,
+    dataObjectSettings = S3ObjectSettings(
+      bucket = "gu-contributions-public",
+      key = s"epic/$stage/${EpicHoldbackTestsController.name}.json",
+      publicRead = true,  // This data will be requested by dotcom
+      cacheControl = Some("max-age=30"),
+      surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
+    ),
+    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${EpicHoldbackTestsController.name}.json", ws),
+    runtime = runtime
+  ) with Circe

--- a/app/controllers/epic/EpicHoldbackTestsController.scala
+++ b/app/controllers/epic/EpicHoldbackTestsController.scala
@@ -29,10 +29,10 @@ class EpicHoldbackTestsController(
     dataObjectSettings = S3ObjectSettings(
       bucket = "gu-contributions-public",
       key = s"epic/$stage/${EpicHoldbackTestsController.name}.json",
-      publicRead = true,  // This data will be requested by dotcom
-      cacheControl = Some("max-age=30"),
-      surrogateControl = Some("max-age=86400")  // Cache for a day, and use cache purging after updates
+      publicRead = false,
+      cacheControl = None,
+      surrogateControl = None
     ),
-    fastlyPurger = FastlyPurger.fastlyPurger(stage, s"${EpicHoldbackTestsController.name}.json", ws),
+    fastlyPurger = None,
     runtime = runtime
   ) with Circe

--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -63,7 +63,6 @@ case class EpicTest(
   alwaysAsk: Boolean = false,
   maxViews: Option[MaxViews],
   userCohort: Option[UserCohort] = None,
-  isLiveBlog: Boolean = false,
   hasCountryName: Boolean = false,
   variants: List[EpicVariant],
   highPriority: Boolean = false, // has been removed from form, but might be used in future

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -61,6 +61,8 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new AmountsController(authAction, controllerComponents, stage, runtime),
     new EpicTestsController(authAction, controllerComponents, wsClient, stage, runtime),
     new EpicTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
+    new EpicHoldbackTestsController(authAction, controllerComponents, wsClient, stage, runtime),
+    new EpicHoldbackTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
     new LiveblogEpicTestsController(authAction, controllerComponents, wsClient, stage, runtime),
     new LiveblogEpicTestArchiveController(authAction, controllerComponents, wsClient, stage, runtime),
     new AppleNewsEpicTestsController(authAction, controllerComponents, wsClient, stage, runtime),

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET /switches                                       controllers.Application.inde
 GET /contribution-types                             controllers.Application.index
 GET /amounts                                        controllers.Application.index
 GET /epic-tests                                     controllers.Application.index
+GET /epic-holdback-tests                            controllers.Application.index
 GET /liveblog-epic-tests                            controllers.Application.index
 GET /apple-news-epic-tests                          controllers.Application.index
 GET /amp-epic-tests                                 controllers.Application.index
@@ -41,6 +42,16 @@ POST  /frontend/epic-tests/takecontrol              controllers.epic.EpicTestsCo
 POST  /frontend/epic-tests/archive                  controllers.epic.EpicTestArchiveController.set
 GET   /frontend/epic-tests/archive/:testName        controllers.epic.EpicTestArchiveController.get(testName: String)
 GET   /frontend/epic-tests/archived-test-names      controllers.epic.EpicTestArchiveController.list
+
+# ----- epic holdback tests ----- #
+GET   /frontend/epic-holdback-tests                          controllers.epic.EpicHoldbackTestsController.get
+POST  /frontend/epic-holdback-tests/update                   controllers.epic.EpicHoldbackTestsController.set
+POST  /frontend/epic-holdback-tests/lock                     controllers.epic.EpicHoldbackTestsController.lock
+POST  /frontend/epic-holdback-tests/unlock                   controllers.epic.EpicHoldbackTestsController.unlock
+POST  /frontend/epic-holdback-tests/takecontrol              controllers.epic.EpicHoldbackTestsController.takecontrol
+POST  /frontend/epic-holdback-tests/archive                  controllers.epic.EpicHoldbackTestArchiveController.set
+GET   /frontend/epic-holdback-tests/archive/:testName        controllers.epic.EpicHoldbackTestArchiveController.get(testName: String)
+GET   /frontend/epic-holdback-tests/archived-test-names      controllers.epic.EpicHoldbackTestArchiveController.list
 
 # ----- liveblog epic tests ----- #
 GET   /frontend/liveblog-epic-tests                          controllers.epic.LiveblogEpicTestsController.get

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -302,7 +302,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {epicEditorConfig.allowContentTargetting && (
+      {epicEditorConfig.allowContentTargeting && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Target content
@@ -319,7 +319,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {epicEditorConfig.allowLocationTargetting && (
+      {epicEditorConfig.allowLocationTargeting && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Target audience
@@ -331,7 +331,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
             isDisabled={!editMode}
-            showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargetting}
+            showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargeting}
           />
         </div>
       )}

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
-import {
-  ControlProportionSettings,
-  EpicTest,
-  EpicVariant,
-  isNotAllowedVariantSplit,
-  isOnlyAllowedOneVariant,
-  MaxEpicViews,
-} from './epicTestsForm';
-import { ArticlesViewedSettings, UserCohort, EpicType } from '../helpers/shared';
+import { ControlProportionSettings, EpicTest, EpicVariant, MaxEpicViews } from './epicTestsForm';
+import { ArticlesViewedSettings, UserCohort, EpicEditorConfig } from '../helpers/shared';
 import { makeStyles, FormControlLabel, Switch, Theme, Typography } from '@material-ui/core';
 import TestEditorHeader from '../testEditorHeader';
 import TestVariantsEditor from '../testVariantsEditor';
@@ -73,7 +66,7 @@ const copyHasTemplate = (test: EpicTest, template: string): boolean =>
 interface EpicTestEditorProps {
   test: EpicTest;
   hasChanged: boolean;
-  epicType: EpicType;
+  epicEditorConfig: EpicEditorConfig;
   onChange: (updatedTest: EpicTest) => void;
   onValidationChange: (isValid: boolean) => void;
   visible: boolean;
@@ -88,7 +81,7 @@ interface EpicTestEditorProps {
 
 const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   test,
-  epicType,
+  epicEditorConfig,
   onChange,
   editMode,
   onDelete,
@@ -100,10 +93,6 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   onValidationChange,
 }: EpicTestEditorProps) => {
   const classes = useStyles();
-
-  const isAMP = epicType === 'AMP';
-  const isAppleNews = epicType === 'APPLE_NEWS';
-  const isOffPlatform = isAMP || isAppleNews;
 
   const setValidationStatusForField = useValidation(onValidationChange);
 
@@ -120,7 +109,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
     if (!!test.articlesViewedSettings) {
       return test.articlesViewedSettings;
     }
-    if (!isOffPlatform && copyHasTemplate(test, articleCountTemplate)) {
+    if (epicEditorConfig.allowArticleCount && copyHasTemplate(test, articleCountTemplate)) {
       return DEFAULT_ARTICLES_VIEWED_SETTINGS;
     }
     return undefined;
@@ -232,7 +221,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
     <EpicTestVariantEditor
       key={variant.name}
       variant={variant}
-      epicType={epicType}
+      epicEditorConfig={epicEditorConfig}
       editMode={editMode}
       onVariantChange={onVariantChange}
       onDelete={(): void => onVariantDelete(variant.name)}
@@ -255,7 +244,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         />
       </div>
 
-      {!isOnlyAllowedOneVariant(epicType) && (
+      {epicEditorConfig.allowMultipleVariants && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants
@@ -274,7 +263,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {!isNotAllowedVariantSplit(epicType) && test.variants.length > 0 && (
+      {epicEditorConfig.allowCustomVariantSplit && test.variants.length > 1 && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants split
@@ -291,7 +280,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {isOnlyAllowedOneVariant(epicType) && (
+      {!epicEditorConfig.allowMultipleVariants && (
         <div className={classes.sectionContainer} key={test.name}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Copy
@@ -301,7 +290,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             <EpicTestVariantEditor
               key={test.variants[0].name}
               variant={test.variants[0]}
-              epicType={epicType}
+              epicEditorConfig={epicEditorConfig}
               editMode={editMode}
               onVariantChange={onVariantChange}
               onDelete={(): void => onVariantDelete(test.variants[0].name)}
@@ -313,7 +302,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {!isAMP && (
+      {epicEditorConfig.allowContentTargetting && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Target content
@@ -330,7 +319,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {!isAppleNews && (
+      {epicEditorConfig.allowLocationTargetting && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Target audience
@@ -342,12 +331,12 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
             isDisabled={!editMode}
-            showSupporterStatusSelector={epicType !== 'AMP'}
+            showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargetting}
           />
         </div>
       )}
 
-      {!isOffPlatform && (
+      {epicEditorConfig.allowViewFrequencySettings && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             View frequency settings
@@ -373,7 +362,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {!isOffPlatform && (
+      {epicEditorConfig.allowArticleCount && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Article count

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
-import { ControlProportionSettings, EpicTest, EpicVariant, MaxEpicViews } from './epicTestsForm';
+import {
+  ControlProportionSettings,
+  EpicTest,
+  EpicVariant,
+  isNotAllowedVariantSplit,
+  isOnlyAllowedOneVariant,
+  MaxEpicViews,
+} from './epicTestsForm';
 import { ArticlesViewedSettings, UserCohort, EpicType } from '../helpers/shared';
 import { makeStyles, FormControlLabel, Switch, Theme, Typography } from '@material-ui/core';
 import TestEditorHeader from '../testEditorHeader';
@@ -248,7 +255,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         />
       </div>
 
-      {!isAppleNews && (
+      {!isOnlyAllowedOneVariant(epicType) && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants
@@ -267,7 +274,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {!isOffPlatform && test.variants.length > 0 && (
+      {!isNotAllowedVariantSplit(epicType) && test.variants.length > 0 && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants split
@@ -284,7 +291,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {isAppleNews && (
+      {isOnlyAllowedOneVariant(epicType) && (
         <div className={classes.sectionContainer} key={test.name}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Copy

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { EpicVariant } from './epicTestsForm';
+import { EpicVariant, isOnlyAllowedOneVariant } from './epicTestsForm';
 import { Cta, EpicType, TickerSettings } from '../helpers/shared';
 import { Theme, Typography, makeStyles, TextField } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
@@ -8,13 +8,15 @@ import EpicTestTickerEditor from './epicTestTickerEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const getUseStyles = (isOffPlatform: boolean) => {
+const getUseStyles = (epicType: EpicType) => {
+  const shouldSkipPadding = isOnlyAllowedOneVariant(epicType);
+
   const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     container: {
       width: '100%',
-      paddingTop: isOffPlatform ? 0 : spacing(2),
-      paddingLeft: isOffPlatform ? 0 : spacing(4),
-      paddingRight: isOffPlatform ? 0 : spacing(10),
+      paddingTop: shouldSkipPadding ? 0 : spacing(2),
+      paddingLeft: shouldSkipPadding ? 0 : spacing(4),
+      paddingRight: shouldSkipPadding ? 0 : spacing(10),
 
       '& > * + *': {
         marginTop: spacing(1),
@@ -71,7 +73,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   const isLiveblog = epicType === 'LIVEBLOG';
   const isOffPlatform = epicType === 'APPLE_NEWS' || epicType === 'AMP';
 
-  const classes = getUseStyles(isOffPlatform)();
+  const classes = getUseStyles(epicType)();
 
   const defaultValues: FormData = {
     heading: variant.heading || '',

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -1,22 +1,20 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { EpicVariant, isOnlyAllowedOneVariant } from './epicTestsForm';
-import { Cta, EpicType, TickerSettings } from '../helpers/shared';
+import { EpicVariant } from './epicTestsForm';
+import { Cta, EpicEditorConfig, TickerSettings } from '../helpers/shared';
 import { Theme, Typography, makeStyles, TextField } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
 import EpicTestTickerEditor from './epicTestTickerEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const getUseStyles = (epicType: EpicType) => {
-  const shouldSkipPadding = isOnlyAllowedOneVariant(epicType);
-
+const getUseStyles = (shouldAddPadding: boolean) => {
   const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     container: {
       width: '100%',
-      paddingTop: shouldSkipPadding ? 0 : spacing(2),
-      paddingLeft: shouldSkipPadding ? 0 : spacing(4),
-      paddingRight: shouldSkipPadding ? 0 : spacing(10),
+      paddingTop: shouldAddPadding ? spacing(2) : 0,
+      paddingLeft: shouldAddPadding ? spacing(4) : 0,
+      paddingRight: shouldAddPadding ? spacing(10) : 0,
 
       '& > * + *': {
         marginTop: spacing(1),
@@ -56,7 +54,7 @@ interface FormData {
 
 interface EpicTestVariantEditorProps {
   variant: EpicVariant;
-  epicType: EpicType;
+  epicEditorConfig: EpicEditorConfig;
   onVariantChange: (updatedVariant: EpicVariant) => void;
   editMode: boolean;
   onDelete: () => void;
@@ -67,13 +65,10 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   variant,
   onVariantChange,
   editMode,
-  epicType,
+  epicEditorConfig,
   onValidationChange,
 }: EpicTestVariantEditorProps) => {
-  const isLiveblog = epicType === 'LIVEBLOG';
-  const isOffPlatform = epicType === 'APPLE_NEWS' || epicType === 'AMP';
-
-  const classes = getUseStyles(epicType)();
+  const classes = getUseStyles(epicEditorConfig.allowMultipleVariants)();
 
   const defaultValues: FormData = {
     heading: variant.heading || '',
@@ -134,7 +129,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
 
   return (
     <div className={classes.container}>
-      {!isLiveblog && (
+      {epicEditorConfig.allowVariantHeader && (
         <div>
           <TextField
             inputRef={register({ validate: invalidTemplateValidator })}
@@ -171,7 +166,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
         />
       </div>
 
-      {!isLiveblog && (
+      {epicEditorConfig.allowVariantHighlightedText && (
         <div>
           <TextField
             inputRef={register({
@@ -194,7 +189,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
         </div>
       )}
 
-      {!isLiveblog && !isOffPlatform && (
+      {epicEditorConfig.allowVariantImageUrl && (
         <div>
           <TextField
             inputRef={register()}
@@ -210,7 +205,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
         </div>
       )}
 
-      {!isLiveblog && !isOffPlatform && (
+      {epicEditorConfig.allowVariantFooter && (
         <div>
           <TextField
             inputRef={register()}
@@ -226,7 +221,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
         </div>
       )}
 
-      {epicType !== 'APPLE_NEWS' && (
+      {epicEditorConfig.allowVariantCustomPrimaryCta && (
         <div className={classes.sectionContainer}>
           <Typography className={classes.sectionHeader} variant="h4">
             Buttons
@@ -239,12 +234,12 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             updateSecondaryCta={updateSecondaryCta}
             isDisabled={!editMode}
             onValidationChange={onValidationChange}
-            supportSecondaryCta={!isOffPlatform}
+            supportSecondaryCta={epicEditorConfig.allowVariantCustomSecondaryCta}
           />
         </div>
       )}
 
-      {!isLiveblog && epicType !== 'APPLE_NEWS' && (
+      {epicEditorConfig.allowVariantTicker && (
         <div className={classes.sectionContainer}>
           <Typography className={classes.sectionHeader} variant="h4">
             Ticker

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -8,7 +8,6 @@ import {
   ArticlesViewedSettings,
   Test,
   Variant,
-  EpicType,
   EpicEditorConfig,
   ARTICLE_EPIC_CONFIG,
   ARTICLE_EPIC_HOLDBACK_CONFIG,
@@ -86,18 +85,6 @@ export interface EpicTest extends Test {
 }
 
 type Props = InnerComponentProps<EpicTest>;
-
-const EPICS_THAT_ONLY_ALLOW_A_SINGLE_VARIANT: EpicType[] = ['ARTICLE_HOLDBACK', 'APPLE_NEWS'];
-const EPICS_THAT_DONT_ALLOW_VARIANT_SPLIT: EpicType[] = [
-  ...EPICS_THAT_ONLY_ALLOW_A_SINGLE_VARIANT,
-  'AMP',
-];
-
-export const isOnlyAllowedOneVariant = (epicType: EpicType): boolean =>
-  EPICS_THAT_ONLY_ALLOW_A_SINGLE_VARIANT.includes(epicType);
-
-export const isNotAllowedVariantSplit = (epicType: EpicType): boolean =>
-  EPICS_THAT_DONT_ALLOW_VARIANT_SPLIT.includes(epicType);
 
 const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> => {
   const createDefaultEpicTest = (newTestName: string, newTestNickname: string): EpicTest => ({

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -82,16 +82,27 @@ export interface EpicTest extends Test {
 
 type Props = InnerComponentProps<EpicTest>;
 
+const EPICS_THAT_ONLY_ALLOW_A_SINGLE_VARIANT: EpicType[] = ['ARTICLE_HOLDBACK', 'APPLE_NEWS'];
+const EPICS_THAT_DONT_ALLOW_VARIANT_SPLIT: EpicType[] = [
+  ...EPICS_THAT_ONLY_ALLOW_A_SINGLE_VARIANT,
+  'AMP',
+];
+
+export const isOnlyAllowedOneVariant = (epicType: EpicType): boolean =>
+  EPICS_THAT_ONLY_ALLOW_A_SINGLE_VARIANT.includes(epicType);
+
+export const isNotAllowedVariantSplit = (epicType: EpicType): boolean =>
+  EPICS_THAT_DONT_ALLOW_VARIANT_SPLIT.includes(epicType);
+
 const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
   const isLiveBlog = epicType === 'LIVEBLOG';
-  const isOffPlatform = epicType === 'APPLE_NEWS' || epicType === 'AMP';
 
   const createDefaultEpicTest = (newTestName: string, newTestNickname: string): EpicTest => ({
     ...getDefaultTest(),
     name: newTestName,
     nickname: newTestNickname,
     isLiveBlog: isLiveBlog,
-    variants: isOffPlatform ? [{ ...getDefaultVariant() }] : [],
+    variants: isOnlyAllowedOneVariant(epicType) ? [{ ...getDefaultVariant() }] : [],
   });
 
   const EpicTestsForm: React.FC<Props> = ({

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -9,6 +9,12 @@ import {
   Test,
   Variant,
   EpicType,
+  EpicEditorConfig,
+  ARTICLE_EPIC_CONFIG,
+  ARTICLE_EPIC_HOLDBACK_CONFIG,
+  LIVEBLOG_EPIC_CONFIG,
+  APPLE_NEWS_EPIC_CONFIG,
+  AMP_EPIC_CONFIG,
 } from '../helpers/shared';
 import { InnerComponentProps } from '../testEditor';
 import TestsForm from '../testEditor';
@@ -71,7 +77,6 @@ export interface EpicTest extends Test {
   alwaysAsk: boolean;
   maxViews?: MaxEpicViews;
   userCohort: UserCohort;
-  isLiveBlog: boolean;
   hasCountryName: boolean;
   variants: EpicVariant[];
   highPriority: boolean; // has been removed from form, but might be used in future
@@ -94,15 +99,12 @@ export const isOnlyAllowedOneVariant = (epicType: EpicType): boolean =>
 export const isNotAllowedVariantSplit = (epicType: EpicType): boolean =>
   EPICS_THAT_DONT_ALLOW_VARIANT_SPLIT.includes(epicType);
 
-const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
-  const isLiveBlog = epicType === 'LIVEBLOG';
-
+const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> => {
   const createDefaultEpicTest = (newTestName: string, newTestNickname: string): EpicTest => ({
     ...getDefaultTest(),
     name: newTestName,
     nickname: newTestNickname,
-    isLiveBlog: isLiveBlog,
-    variants: isOnlyAllowedOneVariant(epicType) ? [{ ...getDefaultVariant() }] : [],
+    variants: epicEditorConfig.allowMultipleVariants ? [] : [{ ...getDefaultVariant() }],
   });
 
   const EpicTestsForm: React.FC<Props> = ({
@@ -150,7 +152,7 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
             <EpicTestEditor
               test={selectedTest}
               hasChanged={selectedTestHasBeenModified}
-              epicType={epicType}
+              epicEditorConfig={epicEditorConfig}
               onChange={onTestChange}
               onValidationChange={onTestErrorStatusChange}
               visible
@@ -181,24 +183,24 @@ const getEpicTestForm = (epicType: EpicType): React.FC<Props> => {
 };
 
 export const ArticleEpicTestsForm = TestsForm(
-  getEpicTestForm('ARTICLE'),
+  getEpicTestForm(ARTICLE_EPIC_CONFIG),
   FrontendSettingsType.epicTests,
 );
 
 export const ArticleEpicHoldbackTestsForm = TestsForm(
-  getEpicTestForm('ARTICLE_HOLDBACK'),
+  getEpicTestForm(ARTICLE_EPIC_HOLDBACK_CONFIG),
   FrontendSettingsType.epicHoldbackTests,
 );
 
 export const LiveblogEpicTestsForm = TestsForm(
-  getEpicTestForm('LIVEBLOG'),
+  getEpicTestForm(LIVEBLOG_EPIC_CONFIG),
   FrontendSettingsType.liveblogEpicTests,
 );
 export const AppleNewsEpicTestsForm = TestsForm(
-  getEpicTestForm('APPLE_NEWS'),
+  getEpicTestForm(APPLE_NEWS_EPIC_CONFIG),
   FrontendSettingsType.appleNewsEpicTests,
 );
 export const AMPEpicTestsForm = TestsForm(
-  getEpicTestForm('AMP'),
+  getEpicTestForm(AMP_EPIC_CONFIG),
   FrontendSettingsType.ampEpicTests,
 );

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -173,6 +173,12 @@ export const ArticleEpicTestsForm = TestsForm(
   getEpicTestForm('ARTICLE'),
   FrontendSettingsType.epicTests,
 );
+
+export const ArticleEpicHoldbackTestsForm = TestsForm(
+  getEpicTestForm('ARTICLE_HOLDBACK'),
+  FrontendSettingsType.epicHoldbackTests,
+);
+
 export const LiveblogEpicTestsForm = TestsForm(
   getEpicTestForm('LIVEBLOG'),
   FrontendSettingsType.liveblogEpicTests,

--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -59,7 +59,6 @@ const DEV_AND_CODE_DEFAULT_TEST: EpicTest = {
   alwaysAsk: false,
   maxViews: DEFAULT_MAX_EPIC_VIEWS,
   userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
-  isLiveBlog: false,
   hasCountryName: false,
   variants: [DEV_AND_CODE_DEFAULT_VARIANT],
   highPriority: false, // has been removed from form, but might be used in future
@@ -78,7 +77,6 @@ const PROD_DEFAULT_TEST: EpicTest = {
   alwaysAsk: false,
   maxViews: DEFAULT_MAX_EPIC_VIEWS,
   userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
-  isLiveBlog: false,
   hasCountryName: false,
   variants: [],
   highPriority: false, // has been removed from form, but might be used in future

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -16,6 +16,111 @@ export interface Test {
 
 export type EpicType = 'ARTICLE' | 'ARTICLE_HOLDBACK' | 'LIVEBLOG' | 'APPLE_NEWS' | 'AMP';
 
+export interface EpicEditorConfig {
+  // test level settings
+  allowMultipleVariants: boolean;
+  allowCustomVariantSplit: boolean;
+  allowContentTargetting: boolean;
+  allowLocationTargetting: boolean;
+  allowSupporterStatusTargetting: boolean;
+  allowViewFrequencySettings: boolean;
+  allowArticleCount: boolean;
+
+  // variant level settings
+  allowVariantHeader: boolean;
+  allowVariantHighlightedText: boolean;
+  allowVariantImageUrl: boolean;
+  allowVariantFooter: boolean;
+  allowVariantCustomPrimaryCta: boolean;
+  allowVariantCustomSecondaryCta: boolean;
+  allowVariantTicker: boolean;
+}
+
+export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
+  allowMultipleVariants: true,
+  allowCustomVariantSplit: true,
+  allowContentTargetting: true,
+  allowLocationTargetting: true,
+  allowSupporterStatusTargetting: true,
+  allowViewFrequencySettings: true,
+  allowArticleCount: true,
+  allowVariantHeader: true,
+  allowVariantHighlightedText: true,
+  allowVariantImageUrl: true,
+  allowVariantFooter: true,
+  allowVariantCustomPrimaryCta: true,
+  allowVariantCustomSecondaryCta: true,
+  allowVariantTicker: true,
+};
+
+export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
+  allowMultipleVariants: false,
+  allowCustomVariantSplit: false,
+  allowContentTargetting: true,
+  allowLocationTargetting: true,
+  allowSupporterStatusTargetting: true,
+  allowViewFrequencySettings: true,
+  allowArticleCount: true,
+  allowVariantHeader: true,
+  allowVariantHighlightedText: true,
+  allowVariantImageUrl: true,
+  allowVariantFooter: true,
+  allowVariantCustomPrimaryCta: true,
+  allowVariantCustomSecondaryCta: true,
+  allowVariantTicker: true,
+};
+
+export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
+  allowMultipleVariants: true,
+  allowCustomVariantSplit: true,
+  allowContentTargetting: true,
+  allowLocationTargetting: true,
+  allowSupporterStatusTargetting: true,
+  allowViewFrequencySettings: true,
+  allowArticleCount: true,
+  allowVariantHeader: false,
+  allowVariantHighlightedText: false,
+  allowVariantImageUrl: false,
+  allowVariantFooter: false,
+  allowVariantCustomPrimaryCta: true,
+  allowVariantCustomSecondaryCta: true,
+  allowVariantTicker: false,
+};
+
+export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
+  allowMultipleVariants: false,
+  allowCustomVariantSplit: false,
+  allowContentTargetting: true,
+  allowLocationTargetting: false,
+  allowSupporterStatusTargetting: true,
+  allowViewFrequencySettings: false,
+  allowArticleCount: false,
+  allowVariantHeader: true,
+  allowVariantHighlightedText: true,
+  allowVariantImageUrl: false,
+  allowVariantFooter: false,
+  allowVariantCustomPrimaryCta: false,
+  allowVariantCustomSecondaryCta: false,
+  allowVariantTicker: false,
+};
+
+export const AMP_EPIC_CONFIG: EpicEditorConfig = {
+  allowMultipleVariants: true,
+  allowCustomVariantSplit: false,
+  allowContentTargetting: false,
+  allowLocationTargetting: true,
+  allowSupporterStatusTargetting: false,
+  allowViewFrequencySettings: false,
+  allowArticleCount: false,
+  allowVariantHeader: true,
+  allowVariantHighlightedText: true,
+  allowVariantImageUrl: false,
+  allowVariantFooter: false,
+  allowVariantCustomPrimaryCta: true,
+  allowVariantCustomSecondaryCta: false,
+  allowVariantTicker: true,
+};
+
 export interface LockStatus {
   locked: boolean;
   email?: string;

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -14,7 +14,7 @@ export interface Test {
   variants: Variant[];
 }
 
-export type EpicType = 'ARTICLE' | 'LIVEBLOG' | 'APPLE_NEWS' | 'AMP';
+export type EpicType = 'ARTICLE' | 'ARTICLE_HOLDBACK' | 'LIVEBLOG' | 'APPLE_NEWS' | 'AMP';
 
 export interface LockStatus {
   locked: boolean;

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -14,15 +14,13 @@ export interface Test {
   variants: Variant[];
 }
 
-export type EpicType = 'ARTICLE' | 'ARTICLE_HOLDBACK' | 'LIVEBLOG' | 'APPLE_NEWS' | 'AMP';
-
 export interface EpicEditorConfig {
   // test level settings
   allowMultipleVariants: boolean;
   allowCustomVariantSplit: boolean;
-  allowContentTargetting: boolean;
-  allowLocationTargetting: boolean;
-  allowSupporterStatusTargetting: boolean;
+  allowContentTargeting: boolean;
+  allowLocationTargeting: boolean;
+  allowSupporterStatusTargeting: boolean;
   allowViewFrequencySettings: boolean;
   allowArticleCount: boolean;
 
@@ -39,9 +37,9 @@ export interface EpicEditorConfig {
 export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: true,
   allowCustomVariantSplit: true,
-  allowContentTargetting: true,
-  allowLocationTargetting: true,
-  allowSupporterStatusTargetting: true,
+  allowContentTargeting: true,
+  allowLocationTargeting: true,
+  allowSupporterStatusTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: true,
@@ -56,9 +54,9 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
 export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: false,
   allowCustomVariantSplit: false,
-  allowContentTargetting: true,
-  allowLocationTargetting: true,
-  allowSupporterStatusTargetting: true,
+  allowContentTargeting: true,
+  allowLocationTargeting: true,
+  allowSupporterStatusTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: true,
@@ -73,9 +71,9 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
 export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: true,
   allowCustomVariantSplit: true,
-  allowContentTargetting: true,
-  allowLocationTargetting: true,
-  allowSupporterStatusTargetting: true,
+  allowContentTargeting: true,
+  allowLocationTargeting: true,
+  allowSupporterStatusTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: false,
@@ -90,9 +88,9 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
 export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: false,
   allowCustomVariantSplit: false,
-  allowContentTargetting: true,
-  allowLocationTargetting: false,
-  allowSupporterStatusTargetting: true,
+  allowContentTargeting: true,
+  allowLocationTargeting: false,
+  allowSupporterStatusTargeting: true,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,
@@ -107,9 +105,9 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
 export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: true,
   allowCustomVariantSplit: false,
-  allowContentTargetting: false,
-  allowLocationTargetting: true,
-  allowSupporterStatusTargetting: false,
+  allowContentTargeting: false,
+  allowLocationTargeting: true,
+  allowSupporterStatusTargeting: false,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -130,6 +130,11 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Epic" />
           </ListItem>
         </Link>
+        <Link key="Epic Holdback" to="/epic-holdback-tests" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Epic Holdback">
+            <ListItemText primary="Epic Holdback" />
+          </ListItem>
+        </Link>
         <Link key="Liveblog Epic" to="/liveblog-epic-tests" className={classes.link}>
           <ListItem className={classes.listItem} button key="Liveblog Epic">
             <ListItemText primary="Liveblog Epic" />

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -8,6 +8,7 @@ import ContributionTypesForm from './components/contributionTypes';
 import ConfiguredAmountsEditor from './components/amounts/configuredAmountsEditor';
 import {
   ArticleEpicTestsForm,
+  ArticleEpicHoldbackTestsForm,
   LiveblogEpicTestsForm,
   AppleNewsEpicTestsForm,
   AMPEpicTestsForm,
@@ -111,6 +112,12 @@ const AppRouter = withStyles(styles)(({ classes }: Props) => {
             path="/epic-tests"
             render={(): React.ReactElement =>
               createComponent(<ArticleEpicTestsForm />, 'Epic Tests')
+            }
+          />
+          <Route
+            path="/epic-holdback-tests"
+            render={(): React.ReactElement =>
+              createComponent(<ArticleEpicHoldbackTestsForm />, 'Epic Holdback Tests')
             }
           />
           <Route

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -8,6 +8,7 @@ export enum SupportFrontendSettingsType {
 
 export enum FrontendSettingsType {
   epicTests = 'epic-tests',
+  epicHoldbackTests = 'epic-holdback-tests',
   liveblogEpicTests = 'liveblog-epic-tests',
   appleNewsEpicTests = 'apple-news-epic-tests',
   ampEpicTests = 'amp-epic-tests',


### PR DESCRIPTION
## What does this change?
Adds a new channel in the tool for epic holdback tests. These are treated as a normal list of tests, with the restriction that a user has no control over the variants. A single variant named 'CONTROL' is created when a new test is created (same as for Apple News too). Over on the dotcom-components side, based on a users mvtId we will funnel 1% of our audience through this holdback stack instead of the regular one. 

I think the logic for hiding/showing different parts of the epic editor is getting a little tricky to read. I think this is because we encode the type of the epic through an `EpicType` and then make the editor handle the logic based on that type. I reckon we can invert this, and instead provide and `EpicConfig` that will configure which parts of the tool to show/hide e.g.

```ts
interface EpicConfig {
  onlyShowOneVariant: boolean;
  allowCustomVariantSplit: boolean;
  /* ... */
}

const ARTICLE_EPIC_CONFIG : EpicConfig = {
  onlyShowOneVariant: false,
  allowCustomVariantSplit: true,
  /* ... */
}

const LIVEBLOG_EPIC_CONFIG : EpicConfig = {
  onlyShowOneVariant: true,
  allowCustomVariantSplit: false,
  /* ... */
}
```

I'm happy to do this refactor, but it felt like it made sense to do in a follow up PR - what do we think? 

## TODO
- create PROD/CODE s3 files (tests + locks)

## Images
<img width="1792" alt="Screenshot 2021-01-20 at 13 45 30" src="https://user-images.githubusercontent.com/17720442/105183196-ce6b7b00-5b25-11eb-8fa7-7478b4ae3128.png">
