### PR TITLE
Show AC above in live preview

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -22,6 +22,7 @@ interface EpicProps {
   };
   countryCode?: string;
   numArticles: number;
+  hasConsentForArticleCount?: boolean;
 }
 
 const buildProps = (variant: EpicVariant): EpicProps => ({
@@ -32,6 +33,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     highlightedText: variant.highlightedText,
     showTicker: false,
     cta: variant.cta,
+    separateArticleCount: variant.separateArticleCount,
   },
   tracking: {
     ophanPageId: 'ophanPageId',
@@ -47,6 +49,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
   },
   numArticles: 13,
   countryCode: 'GB',
+  hasConsentForArticleCount: true,
 });
 
 const useStyles = makeStyles(({}: Theme) => ({


### PR DESCRIPTION
## What does this change?
Show AC above in live preview

<img width="759" alt="Screenshot 2021-06-30 at 11 16 44" src="https://user-images.githubusercontent.com/17720442/123944201-ccd79600-d994-11eb-8e42-7387994562e3.png">
