### PR TITLE
Enable viewing of other tests while editing

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -33,7 +33,6 @@ const testCopyHasTemplate = (test: BannerTest, template: string): boolean =>
 
 interface BannerTestEditorProps {
   test: BannerTest;
-  hasChanged: boolean;
   onChange: (updatedTest: BannerTest) => void;
   onValidationChange: (isValid: boolean) => void;
   visible: boolean;

--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -20,7 +20,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
   const BannerTestsForm: React.FC<Props> = ({
     tests,
     selectedTestName,
-    selectedTestHasBeenModified,
+    editedTestName,
     onTestChange,
     onTestPriorityChange,
     onTestSelected,
@@ -40,14 +40,11 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
     setRegionFilter,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
-      if (selectedTestHasBeenModified) {
-        alert('Please either save or discard before creating a test.');
-      } else {
-        onTestCreate(createDefaultBannerTest(name, nickname));
-      }
+      onTestCreate(createDefaultBannerTest(name, nickname));
     };
 
     const selectedTest = tests.find(t => t.name === selectedTestName);
+    const selectedTestIsBeingEdited = selectedTestName === editedTestName;
 
     return (
       <TestsFormLayout
@@ -55,6 +52,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
           <Sidebar<BannerTest>
             tests={tests}
             selectedTestName={selectedTestName}
+            editedTestName={editedTestName}
             onTestPriorityChange={onTestPriorityChange}
             onTestSelected={onTestSelected}
             createTest={createTest}
@@ -70,11 +68,10 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
           selectedTestName && selectedTest ? (
             <BannerTestEditor
               test={selectedTest}
-              hasChanged={selectedTestHasBeenModified}
               onChange={onTestChange}
               onValidationChange={onTestErrorStatusChange}
               visible
-              editMode={editMode}
+              editMode={editMode && selectedTestIsBeingEdited}
               onDelete={onTestDelete}
               onArchive={onTestArchive}
               onTestSelected={onTestSelected}
@@ -87,6 +84,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
           ) : null
         }
         selectedTestName={selectedTestName}
+        editedTestName={editedTestName}
         lockStatus={lockStatus}
         requestTakeControl={requestTakeControl}
         requestLock={requestLock}

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -36,7 +36,6 @@ const copyHasTemplate = (test: EpicTest, template: string): boolean =>
 
 interface EpicTestEditorProps {
   test: EpicTest;
-  hasChanged: boolean;
   epicEditorConfig: EpicEditorConfig;
   onChange: (updatedTest: EpicTest) => void;
   onValidationChange: (isValid: boolean) => void;

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -104,7 +104,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
   const EpicTestsForm: React.FC<Props> = ({
     tests,
     selectedTestName,
-    selectedTestHasBeenModified,
+    editedTestName,
     onTestSelected,
     onTestSave,
     onTestDelete,
@@ -124,14 +124,11 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
     setRegionFilter,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
-      if (selectedTestHasBeenModified) {
-        alert('Please either save or discard before creating a test.');
-      } else {
-        onTestCreate(createDefaultEpicTest(name, nickname));
-      }
+      onTestCreate(createDefaultEpicTest(name, nickname));
     };
 
     const selectedTest = tests.find(t => t.name === selectedTestName);
+    const selectedTestIsBeingEdited = selectedTestName === editedTestName;
 
     return (
       <TestsFormLayout
@@ -139,6 +136,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
           <Sidebar<EpicTest>
             tests={tests}
             selectedTestName={selectedTestName}
+            editedTestName={editedTestName}
             onTestPriorityChange={onTestPriorityChange}
             onTestSelected={onTestSelected}
             testNamePrefix={epicEditorConfig.testNamePrefix}
@@ -154,12 +152,11 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
           selectedTestName && selectedTest ? (
             <EpicTestEditor
               test={selectedTest}
-              hasChanged={selectedTestHasBeenModified}
               epicEditorConfig={epicEditorConfig}
               onChange={onTestChange}
               onValidationChange={onTestErrorStatusChange}
               visible
-              editMode={editMode}
+              editMode={editMode && selectedTestIsBeingEdited}
               onDelete={onTestDelete}
               onArchive={onTestArchive}
               onTestSelected={onTestSelected}
@@ -173,6 +170,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
           ) : null
         }
         selectedTestName={selectedTestName}
+        editedTestName={editedTestName}
         lockStatus={lockStatus}
         requestTakeControl={requestTakeControl}
         requestLock={requestLock}

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -23,7 +23,6 @@ import { useStyles } from '../helpers/testEditorStyles';
 
 interface HeaderTestEditorProps {
   test: HeaderTest;
-  hasChanged: boolean;
   onChange: (updatedTest: HeaderTest) => void;
   onValidationChange: (isValid: boolean) => void;
   visible: boolean;

--- a/public/src/components/channelManagement/headerTests/headerTestsForm.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestsForm.tsx
@@ -19,7 +19,7 @@ const getHeaderTestsForm = (): React.FC<Props> => {
   const HeaderTestsForm: React.FC<Props> = ({
     tests,
     selectedTestName,
-    selectedTestHasBeenModified,
+    editedTestName,
     onTestChange,
     onTestPriorityChange,
     onTestSelected,
@@ -39,14 +39,11 @@ const getHeaderTestsForm = (): React.FC<Props> => {
     setRegionFilter,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
-      if (selectedTestHasBeenModified) {
-        alert('Please either save or discard before creating a test.');
-      } else {
-        onTestCreate(createDefaultHeaderTest(name, nickname));
-      }
+      onTestCreate(createDefaultHeaderTest(name, nickname));
     };
 
     const selectedTest = tests.find(t => t.name === selectedTestName);
+    const selectedTestIsBeingEdited = selectedTestName === editedTestName;
 
     return (
       <TestsFormLayout
@@ -54,6 +51,7 @@ const getHeaderTestsForm = (): React.FC<Props> => {
           <Sidebar<HeaderTest>
             tests={tests}
             selectedTestName={selectedTestName}
+            editedTestName={editedTestName}
             onTestPriorityChange={onTestPriorityChange}
             onTestSelected={onTestSelected}
             createTest={createTest}
@@ -69,11 +67,10 @@ const getHeaderTestsForm = (): React.FC<Props> => {
           selectedTestName && selectedTest ? (
             <HeaderTestEditor
               test={selectedTest}
-              hasChanged={selectedTestHasBeenModified}
               onChange={onTestChange}
               onValidationChange={onTestErrorStatusChange}
               visible
-              editMode={editMode}
+              editMode={editMode && selectedTestIsBeingEdited}
               onDelete={onTestDelete}
               onArchive={onTestArchive}
               onTestSelected={onTestSelected}
@@ -86,6 +83,7 @@ const getHeaderTestsForm = (): React.FC<Props> => {
           ) : null
         }
         selectedTestName={selectedTestName}
+        editedTestName={editedTestName}
         lockStatus={lockStatus}
         requestTakeControl={requestTakeControl}
         requestLock={requestLock}

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -33,6 +33,7 @@ const styles = createStyles({
 interface SidebarProps<T extends Test> {
   tests: T[];
   selectedTestName: string | null;
+  editedTestName: string | null;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
   testNamePrefix?: string;
@@ -49,6 +50,7 @@ function Sidebar<T extends Test>({
   tests,
   isInEditMode,
   selectedTestName,
+  editedTestName,
   onTestPriorityChange,
   onTestSelected,
   testNamePrefix,
@@ -97,6 +99,7 @@ function Sidebar<T extends Test>({
           tests={filterTests(tests)}
           isInEditMode={isInEditMode}
           selectedTestName={selectedTestName}
+          editedTestName={editedTestName}
           onTestPriorityChange={onTestPriorityChange}
           onTestSelected={onTestSelected}
         />

--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -48,6 +48,7 @@ const styles = ({ palette, spacing }: Theme) =>
 interface StickyBottomBarProps extends WithStyles<typeof styles> {
   isInEditMode: boolean;
   selectedTestName: string | null;
+  editedTestName: string | null;
   lockStatus: LockStatus;
   requestTakeControl: () => void;
   requestLock: () => void;
@@ -59,6 +60,7 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
   classes,
   isInEditMode,
   selectedTestName,
+  editedTestName,
   lockStatus,
   requestTakeControl,
   requestLock,
@@ -76,7 +78,7 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
         <StickyBottomBarStatus isInEditMode={isInEditMode} isLocked={lockStatus.locked} />
         <StickyBottomBarDetail
           isInEditMode={isInEditMode}
-          selectedTestName={selectedTestName}
+          editedTestName={editedTestName}
           lockStatus={lockStatus}
         />
       </div>
@@ -84,7 +86,7 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
       <div className={classes.actionButtonContainer}>
         <StickyBottomBarActionButtons
           isInEditMode={isInEditMode}
-          hasTestSelected={selectedTestName !== undefined}
+          selectedTestIsBeingEdited={!!editedTestName && selectedTestName === editedTestName}
           isLocked={lockStatus.locked}
           requestTakeControl={requestTakeControl}
           requestLock={requestLock}

--- a/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
@@ -125,7 +125,9 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
     >
       {/*eslint-disable-next-line react/prop-types */}
       <Typography className={classes.buttonText}>
-        {selectedTestIsBeingEdited ? SAVE_BUTTON_TEST_SELECTED_TEXT : SAVE_BUTTON_TEST_NOT_SELECTED_TEXT}
+        {selectedTestIsBeingEdited
+          ? SAVE_BUTTON_TEST_SELECTED_TEXT
+          : SAVE_BUTTON_TEST_NOT_SELECTED_TEXT}
       </Typography>
     </Button>
   );

--- a/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
@@ -52,7 +52,7 @@ const SAVE_BUTTON_TEST_NOT_SELECTED_TEXT = 'Save changes';
 
 interface StickyBottomBarActionButtonsProps extends WithStyles<typeof styles> {
   isInEditMode: boolean;
-  hasTestSelected: boolean;
+  selectedTestIsBeingEdited: boolean;
   isLocked: boolean;
   requestTakeControl: () => void;
   requestLock: () => void;
@@ -63,7 +63,7 @@ interface StickyBottomBarActionButtonsProps extends WithStyles<typeof styles> {
 const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> = ({
   classes,
   isInEditMode,
-  hasTestSelected,
+  selectedTestIsBeingEdited,
   isLocked,
   requestTakeControl,
   requestLock,
@@ -125,7 +125,7 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
     >
       {/*eslint-disable-next-line react/prop-types */}
       <Typography className={classes.buttonText}>
-        {hasTestSelected ? SAVE_BUTTON_TEST_SELECTED_TEXT : SAVE_BUTTON_TEST_NOT_SELECTED_TEXT}
+        {selectedTestIsBeingEdited ? SAVE_BUTTON_TEST_SELECTED_TEXT : SAVE_BUTTON_TEST_NOT_SELECTED_TEXT}
       </Typography>
     </Button>
   );
@@ -189,16 +189,8 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
 
       <div className={classes.rightContainer}>
         {isInEditMode ? (
-          hasTestSelected ? (
-            // Edit mode + test selected
-            <>
-              {/* <PreviewButton /> */}
-              <SaveButton />
-            </>
-          ) : (
-            // Edit mode + no test selected
-            <SaveButton />
-          )
+          // Edit mode
+          <SaveButton />
         ) : isLocked ? (
           // Read only mode + locked
           <TakeControlButton />

--- a/public/src/components/channelManagement/stickyBottomBarDetail.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarDetail.tsx
@@ -13,7 +13,7 @@ const styles = createStyles({
 
 interface StickyBottomBarDetailProps extends WithStyles<typeof styles> {
   isInEditMode: boolean;
-  selectedTestName: string | null;
+  editedTestName: string | null;
   lockStatus: LockStatus;
 }
 
@@ -58,10 +58,10 @@ const formattedTimestamp = (timestamp: string): string => {
 const StickyBottomBarDetail: React.FC<StickyBottomBarDetailProps> = ({
   classes,
   isInEditMode,
-  selectedTestName,
+  editedTestName,
   lockStatus,
 }: StickyBottomBarDetailProps) => {
-  let text = selectedTestName == null ? '' : `- ${selectedTestName}`;
+  let text = editedTestName == null ? '' : `- ${editedTestName}`;
 
   if (!isInEditMode && lockStatus.locked && lockStatus.email && lockStatus.timestamp) {
     const name = formattedName(lockStatus.email);

--- a/public/src/components/channelManagement/stickyBottomBarStatus.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarStatus.tsx
@@ -17,7 +17,7 @@ interface StickyBottomBarStatusProps extends WithStyles<typeof styles> {
 
 const LOCKED_TEXT = 'Locked for editing';
 const READ_ONLY_MODE_TEXT = 'Read only mode';
-const EDIT_MODE_TEXT = 'Edit mode';
+const EDIT_MODE_TEXT = 'Editing';
 
 const StickyBottomBarStatus: React.FC<StickyBottomBarStatusProps> = ({
   classes,

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -20,6 +20,7 @@ interface TestListProps<T extends Test> {
   tests: T[];
   isInEditMode: boolean;
   selectedTestName: string | null;
+  editedTestName: string | null;
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
 }
@@ -29,6 +30,7 @@ const TestList = <T extends Test>({
   tests,
   isInEditMode,
   selectedTestName,
+  editedTestName,
   onTestPriorityChange,
   onTestSelected,
 }: TestListProps<T> & WithStyles<typeof styles>): React.ReactElement => {
@@ -56,6 +58,7 @@ const TestList = <T extends Test>({
                         <TestListTest
                           test={test}
                           isSelected={test.name === selectedTestName}
+                          isEdited={test.name === editedTestName}
                           onClick={(): void => onTestSelected(test.name)}
                         />
                       </div>
@@ -66,6 +69,7 @@ const TestList = <T extends Test>({
                     key={test.name}
                     test={test}
                     isSelected={test.name === selectedTestName}
+                    isEdited={test.name === editedTestName}
                     onClick={(): void => onTestSelected(test.name)}
                   />
                 ),

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -55,6 +55,9 @@ const styles = ({ palette }: Theme) =>
         marginLeft: '4px',
       },
     },
+    whitePencil: {
+      color: 'white',
+    },
   });
 
 interface TestListTestProps extends WithStyles<typeof styles> {
@@ -86,7 +89,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
   return (
     <ListItem className={containerClasses.join(' ')} button={true} onClick={onClick} ref={ref}>
       <div className={classes.labelAndNameContainer}>
-        {isEdited && <EditIcon />}
+        {isEdited && (isSelected ? <EditIcon className={classes.whitePencil} /> : <EditIcon />)}
         <TestListTestLiveLabel isLive={test.isOn} shouldInvertColor={shouldInvertColor} />
         <TestListTestName
           name={test.name}

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -86,7 +86,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
   return (
     <ListItem className={containerClasses.join(' ')} button={true} onClick={onClick} ref={ref}>
       <div className={classes.labelAndNameContainer}>
-        { isEdited && <EditIcon /> }
+        {isEdited && <EditIcon />}
         <TestListTestLiveLabel isLive={test.isOn} shouldInvertColor={shouldInvertColor} />
         <TestListTestName
           name={test.name}

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -6,6 +6,7 @@ import TestListTestLiveLabel from './testListTestLiveLabel';
 import TestListTestName from './testListTestName';
 import TestListTestArticleCountLabel from './testListTestArticleCountLabel';
 import useHover from '../../hooks/useHover';
+import EditIcon from '@material-ui/icons/Edit';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ palette }: Theme) =>
@@ -59,6 +60,7 @@ const styles = ({ palette }: Theme) =>
 interface TestListTestProps extends WithStyles<typeof styles> {
   test: Test;
   isSelected: boolean;
+  isEdited: boolean;
   onClick: () => void;
 }
 
@@ -66,6 +68,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
   classes,
   test,
   isSelected,
+  isEdited,
   onClick,
 }: TestListTestProps) => {
   const hasArticleCount = test.articlesViewedSettings !== undefined;
@@ -83,6 +86,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
   return (
     <ListItem className={containerClasses.join(' ')} button={true} onClick={onClick} ref={ref}>
       <div className={classes.labelAndNameContainer}>
+        { isEdited && <EditIcon /> }
         <TestListTestLiveLabel isLive={test.isOn} shouldInvertColor={shouldInvertColor} />
         <TestListTestName
           name={test.name}

--- a/public/src/components/channelManagement/testsFormLayout.tsx
+++ b/public/src/components/channelManagement/testsFormLayout.tsx
@@ -44,6 +44,7 @@ interface Props extends WithStyles<typeof styles> {
   sidebar: JSX.Element;
   testEditor: JSX.Element | null;
   selectedTestName: string | null;
+  editedTestName: string | null;
   editMode: boolean;
   lockStatus: LockStatus;
   requestTakeControl: () => void;
@@ -57,6 +58,7 @@ const TestsFormLayout: React.FC<Props> = ({
   sidebar,
   testEditor,
   selectedTestName,
+  editedTestName,
   save,
   cancel,
   editMode,
@@ -86,6 +88,7 @@ const TestsFormLayout: React.FC<Props> = ({
       <StickyBottomBar
         isInEditMode={editMode}
         selectedTestName={selectedTestName}
+        editedTestName={editedTestName}
         lockStatus={lockStatus}
         requestTakeControl={requestTakeControl}
         requestLock={requestLock}


### PR DESCRIPTION
Currently when you start editing a test, you cannot view other tests.
This is because the Save button applies to only that test, but in reality all tests are saved to a single json file, so we cannot allow a user to selectively save individual tests without making a larger architectural change.

A quick compromise is to enable read-only viewing of other tests, but the Save button still applies to the single test being edited.

### Viewing the test that is being edited:
![Screen Shot 2022-01-27 at 15 13 18](https://user-images.githubusercontent.com/1513454/151387072-779a9c0a-5f02-4585-8ac2-869c948f0983.png)


### Viewing another test (unable to edit):
![Screen Shot 2022-01-27 at 15 13 23](https://user-images.githubusercontent.com/1513454/151387096-9bcfa3cd-37b6-441c-95d7-c9c83306883b.png)

