### PR TITLE
Add schedule to banner deploy page

### DIFF
--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import { Button, Theme, withStyles, createStyles, WithStyles } from '@material-ui/core';
+import { Button, Theme, makeStyles } from '@material-ui/core';
 import { BannerChannel } from './bannerDeployDashboard';
 import BannerChannelDeployerTable from './bannerDeployChannelDeployerTable';
 
@@ -11,14 +11,13 @@ import {
 } from '../../../utils/requests';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(2),
-      },
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(2),
     },
-  });
+  },
+}));
 
 export interface BannerDeployRegion {
   timestamp: number;
@@ -47,14 +46,15 @@ interface DataFromServer {
   email: string;
 }
 
-type BannerDeployChannelDeployerProps = WithStyles<typeof styles> & {
+interface BannerDeployChannelDeployerProps {
   channel: BannerChannel;
-};
+}
 
 const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = ({
-  classes,
   channel,
 }: BannerDeployChannelDeployerProps) => {
+  const classes = useStyles();
+
   const isChannel1 = channel === 'CHANNEL1';
   const settingsType = isChannel1
     ? FrontendSettingsType.bannerDeploy
@@ -149,4 +149,4 @@ const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = 
   );
 };
 
-export default withStyles(styles)(BannerDeployChannelDeployer);
+export default BannerDeployChannelDeployer;

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -23,20 +23,18 @@ import BannerDeployChannelDeployerTableRow from './bannerDeployChannelDeployerTa
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
   createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(2),
-      },
+    schedule: {
+      paddingLeft: spacing(3),
     },
   });
 
-type BannerDeployChannelDeployerTableProps = WithStyles<typeof styles> & {
+interface BannerDeployChannelDeployerTableProps extends WithStyles<typeof styles> {
   channel: BannerChannel;
   bannerDeploys?: BannerDeploys;
   bannersToRedeploy: BannersToRedeploy;
   onRedeployAllClick: (shouldRedeploy: boolean) => void;
   onRedeployClick: (region: string, shouldRedeploy: boolean) => void;
-};
+}
 
 const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTableProps> = ({
   channel,
@@ -44,10 +42,27 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
   bannersToRedeploy,
   onRedeployAllClick,
   onRedeployClick,
+  classes,
 }: BannerDeployChannelDeployerTableProps) => {
   const isChannel1 = channel === 'CHANNEL1';
   const shouldRedeployAllBanners = Object.values(bannersToRedeploy).every(
     shouldRedeploy => shouldRedeploy,
+  );
+
+  const Schedule = (): JSX.Element => (
+    <div className={classes.schedule}>
+      This banner is automatically deployed at:
+      {isChannel1 ? (
+        <ul>
+          <li>9am every Sunday</li>
+        </ul>
+      ) : (
+        <ul>
+          <li>8am every Monday</li>
+          <li>8am every Friday</li>
+        </ul>
+      )}
+    </div>
   );
 
   return (
@@ -57,6 +72,7 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
           {isChannel1 ? 'Banner 1' : 'Banner 2'}
         </Typography>
       </Toolbar>
+      <Schedule />
       <Table aria-label="simple table">
         <TableHead>
           <TableRow>
@@ -67,7 +83,7 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
               />
             </TableCell>
             <TableCell>Region</TableCell>
-            <TableCell>Last Deploy (UTC)</TableCell>
+            <TableCell>Last Manual Deploy (UTC)</TableCell>
             <TableCell>User</TableCell>
           </TableRow>
         </TableHead>

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -12,23 +12,19 @@ import {
   TableCell,
   Toolbar,
   Typography,
-  withStyles,
-  createStyles,
-  WithStyles,
+  makeStyles,
 } from '@material-ui/core';
 import { BannerChannel } from './bannerDeployDashboard';
 import { BannerDeploys, BannersToRedeploy } from './bannerDeployChannelDeployer';
 import BannerDeployChannelDeployerTableRow from './bannerDeployChannelDeployerTableRow';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    schedule: {
-      paddingLeft: spacing(3),
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  schedule: {
+    paddingLeft: spacing(3),
+  },
+}));
 
-interface BannerDeployChannelDeployerTableProps extends WithStyles<typeof styles> {
+interface BannerDeployChannelDeployerTableProps {
   channel: BannerChannel;
   bannerDeploys?: BannerDeploys;
   bannersToRedeploy: BannersToRedeploy;
@@ -42,8 +38,9 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
   bannersToRedeploy,
   onRedeployAllClick,
   onRedeployClick,
-  classes,
 }: BannerDeployChannelDeployerTableProps) => {
+  const classes = useStyles();
+
   const isChannel1 = channel === 'CHANNEL1';
   const shouldRedeployAllBanners = Object.values(bannersToRedeploy).every(
     shouldRedeploy => shouldRedeploy,
@@ -107,4 +104,4 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
   );
 };
 
-export default withStyles(styles)(BannerDeployChannelDeployerTable);
+export default BannerDeployChannelDeployerTable;

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
@@ -1,34 +1,30 @@
 import React from 'react';
 
-import { Theme, withStyles, createStyles, WithStyles } from '@material-ui/core';
+import { Theme, makeStyles } from '@material-ui/core';
 
 import BannerDeployeChannelDeployer from './bannerDeployChannelDeployer';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    scrollableContainer: {
-      overflow: 'auto',
-    },
-    container: {
-      padding: `${spacing(6)}px ${spacing(9)}px`,
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  scrollableContainer: {
+    overflow: 'auto',
+  },
+  container: {
+    padding: `${spacing(6)}px ${spacing(9)}px`,
 
-      '& > * + *': {
-        marginTop: spacing(4),
-      },
+    '& > * + *': {
+      marginTop: spacing(4),
     },
-    tableContainer: {
-      width: '45%',
-    },
-  });
+  },
+  tableContainer: {
+    width: '45%',
+  },
+}));
 
 export type BannerChannel = 'CHANNEL1' | 'CHANNEL2';
 
-type BannerDeployDashboardProps = WithStyles<typeof styles>;
-
-const BannerDeployDashboard: React.FC<BannerDeployDashboardProps> = ({
-  classes,
-}: BannerDeployDashboardProps) => {
+const BannerDeployDashboard: React.FC = () => {
+  const classes = useStyles();
   return (
     <div className={classes.scrollableContainer}>
       <div className={classes.container}>
@@ -43,4 +39,4 @@ const BannerDeployDashboard: React.FC<BannerDeployDashboardProps> = ({
   );
 };
 
-export default withStyles(styles)(BannerDeployDashboard);
+export default BannerDeployDashboard;


### PR DESCRIPTION
Adds a note about the scheduled deploys for the banners.
see https://github.com/guardian/support-dotcom-components/pull/565

![Screen Shot 2021-11-17 at 09 23 12](https://user-images.githubusercontent.com/1513454/142178843-30725f48-4b5e-4fae-b001-f388073d9e01.png)
