### PR TITLE
Add hardcoded epic test switch

### DIFF
--- a/app/models/ChannelSwitches.scala
+++ b/app/models/ChannelSwitches.scala
@@ -6,7 +6,8 @@ import io.circe.generic.auto._
 case class ChannelSwitches(
   enableEpics: Boolean,
   enableBanners: Boolean,
-  enableSuperMode: Boolean
+  enableSuperMode: Boolean,
+  enableHardcodedEpicTests: Boolean,
 )
 
 object ChannelSwitches {

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-type SwitchName = 'enableBanners' | 'enableEpics' | 'enableSuperMode';
+type SwitchName = 'enableBanners' | 'enableEpics' | 'enableSuperMode' | 'enableHardcodedEpicTests';
 
 type ChannelSwitches = {
   [key in SwitchName]: boolean;
@@ -88,6 +88,12 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
         name="enableSuperMode"
         label="Enable Article Super Mode"
         enabled={switches.enableSuperMode}
+        setSwitch={onSwitchChange}
+      />
+      <ChannelSwitch
+        name="enableHardcodedEpicTests"
+        label="Enable hardcoded epic tests"
+        enabled={switches.enableHardcodedEpicTests}
         setSwitch={onSwitchChange}
       />
 


### PR DESCRIPTION
TODO - make dotcom-components use this boolean

![Screen Shot 2021-09-06 at 13 26 41](https://user-images.githubusercontent.com/1513454/132217369-404855cd-16a8-4683-872a-90088af7e426.png)
