### PR TITLE
Fix variant preview

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -39,6 +39,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     cta: variant.cta,
     separateArticleCount: variant.separateArticleCount,
     showSignInLink: variant.showSignInLink,
+    backgroundImageUrl: variant.backgroundImageUrl,
   },
   tracking: {
     ophanPageId: 'ophanPageId',

--- a/public/src/hooks/useModule.ts
+++ b/public/src/hooks/useModule.ts
@@ -24,8 +24,8 @@ export const useModule = <T>(path: string, name: string): React.FC<T> | undefine
 
     const baseUrl =
       stage === 'PROD'
-        ? `https://contributions.guardianapis.com/modules/${moduleVersion}`
-        : `https://contributions.code.dev-guardianapis.com/modules/${moduleVersion}`;
+        ? `https://contributions.guardianapis.com/modules/v${moduleVersion}`
+        : `https://contributions.code.dev-guardianapis.com/modules/v${moduleVersion}`;
 
     window.remoteImport(`${baseUrl}/${path}`).then(bannerModule => {
       setModule(() => withPreviewStyles(bannerModule[name]));


### PR DESCRIPTION
## What does this change?
Fix variant preview - url needs to be `modules/v3` & pass in `backgroundImageUrl` prop for epics