### PR TITLE
Add functionality to batch delete or archive draft tests

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -27,6 +27,8 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
     onTestSave,
     onTestDelete,
     onTestArchive,
+    onBatchTestDelete,
+    onBatchTestArchive,
     onTestCreate,
     onTestErrorStatusChange,
     lockStatus,
@@ -59,6 +61,8 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
             isInEditMode={editMode}
             regionFilter={regionFilter}
             setRegionFilter={setRegionFilter}
+            onBatchTestDelete={onBatchTestDelete}
+            onBatchTestArchive={onBatchTestArchive}
           />
         }
         testEditor={

--- a/public/src/components/channelManagement/batchProcessTestButton.tsx
+++ b/public/src/components/channelManagement/batchProcessTestButton.tsx
@@ -23,7 +23,6 @@ const styles = createStyles({
 
 interface BatchProcessTestButtonProps extends WithStyles<typeof styles> {
   draftTests: Test[];
-  tests: Test[];
   onBatchTestDelete: (batchTestNames: string[]) => void;
   onBatchTestArchive: (batchTestNames: string[]) => void;
 }
@@ -31,7 +30,6 @@ interface BatchProcessTestButtonProps extends WithStyles<typeof styles> {
 const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
   classes,
   draftTests,
-  tests,
   onBatchTestDelete,
   onBatchTestArchive,
 }: BatchProcessTestButtonProps) => {
@@ -50,7 +48,6 @@ const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
         isOpen={isOpen}
         close={close}
         draftTests={draftTests}
-        tests={tests}
         onBatchTestDelete={onBatchTestDelete}
         onBatchTestArchive={onBatchTestArchive}
       />

--- a/public/src/components/channelManagement/batchProcessTestButton.tsx
+++ b/public/src/components/channelManagement/batchProcessTestButton.tsx
@@ -24,8 +24,8 @@ const styles = createStyles({
 interface BatchProcessTestButtonProps extends WithStyles<typeof styles> {
   draftTests: Test[];
   tests: Test[];
-  onBatchTestDelete: (batchTestNames: string) => void;
-  onBatchTestArchive: (batchTestNames: string) => void;
+  onBatchTestDelete: (batchTestNames: string[]) => void;
+  onBatchTestArchive: (batchTestNames: string[]) => void;
 }
 
 const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({

--- a/public/src/components/channelManagement/batchProcessTestButton.tsx
+++ b/public/src/components/channelManagement/batchProcessTestButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Button, createStyles, Typography, WithStyles, withStyles } from '@material-ui/core';
+import { Test } from './helpers/shared';
+import ArchiveIcon from '@material-ui/icons/Archive';
+
+import BatchProcessTestDialog from './batchProcessTestDialog';
+import useOpenable from '../../hooks/useOpenable';
+
+const styles = createStyles({
+  button: {
+    borderStyle: 'dashed',
+    justifyContent: 'start',
+    height: '48px',
+    marginTop: '8px',
+  },
+  text: {
+    fontSize: '12px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+  },
+});
+
+interface BatchProcessTestButtonProps extends WithStyles<typeof styles> {
+  draftTests: Test[];
+  tests: Test[];
+  onBatchTestDelete: (batchTestNames: string) => void;
+  onBatchTestArchive: (batchTestNames: string) => void;
+}
+
+const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
+  classes,
+  draftTests,
+  tests,
+  onBatchTestDelete,
+  onBatchTestArchive,
+}: BatchProcessTestButtonProps) => {
+  const [isOpen, open, close] = useOpenable();
+  return (
+    <>
+      <Button
+        variant="outlined"
+        className={classes.button}
+        startIcon={<ArchiveIcon />}
+        onClick={open}
+      >
+        <Typography className={classes.text}>Batch archive/delete tests</Typography>
+      </Button>
+      <BatchProcessTestDialog
+        isOpen={isOpen}
+        close={close}
+        draftTests={draftTests}
+        tests={tests}
+        onBatchTestDelete={onBatchTestDelete}
+        onBatchTestArchive={onBatchTestArchive}
+      />
+    </>
+  );
+};
+
+export default withStyles(styles)(BatchProcessTestButton);

--- a/public/src/components/channelManagement/batchProcessTestDialog.tsx
+++ b/public/src/components/channelManagement/batchProcessTestDialog.tsx
@@ -128,10 +128,10 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
                   <Checkbox
                     edge="start"
                     checked={selectedTests.indexOf(t.name) >= 0}
-                    tabIndex={-1}
-                    disableRipple
+                    // tabIndex={-1}
+                    // disableRipple
                     inputProps={{ 'aria-labelledby': labelId }}
-                    onClick={handleToggle(t.name)}
+                    onChange={handleToggle(t.name)}
                   />
                 </ListItemIcon>
                 <ListItemText id={labelId} primary={t.nickname || t.name} />

--- a/public/src/components/channelManagement/batchProcessTestDialog.tsx
+++ b/public/src/components/channelManagement/batchProcessTestDialog.tsx
@@ -128,8 +128,6 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
                   <Checkbox
                     edge="start"
                     checked={selectedTests.indexOf(t.name) >= 0}
-                    // tabIndex={-1}
-                    // disableRipple
                     inputProps={{ 'aria-labelledby': labelId }}
                     onChange={handleToggle(t.name)}
                   />

--- a/public/src/components/channelManagement/batchProcessTestDialog.tsx
+++ b/public/src/components/channelManagement/batchProcessTestDialog.tsx
@@ -1,0 +1,238 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  createStyles,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Checkbox,
+  Typography,
+  WithStyles,
+  withStyles,
+} from '@material-ui/core';
+import { Test } from './helpers/shared';
+import CloseIcon from '@material-ui/icons/Close';
+import useOpenable from '../../hooks/useOpenable';
+
+const styles = createStyles({
+  dialogHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '8px',
+  },
+});
+
+type FormData = {
+  selectedTests: Test[];
+};
+
+interface BatchProcessTestDialogProps extends WithStyles<typeof styles> {
+  isOpen: boolean;
+  close: () => void;
+  draftTests: Test[];
+  tests: Test[];
+  onBatchTestDelete: (batchTestNames: string) => void;
+  onBatchTestArchive: (batchTestNames: string) => void;
+}
+
+const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
+  classes,
+  isOpen,
+  close,
+  draftTests,
+  onBatchTestDelete,
+  onBatchTestArchive,
+}: BatchProcessTestDialogProps) => {
+  const defaultValues = {
+    selectedTests: [],
+  };
+
+  const { handleSubmit } = useForm<FormData>({
+    defaultValues,
+  });
+
+  const currentSelectedTests: Test[] = [];
+
+  const [checked, setChecked] = useState([-1]);
+  const [selectedBatchProcess, setSelectedBatchProcess] = useState('');
+  const [selectedTests, setSelectedTests] = useState(currentSelectedTests);
+
+  const getSelectedTests = (): Test[] => {
+    currentSelectedTests.length = 0;
+
+    checked.forEach(i => {
+      if (i >= 0) {
+        currentSelectedTests.push(draftTests[i]);
+      }
+    });
+    return currentSelectedTests;
+  };
+
+  const getSelectedTestNames = (): string => {
+    if (!selectedTests) {
+      return '';
+    }
+
+    const namesArray: string[] = [];
+    selectedTests.forEach(t => namesArray.push(t.name));
+    return namesArray.join(', ');
+  };
+
+  const [isConfirmOpen, confirmOpen, confirmClose] = useOpenable();
+
+  const onArchiveSubmit = (): void => {
+    setSelectedTests(getSelectedTests());
+    setSelectedBatchProcess('ARCHIVE');
+    confirmOpen();
+  };
+
+  const completeArchiveSubmit = (): void => {
+    confirmClose();
+    const selectedNames = getSelectedTestNames();
+    onBatchTestArchive(selectedNames);
+    setSelectedBatchProcess('');
+    setChecked([-1]);
+    close();
+  };
+
+  const onDeleteSubmit = (): void => {
+    setSelectedTests(getSelectedTests());
+    setSelectedBatchProcess('DELETE');
+    confirmOpen();
+  };
+
+  const completeDeleteSubmit = (): void => {
+    const selectedNames = getSelectedTestNames();
+    confirmClose();
+    onBatchTestDelete(selectedNames);
+    setSelectedBatchProcess('');
+    setChecked([-1]);
+    close();
+  };
+
+  const onCancel = (): void => {
+    setChecked([-1]);
+    close();
+  };
+
+  const handleToggle = (value: number) => (): void => {
+    const currentIndex = checked.indexOf(value);
+    const newChecked = [...checked];
+
+    if (currentIndex < 0) {
+      newChecked.push(value);
+    } else {
+      newChecked.splice(currentIndex, 1);
+    }
+    setChecked(newChecked);
+  };
+
+  const isDelete = (): boolean => {
+    if (selectedBatchProcess === 'DELETE') {
+      return true;
+    }
+    return false;
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onCancel}
+      fullWidth={true}
+      maxWidth="sm"
+      aria-labelledby="batch-process-dialog-title"
+    >
+      <div className={classes.dialogHeader}>
+        <DialogTitle id="batch-process-dialog-title">Batch archive or delete tests</DialogTitle>
+        <IconButton onClick={onCancel} aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </div>
+      <DialogContent dividers>
+        <List>
+          {draftTests.map((t, index) => {
+            const labelId = `checkbox-label-${t.name}`,
+              value = index;
+
+            return (
+              <ListItem key={value} onClick={handleToggle(value)}>
+                <ListItemIcon>
+                  <Checkbox
+                    edge="start"
+                    checked={checked.indexOf(value) !== -1}
+                    tabIndex={-1}
+                    disableRipple
+                    inputProps={{ 'aria-labelledby': labelId }}
+                  />
+                </ListItemIcon>
+                <ListItemText id={labelId} primary={t.nickname || t.name} />
+              </ListItem>
+            );
+          })}
+        </List>
+      </DialogContent>
+      <Dialog
+        open={isConfirmOpen}
+        onClose={confirmClose}
+        fullWidth={true}
+        maxWidth="sm"
+        aria-labelledby="batch-process-dialog-confirm-title"
+      >
+        <div className={classes.dialogHeader}>
+          <DialogTitle id="batch-process-dialog-title">
+            Batch {isDelete() ? 'delete' : 'archive'} tests
+          </DialogTitle>
+          <IconButton onClick={confirmClose} aria-label="close">
+            <CloseIcon />
+          </IconButton>
+        </div>
+        <DialogContent dividers>
+          <Typography>
+            Please confirm. The following tests will be{' '}
+            <strong>{isDelete() ? 'deleted' : 'archived'}</strong>:
+          </Typography>
+          <ul>
+            {selectedTests.map((t, i) => (
+              <li key={i}>{t.nickname || t.name}</li>
+            ))}
+          </ul>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleSubmit(confirmClose)} color="primary">
+            Cancel
+          </Button>
+          {isDelete() ? (
+            <Button onClick={handleSubmit(completeDeleteSubmit)} color="secondary">
+              Delete
+            </Button>
+          ) : (
+            <Button onClick={handleSubmit(completeArchiveSubmit)} color="secondary">
+              Archive
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+      <DialogActions>
+        <Button onClick={handleSubmit(onCancel)} color="primary">
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit(onArchiveSubmit)} color="secondary">
+          Archive
+        </Button>
+        <Button onClick={handleSubmit(onDeleteSubmit)} color="secondary">
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default withStyles(styles)(BatchProcessTestDialog);

--- a/public/src/components/channelManagement/batchProcessTestDialog.tsx
+++ b/public/src/components/channelManagement/batchProcessTestDialog.tsx
@@ -33,7 +33,6 @@ interface BatchProcessTestDialogProps extends WithStyles<typeof styles> {
   isOpen: boolean;
   close: () => void;
   draftTests: Test[];
-  tests: Test[];
   onBatchTestDelete: (batchTestNames: string[]) => void;
   onBatchTestArchive: (batchTestNames: string[]) => void;
 }
@@ -93,21 +92,16 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
     setSelectedTests(currentSelected);
   };
 
-  const getTestNickname = (val: string): string => {
-    const myTestArray = draftTests.filter(t => val === t.name);
+  const getTestNickname = (name: string): string => {
+    const test = draftTests.find(t => name === t.name);
 
-    if (myTestArray.length) {
-      return myTestArray[0].nickname || val;
+    if (test) {
+      return test.nickname || name;
     }
-    return val;
+    return name;
   };
 
-  const isDelete = (): boolean => {
-    if (selectedBatchProcess === 'DELETE') {
-      return true;
-    }
-    return false;
-  };
+  const isDelete = selectedBatchProcess === 'DELETE';
 
   return (
     <Dialog
@@ -129,15 +123,15 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
             const labelId = `checkbox-label-${t.name}`;
 
             return (
-              <ListItem key={index} onClick={handleToggle(t.name)}>
+              <ListItem key={index}>
                 <ListItemIcon>
                   <Checkbox
                     edge="start"
                     checked={selectedTests.indexOf(t.name) >= 0}
-                    // value={t.name}
                     tabIndex={-1}
                     disableRipple
                     inputProps={{ 'aria-labelledby': labelId }}
+                    onClick={handleToggle(t.name)}
                   />
                 </ListItemIcon>
                 <ListItemText id={labelId} primary={t.nickname || t.name} />
@@ -155,7 +149,7 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
       >
         <div className={classes.dialogHeader}>
           <DialogTitle id="batch-process-dialog-title">
-            Batch {isDelete() ? 'delete' : 'archive'} tests
+            Batch {isDelete ? 'delete' : 'archive'} tests
           </DialogTitle>
           <IconButton onClick={confirmClose} aria-label="close">
             <CloseIcon />
@@ -164,7 +158,7 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
         <DialogContent dividers>
           <Typography>
             Please confirm. The following tests will be{' '}
-            <strong>{isDelete() ? 'deleted' : 'archived'}</strong>:
+            <strong>{isDelete ? 'deleted' : 'archived'}</strong>:
           </Typography>
           <ul>
             {selectedTests.map((t, i) => (
@@ -176,7 +170,7 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
           <Button onClick={confirmClose} color="primary">
             Cancel
           </Button>
-          {isDelete() ? (
+          {isDelete ? (
             <Button onClick={completeDeleteSubmit} color="secondary">
               Delete
             </Button>

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -107,6 +107,8 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
     onTestSave,
     onTestDelete,
     onTestArchive,
+    onBatchTestDelete,
+    onBatchTestArchive,
     onTestErrorStatusChange,
     onTestChange,
     onTestCreate,
@@ -142,6 +144,8 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
             isInEditMode={editMode}
             regionFilter={regionFilter}
             setRegionFilter={setRegionFilter}
+            onBatchTestDelete={onBatchTestDelete}
+            onBatchTestArchive={onBatchTestArchive}
           />
         }
         testEditor={

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -77,7 +77,6 @@ function Sidebar<T extends Test>({
           />
           <BatchProcessTestButton
             // filter out live tests and any test currently being edited
-            tests={tests}
             draftTests={tests.filter(t => (!t.isOn && t.name !== selectedTestName ? true : false))}
             onBatchTestDelete={onBatchTestDelete}
             onBatchTestArchive={onBatchTestArchive}

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -4,6 +4,7 @@ import { Test } from './helpers/shared';
 import TestList from './testList';
 import TestPriorityLabelList from './testPriorityLabelList';
 import NewTestButton from './newTestButton';
+import BatchProcessTestButton from './batchProcessTestButton';
 
 import TestListSidebarFilterSelector from './testListSidebarFilterSelector';
 import { RegionsAndAll } from '../../utils/models';
@@ -39,6 +40,8 @@ interface SidebarProps<T extends Test> {
   isInEditMode: boolean;
   regionFilter: RegionsAndAll;
   setRegionFilter: (regionValue: RegionsAndAll) => void;
+  onBatchTestDelete: (batchTestNames: string) => void;
+  onBatchTestArchive: (batchTestNames: string) => void;
 }
 
 function Sidebar<T extends Test>({
@@ -52,6 +55,8 @@ function Sidebar<T extends Test>({
   createTest,
   regionFilter,
   setRegionFilter,
+  onBatchTestDelete,
+  onBatchTestArchive,
 }: SidebarProps<T> & WithStyles<typeof styles>): React.ReactElement<SidebarProps<T>> {
   const filterTests = function(testsToFilter: Test[]): Test[] {
     if (isInEditMode || 'ALL' === regionFilter) {
@@ -69,6 +74,13 @@ function Sidebar<T extends Test>({
             existingNicknames={tests.map(t => t.nickname || '')}
             testNamePrefix={testNamePrefix}
             createTest={createTest}
+          />
+          <BatchProcessTestButton
+            // filter out live tests and any test currently being edited
+            tests={tests}
+            draftTests={tests.filter(t => (!t.isOn && t.name !== selectedTestName ? true : false))}
+            onBatchTestDelete={onBatchTestDelete}
+            onBatchTestArchive={onBatchTestArchive}
           />
           <Typography className={classes.header}>EDITING: tests in priority order</Typography>
         </>

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -40,8 +40,8 @@ interface SidebarProps<T extends Test> {
   isInEditMode: boolean;
   regionFilter: RegionsAndAll;
   setRegionFilter: (regionValue: RegionsAndAll) => void;
-  onBatchTestDelete: (batchTestNames: string) => void;
-  onBatchTestArchive: (batchTestNames: string) => void;
+  onBatchTestDelete: (batchTestNames: string[]) => void;
+  onBatchTestArchive: (batchTestNames: string[]) => void;
 }
 
 function Sidebar<T extends Test>({

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -21,6 +21,8 @@ export interface InnerComponentProps<T extends Test> {
   onTestSave: () => void;
   onTestDelete: () => void;
   onTestArchive: () => void;
+  onBatchTestDelete: (batchTestNames: string) => void;
+  onBatchTestArchive: (batchTestNames: string) => void;
   onTestCreate: (newTest: T) => void;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
@@ -191,6 +193,37 @@ const TestEditor = <T extends Test>(
       });
     };
 
+    const onBatchTestDelete = (batchTestNames: string): void => {
+      if (!tests || !batchTestNames) {
+        return;
+      }
+
+      const updatedTests = tests.filter(t => batchTestNames.indexOf(t.name) < 0);
+
+      save(updatedTests).catch(e => console.log('onBatchTestDelete: error encountered', e));
+    };
+
+    const onBatchTestArchive = (batchTestNames: string): void => {
+      if (!tests || !batchTestNames) {
+        return;
+      }
+
+      const promiseArray: Promise<Response>[] = [];
+
+      tests.forEach(t => {
+        if (batchTestNames.indexOf(t.name) >= 0) {
+          promiseArray.push(archiveTest(t, settingsType));
+        }
+      });
+
+      Promise.all(promiseArray)
+        .then(() => {
+          const updatedTests = tests.filter(t => batchTestNames.indexOf(t.name) < 0);
+          return save(updatedTests);
+        })
+        .catch(e => console.log('onBatchTestArchive: error encountered', e));
+    };
+
     const onTestChange = (updatedTest: T): void => {
       if (!tests) {
         return;
@@ -262,6 +295,8 @@ const TestEditor = <T extends Test>(
               onTestSave={onTestSave}
               onTestDelete={onTestDelete}
               onTestArchive={onTestArchive}
+              onBatchTestDelete={onBatchTestDelete}
+              onBatchTestArchive={onBatchTestArchive}
               onTestCreate={onTestCreate}
               onTestSelected={onSelectedTestName}
               requestTakeControl={requestTestsTakeControl}

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -21,8 +21,8 @@ export interface InnerComponentProps<T extends Test> {
   onTestSave: () => void;
   onTestDelete: () => void;
   onTestArchive: () => void;
-  onBatchTestDelete: (batchTestNames: string) => void;
-  onBatchTestArchive: (batchTestNames: string) => void;
+  onBatchTestDelete: (batchTestNames: string[]) => void;
+  onBatchTestArchive: (batchTestNames: string[]) => void;
   onTestCreate: (newTest: T) => void;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
@@ -193,7 +193,7 @@ const TestEditor = <T extends Test>(
       });
     };
 
-    const onBatchTestDelete = (batchTestNames: string): void => {
+    const onBatchTestDelete = (batchTestNames: string[]): void => {
       if (!tests || !batchTestNames) {
         return;
       }
@@ -203,7 +203,7 @@ const TestEditor = <T extends Test>(
       save(updatedTests).catch(e => console.log('onBatchTestDelete: error encountered', e));
     };
 
-    const onBatchTestArchive = (batchTestNames: string): void => {
+    const onBatchTestArchive = (batchTestNames: string[]): void => {
       if (!tests || !batchTestNames) {
         return;
       }


### PR DESCRIPTION
## What does this change?
This PR adds a new button at the top of the tests list when in EDIT mode which gives the user the ability to select multiple DRAFT tests, excluding the test currently being edited (if any) and either archive them, or delete them, in one operation:

New button at the top of the tests list when in EDIT mode:
![Screenshot 2021-10-26 at 16 28 13](https://user-images.githubusercontent.com/5357530/138911899-456a0c3d-4a11-4271-b48f-a415e1943b96.png)

Dialog where users can select tests for archive or deletion:
![Screenshot 2021-10-26 at 16 28 24](https://user-images.githubusercontent.com/5357530/138912078-a170611b-bb53-4a39-866e-96f65dbacb9d.png)

Users are asked to confirm the archive/deletion operation before performing it:
![Screenshot 2021-10-26 at 16 28 47](https://user-images.githubusercontent.com/5357530/138912199-5331e730-2bdd-407a-92b9-26f75a5221aa.png)

## Testing

1. Create several new tests
2. Select one of the new tests
3. In EDIT mode, click on the new batch archive/delete button
4. Check that the tests listed in the dialog are all in draft, and that the test being edited is not included in the list
5. Click cancel to dismiss the dialog
6. Click on the archive/delete button again; confirm that all boxes displayed are unchecked
7. Select 2 or more tests and click on the delete button; check that the confirm dialog appears, listing the selected tests
8. Click the cancel button; check that the original dialog still displays, with checked boxes unmodified
9. Click on the delete button, and the delete button on the confirm dialog - the selected tests should be deleted
10. Repeat the above steps, but this time for the Archive option

To check that the archive functionality works, open the AWS S3 console and confirm that the archived tests appear in the appropriate bucket - https://s3.console.aws.amazon.com/s3/buckets/support-admin-console?prefix=CODE/&region=eu-west-1

