### PR TITLE
Add header switch

### DIFF
--- a/app/models/ChannelSwitches.scala
+++ b/app/models/ChannelSwitches.scala
@@ -1,16 +1,19 @@
 package models
 
 import io.circe.{ Decoder, Encoder }
-import io.circe.generic.auto._
+import io.circe.generic.extras.auto._
+import io.circe.generic.extras.Configuration
 
 case class ChannelSwitches(
   enableEpics: Boolean,
   enableBanners: Boolean,
+  enableHeaders: Boolean = true,
   enableSuperMode: Boolean,
   enableHardcodedEpicTests: Boolean,
 )
 
 object ChannelSwitches {
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val decoder = Decoder[ChannelSwitches]
   implicit val encoder = Encoder[ChannelSwitches]
 }

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -22,7 +22,12 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-type SwitchName = 'enableBanners' | 'enableEpics' | 'enableSuperMode' | 'enableHardcodedEpicTests';
+type SwitchName =
+  | 'enableBanners'
+  | 'enableEpics'
+  | 'enableHeaders'
+  | 'enableSuperMode'
+  | 'enableHardcodedEpicTests';
 
 type ChannelSwitches = {
   [key in SwitchName]: boolean;
@@ -82,6 +87,12 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
         name="enableBanners"
         label="Enable Banners"
         enabled={switches.enableBanners}
+        setSwitch={onSwitchChange}
+      />
+      <ChannelSwitch
+        name="enableHeaders"
+        label="Enable Headers"
+        enabled={switches.enableHeaders}
         setSwitch={onSwitchChange}
       />
       <ChannelSwitch


### PR DESCRIPTION
## What does this change?

Add a switch to enable/disable the headers on dotcom. SDC PR: https://github.com/guardian/support-dotcom-components/pull/602
