### PR TITLE
Make mobile banner copy configurable

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -17,9 +17,21 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
   case object GuardianWeeklyBanner extends BannerTemplate
 }
 
+case class BannerContent(
+  heading: Option[String],
+  messageText: String,
+  highlightedText: Option[String],
+  cta: Option[Cta],
+  secondaryCta: Option[Cta]
+)
+
 case class BannerVariant(
   name: String,
   template: BannerTemplate,
+  bannerContent: Option[BannerContent],
+  mobileBannerContent: Option[BannerContent],
+
+  // Deprecated - use bannerContent / mobileBannerContent
   heading: Option[String],
   body: String,
   highlightedText: Option[String],

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -33,7 +33,7 @@ case class BannerVariant(
 
   // Deprecated - use bannerContent / mobileBannerContent
   heading: Option[String],
-  body: String,
+  body: Option[String],
   highlightedText: Option[String],
   cta: Option[Cta],
   secondaryCta: Option[Cta]

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -14,7 +14,7 @@ import TestEditorArticleCountEditor, {
 import TestEditorActionButtons from '../testEditorActionButtons';
 import LiveSwitch from '../../shared/liveSwitch';
 import useValidation from '../hooks/useValidation';
-import { BannerTest, BannerVariant } from '../../../models/banner';
+import { BannerContent, BannerTest, BannerVariant } from '../../../models/banner';
 import { getDefaultVariant } from './utils/defaults';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -56,10 +56,13 @@ const styles = ({ spacing, palette }: Theme) =>
     },
   });
 
