### PR TITLE
Add region selector for apple news epics

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -300,6 +300,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             onRegionsUpdate={onRegionsChange}
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
+            supportedRegions={epicEditorConfig.supportedRegions}
             isDisabled={!editMode}
             showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargeting}
           />

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -1,3 +1,4 @@
+import { Region } from '../../../utils/models';
 import { ValidationStatus } from './validation';
 
 export interface Variant {
@@ -20,6 +21,7 @@ export interface EpicEditorConfig {
   allowCustomVariantSplit: boolean;
   allowContentTargeting: boolean;
   allowLocationTargeting: boolean;
+  supportedRegions?: Region[];
   allowSupporterStatusTargeting: boolean;
   allowViewFrequencySettings: boolean;
   allowArticleCount: boolean;
@@ -99,8 +101,9 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: false,
   allowCustomVariantSplit: false,
   allowContentTargeting: true,
-  allowLocationTargeting: false,
-  allowSupporterStatusTargeting: true,
+  allowLocationTargeting: true,
+  supportedRegions: [Region.UnitedStates, Region.AUDCountries],
+  allowSupporterStatusTargeting: false,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -24,6 +24,7 @@ interface TestEditorTargetAudienceSelectorProps extends WithStyles<typeof styles
   onRegionsUpdate: (selectedRegions: Region[]) => void;
   selectedCohort: UserCohort;
   onCohortChange: (updatedCohort: UserCohort) => void;
+  supportedRegions?: Region[];
   isDisabled: boolean;
   showSupporterStatusSelector: boolean;
 }
@@ -33,6 +34,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   onRegionsUpdate,
   selectedCohort,
   onCohortChange,
+  supportedRegions,
   isDisabled,
   showSupporterStatusSelector,
 }: TestEditorTargetAudienceSelectorProps) => {
@@ -41,6 +43,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
       <TestEditorTargetRegionsSelector
         selectedRegions={selectedRegions}
         onRegionsUpdate={onRegionsUpdate}
+        supportedRegions={supportedRegions}
         isDisabled={isDisabled}
       />
 

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -40,16 +40,20 @@ const ALL_REGIONS = Object.values(Region);
 interface TestEditorTargetRegionsSelectorProps extends WithStyles<typeof styles> {
   selectedRegions: Region[];
   onRegionsUpdate: (selectedRegions: Region[]) => void;
+  supportedRegions?: Region[];
   isDisabled: boolean;
 }
 const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorProps> = ({
   classes,
   selectedRegions,
   onRegionsUpdate,
+  supportedRegions,
   isDisabled,
 }: TestEditorTargetRegionsSelectorProps) => {
+  const allRegions = supportedRegions || ALL_REGIONS;
+
   const onAllRegionsChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    onRegionsUpdate(event.target.checked ? ALL_REGIONS : []);
+    onRegionsUpdate(event.target.checked ? allRegions : []);
   };
 
   const onSingleRegionChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -71,7 +75,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
         <FormControlLabel
           control={
             <Checkbox
-              checked={selectedRegions.length === ALL_REGIONS.length}
+              checked={selectedRegions.length === allRegions.length}
               value={'allRegions'}
               onChange={onAllRegionsChange}
               disabled={isDisabled}
@@ -80,7 +84,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
           label={'All regions'}
         />
         <FormGroup className={classes.indentedContainer}>
-          {ALL_REGIONS.map(region => (
+          {allRegions.map(region => (
             <FormControlLabel
               key={region}
               control={


### PR DESCRIPTION
## What does this change?

Add a region selector for apple news epics. We're launching apple news in Aus so we want to be able to target epics specific to the US or Australia. 

## Images

<img width="314" alt="Screenshot 2021-09-01 at 11 55 33" src="https://user-images.githubusercontent.com/17720442/131659902-e60fdbf7-eed9-42d4-876c-39a89c6bb97f.png">

