### PR TITLE
Allow outbound traffic from Wazuh scanner

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -71,6 +71,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
       - !Ref InstanceSecurityGroup
+      - !Ref WazuhSecurityGroup
       InstanceType: t4g.micro
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -248,6 +249,18 @@ Resources:
       - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
+        CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId:
+        Ref: VpcId
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
         CidrIp: 0.0.0.0/0
 
   LogGroup:


### PR DESCRIPTION
## What are you doing in this PR?

This is opening ports 1514 and 1515 for outbound traffic, which is currently restricted to port 443.

## Why are you doing this?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

The scanner has already been installed in the ami image, but it's attempt to connect with the central server is being block by the instance security group. Hopefully this will fix it, otherwise I'll have to review network ACLs!

## Testing

Tested in code ✅