### PR TITLE
Banner editor padding

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -242,7 +242,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   };
 
   return (
-    <div>
+    <div className={classes.container}>
       <div className={classes.sectionContainer}>
         <Typography className={classes.sectionHeader} variant="h4">
           Banner template


### PR DESCRIPTION
## What does this change?
I noticed we'd lost the padding on the banner variant editor - this adds it back!

## Images

### before

<img width="1195" alt="Screenshot 2021-04-27 at 09 03 58" src="https://user-images.githubusercontent.com/17720442/116207852-35f22180-a738-11eb-9900-8ce5b6bc47b4.png">

### after

<img width="1195" alt="Screenshot 2021-04-27 at 09 03 29" src="https://user-images.githubusercontent.com/17720442/116207859-37bbe500-a738-11eb-9a7f-c0cfc647ff76.png">