-const copyHasTemplate = (test: BannerTest, template: string): boolean =>
+const copyHasTemplate = (content: BannerContent, template: string): boolean =>
+  (content.heading && content.heading.includes(template)) || content.messageText.includes(template);
+const testCopyHasTemplate = (test: BannerTest, template: string): boolean =>
   test.variants.some(
     variant =>
-      (variant.heading && variant.heading.includes(template)) || variant.body.includes(template),
+      (variant.bannerContent && copyHasTemplate(variant.bannerContent, template)) ||
+      (variant.mobileBannerContent && copyHasTemplate(variant.mobileBannerContent, template)),
   );
 
 interface BannerTestEditorProps extends WithStyles<typeof styles> {
@@ -103,7 +106,7 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
     if (!!test.articlesViewedSettings) {
       return test.articlesViewedSettings;
     }
-    if (copyHasTemplate(test, articleCountTemplate)) {
+    if (testCopyHasTemplate(test, articleCountTemplate)) {
       return DEFAULT_ARTICLES_VIEWED_SETTINGS;
     }
     return undefined;

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -62,7 +62,7 @@ const HIGHTLIGHTED_TEXT_HELPER_TEXT = 'Final sentence of body copy';
 
 type DeviceType = 'ALL' | 'MOBILE' | 'NOT_MOBILE';
 
-const getFieldNameSuffix = (deviceType: DeviceType): string => {
+const getLabelSuffix = (deviceType: DeviceType): string => {
   switch (deviceType) {
     case 'MOBILE':
       return ' (mobile only)';
@@ -122,7 +122,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
     onChange({ ...content, secondaryCta: updatedCta });
   };
 
-  const labelSuffix = getFieldNameSuffix(deviceType);
+  const labelSuffix = getLabelSuffix(deviceType);
 
   return (
     <>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -67,7 +67,7 @@ const getLabelSuffix = (deviceType: DeviceType): string => {
     case 'MOBILE':
       return ' (mobile only)';
     case 'NOT_MOBILE':
-      return ' (from tablet)';
+      return ' (tablet + desktop)';
     default:
       return ' (all devices)';
   }
@@ -287,7 +287,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
             value="enabled"
             key="enabled"
             control={<Radio />}
-            label="Show different copy on mobile..."
+            label="Show different copy on mobile"
             disabled={!editMode}
           />
         </RadioGroup>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import {
-  createStyles,
   FormControlLabel,
   Radio,
   RadioGroup,
   TextField,
   Theme,
   Typography,
-  WithStyles,
-  withStyles,
+  makeStyles,
 } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
@@ -20,41 +18,40 @@ import { getDefaultVariant } from './utils/defaults';
 import useValidation from '../hooks/useValidation';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette, spacing }: Theme) =>
-  createStyles({
-    container: {
-      width: '100%',
-      paddingTop: spacing(2),
-      paddingLeft: spacing(4),
-      paddingRight: spacing(10),
+const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
+  container: {
+    width: '100%',
+    paddingTop: spacing(2),
+    paddingLeft: spacing(4),
+    paddingRight: spacing(10),
 
-      '& > * + *': {
-        marginTop: spacing(3),
-      },
+    '& > * + *': {
+      marginTop: spacing(3),
     },
-    hook: {
-      maxWidth: '400px',
+  },
+  hook: {
+    maxWidth: '400px',
+  },
+  sectionHeader: {
+    fontSize: 16,
+    color: palette.grey[900],
+    fontWeight: 500,
+  },
+  sectionContainer: {
+    paddingTop: spacing(2),
+    paddingBottom: spacing(2),
+    borderBottom: `1px solid ${palette.grey[500]}`,
+    '& > * + *': {
+      marginTop: spacing(3),
     },
-    sectionHeader: {
-      fontSize: 16,
-      color: palette.grey[900],
-      fontWeight: 500,
-    },
-    sectionContainer: {
-      paddingTop: spacing(2),
-      paddingBottom: spacing(2),
-      borderBottom: `1px solid ${palette.grey[500]}`,
-      '& > * + *': {
-        marginTop: spacing(3),
-      },
-    },
-    contentContainer: {
-      marginLeft: spacing(2),
-    },
-    buttonsContainer: {
-      marginTop: spacing(2),
-    },
-  });
+  },
+  contentContainer: {
+    marginLeft: spacing(2),
+  },
+  buttonsContainer: {
+    marginTop: spacing(2),
+  },
+}));
 
 const HEADER_DEFAULT_HELPER_TEXT = 'Assitive text';
 const BODY_DEFAULT_HELPER_TEXT = 'Main banner message, including paragraph breaks';
@@ -73,7 +70,7 @@ const getLabelSuffix = (deviceType: DeviceType): string => {
   }
 };
 
-interface BannerTestVariantContentEditorProps extends WithStyles<typeof styles> {
+interface BannerTestVariantContentEditorProps {
   content: BannerContent;
   template: BannerTemplate;
   onChange: (updatedContent: BannerContent) => void;
@@ -83,7 +80,6 @@ interface BannerTestVariantContentEditorProps extends WithStyles<typeof styles> 
 }
 
 const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorProps> = ({
-  classes,
   content,
   template,
   onChange,
@@ -91,6 +87,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
   editMode,
   deviceType,
 }: BannerTestVariantContentEditorProps) => {
+  const classes = useStyles();
+
   const defaultValues: BannerContent = {
     heading: content.heading || '',
     messageText: content.messageText,
@@ -202,9 +200,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
   );
 };
 
-const BannerTestVariantContentEditorWithStyles = withStyles(styles)(BannerTestVariantContentEditor);
-
-interface BannerTestVariantEditorProps extends WithStyles<typeof styles> {
+interface BannerTestVariantEditorProps {
   variant: BannerVariant;
   onVariantChange: (updatedVariant: BannerVariant) => void;
   editMode: boolean;
@@ -213,12 +209,12 @@ interface BannerTestVariantEditorProps extends WithStyles<typeof styles> {
 }
 
 const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
-  classes,
   variant,
   editMode,
   onValidationChange,
   onVariantChange,
 }: BannerTestVariantEditorProps) => {
+  const classes = useStyles();
   const setValidationStatusForField = useValidation(onValidationChange);
 
   const content: BannerContent = variant.bannerContent || {
@@ -259,7 +255,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
       </div>
 
       <div className={classes.sectionContainer}>
-        <BannerTestVariantContentEditorWithStyles
+        <BannerTestVariantContentEditor
           content={content}
           template={variant.template}
           onChange={(updatedContent: BannerContent): void =>
@@ -292,7 +288,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           />
         </RadioGroup>
         {variant.mobileBannerContent && (
-          <BannerTestVariantContentEditorWithStyles
+          <BannerTestVariantContentEditor
             content={variant.mobileBannerContent}
             template={variant.template}
             onChange={(updatedContent: BannerContent): void =>
@@ -310,4 +306,4 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   );
 };
 
-export default withStyles(styles)(BannerTestVariantEditor);
+export default BannerTestVariantEditor;

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -2,6 +2,9 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import {
   createStyles,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
   TextField,
   Theme,
   Typography,
@@ -12,7 +15,9 @@ import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
-import { BannerTemplate, BannerVariant } from '../../../models/banner';
+import { BannerContent, BannerTemplate, BannerVariant } from '../../../models/banner';
+import { getDefaultVariant } from './utils/defaults';
+import useValidation from '../hooks/useValidation';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette, spacing }: Theme) =>
@@ -36,12 +41,18 @@ const styles = ({ palette, spacing }: Theme) =>
       fontWeight: 500,
     },
     sectionContainer: {
-      paddingTop: spacing(1),
+      paddingTop: spacing(2),
       paddingBottom: spacing(2),
       borderBottom: `1px solid ${palette.grey[500]}`,
       '& > * + *': {
         marginTop: spacing(3),
       },
+    },
+    contentContainer: {
+      marginLeft: spacing(2),
+    },
+    buttonsContainer: {
+      marginTop: spacing(2),
     },
   });
 
@@ -49,11 +60,149 @@ const HEADER_DEFAULT_HELPER_TEXT = 'Assitive text';
 const BODY_DEFAULT_HELPER_TEXT = 'Main banner message, including paragraph breaks';
 const HIGHTLIGHTED_TEXT_HELPER_TEXT = 'Final sentence of body copy';
 
-interface FormData {
-  heading: string;
-  body: string;
-  highlightedText: string;
+type DeviceType = 'ALL' | 'MOBILE' | 'NOT_MOBILE';
+
+const getFieldNameSuffix = (deviceType: DeviceType): string => {
+  switch (deviceType) {
+    case 'MOBILE':
+      return ' (mobile only)';
+    case 'NOT_MOBILE':
+      return ' (from tablet)';
+    default:
+      return ' (all devices)';
+  }
+};
+
+interface BannerTestVariantContentEditorProps extends WithStyles<typeof styles> {
+  content: BannerContent;
+  template: BannerTemplate;
+  onChange: (updatedContent: BannerContent) => void;
+  onValidationChange: (isValid: boolean) => void;
+  editMode: boolean;
+  deviceType: DeviceType;
 }
+
+const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorProps> = ({
+  classes,
+  content,
+  template,
+  onChange,
+  onValidationChange,
+  editMode,
+  deviceType,
+}: BannerTestVariantContentEditorProps) => {
+  const defaultValues: BannerContent = {
+    heading: content.heading || '',
+    messageText: content.messageText,
+    highlightedText: content.highlightedText || '',
+  };
+
+  const { register, handleSubmit, errors, trigger } = useForm<BannerContent>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    trigger();
+  }, []);
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange(isValid);
+  }, [errors.messageText, errors.heading, errors.highlightedText]);
+
+  const onSubmit = ({ heading, messageText, highlightedText }: BannerContent): void => {
+    onChange({ ...content, heading, messageText, highlightedText });
+  };
+
+  const updatePrimaryCta = (updatedCta?: Cta): void => {
+    onChange({ ...content, cta: updatedCta });
+  };
+  const updateSecondaryCta = (updatedCta?: Cta): void => {
+    onChange({ ...content, secondaryCta: updatedCta });
+  };
+
+  const labelSuffix = getFieldNameSuffix(deviceType);
+
+  return (
+    <>
+      <Typography className={classes.sectionHeader} variant="h4">
+        {`Content${labelSuffix}`}
+      </Typography>
+      <div className={classes.contentContainer}>
+        <TextField
+          inputRef={register({ validate: invalidTemplateValidator })}
+          error={errors.heading !== undefined}
+          helperText={errors.heading ? errors.heading.message : HEADER_DEFAULT_HELPER_TEXT}
+          onBlur={handleSubmit(onSubmit)}
+          name="heading"
+          label="Header"
+          margin="normal"
+          variant="outlined"
+          disabled={!editMode}
+          fullWidth
+        />
+
+        <TextField
+          inputRef={register({
+            required: EMPTY_ERROR_HELPER_TEXT,
+            validate: invalidTemplateValidator,
+          })}
+          error={errors.messageText !== undefined}
+          helperText={errors.messageText ? errors.messageText.message : BODY_DEFAULT_HELPER_TEXT}
+          onBlur={handleSubmit(onSubmit)}
+          name="messageText"
+          label="Body copy"
+          margin="normal"
+          variant="outlined"
+          multiline
+          rows={10}
+          disabled={!editMode}
+          fullWidth
+        />
+
+        {template === BannerTemplate.ContributionsBanner && (
+          <TextField
+            inputRef={register({
+              validate: invalidTemplateValidator,
+            })}
+            error={errors.highlightedText !== undefined}
+            helperText={
+              errors.highlightedText
+                ? errors.highlightedText.message
+                : HIGHTLIGHTED_TEXT_HELPER_TEXT
+            }
+            onBlur={handleSubmit(onSubmit)}
+            name="highlightedText"
+            label="Highlighted text"
+            margin="normal"
+            variant="outlined"
+            disabled={!editMode}
+            fullWidth
+          />
+        )}
+
+        <div className={classes.buttonsContainer}>
+          <Typography className={classes.sectionHeader} variant="h4">
+            {`Buttons${labelSuffix}`}
+          </Typography>
+
+          <VariantEditorButtonsEditor
+            primaryCta={content.cta}
+            secondaryCta={content.secondaryCta}
+            updatePrimaryCta={updatePrimaryCta}
+            updateSecondaryCta={updateSecondaryCta}
+            isDisabled={!editMode}
+            onValidationChange={onValidationChange}
+            supportSecondaryCta={true}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+const BannerTestVariantContentEditorWithStyles = withStyles(styles)(BannerTestVariantContentEditor);
 
 interface BannerTestVariantEditorProps extends WithStyles<typeof styles> {
   variant: BannerVariant;
@@ -70,39 +219,34 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   onValidationChange,
   onVariantChange,
 }: BannerTestVariantEditorProps) => {
-  const defaultValues: FormData = {
-    heading: variant.heading || '',
-    body: variant.body,
-    highlightedText: variant.highlightedText || '',
+  const setValidationStatusForField = useValidation(onValidationChange);
+
+  const content: BannerContent = variant.bannerContent || {
+    heading: variant.heading,
+    messageText: variant.body || '',
+    highlightedText: variant.highlightedText,
+    cta: variant.cta,
+    secondaryCta: variant.secondaryCta,
   };
 
-  const { register, handleSubmit, errors, trigger } = useForm<FormData>({
-    mode: 'onChange',
-    defaultValues,
-  });
-
-  useEffect(() => {
-    trigger();
-  }, []);
-
-  useEffect(() => {
-    const isValid = Object.keys(errors).length === 0;
-    onValidationChange(isValid);
-  }, [errors.body, errors.heading, errors.highlightedText]);
-
-  const onSubmit = ({ heading, body, highlightedText }: FormData): void => {
-    onVariantChange({ ...variant, heading, body, highlightedText });
-  };
-
-  const updatePrimaryCta = (updatedCta?: Cta): void => {
-    onVariantChange({ ...variant, cta: updatedCta });
-  };
-  const updateSecondaryCta = (updatedCta?: Cta): void => {
-    onVariantChange({ ...variant, secondaryCta: updatedCta });
+  const onMobileContentRadioChange = (): void => {
+    if (variant.mobileBannerContent === undefined) {
+      onVariantChange({
+        ...variant,
+        mobileBannerContent: getDefaultVariant().bannerContent,
+      });
+    } else {
+      // remove mobile content and clear any validation errors
+      setValidationStatusForField('mobileContent', true);
+      onVariantChange({
+        ...variant,
+        mobileBannerContent: undefined,
+      });
+    }
   };
 
   return (
-    <div className={classes.container}>
+    <div>
       <div className={classes.sectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">
           Banner template
@@ -114,70 +258,53 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
         />
       </div>
 
-      <TextField
-        inputRef={register({ validate: invalidTemplateValidator })}
-        error={errors.heading !== undefined}
-        helperText={errors.heading ? errors.heading.message : HEADER_DEFAULT_HELPER_TEXT}
-        onBlur={handleSubmit(onSubmit)}
-        name="heading"
-        label="Header"
-        margin="normal"
-        variant="outlined"
-        disabled={!editMode}
-        fullWidth
-      />
-
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-          validate: invalidTemplateValidator,
-        })}
-        error={errors.body !== undefined}
-        helperText={errors.body ? errors.body.message : BODY_DEFAULT_HELPER_TEXT}
-        onBlur={handleSubmit(onSubmit)}
-        name="body"
-        label="Body copy"
-        margin="normal"
-        variant="outlined"
-        multiline
-        rows={10}
-        disabled={!editMode}
-        fullWidth
-      />
-
-      {variant.template === BannerTemplate.ContributionsBanner && (
-        <TextField
-          inputRef={register({
-            validate: invalidTemplateValidator,
-          })}
-          error={errors.highlightedText !== undefined}
-          helperText={
-            errors.highlightedText ? errors.highlightedText.message : HIGHTLIGHTED_TEXT_HELPER_TEXT
-          }
-          onBlur={handleSubmit(onSubmit)}
-          name="highlightedText"
-          label="Highlighted text"
-          margin="normal"
-          variant="outlined"
-          disabled={!editMode}
-          fullWidth
-        />
-      )}
-
       <div className={classes.sectionContainer}>
-        <Typography className={classes.sectionHeader} variant="h4">
-          Buttons
-        </Typography>
-
-        <VariantEditorButtonsEditor
-          primaryCta={variant.cta}
-          secondaryCta={variant.secondaryCta}
-          updatePrimaryCta={updatePrimaryCta}
-          updateSecondaryCta={updateSecondaryCta}
-          isDisabled={!editMode}
-          onValidationChange={onValidationChange}
-          supportSecondaryCta={true}
+        <BannerTestVariantContentEditorWithStyles
+          content={content}
+          template={variant.template}
+          onChange={(updatedContent: BannerContent): void =>
+            onVariantChange({ ...variant, bannerContent: updatedContent })
+          }
+          onValidationChange={(isValid): void =>
+            setValidationStatusForField('mainContent', isValid)
+          }
+          editMode={editMode}
+          deviceType={variant.mobileBannerContent === undefined ? 'ALL' : 'NOT_MOBILE'}
         />
+
+        <RadioGroup
+          value={variant.mobileBannerContent !== undefined ? 'enabled' : 'disabled'}
+          onChange={onMobileContentRadioChange}
+        >
+          <FormControlLabel
+            value="disabled"
+            key="disabled"
+            control={<Radio />}
+            label="Show the same copy across devices"
+            disabled={!editMode}
+          />
+          <FormControlLabel
+            value="enabled"
+            key="enabled"
+            control={<Radio />}
+            label="Show different copy on mobile..."
+            disabled={!editMode}
+          />
+        </RadioGroup>
+        {variant.mobileBannerContent && (
+          <BannerTestVariantContentEditorWithStyles
+            content={variant.mobileBannerContent}
+            template={variant.template}
+            onChange={(updatedContent: BannerContent): void =>
+              onVariantChange({ ...variant, mobileBannerContent: updatedContent })
+            }
+            onValidationChange={(isValid): void =>
+              setValidationStatusForField('mobileContent', isValid)
+            }
+            editMode={editMode}
+            deviceType={'MOBILE'}
+          />
+        )}
       </div>
     </div>
   );

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -6,24 +6,28 @@ import { getStage } from '../../../../utils/stage';
 const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
   template: BannerTemplate.ContributionsBanner,
-  heading: 'We chose a different approach. Will you support it?',
-  body:
-    'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
-  highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
-  cta: {
-    text: 'Support the Guardian',
-    baseUrl: 'https://support.theguardian.com/contribute',
+  bannerContent: {
+    heading: 'We chose a different approach. Will you support it?',
+    messageText:
+      'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+    highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+    cta: {
+      text: 'Support the Guardian',
+      baseUrl: 'https://support.theguardian.com/contribute',
+    },
   },
 };
 
 const PROD_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
   template: BannerTemplate.ContributionsBanner,
