### PR TITLE
Reinstate overflow:hidden on page <main> element

### DIFF
--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -130,6 +130,7 @@ const styles = ({ palette, spacing }: Theme) =>
       marginLeft: spacing(4),
       marginRight: spacing(4),
       marginBottom: spacing(4),
+      overflowY: 'auto',
     },
   });
 

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -87,6 +87,7 @@ const styles = ({ palette, mixins, typography, transitions }: Theme) =>
     appContent: {
       display: 'flex',
       flexDirection: 'column',
+      overflow: 'hidden',
       flexGrow: 1,
       backgroundColor: palette.grey[100],
     },


### PR DESCRIPTION
Fixes regression caused by PR #237

Current situation: black toolbar no longer fixed to bottom of viewport on pages (eg Epic) which trigger an overflow-y scrollbar
![Screenshot 2021-10-07 at 10 41 58](https://user-images.githubusercontent.com/5357530/136363426-432deffb-4554-4d20-8a13-df06833f3cac.png)

Fix: reverts the CSS fixing the toolbar to the bottom of the viewport, and includes an alternative fix so that users can scroll down to reach the action buttons on the Switches page
![Screenshot 2021-10-07 at 10 42 26](https://user-images.githubusercontent.com/5357530/136363672-d8a97b04-2774-4944-bacf-16ba66a6c41a.png)
![Screenshot 2021-10-07 at 10 42 54](https://user-images.githubusercontent.com/5357530/136363693-cb363c5c-cfcf-423f-8dd7-cb8e690feb7f.png)


