### PR TITLE
Enable header web preview

### DIFF
--- a/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
@@ -53,10 +53,9 @@ const TestEditorVariantSummaryWebPreviewButton: React.FC<TestEditorVariantSummar
   isDisabled,
 }: TestEditorVariantSummaryPreviewButtonProps) => {
   const isIncompatiblePlatform = ['AMP', 'APPLE_NEWS'].includes(platform);
-  const isExcludedTestType = ['HEADER'].includes(testType);
 
   const checkForDisabledButton = (): boolean => {
-    if (isIncompatiblePlatform || isExcludedTestType) {
+    if (isIncompatiblePlatform) {
       return true;
     }
     return isDisabled;
@@ -65,9 +64,6 @@ const TestEditorVariantSummaryWebPreviewButton: React.FC<TestEditorVariantSummar
   const getButtonCopy = (): string => {
     if (isIncompatiblePlatform) {
       return `WEB PREVIEW UNAVAILABLE FOR ${platform.replace('_', ' ')}`;
-    }
-    if (isExcludedTestType) {
-      return `WEB PREVIEW UNAVAILABLE FOR ${testType}`;
     }
     return 'WEB PREVIEW';
   };


### PR DESCRIPTION
the `?force-header` query string parameter is now supported by dotcom
![Screen Shot 2022-02-01 at 14 54 09](https://user-images.githubusercontent.com/1513454/151991817-45235daf-7d21-417a-99c2-01e61c15664a.png)
