### PR TITLE
upgrade play to 2.8.13; com.gu.play-googleauth to 2.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val circeVersion = "0.14.1"
 
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
-  "com.gu.play-googleauth" %% "play-v28" % "2.1.1",
+  "com.gu.play-googleauth" %% "play-v28" % "2.2.2",
   "com.gu" %% "simple-configuration-ssm" % "1.5.7",
   "software.amazon.awssdk" % "s3" % "2.17.99",
   "io.circe" %% "circe-core" % circeVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
PR created in response to a Snyk alert.

The dependency akka-http-core has been marked by snyk as high severity.

Updates to scaffeine/play-googleauth necessary because of a scala-java8-compat_2.13 version incompatibility

This PR in support-admin-console mirrors [PR 3406 created in support-frontend](https://github.com/guardian/support-frontend/pull/3406); discoveries made in either investigation need to be checked for in the other. 

The memsub-promotions repo also has this vulnerability.
