### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@types/react-router-dom": "^4.3.5",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
+    "csstype": "^2.6.18",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-prettier": "^3.1.2",
@@ -32,6 +33,9 @@
     "react-hook-form": "^6.7.2",
     "react-router-dom": "^5.0.1",
     "@emotion/react": "^11.4.0"
+  },
+  "resolutions": {
+    "csstype": "^2.6.18"
   },
   "scripts": {
     "build": "webpack --config webpack.prod.js",

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -33,7 +33,7 @@ import Typography from '@material-ui/core/Typography';
 import IndexPage from './components/indexPage';
 import { getTheme } from './utils/theme';
 import ChannelSwitches from './components/channelManagement/ChannelSwitches';
-import { FontWeightProperty } from "csstype";
+import { FontWeightProperty } from 'csstype';
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -33,6 +33,7 @@ import Typography from '@material-ui/core/Typography';
 import IndexPage from './components/indexPage';
 import { getTheme } from './utils/theme';
 import ChannelSwitches from './components/channelManagement/ChannelSwitches';
+import { FontWeightProperty } from "csstype";
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
@@ -94,7 +95,7 @@ const styles = ({ palette, mixins, typography, transitions }: Theme) =>
     toolbar: mixins.toolbar as CSSProperties, // createStyles expects material-ui's CSSProperties type, not react's
     heading: {
       fontSize: typography.pxToRem(24),
-      fontWeight: typography.fontWeightMedium,
+      fontWeight: typography.fontWeightMedium as FontWeightProperty,
     },
   });
 


### PR DESCRIPTION
there seems to be an issue with a mismatch in the `csstype` dependency, it's not the result of something we've changed.
For now forcing the version and using a type cast in the relevant place solves this.

This error was causing the `main` build to fail:
```
ERROR in /opt/teamcity/buildAgent/work/4e07988844504b26/public/src/main.tsx
ERROR in /opt/teamcity/buildAgent/work/4e07988844504b26/public/src/main.tsx(97,7)
TS2322: Type '"-moz-initial" | "inherit" | "initial" | "revert" | "unset" | "normal" | "bold" | "bolder" | "lighter" | (string & {}) | (number & {}) | undefined' is not assignable to type 'number | "-moz-initial" | "inherit" | "initial" | "revert" | "unset" | "normal" | "bold" | "bolder" | "lighter" | PropsFunc<{}, number | "-moz-initial" | "inherit" | "initial" | "revert" | ... 5 more ... | undefined> | undefined'.
Type 'string & {}' is not assignable to type 'number | "-moz-initial" | "inherit" | "initial" | "revert" | "unset" | "normal" | "bold" | "bolder" | "lighter" | PropsFunc<{}, number | "-moz-initial" | "inherit" | "initial" | "revert" | ... 5 more ... | undefined> | undefined'.
Type 'string & {}' is not assignable to type '"lighter"'.
```