### PR TITLE
Make cta fields required

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.IndexedSeq
 
 case class ControlProportionSettings(proportion: Float, offset: Int)
 
-case class Cta(text: Option[String], baseUrl: Option[String])
+case class Cta(text: String, baseUrl: String)
 
 sealed trait SecondaryCta
 

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
@@ -19,6 +19,11 @@ const DEFAULT_PRIMARY_CTA: Cta = {
   baseUrl: 'https://support.theguardian.com/contribute',
 };
 
+const DEFAULT_SECONDARY_CTA: Cta = {
+  text: '',
+  baseUrl: '',
+};
+
 interface EpicTestVariantEditorButtonsEditorProps extends WithStyles<typeof styles> {
   primaryCta?: Cta;
   secondaryCta?: SecondaryCta;
@@ -56,6 +61,7 @@ const EpicTestVariantEditorButtonsEditor: React.FC<EpicTestVariantEditorButtonsE
           isDisabled={isDisabled}
           cta={secondaryCta}
           updateCta={updateSecondaryCta}
+          defaultCta={DEFAULT_SECONDARY_CTA}
           onValidationChange={onValidationChange}
         />
       )}

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -147,8 +147,8 @@ export interface TestStatus {
 }
 
 export interface Cta {
-  text?: string;
-  baseUrl?: string;
+  text: string;
+  baseUrl: string;
 }
 
 export enum SecondaryCtaType {

--- a/public/src/components/channelManagement/variantEditorCtaFieldsEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorCtaFieldsEditor.tsx
@@ -38,8 +38,8 @@ const VariantEditorCtaFieldsEditor: React.FC<VariantEditorCtaFieldsEditorProps> 
   isDisabled,
 }: VariantEditorCtaFieldsEditorProps) => {
   const defaultValues: FormData = {
-    text: cta.text || '',
-    baseUrl: cta.baseUrl || '',
+    text: cta.text,
+    baseUrl: cta.baseUrl,
   };
 
   const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });

--- a/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
@@ -34,6 +34,7 @@ interface VariantEditorSecondaryCtaEditorProps extends WithStyles<typeof styles>
   updateCta: (updatedCta?: SecondaryCta) => void;
   onValidationChange: (isValid: boolean) => void;
   isDisabled: boolean;
+  defaultCta: Cta;
 }
 
 const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorProps> = ({
@@ -43,12 +44,13 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
   updateCta,
   onValidationChange,
   isDisabled,
+  defaultCta,
 }: VariantEditorSecondaryCtaEditorProps) => {
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     const value = event.target.value as SecondaryCtaType | 'None';
 
     if (value === SecondaryCtaType.Custom) {
-      updateCta({ type: SecondaryCtaType.Custom, cta: {} });
+      updateCta({ type: SecondaryCtaType.Custom, cta: defaultCta });
     } else if (value === SecondaryCtaType.ContributionsReminder) {
       updateCta({ type: SecondaryCtaType.ContributionsReminder });
     } else {


### PR DESCRIPTION
## What does this change?
Make the `Cta` fields required to match with dotcom-components.