### PR TITLE
Fix control proportion bug

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -21,7 +21,10 @@ import { ARTICLE_COUNT_TEMPLATE, COUNTRY_NAME_TEMPLATE } from '../helpers/valida
 import TestVariantsSplitEditor from '../testVariantsSplitEditor';
 import { getDefaultVariant } from './utils/defaults';
 import LiveSwitch from '../../shared/liveSwitch';
-import { ControlProportionSettings } from '../helpers/controlProportionSettings';
+import {
+  canHaveCustomVariantSplit,
+  ControlProportionSettings,
+} from '../helpers/controlProportionSettings';
 import { useStyles } from '../helpers/testEditorStyles';
 
 const copyHasTemplate = (test: EpicTest, template: string): boolean =>
@@ -107,7 +110,11 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
 
   const onVariantDelete = (deletedVariantName: string): void => {
     const updatedVariantList = test.variants.filter(variant => variant.name !== deletedVariantName);
-    onVariantsChange(updatedVariantList);
+    const controlProportionSettings = canHaveCustomVariantSplit(updatedVariantList)
+      ? test.controlProportionSettings
+      : undefined;
+
+    updateTest({ ...test, variants: updatedVariantList, controlProportionSettings });
   };
 
   const createVariant = (name: string): void => {
@@ -233,7 +240,7 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         </div>
       )}
 
-      {epicEditorConfig.allowCustomVariantSplit && test.variants.length > 1 && (
+      {epicEditorConfig.allowCustomVariantSplit && canHaveCustomVariantSplit(test.variants) && (
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants split

--- a/public/src/components/channelManagement/helpers/controlProportionSettings.ts
+++ b/public/src/components/channelManagement/helpers/controlProportionSettings.ts
@@ -1,4 +1,18 @@
+import { Variant } from './shared';
+
 export interface ControlProportionSettings {
   proportion: number;
   offset: number;
+}
+
+export function hasControl(variants: Variant[]): boolean {
+  return variants.findIndex(v => v.name.toLowerCase() === 'control') > -1;
+}
+
+export function hasNonControlVariant(variants: Variant[]): boolean {
+  return variants.filter(v => v.name !== 'control').length > 0;
+}
+
+export function canHaveCustomVariantSplit(variants: Variant[]): boolean {
+  return hasControl(variants) && hasNonControlVariant(variants);
 }

--- a/public/src/components/channelManagement/testVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/testVariantsSplitEditor.tsx
@@ -11,12 +11,9 @@ import {
 import { Variant } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 import { useForm } from 'react-hook-form';
-import { ControlProportionSettings } from './helpers/controlProportionSettings';
+import { ControlProportionSettings, hasControl } from './helpers/controlProportionSettings';
 
 const MAX_MVT = 1_000_000;
-
-const hasControl = (variants: Variant[]): boolean =>
-  !!variants.find(v => v.name.toLowerCase() === 'control');
 
 const randomMvt = (): number => Math.round(Math.random() * MAX_MVT);
 
@@ -169,7 +166,7 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
           />
         </RadioGroup>
 
-        {controlProportionSettings && hasControl(variants) && (
+        {controlProportionSettings && (
           <div className={classes.variantsContainer}>
             <div>
               <TextField


### PR DESCRIPTION
## What does this change?
Fix control proportion bug where a test with 0 or 1 variant(s) can have `controlProportionSettings` set. This caused a bug in support-dotcom-components that led to 500s. We've fixed the SDC bug in this [PR](https://github.com/guardian/support-dotcom-components/pull/532), but this PR ensures that we reset the `controlProportionSettings` settings when dropping down to just a single variant. 