-  body: '',
-  highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
-  cta: {
-    text: 'Support the Guardian',
-    baseUrl: 'https://support.theguardian.com/contribute',
+  bannerContent: {
+    messageText: '',
+    highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+    cta: {
+      text: 'Support the Guardian',
+      baseUrl: 'https://support.theguardian.com/contribute',
+    },
   },
 };
 

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -12,10 +12,22 @@ export enum BannerTemplate {
   DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',
 }
+
+export interface BannerContent {
+  heading?: string;
+  messageText: string;
+  highlightedText?: string;
+  cta?: Cta;
+  secondaryCta?: Cta;
+}
 export interface BannerVariant extends Variant {
   template: BannerTemplate;
+  bannerContent?: BannerContent;
+  mobileBannerContent?: BannerContent;
+
+  // Deprecated - use bannerContent / mobileBannerContent
   heading?: string;
-  body: string;
+  body?: string;
   highlightedText?: string;
   cta?: Cta;
   secondaryCta?: Cta;


### PR DESCRIPTION
Backend PR: https://github.com/guardian/support-dotcom-components/pull/373

This PR changes the banner test variant model to include:
```
  bannerContent: Option[BannerContent],
  mobileBannerContent: Option[BannerContent],
```

For the migration it will support both the old and new models.

### Screenshots
By default there is no mobile-specific content:
![Screen Shot 2021-02-24 at 11 47 38](https://user-images.githubusercontent.com/1513454/108996401-3a498200-7696-11eb-87af-cfc8e2e72b62.png)

A new content editor is added below if radio button changes:
![Screen Shot 2021-02-24 at 11 47 53](https://user-images.githubusercontent.com/1513454/108996428-42092680-7696-11eb-8de9-832c81c09469.png)

And the label above changes as well:
![Screen Shot 2021-02-24 at 11 48 13](https://user-images.githubusercontent.com/1513454/108996474-551bf680-7696-11eb-88ae-90a84b821bfd.png)
