### PR TITLE
Add g200 banner template

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -15,6 +15,7 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
   case object ContributionsBanner extends BannerTemplate
   case object DigitalSubscriptionsBanner extends BannerTemplate
   case object GuardianWeeklyBanner extends BannerTemplate
+  case object G200Banner extends BannerTemplate
 }
 
 case class BannerContent(

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -27,6 +27,7 @@ const templatesWithLabels = [
   { template: BannerTemplate.ContributionsBanner, label: 'Contributions' },
   { template: BannerTemplate.DigitalSubscriptionsBanner, label: 'Digital subscriptions' },
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
+  { template: BannerTemplate.G200Banner, label: 'G200' },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -127,19 +127,22 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
       <Typography className={classes.sectionHeader} variant="h4">
         {`Content${labelSuffix}`}
       </Typography>
+
       <div className={classes.contentContainer}>
-        <TextField
-          inputRef={register({ validate: invalidTemplateValidator })}
-          error={errors.heading !== undefined}
-          helperText={errors.heading ? errors.heading.message : HEADER_DEFAULT_HELPER_TEXT}
-          onBlur={handleSubmit(onSubmit)}
-          name="heading"
-          label="Header"
-          margin="normal"
-          variant="outlined"
-          disabled={!editMode}
-          fullWidth
-        />
+        {template !== BannerTemplate.G200Banner && (
+          <TextField
+            inputRef={register({ validate: invalidTemplateValidator })}
+            error={errors.heading !== undefined}
+            helperText={errors.heading ? errors.heading.message : HEADER_DEFAULT_HELPER_TEXT}
+            onBlur={handleSubmit(onSubmit)}
+            name="heading"
+            label="Header"
+            margin="normal"
+            variant="outlined"
+            disabled={!editMode}
+            fullWidth
+          />
+        )}
 
         <TextField
           inputRef={register({
@@ -159,26 +162,27 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
           fullWidth
         />
 
-        {template === BannerTemplate.ContributionsBanner && (
-          <TextField
-            inputRef={register({
-              validate: invalidTemplateValidator,
-            })}
-            error={errors.highlightedText !== undefined}
-            helperText={
-              errors.highlightedText
-                ? errors.highlightedText.message
-                : HIGHTLIGHTED_TEXT_HELPER_TEXT
-            }
-            onBlur={handleSubmit(onSubmit)}
-            name="highlightedText"
-            label="Highlighted text"
-            margin="normal"
-            variant="outlined"
-            disabled={!editMode}
-            fullWidth
-          />
-        )}
+        {template === BannerTemplate.ContributionsBanner ||
+          (template === BannerTemplate.G200Banner && (
+            <TextField
+              inputRef={register({
+                validate: invalidTemplateValidator,
+              })}
+              error={errors.highlightedText !== undefined}
+              helperText={
+                errors.highlightedText
+                  ? errors.highlightedText.message
+                  : HIGHTLIGHTED_TEXT_HELPER_TEXT
+              }
+              onBlur={handleSubmit(onSubmit)}
+              name="highlightedText"
+              label="Highlighted text"
+              margin="normal"
+              variant="outlined"
+              disabled={!editMode}
+              fullWidth
+            />
+          ))}
 
         <div className={classes.buttonsContainer}>
           <Typography className={classes.sectionHeader} variant="h4">

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -9,6 +9,7 @@ import { BannerTemplate, BannerVariant } from '../../../models/banner';
 import { Cta } from '../helpers/shared';
 import Typography from '@material-ui/core/Typography';
 import { withPreviewStyles } from '../previewContainer';
+import { getStage } from '../../../utils/stage';
 
 export interface BannerContent {
   heading?: string;
@@ -75,6 +76,10 @@ const bannerModules = {
     path: 'contributions/ContributionsBanner.js',
     name: 'ContributionsBanner',
   },
+  [BannerTemplate.G200Banner]: {
+    path: 'g200/G200Banner.js',
+    name: 'G200Banner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
@@ -120,15 +125,16 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
       emotion,
     };
 
-    window
-      .remoteImport(
-        `https://contributions.guardianapis.com/modules/v1/banners/${
-          bannerModules[variant.template].path
-        }`,
-      )
-      .then(bannerModule => {
-        setBanner(() => withPreviewStyles(bannerModule[bannerModules[variant.template].name]));
-      });
+    const stage = getStage();
+
+    const baseUrl =
+      stage === 'PROD'
+        ? 'https://contributions.guardianapis.com/modules/v1/banners'
+        : 'https://contributions.code.dev-guardianapis.com/modules/v1/banners';
+
+    window.remoteImport(`${baseUrl}/${bannerModules[variant.template].path}`).then(bannerModule => {
+      setBanner(() => withPreviewStyles(bannerModule[bannerModules[variant.template].name]));
+    });
   }, [variant.template]);
 
   const toggleDrawer = (open: boolean) => (event: React.MouseEvent): void => {

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -5,6 +5,7 @@ import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
 import { EpicVariant } from './epicTestsForm';
 import { withPreviewStyles } from '../previewContainer';
+import { getStage } from '../../../utils/stage';
 
 interface EpicProps {
   variant: EpicVariant;
@@ -75,11 +76,16 @@ const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
       emotion,
     };
 
-    window
-      .remoteImport('https://contributions.guardianapis.com/modules/v1/epics/ContributionsEpic.js')
-      .then(epicModule => {
-        setEpic(() => withPreviewStyles(epicModule.ContributionsEpic));
-      });
+    const stage = getStage();
+
+    const url =
+      stage === 'PROD'
+        ? 'https://contributions.guardianapis.com/modules/v1/epics/ContributionsEpic.js'
+        : 'https://contributions.code.dev-guardianapis.com/modules/v1/epics/ContributionsEpic.js';
+
+    window.remoteImport(url).then(epicModule => {
+      setEpic(() => withPreviewStyles(epicModule.ContributionsEpic));
+    });
   }, []);
 
   const props = buildProps(variant);

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -11,6 +11,7 @@ export enum BannerTemplate {
   ContributionsBanner = 'ContributionsBanner',
   DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',
+  G200Banner = 'G200Banner',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
## What does this change?
Add g200 banner template as a new banner variant in the tool. Additionally, points the `CODE/DEV` versions of the tool at the `CODE` versions of the modules.

### Images

<img width="1792" alt="Screenshot 2021-04-26 at 12 08 26" src="https://user-images.githubusercontent.com/17720442/116073920-f28caa00-a688-11eb-9ee1-3c0852530d80.png">
