### PR TITLE
add enableQuantumMetric to the switchboard

### DIFF
--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -49,6 +49,7 @@ case class SupportFrontendSwitches(
   enableRecaptchaFrontend: SwitchState,
   enableContributionsCampaign: SwitchState = Off,
   forceContributionsCampaign: SwitchState = Off,
+  enableQuantumMetric: SwitchState = Off
 )
 
 object SupportFrontendSwitches {

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -54,6 +54,7 @@ interface Switches {
   enableRecaptchaFrontend: SwitchState;
   enableContributionsCampaign: SwitchState;
   forceContributionsCampaign: SwitchState;
+  enableQuantumMetric: SwitchState;
   experiments: {
     [featureSwitch: string]: {
       name: string;
@@ -166,6 +167,7 @@ class Switchboard extends React.Component<Props, Switches> {
       enableRecaptchaFrontend: SwitchState.Off,
       enableContributionsCampaign: SwitchState.Off,
       forceContributionsCampaign: SwitchState.Off,
+      enableQuantumMetric: SwitchState.Off,
       experiments: {},
     };
     this.previousStateFromServer = null;
@@ -411,6 +413,24 @@ class Switchboard extends React.Component<Props, Switches> {
                 />
               }
               label="Force all users into the contributions campaign"
+            />
+          </FormControl>
+
+          <FormControl component={'fieldset' as 'div'} className={classes.formControl}>
+            <FormLabel component={'legend' as 'label'}>Other switches</FormLabel>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={switchStateToBoolean(this.state.enableQuantumMetric)}
+                  onChange={(event): void =>
+                    this.setState({
+                      enableQuantumMetric: booleanToSwitchState(event.target.checked),
+                    })
+                  }
+                  value={switchStateToBoolean(this.state.enableQuantumMetric)}
+                />
+              }
+              label="Enable Quantum Metric"
             />
           </FormControl>
         </div>

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -46,7 +46,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       |      "enableRecaptchaBackend" : "On",
       |      "enableRecaptchaFrontend" : "On",
       |      "enableContributionsCampaign" : "On",
-      |      "forceContributionsCampaign" : "On"
+      |      "forceContributionsCampaign" : "On",
+      |      "enableQuantumMetric" : "On"
       |}
     """.stripMargin
 
@@ -80,7 +81,8 @@ class S3JsonSpec extends FlatSpec with Matchers with EitherValues {
       enableRecaptchaBackend = On,
       enableRecaptchaFrontend = On,
       enableContributionsCampaign = On,
-      forceContributionsCampaign = On
+      forceContributionsCampaign = On,
+      enableQuantumMetric = On
     ),
     version = "v1"
   )


### PR DESCRIPTION
In its own section for now because it's not in the `experiments` object.
We need to redesign/reimplement this page