### PR TITLE
Remove deprecated banner fields

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -34,13 +34,6 @@ case class BannerVariant(
   template: BannerTemplate,
   bannerContent: Option[BannerContent],
   mobileBannerContent: Option[BannerContent],
-
-  // Deprecated - use bannerContent / mobileBannerContent
-  heading: Option[String],
-  body: Option[String],
-  highlightedText: Option[String],
-  cta: Option[Cta],
-  secondaryCta: Option[Cta],
   separateArticleCount: Option[Boolean]
 )
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -260,14 +260,6 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   const classes = useStyles();
   const setValidationStatusForField = useValidation(onValidationChange);
 
-  const content: BannerContent = variant.bannerContent || {
-    heading: variant.heading,
-    messageText: variant.body || '',
-    highlightedText: variant.highlightedText,
-    cta: variant.cta,
-    secondaryCta: variant.secondaryCta,
-  };
-
   const onMobileContentRadioChange = (): void => {
     if (variant.mobileBannerContent === undefined) {
       onVariantChange({
@@ -299,7 +291,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
 
       <div className={classes.sectionContainer}>
         <BannerTestVariantContentEditor
-          content={content}
+          content={variant.bannerContent}
           template={variant.template}
           onChange={(updatedContent: BannerContent): void =>
             onVariantChange({ ...variant, bannerContent: updatedContent })

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -30,13 +30,6 @@ export interface BannerVariant extends Variant {
   template: BannerTemplate;
   bannerContent: BannerContent;
   mobileBannerContent?: BannerContent;
-
-  // Deprecated - use bannerContent / mobileBannerContent
-  heading?: string;
-  body?: string;
-  highlightedText?: string;
-  cta?: Cta;
-  secondaryCta?: Cta;
   separateArticleCount?: boolean;
 }
 


### PR DESCRIPTION
The `BannerVariant` model has an optional seperate field for mobile content:
```
bannerContent: BannerContent;
mobileBannerContent?: BannerContent;
```

Historically this was not the case, and in the migration to support both we left some legacy fields in the model.
This PR removes them - they've not been used for a while.

I've archived some very old draft tests which still had the old model