### PR TITLE
Add US EOY Giving Tuesday banner to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -23,37 +23,37 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
 }
 
 case class BannerContent(
-    heading: Option[String],
-    messageText: String,
-    highlightedText: Option[String],
-    cta: Option[Cta],
-    secondaryCta: Option[SecondaryCta]
+  heading: Option[String],
+  messageText: String,
+  highlightedText: Option[String],
+  cta: Option[Cta],
+  secondaryCta: Option[SecondaryCta]
 )
 
 case class BannerVariant(
-    name: String,
-    template: BannerTemplate,
-    bannerContent: Option[BannerContent],
-    mobileBannerContent: Option[BannerContent],
+  name: String,
+  template: BannerTemplate,
+  bannerContent: Option[BannerContent],
+  mobileBannerContent: Option[BannerContent],
 
-    // Deprecated - use bannerContent / mobileBannerContent
-    heading: Option[String],
-    body: Option[String],
-    highlightedText: Option[String],
-    cta: Option[Cta],
-    secondaryCta: Option[Cta]
+  // Deprecated - use bannerContent / mobileBannerContent
+  heading: Option[String],
+  body: Option[String],
+  highlightedText: Option[String],
+  cta: Option[Cta],
+  secondaryCta: Option[Cta]
 )
 
 case class BannerTest(
-    name: String,
-    nickname: Option[String],
-    isOn: Boolean,
-    minArticlesBeforeShowingBanner: Int,
-    userCohort: UserCohort,
-    locations: List[Region] = Nil,
-    variants: List[BannerVariant],
-    articlesViewedSettings: Option[ArticlesViewedSettings] = None,
-    controlProportionSettings: Option[ControlProportionSettings] = None
+  name: String,
+  nickname: Option[String],
+  isOn: Boolean,
+  minArticlesBeforeShowingBanner: Int,
+  userCohort: UserCohort,
+  locations: List[Region] = Nil,
+  variants: List[BannerVariant],
+  articlesViewedSettings: Option[ArticlesViewedSettings] = None,
+  controlProportionSettings: Option[ControlProportionSettings] = None
 )
 
 case class BannerTests(tests: List[BannerTest])

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -7,10 +7,9 @@ import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable.IndexedSeq
 
+
 sealed trait BannerTemplate extends EnumEntry
-object BannerTemplate
-    extends Enum[BannerTemplate]
-    with CirceEnum[BannerTemplate] {
+object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate] {
   override val values: IndexedSeq[BannerTemplate] = findValues
 
   case object ContributionsBanner extends BannerTemplate

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -7,9 +7,10 @@ import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable.IndexedSeq
 
-
 sealed trait BannerTemplate extends EnumEntry
-object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate] {
+object BannerTemplate
+    extends Enum[BannerTemplate]
+    with CirceEnum[BannerTemplate] {
   override val values: IndexedSeq[BannerTemplate] = findValues
 
   case object ContributionsBanner extends BannerTemplate
@@ -19,40 +20,41 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
   case object InvestigationsMomentBanner extends BannerTemplate
   case object EnvironmentMomentBanner extends BannerTemplate
   case object UsEoyMomentBanner extends BannerTemplate
+  case object UsEoyMomentGivingTuesdayBanner extends BannerTemplate
 }
 
 case class BannerContent(
-  heading: Option[String],
-  messageText: String,
-  highlightedText: Option[String],
-  cta: Option[Cta],
-  secondaryCta: Option[SecondaryCta]
+    heading: Option[String],
+    messageText: String,
+    highlightedText: Option[String],
+    cta: Option[Cta],
+    secondaryCta: Option[SecondaryCta]
 )
 
 case class BannerVariant(
-  name: String,
-  template: BannerTemplate,
-  bannerContent: Option[BannerContent],
-  mobileBannerContent: Option[BannerContent],
+    name: String,
+    template: BannerTemplate,
+    bannerContent: Option[BannerContent],
+    mobileBannerContent: Option[BannerContent],
 
-  // Deprecated - use bannerContent / mobileBannerContent
-  heading: Option[String],
-  body: Option[String],
-  highlightedText: Option[String],
-  cta: Option[Cta],
-  secondaryCta: Option[Cta]
+    // Deprecated - use bannerContent / mobileBannerContent
+    heading: Option[String],
+    body: Option[String],
+    highlightedText: Option[String],
+    cta: Option[Cta],
+    secondaryCta: Option[Cta]
 )
 
 case class BannerTest(
-  name: String,
-  nickname: Option[String],
-  isOn: Boolean,
-  minArticlesBeforeShowingBanner: Int,
-  userCohort: UserCohort,
-  locations: List[Region] = Nil,
-  variants: List[BannerVariant],
-  articlesViewedSettings: Option[ArticlesViewedSettings] = None,
-  controlProportionSettings: Option[ControlProportionSettings] = None
+    name: String,
+    nickname: Option[String],
+    isOn: Boolean,
+    minArticlesBeforeShowingBanner: Int,
+    userCohort: UserCohort,
+    locations: List[Region] = Nil,
+    variants: List[BannerVariant],
+    articlesViewedSettings: Option[ArticlesViewedSettings] = None,
+    controlProportionSettings: Option[ControlProportionSettings] = None
 )
 
 case class BannerTests(tests: List[BannerTest])

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -34,6 +34,10 @@ const templatesWithLabels = [
   { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },
   { template: BannerTemplate.EnvironmentMomentBanner, label: 'Environment moment' },
   { template: BannerTemplate.UsEoyMomentBanner, label: 'US EOY moment' },
+  {
+    template: BannerTemplate.UsEoyMomentGivingTuesdayBanner,
+    label: 'US EOY Giving Tuesday moment',
+  },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -106,6 +106,10 @@ const bannerModules = {
     path: 'usEoyMoment/UsEoyMomentBanner.js',
     name: 'UsEoyMomentBanner',
   },
+  [BannerTemplate.UsEoyMomentGivingTuesdayBanner]: {
+    path: 'usEoyMoment/UsEoyMomentGivingTuesdayBanner.js',
+    name: 'UsEoyMomentGivingTuesdayBanner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -17,6 +17,7 @@ export enum BannerTemplate {
   InvestigationsMomentBanner = 'InvestigationsMomentBanner',
   EnvironmentMomentBanner = 'EnvironmentMomentBanner',
   UsEoyMomentBanner = 'UsEoyMomentBanner',
+  UsEoyMomentGivingTuesdayBanner = 'UsEoyMomentGivingTuesdayBanner',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
## What does this change?
This PR adds the US End of Year moment banner to the Reader Revenue Control Panel.

## Images
<img width="321" alt="Screenshot 2021-11-26 at 12 24 52" src="https://user-images.githubusercontent.com/44685872/143580930-5cee21f0-694c-4256-a624-13dd177e2ebc.png">
<img width="1439" alt="Screenshot 2021-11-26 at 12 26 34" src="https://user-images.githubusercontent.com/44685872/143580953-c8bc8967-2e36-4236-8d73-3bccb27de41d.png">


