### PR TITLE
Add US EOY banner to Reader Revenue Control Panel

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -18,6 +18,7 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
   case object GuardianWeeklyBanner extends BannerTemplate
   case object InvestigationsMomentBanner extends BannerTemplate
   case object EnvironmentMomentBanner extends BannerTemplate
+  case object UsEoyMomentBanner extends BannerTemplate
 }
 
 case class BannerContent(

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -33,6 +33,7 @@ const templatesWithLabels = [
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
   { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },
   { template: BannerTemplate.EnvironmentMomentBanner, label: 'Environment moment' },
+  { template: BannerTemplate.UsEoyMomentBanner, label: 'US EOY moment' },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -103,7 +103,7 @@ const bannerModules = {
     name: 'EnvironmentMomentBanner',
   },
   [BannerTemplate.UsEoyMomentBanner]: {
-    path: 'environmentMoment/UsEoyMomentBanner.js',
+    path: 'usEoyMoment/UsEoyMomentBanner.js',
     name: 'UsEoyMomentBanner',
   },
 };

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -102,6 +102,10 @@ const bannerModules = {
     path: 'environmentMoment/EnvironmentMomentBanner.js',
     name: 'EnvironmentMomentBanner',
   },
+  [BannerTemplate.UsEoyMomentBanner]: {
+    path: 'environmentMoment/UsEoyMomentBanner.js',
+    name: 'UsEoyMomentBanner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -16,6 +16,7 @@ export enum BannerTemplate {
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',
   InvestigationsMomentBanner = 'InvestigationsMomentBanner',
   EnvironmentMomentBanner = 'EnvironmentMomentBanner',
+  UsEoyMomentBanner = 'UsEoyMomentBanner',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
Co-authored-by: Maria Olanipekun <marialani@users.noreply.github.com>

## What does this change?

This PR adds the US End of Year moment banner to the Reader Revenue Control Panel.

## Images
![Screenshot 2021-11-19 at 12 51 42](https://user-images.githubusercontent.com/7883129/142625858-127c39b7-32a2-49eb-bf6b-5b7592c6cd6e.png)

![Screenshot 2021-11-19 at 13 54 01](https://user-images.githubusercontent.com/7883129/142633864-0636c988-5670-4454-9be9-de781cc6748c.png)


