### PR TITLE
Add separate article count settings to variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ package-lock.json
 .DS_Store
 .bloop/
 .metals/
-project/.bloop/
+project

--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -39,6 +39,18 @@ case class TickerSettings(
   copy: TickerCopy
 )
 
+sealed trait SeparateArticleCountType extends EnumEntry
+object SeparateArticleCountType extends Enum[SeparateArticleCountType] with CirceEnum[SeparateArticleCountType] {
+  override val values: IndexedSeq[SeparateArticleCountType] = findValues
+
+  case object above extends SeparateArticleCountType
+}
+
+
+case class SeparateArticleCount(
+  `type`: SeparateArticleCountType,
+)
+
 case class EpicVariant(
   name: String,
   heading: Option[String],
@@ -49,7 +61,8 @@ case class EpicVariant(
   tickerSettings: Option[TickerSettings] = None,
   backgroundImageUrl: Option[String] = None,
   cta: Option[Cta],
-  secondaryCta: Option[Cta]
+  secondaryCta: Option[Cta],
+  separateArticleCount: Option[SeparateArticleCount],
 )
 case class EpicTest(
   name: String,

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { EpicVariant } from './epicTestsForm';
+import { EpicVariant, SeparateArticleCount } from './epicTestsForm';
 import { Cta, EpicEditorConfig, TickerSettings } from '../helpers/shared';
 import { Theme, Typography, makeStyles, TextField } from '@material-ui/core';
 import VariantEditorButtonsEditor from '../variantEditorButtonsEditor';
+import VariantEditorSeparateArticleCountEditor from '../variantEditorSeparateArticleCountEditor';
 import EpicTestTickerEditor from './epicTestTickerEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 
@@ -123,6 +124,9 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   const updateSecondaryCta = (updatedCta?: Cta): void => {
     onVariantChange({ ...variant, secondaryCta: updatedCta });
   };
+  const updateSeparateArticleCount = (updatedSeparateArticleCount?: SeparateArticleCount): void => {
+    onVariantChange({ ...variant, separateArticleCount: updatedSeparateArticleCount });
+  };
   const updateTickerSettings = (updatedTickerSettings?: TickerSettings): void => {
     onVariantChange({ ...variant, tickerSettings: updatedTickerSettings });
   };
@@ -238,6 +242,20 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             isDisabled={!editMode}
             onValidationChange={onValidationChange}
             supportSecondaryCta={epicEditorConfig.allowVariantCustomSecondaryCta}
+          />
+        </div>
+      )}
+
+      {epicEditorConfig.allowVariantSeparateArticleCount && (
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.sectionHeader} variant="h4">
+            Separate article count
+          </Typography>
+
+          <VariantEditorSeparateArticleCountEditor
+            separateArticleCount={variant.separateArticleCount}
+            updateSeparateArticleCount={updateSeparateArticleCount}
+            isDisabled={!editMode}
           />
         </div>
       )}

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -41,6 +41,11 @@ export interface TickerSettings {
   currencySymbol: string;
   copy: TickerCopy;
 }
+
+export interface SeparateArticleCount {
+  type: 'above';
+}
+
 export interface EpicVariant extends Variant {
   heading?: string;
   paragraphs: string[];
@@ -51,6 +56,7 @@ export interface EpicVariant extends Variant {
   backgroundImageUrl?: string;
   cta?: Cta;
   secondaryCta?: Cta;
+  separateArticleCount?: SeparateArticleCount;
 }
 
 export interface MaxEpicViews {

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -32,6 +32,7 @@ export interface EpicEditorConfig {
   allowVariantFooter: boolean;
   allowVariantCustomPrimaryCta: boolean;
   allowVariantCustomSecondaryCta: boolean;
+  allowVariantSeparateArticleCount: boolean;
   allowVariantTicker: boolean;
   requireVariantHeader: boolean;
 }
@@ -50,6 +51,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantFooter: true,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: true,
+  allowVariantSeparateArticleCount: true,
   allowVariantTicker: true,
   requireVariantHeader: true,
 };
@@ -69,6 +71,7 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowVariantFooter: true,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: true,
+  allowVariantSeparateArticleCount: true,
   allowVariantTicker: true,
   requireVariantHeader: true,
 };
@@ -87,6 +90,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantFooter: false,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: true,
+  allowVariantSeparateArticleCount: false,
   allowVariantTicker: false,
   requireVariantHeader: false,
 };
@@ -105,6 +109,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantFooter: false,
   allowVariantCustomPrimaryCta: false,
   allowVariantCustomSecondaryCta: false,
+  allowVariantSeparateArticleCount: false,
   allowVariantTicker: false,
   requireVariantHeader: true,
 };
@@ -123,6 +128,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantFooter: false,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: false,
+  allowVariantSeparateArticleCount: false,
   allowVariantTicker: true,
   requireVariantHeader: true,
 };

--- a/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import { SeparateArticleCount } from './epicTests/epicTestsForm';
+
+interface VariantEditorSeparateArticleCountEditorProps {
+  separateArticleCount?: SeparateArticleCount;
+  updateSeparateArticleCount: (separateArticleCount?: SeparateArticleCount) => void;
+  isDisabled: boolean;
+}
+
+const VariantEditorSeparateArticleCountEditor: React.FC<VariantEditorSeparateArticleCountEditorProps> = ({
+  separateArticleCount,
+  updateSeparateArticleCount,
+  isDisabled,
+}: VariantEditorSeparateArticleCountEditorProps) => {
+  const onChange = (): void => {
+    updateSeparateArticleCount(Boolean(separateArticleCount) ? undefined : { type: 'above' });
+  };
+
+  return (
+    <div>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={Boolean(separateArticleCount)}
+            onChange={onChange}
+            color="primary"
+            disabled={isDisabled}
+          />
+        }
+        label="Above"
+      />
+    </div>
+  );
+};
+
+export default VariantEditorSeparateArticleCountEditor;


### PR DESCRIPTION
## What does this change?
Adds a variant level config to turn on/off the separate article count feature. For now it is effectively either on/off, but we've given ourselves some leeway in the model to add new fields/allow new types of article count. 

The corresponding SDC PR is: https://github.com/guardian/support-dotcom-components/pull/417. 

## Images
<img width="505" alt="Screenshot 2021-04-12 at 15 06 13" src="https://user-images.githubusercontent.com/17720442/114416719-e0027300-9ba8-11eb-9a54-04f0c27aebf0.png">
