### PR TITLE
Banner separateArticleCount toggle

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -42,7 +42,8 @@ case class BannerVariant(
   body: Option[String],
   highlightedText: Option[String],
   cta: Option[Cta],
-  secondaryCta: Option[Cta]
+  secondaryCta: Option[Cta],
+  separateArticleCount: Option[Boolean]
 )
 
 case class BannerTest(

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -8,6 +8,7 @@ import {
   Theme,
   Typography,
   makeStyles,
+  Switch,
 } from '@material-ui/core';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
 import VariantEditorCopyLengthWarning from '../variantEditorCopyLengthWarning';
@@ -51,6 +52,18 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   },
   buttonsContainer: {
     marginTop: spacing(2),
+  },
+  switchContainer: {
+    display: 'flex',
+    alignItems: 'center',
+
+    '& > * + *': {
+      marginLeft: spacing(1),
+    },
+  },
+  switchLabel: {
+    fontSize: '14px',
+    fontWeight: 500,
   },
 }));
 
@@ -331,6 +344,23 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
             deviceType={'MOBILE'}
           />
         )}
+      </div>
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.sectionHeader} variant="h4">
+          Separate article count (displayed only for users with at least 5 article views)
+        </Typography>
+
+        <div className={classes.switchContainer}>
+          <Typography className={classes.switchLabel}>Disabled</Typography>
+          <Switch
+            checked={!!variant.separateArticleCount}
+            onChange={(e): void =>
+              onVariantChange({ ...variant, separateArticleCount: e.target.checked })
+            }
+            disabled={!editMode}
+          />
+          <Typography className={classes.switchLabel}>Enabled</Typography>
+        </div>
       </div>
     </div>
   );

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -39,6 +39,7 @@ export interface BannerVariant extends Variant {
   highlightedText?: string;
   cta?: Cta;
   secondaryCta?: Cta;
+  separateArticleCount?: boolean;
 }
 
 export interface BannerTest extends Test {


### PR DESCRIPTION
See SDC PR for details: https://github.com/guardian/support-dotcom-components/pull/623

I've put the switch at the bottom of the variant editor:
![Screen Shot 2022-02-02 at 12 16 44](https://user-images.githubusercontent.com/1513454/152152210-c1b3b6bc-1d30-462d-821e-9e046f39d041.png)
