### PR TITLE
Add scrollbar and padding to Switches and Contribution types pages

### DIFF
--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -56,6 +56,10 @@ const styles = ({ palette, spacing }: Theme) =>
     form: {
       display: 'flex',
       flexDirection: 'row',
+      marginTop: spacing(4),
+      marginLeft: spacing(4),
+      marginRight: spacing(4),
+      marginBottom: spacing(4),
     },
     button: {
       marginRight: spacing(2),

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -125,6 +125,12 @@ const styles = ({ palette, spacing }: Theme) =>
     buttons: {
       marginTop: spacing(2),
     },
+    form: {
+      marginTop: spacing(4),
+      marginLeft: spacing(4),
+      marginRight: spacing(4),
+      marginBottom: spacing(4),
+    },
   });
 
 type Props = WithStyles<typeof styles>;
@@ -231,7 +237,7 @@ class Switchboard extends React.Component<Props, Switches> {
     const { classes } = this.props;
 
     return (
-      <form>
+      <form className={classes.form}>
         <div>
           {/* as "div", as "label" typecasts are to get around this issue: https://github.com/mui-org/material-ui/issues/13744 */}
           <FormControl component={'fieldset' as 'div'} className={classes.formControl}>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -87,7 +87,6 @@ const styles = ({ palette, mixins, typography, transitions }: Theme) =>
     appContent: {
       display: 'flex',
       flexDirection: 'column',
-      overflow: 'hidden',
       flexGrow: 1,
       backgroundColor: palette.grey[100],
     },


### PR DESCRIPTION
Allows users to access buttons on smaller windows

Before:
![Screenshot 2021-10-06 at 15 21 08](https://user-images.githubusercontent.com/5357530/136348529-3ef1d3c7-10dc-458c-a093-bf922f4f9631.png)

After:
![Screenshot 2021-10-06 at 16 07 58](https://user-images.githubusercontent.com/5357530/136348602-e0964b7e-d7dd-4824-ae29-a83635133df9.png)

