### PR TITLE
Fix Liveblog Epic Tests bug - preview panel now displays liveblog epic

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -195,7 +195,9 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
           }
         />
       }
-      variantPreview={<EpicVariantPreview variant={variant} />}
+      variantPreview={
+        <EpicVariantPreview variant={variant} moduleName={epicEditorConfig.moduleName} />
+      }
     />
   );
 

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -6,6 +6,8 @@ import { EpicVariant } from './epicTestsForm';
 import { withPreviewStyles } from '../previewContainer';
 import { getStage } from '../../../utils/stage';
 
+import { EpicModuleName } from '../helpers/shared';
+
 export interface ArticleCounts {
   for52Weeks: number; // The user's total article view count, which currently goes back as far as 52 weeks
   forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
@@ -68,10 +70,12 @@ const useStyles = makeStyles(({}: Theme) => ({
 
 interface EpicVariantPreviewProps {
   variant: EpicVariant;
+  moduleName: EpicModuleName;
 }
 
 const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
   variant,
+  moduleName,
 }: EpicVariantPreviewProps) => {
   const classes = useStyles();
 
@@ -89,11 +93,11 @@ const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
 
     const url =
       stage === 'PROD'
-        ? 'https://contributions.guardianapis.com/modules/v2/epics/ContributionsEpic.js'
-        : 'https://contributions.code.dev-guardianapis.com/modules/v2/epics/ContributionsEpic.js';
+        ? `https://contributions.guardianapis.com/modules/v2/epics/${moduleName}.js`
+        : `https://contributions.code.dev-guardianapis.com/modules/v2/epics/${moduleName}.js`;
 
     window.remoteImport(url).then(epicModule => {
-      setEpic(() => withPreviewStyles(epicModule.ContributionsEpic));
+      setEpic(() => withPreviewStyles(epicModule[moduleName]));
     });
   }, []);
 

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -7,6 +7,8 @@ export interface Variant {
 
 export type TestType = 'EPIC' | 'BANNER';
 
+export type EpicModuleName = 'ContributionsEpic' | 'ContributionsLiveblogEpic';
+
 export interface Test {
   name: string;
   nickname?: string;
@@ -38,6 +40,7 @@ export interface EpicEditorConfig {
   allowVariantTicker: boolean;
   allowVariantChoiceCards: boolean;
   requireVariantHeader: boolean;
+  moduleName: EpicModuleName;
 }
 
 export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
@@ -58,6 +61,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   requireVariantHeader: true,
+  moduleName: 'ContributionsEpic',
 };
 
 export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
@@ -79,6 +83,7 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   requireVariantHeader: true,
+  moduleName: 'ContributionsEpic',
 };
 
 export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
@@ -99,6 +104,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: false,
   allowVariantChoiceCards: false,
   requireVariantHeader: false,
+  moduleName: 'ContributionsLiveblogEpic',
 };
 
 export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
@@ -120,6 +126,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: false,
   allowVariantChoiceCards: false,
   requireVariantHeader: true,
+  moduleName: 'ContributionsEpic',
 };
 
 export const AMP_EPIC_CONFIG: EpicEditorConfig = {
@@ -140,6 +147,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: false,
   requireVariantHeader: true,
+  moduleName: 'ContributionsEpic',
 };
 
 export interface LockStatus {


### PR DESCRIPTION
## What does this change?
On RRPC, the Liveblog Epic Tests preview displayed using the standard Epic layout. This PR fixes that bug.
