### PR TITLE
Change default primary CTA

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
@@ -3,6 +3,7 @@ import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';
+import { DEFAULT_PRIMARY_CTA, DEFAULT_SECONDARY_CTA } from './utils/defaults';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
@@ -13,16 +14,6 @@ const styles = ({ spacing }: Theme) =>
       gridGap: spacing(2),
     },
   });
-
-const DEFAULT_PRIMARY_CTA = {
-  text: 'Support the Guardian',
-  baseUrl: 'https://support.theguardian.com/contribute',
-};
-
-const DEFAULT_SECONDARY_CTA = {
-  text: 'Support the Guardian',
-  baseUrl: 'https://support.theguardian.com/contribute',
-};
 
 interface BannerTestVariantEditorCtasEditorProps extends WithStyles<typeof styles> {
   primaryCta?: Cta;

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -1,7 +1,17 @@
-import { UserCohort } from '../../helpers/shared';
+import { Cta, UserCohort } from '../../helpers/shared';
 import { BannerTest, BannerVariant, BannerTemplate } from '../../../../models/banner';
 
 import { getStage } from '../../../../utils/stage';
+
+export const DEFAULT_PRIMARY_CTA: Cta = {
+  text: 'Support the Guardian',
+  baseUrl: 'https://support.theguardian.com/contribute',
+};
+
+export const DEFAULT_SECONDARY_CTA: Cta = {
+  text: 'Support the Guardian',
+  baseUrl: 'https://support.theguardian.com/contribute',
+};
 
 const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
@@ -11,10 +21,7 @@ const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
     messageText:
       'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
-    cta: {
-      text: 'Support the Guardian',
-      baseUrl: 'https://support.theguardian.com/contribute',
-    },
+    cta: DEFAULT_PRIMARY_CTA,
   },
 };
 
@@ -24,10 +31,7 @@ const PROD_DEFAULT_VARIANT: BannerVariant = {
   bannerContent: {
     messageText: '',
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
-    cta: {
-      text: 'Support the Guardian',
-      baseUrl: 'https://support.theguardian.com/contribute',
-    },
+    cta: DEFAULT_PRIMARY_CTA,
   },
 };
 

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
@@ -3,6 +3,7 @@ import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';
+import { DEFAULT_PRIMARY_CTA, DEFAULT_SECONDARY_CTA } from './utils/defaults';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
@@ -13,16 +14,6 @@ const styles = ({ spacing }: Theme) =>
       gridGap: spacing(2),
     },
   });
-
-const DEFAULT_PRIMARY_CTA: Cta = {
-  text: 'Support the Guardian',
-  baseUrl: 'https://support.theguardian.com/contribute',
-};
-
-const DEFAULT_SECONDARY_CTA: Cta = {
-  text: '',
-  baseUrl: '',
-};
 
 interface EpicTestVariantEditorButtonsEditorProps extends WithStyles<typeof styles> {
   primaryCta?: Cta;

--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -1,4 +1,4 @@
-import { SecondaryCtaType, UserCohort } from '../../helpers/shared';
+import { Cta, SecondaryCtaType, UserCohort } from '../../helpers/shared';
 import { EpicVariant, EpicTest, MaxEpicViews } from '../epicTestsForm';
 
 import { getStage } from '../../../../utils/stage';
@@ -7,6 +7,16 @@ export const DEFAULT_MAX_EPIC_VIEWS: MaxEpicViews = {
   maxViewsCount: 4,
   maxViewsDays: 30,
   minDaysBetweenViews: 0,
+};
+
+export const DEFAULT_PRIMARY_CTA: Cta = {
+  text: 'Continue',
+  baseUrl: 'https://support.theguardian.com/contribute',
+};
+
+export const DEFAULT_SECONDARY_CTA: Cta = {
+  text: '',
+  baseUrl: '',
 };
 
 const DEV_AND_CODE_DEFAULT_VARIANT: EpicVariant = {
@@ -22,10 +32,7 @@ const DEV_AND_CODE_DEFAULT_VARIANT: EpicVariant = {
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
   separateArticleCount: { type: 'above' },
   showTicker: false,
-  cta: {
-    text: 'Support the Guardian',
-    baseUrl: 'https://support.theguardian.com/contribute',
-  },
+  cta: DEFAULT_PRIMARY_CTA,
   secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
   showChoiceCards: false,
 };
@@ -37,10 +44,7 @@ const PROD_DEFAULT_VARIANT: EpicVariant = {
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
   separateArticleCount: { type: 'above' },
   showTicker: false,
-  cta: {
-    text: 'Support the Guardian',
-    baseUrl: 'https://support.theguardian.com/contribute',
-  },
+  cta: DEFAULT_PRIMARY_CTA,
   secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
   showChoiceCards: false,
 };

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -199,11 +199,6 @@ interface ContributionsReminderSecondaryCta {
 
 export type SecondaryCta = CustomSecondaryCta | ContributionsReminderSecondaryCta;
 
-export const defaultCta = {
-  text: 'Support the Guardian',
-  baseUrl: 'https://support.theguardian.com/contribute',
-};
-
 export enum UserCohort {
   Everyone = 'Everyone',
   AllExistingSupporters = 'AllExistingSupporters',


### PR DESCRIPTION
Co-authored-by: Tom Pretty <TomPretty@users.noreply.github.com>
Co-authored-by: Maria Olanipekun <marialani@users.noreply.github.com>
Co-authored-by: Michael Jacobson <michaelbjacobson@users.noreply.github.com>

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR changes the default primary epic CTA to 'Continue'.

We have added default primary and secondary CTA objects for both the banner and epic to defaults.ts so these can be reused and to avoid dupication.

We have removed an unused object from shared.ts.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![Screenshot 2021-11-04 at 15 51 14](https://user-images.githubusercontent.com/7883129/140372080-feba71df-22f2-471f-9bd4-3d304a524107.png)
