### PR TITLE
Add holdback test name prefix

### DIFF
--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -11,6 +11,7 @@ import {
   TextField,
   WithStyles,
   withStyles,
+  InputAdornment,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 
@@ -50,6 +51,7 @@ interface CreateTestDialogProps extends WithStyles<typeof styles> {
   existingNames: string[];
   existingNicknames: string[];
   mode: Mode;
+  testNamePrefix?: string;
   createTest: (name: string, nickname: string) => void;
 }
 
@@ -60,6 +62,7 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
   existingNames,
   existingNicknames,
   mode,
+  testNamePrefix,
   createTest,
 }: CreateTestDialogProps) => {
   const defaultValues = {
@@ -72,7 +75,7 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
   });
 
   const onSubmit = ({ name, nickname }: FormData): void => {
-    createTest(name.toUpperCase(), nickname.toUpperCase());
+    createTest(`${testNamePrefix || ''}${name}`.toUpperCase(), nickname.toUpperCase());
     close();
   };
 
@@ -95,7 +98,7 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
               value: VALID_CHARACTERS_REGEX,
               message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
             },
-            validate: createDuplicateValidator(existingNames),
+            validate: createDuplicateValidator(existingNames, testNamePrefix),
           })}
           error={errors.name !== undefined}
           helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
@@ -103,6 +106,11 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
           label="Full test name"
           margin="normal"
           variant="outlined"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">{testNamePrefix || ''}</InputAdornment>
+            ),
+          }}
           autoFocus
           fullWidth
         />

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -76,6 +76,7 @@ interface EpicTestEditorProps {
   onTestSelected: (testName: string) => void;
   testNames: string[];
   testNicknames: string[];
+  testNamePrefix?: string;
   createTest: (newTest: EpicTest) => void;
 }
 
@@ -89,6 +90,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
   onTestSelected,
   testNames,
   testNicknames,
+  testNamePrefix,
   createTest,
   onValidationChange,
 }: EpicTestEditorProps) => {
@@ -381,6 +383,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         <TestEditorActionButtons
           existingNames={testNames}
           existingNicknames={testNicknames}
+          testNamePrefix={testNamePrefix}
           isDisabled={!editMode}
           onArchive={onArchive}
           onDelete={onDelete}

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -130,6 +130,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
             selectedTestName={selectedTestName}
             onTestPriorityChange={onTestPriorityChange}
             onTestSelected={onTestSelected}
+            testNamePrefix={epicEditorConfig.testNamePrefix}
             createTest={createTest}
             isInEditMode={editMode}
           />
@@ -152,6 +153,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
               testNicknames={
                 tests.map(test => test.nickname).filter(nickname => !!nickname) as string[]
               }
+              testNamePrefix={epicEditorConfig.testNamePrefix}
             />
           ) : null
         }

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -23,6 +23,7 @@ export interface EpicEditorConfig {
   allowSupporterStatusTargeting: boolean;
   allowViewFrequencySettings: boolean;
   allowArticleCount: boolean;
+  testNamePrefix?: string;
 
   // variant level settings
   allowVariantHeader: boolean;
@@ -59,6 +60,7 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowSupporterStatusTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
+  testNamePrefix: 'HOLDBACK__',
   allowVariantHeader: true,
   allowVariantHighlightedText: true,
   allowVariantImageUrl: true,

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -77,10 +77,11 @@ export const createGetDuplicateError = (existing: string[]): ((text: string) => 
 
 export const createDuplicateValidator = (
   existing: string[],
+  testNamePrefix?: string,
 ): ((text: string) => string | boolean) => {
   const existingLowerCased = existing.map(value => value.toLowerCase());
   const duplicateValidator = (text: string): string | boolean => {
-    if (existingLowerCased.includes(text.toLowerCase())) {
+    if (existingLowerCased.includes(`${testNamePrefix || ''}${text}`.toLowerCase())) {
       return DUPLICATE_ERROR_HELPER_TEXT;
     }
     return true;

--- a/public/src/components/channelManagement/newTestButton.tsx
+++ b/public/src/components/channelManagement/newTestButton.tsx
@@ -22,6 +22,7 @@ const styles = createStyles({
 interface NewTestButtonProps extends WithStyles<typeof styles> {
   existingNames: string[];
   existingNicknames: string[];
+  testNamePrefix?: string;
   createTest: (name: string, nickname: string) => void;
 }
 
@@ -29,6 +30,7 @@ const NewTestButton: React.FC<NewTestButtonProps> = ({
   classes,
   existingNames,
   existingNicknames,
+  testNamePrefix,
   createTest,
 }: NewTestButtonProps) => {
   const [isOpen, open, close] = useOpenable();
@@ -42,6 +44,7 @@ const NewTestButton: React.FC<NewTestButtonProps> = ({
         close={close}
         existingNames={existingNames}
         existingNicknames={existingNicknames}
+        testNamePrefix={testNamePrefix}
         createTest={createTest}
         mode="NEW"
       />

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -31,6 +31,7 @@ interface SidebarProps<T extends Test> {
   selectedTestName: string | null;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
+  testNamePrefix?: string;
   createTest: (name: string, nickname: string) => void;
   isInEditMode: boolean;
 }
@@ -42,6 +43,7 @@ function Sidebar<T extends Test>({
   selectedTestName,
   onTestPriorityChange,
   onTestSelected,
+  testNamePrefix,
   createTest,
 }: SidebarProps<T> & WithStyles<typeof styles>): React.ReactElement<SidebarProps<T>> {
   return (
@@ -50,6 +52,7 @@ function Sidebar<T extends Test>({
         <NewTestButton
           existingNames={tests.map(t => t.name)}
           existingNicknames={tests.map(t => t.nickname || '')}
+          testNamePrefix={testNamePrefix}
           createTest={createTest}
         />
       )}

--- a/public/src/components/channelManagement/testEditorActionButtons.tsx
+++ b/public/src/components/channelManagement/testEditorActionButtons.tsx
@@ -44,6 +44,7 @@ const styles = ({ spacing, palette }: Theme) =>
 interface TestEditorActionButtonsProps extends WithStyles<typeof styles> {
   existingNames: string[];
   existingNicknames: string[];
+  testNamePrefix?: string;
   onArchive: () => void;
   onDelete: () => void;
   isDisabled: boolean;
@@ -54,6 +55,7 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
   classes,
   existingNames,
   existingNicknames,
+  testNamePrefix,
   onArchive,
   onDelete,
   isDisabled,
@@ -159,6 +161,7 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
           close={close}
           existingNames={existingNames}
           existingNicknames={existingNicknames}
+          testNamePrefix={testNamePrefix}
           mode="COPY"
           createTest={onCopy}
         />


### PR DESCRIPTION
## What does this change?
Add the ability to set test name prefixes and set the prefix for epic holdback tests to `HOLDBACK__`

## Images

<img width="777" alt="Screenshot 2021-01-25 at 09 30 33" src="https://user-images.githubusercontent.com/17720442/105687433-579cfc00-5ef0-11eb-8509-0c2a747294d5.png">

<img width="1212" alt="Screenshot 2021-01-25 at 09 30 43" src="https://user-images.githubusercontent.com/17720442/105687438-59ff5600-5ef0-11eb-960b-270fdd1067c2.png">
