### PR TITLE
Add copy length warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/react-beautiful-dnd": "^13.0.0",
     "immutability-helper": "^3.0.1",
     "react": "^17.0.2",

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -10,6 +10,7 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
+import VariantEditorCopyLengthWarning from '../variantEditorCopyLengthWarning';
 import { invalidTemplateValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
@@ -56,6 +57,9 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
 const HEADER_DEFAULT_HELPER_TEXT = 'Assitive text';
 const BODY_DEFAULT_HELPER_TEXT = 'Main banner message, including paragraph breaks';
 const HIGHTLIGHTED_TEXT_HELPER_TEXT = 'Final sentence of body copy';
+
+const HEADER_COPY_RECOMMENDED_LENGTH = 50;
+const BODY_COPY_RECOMMENDED_LENGTH = 525;
 
 type DeviceType = 'ALL' | 'MOBILE' | 'NOT_MOBILE';
 
@@ -122,6 +126,9 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
 
   const labelSuffix = getLabelSuffix(deviceType);
 
+  const headerCopyLength = content.heading?.length ?? 0;
+  const bodyCopyLength = content.messageText.length + (content.highlightedText?.length ?? 0);
+
   return (
     <>
       <Typography className={classes.sectionHeader} variant="h4">
@@ -130,59 +137,71 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
 
       <div className={classes.contentContainer}>
         {template !== BannerTemplate.G200Banner && (
-          <TextField
-            inputRef={register({ validate: invalidTemplateValidator })}
-            error={errors.heading !== undefined}
-            helperText={errors.heading ? errors.heading.message : HEADER_DEFAULT_HELPER_TEXT}
-            onBlur={handleSubmit(onSubmit)}
-            name="heading"
-            label="Header"
-            margin="normal"
-            variant="outlined"
-            disabled={!editMode}
-            fullWidth
-          />
+          <div>
+            <TextField
+              inputRef={register({ validate: invalidTemplateValidator })}
+              error={errors.heading !== undefined}
+              helperText={errors.heading ? errors.heading.message : HEADER_DEFAULT_HELPER_TEXT}
+              onBlur={handleSubmit(onSubmit)}
+              name="heading"
+              label="Header"
+              margin="normal"
+              variant="outlined"
+              disabled={!editMode}
+              fullWidth
+            />
+
+            {headerCopyLength > HEADER_COPY_RECOMMENDED_LENGTH && (
+              <VariantEditorCopyLengthWarning charLimit={HEADER_COPY_RECOMMENDED_LENGTH} />
+            )}
+          </div>
         )}
 
-        <TextField
-          inputRef={register({
-            required: EMPTY_ERROR_HELPER_TEXT,
-            validate: invalidTemplateValidator,
-          })}
-          error={errors.messageText !== undefined}
-          helperText={errors.messageText ? errors.messageText.message : BODY_DEFAULT_HELPER_TEXT}
-          onBlur={handleSubmit(onSubmit)}
-          name="messageText"
-          label="Body copy"
-          margin="normal"
-          variant="outlined"
-          multiline
-          rows={10}
-          disabled={!editMode}
-          fullWidth
-        />
-
-        {(template === BannerTemplate.ContributionsBanner ||
-          template === BannerTemplate.G200Banner) && (
+        <div>
           <TextField
             inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
               validate: invalidTemplateValidator,
             })}
-            error={errors.highlightedText !== undefined}
-            helperText={
-              errors.highlightedText
-                ? errors.highlightedText.message
-                : HIGHTLIGHTED_TEXT_HELPER_TEXT
-            }
+            error={errors.messageText !== undefined}
+            helperText={errors.messageText ? errors.messageText.message : BODY_DEFAULT_HELPER_TEXT}
             onBlur={handleSubmit(onSubmit)}
-            name="highlightedText"
-            label="Highlighted text"
+            name="messageText"
+            label="Body copy"
             margin="normal"
             variant="outlined"
+            multiline
+            rows={10}
             disabled={!editMode}
             fullWidth
           />
-        )}
+
+          {(template === BannerTemplate.ContributionsBanner ||
+            template === BannerTemplate.G200Banner) && (
+            <TextField
+              inputRef={register({
+                validate: invalidTemplateValidator,
+              })}
+              error={errors.highlightedText !== undefined}
+              helperText={
+                errors.highlightedText
+                  ? errors.highlightedText.message
+                  : HIGHTLIGHTED_TEXT_HELPER_TEXT
+              }
+              onBlur={handleSubmit(onSubmit)}
+              name="highlightedText"
+              label="Highlighted text"
+              margin="normal"
+              variant="outlined"
+              disabled={!editMode}
+              fullWidth
+            />
+          )}
+
+          {bodyCopyLength > BODY_COPY_RECOMMENDED_LENGTH && (
+            <VariantEditorCopyLengthWarning charLimit={BODY_COPY_RECOMMENDED_LENGTH} />
+          )}
+        </div>
 
         <div className={classes.buttonsContainer}>
           <Typography className={classes.sectionHeader} variant="h4">

--- a/public/src/components/channelManagement/variantEditorCopyLengthWarning.tsx
+++ b/public/src/components/channelManagement/variantEditorCopyLengthWarning.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Alert from '@material-ui/lab/Alert';
+
+interface VariantEditorCopyLengthWarningProps {
+  charLimit: number;
+}
+
+const VariantEditorCopyLengthWarning: React.FC<VariantEditorCopyLengthWarningProps> = ({
+  charLimit,
+}: VariantEditorCopyLengthWarningProps) => {
+  return (
+    <Alert severity="warning">
+      This copy is longer than the recommended <strong>{charLimit}</strong> characters. Please
+      preview across breakpoints before publishing.
+    </Alert>
+  );
+};
+
+export default VariantEditorCopyLengthWarning;


### PR DESCRIPTION
## What does this change?
Add some UI to warn a user when creating a banner test with too much copy (causing the banner to overflow at certain breakpoints). 

**TODO**
- [x] update with proper limits
- [x] update copy?

## Images
<img width="1792" alt="Screenshot 2021-05-27 at 13 30 02" src="https://user-images.githubusercontent.com/17720442/119826681-2fe69080-bef0-11eb-88f9-2609bb071841.png">
