### PR TITLE
Capi proxy endpoints

### DIFF
--- a/app/controllers/CapiController.scala
+++ b/app/controllers/CapiController.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import play.api.mvc.AnyContent
+import play.api.mvc.Results.Ok
+import services.CapiService
+
+import scala.concurrent.ExecutionContext
+
+class CapiController(authAction: AuthAction[AnyContent], capiService: CapiService)(implicit ec: ExecutionContext) {
+
+  def getTags() = authAction.async { request =>
+    capiService
+      .getTags(request.rawQueryString)
+      .map(response => Ok(response))
+  }
+
+  def getSections() = authAction.async { request =>
+    capiService
+      .getSections(request.rawQueryString)
+      .map(response => Ok(response))
+  }
+}

--- a/app/services/CapiService.scala
+++ b/app/services/CapiService.scala
@@ -1,0 +1,19 @@
+package services
+
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CapiService(apiKey: String, wsClient: WSClient)(implicit val ec: ExecutionContext) {
+  private val url = "https://content.guardianapis.com"
+
+  private def request(path: String, querystring: String): Future[String] =
+    wsClient
+      .url(s"$url/$path?api-key=$apiKey&$querystring")
+      .get
+      .map(response => response.body)
+
+  def getTags(querystring: String): Future[String] = request("tags", querystring)
+
+  def getSections(querystring: String): Future[String] = request("sections", querystring)
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -12,7 +12,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.S3
+import services.{CapiService, S3}
 import zio.DefaultRuntime
 
 class AppComponents(context: Context, stage: String) extends BuiltInComponentsFromContext(context) with AhcWSComponents with NoHttpFiltersComponents with AssetsComponents {
@@ -52,6 +52,8 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
 
   private val runtime = new DefaultRuntime {}
 
+  val capiService = new CapiService(configuration.get[String]("capi.apiKey"), wsClient)
+
   override lazy val router: Router = new Routes(
     httpErrorHandler,
     new Application(authAction, controllerComponents, stage),
@@ -76,6 +78,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new BannerDeployController(authAction, controllerComponents, stage, runtime),
     new BannerDeployController2(authAction, controllerComponents, stage, runtime),
     new ChannelSwitchesController(authAction, controllerComponents, stage, runtime),
+    new CapiController(authAction, capiService),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -116,5 +116,9 @@ POST  /frontend/banner-deploy2/update                  controllers.banner.Banner
 GET   /frontend/channel-switches                       controllers.ChannelSwitchesController.get
 POST  /frontend/channel-switches/update                controllers.ChannelSwitchesController.set
 
+# ----- capi ----- #
+GET   /capi/tags                                       controllers.CapiController.getTags
+GET   /capi/sections                                   controllers.CapiController.getSections
+
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
Adds endpoints for querying capi for tags and sections.
Simply proxies the client requests, adding an api-key.

The client will need to extract the array of results, e.g.
```
fetch(`/capi/tags?q=${term}`).then( response => response.json()).then(body => body.response.results)
```