### PR TITLE
Add reminders to banner

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -23,7 +23,7 @@ case class BannerContent(
   messageText: String,
   highlightedText: Option[String],
   cta: Option[Cta],
-  secondaryCta: Option[Cta]
+  secondaryCta: Option[SecondaryCta]
 )
 
 case class BannerVariant(

--- a/app/models/Cta.scala
+++ b/app/models/Cta.scala
@@ -1,0 +1,24 @@
+package models
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.auto._
+import io.circe.{Decoder, Encoder}
+
+case class Cta(text: String, baseUrl: String)
+
+sealed trait SecondaryCta
+
+case class CustomSecondaryCta(
+  `type`: String = "CustomSecondaryCta",
+  cta: Cta,
+) extends SecondaryCta
+
+case class ContributionsReminderSecondaryCta(
+  `type`: String = "ContributionsReminderSecondaryCta",
+) extends SecondaryCta
+
+object SecondaryCta {
+  implicit val customConfig: Configuration = Configuration.default.withDiscriminator("type")
+
+  implicit val secondaryCtaDecoder = Decoder[SecondaryCta]
+  implicit val secondaryCtaEncoder = Encoder[SecondaryCta]
+}

--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -7,26 +7,6 @@ import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable.IndexedSeq
 
-case class Cta(text: String, baseUrl: String)
-
-sealed trait SecondaryCta
-
-case class CustomSecondaryCta(
-  `type`: String = "CustomSecondaryCta",
-  cta: Cta,
-) extends SecondaryCta
-
-case class ContributionsReminderSecondaryCta(
-  `type`: String = "ContributionsReminderSecondaryCta",
-) extends SecondaryCta
-
-object SecondaryCta {
-  implicit val customConfig: Configuration = Configuration.default.withDiscriminator("type")
-
-  implicit val secondaryCtaDecoder = Decoder[SecondaryCta]
-  implicit val secondaryCtaEncoder = Encoder[SecondaryCta]
-}
-
 sealed trait TickerEndType extends EnumEntry
 object TickerEndType extends Enum[TickerEndType] with CirceEnum[TickerEndType] {
   override val values: IndexedSeq[TickerEndType] = findValues

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@material-ui/core';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
-import { Cta } from '../helpers/shared';
+import { Cta, SecondaryCta } from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
 import { BannerContent, BannerTemplate, BannerVariant } from '../../../models/banner';
 import { getDefaultVariant } from './utils/defaults';
@@ -116,7 +116,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
   const updatePrimaryCta = (updatedCta?: Cta): void => {
     onChange({ ...content, cta: updatedCta });
   };
-  const updateSecondaryCta = (updatedCta?: Cta): void => {
+  const updateSecondaryCta = (updatedCta?: SecondaryCta): void => {
     onChange({ ...content, secondaryCta: updatedCta });
   };
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
-import { Cta } from '../helpers/shared';
+import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
+import { Cta, SecondaryCta } from '../helpers/shared';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
@@ -25,9 +26,9 @@ const DEFAULT_SECONDARY_CTA = {
 
 interface BannerTestVariantEditorCtasEditorProps extends WithStyles<typeof styles> {
   primaryCta?: Cta;
-  secondaryCta?: Cta;
+  secondaryCta?: SecondaryCta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
-  updateSecondaryCta: (updatedCta?: Cta) => void;
+  updateSecondaryCta: (updatedCta?: SecondaryCta) => void;
   onValidationChange: (isValid: boolean) => void;
   isDisabled: boolean;
   supportSecondaryCta: boolean;
@@ -55,7 +56,7 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
       />
 
       {supportSecondaryCta && (
-        <VariantEditorCtaEditor
+        <VariantEditorSecondaryCtaEditor
           label="Secondary button"
           isDisabled={isDisabled}
           cta={secondaryCta}

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -6,7 +6,7 @@ import * as emotionTheming from 'emotion-theming';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
 import { BannerTemplate, BannerVariant } from '../../../models/banner';
-import { Cta } from '../helpers/shared';
+import { Cta, SecondaryCta } from '../helpers/shared';
 import Typography from '@material-ui/core/Typography';
 import { withPreviewStyles } from '../previewContainer';
 import { getStage } from '../../../utils/stage';
@@ -16,7 +16,7 @@ export interface BannerContent {
   messageText: string;
   highlightedText?: string;
   cta?: Cta;
-  secondaryCta?: Cta;
+  secondaryCta?: SecondaryCta;
 }
 
 interface BannerProps {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -4,6 +4,7 @@ import {
   Test,
   Variant,
   UserCohort,
+  SecondaryCta,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
@@ -20,7 +21,7 @@ export interface BannerContent {
   messageText: string;
   highlightedText?: string;
   cta?: Cta;
-  secondaryCta?: Cta;
+  secondaryCta?: SecondaryCta;
 }
 export interface BannerVariant extends Variant {
   template: BannerTemplate;


### PR DESCRIPTION
## What does this change?
Update the banner model + UI to support having the option to have a contributions reminder as the secondary cta.

## Migration plan

Merging this will break the tool in PROD. We will have to manually update the the data in s3 for any test that **has a secondary cta**. For tests **without** a secondary cta, the field is **undefined** so will be fine after the merge.

## Images
<img width="1151" alt="Screenshot 2021-05-14 at 13 17 08" src="https://user-images.githubusercontent.com/17720442/118269493-b776dd00-b4b6-11eb-8b4f-0092b9b1e1f5.png">