### PR TITLE
RJR - support paragraphs in banner body copy

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -25,7 +25,8 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
 
 case class BannerContent(
   heading: Option[String],
-  messageText: String,
+  paragraphs: Option[List[String]],
+  messageText: Option[String],
   highlightedText: Option[String],
   cta: Option[Cta],
   secondaryCta: Option[SecondaryCta]

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -23,7 +23,10 @@ import TestVariantsSplitEditor from '../testVariantsSplitEditor';
 import { useStyles } from '../helpers/testEditorStyles';
 
 const copyHasTemplate = (content: BannerContent, template: string): boolean =>
-  (content.heading && content.heading.includes(template)) || content.messageText.includes(template);
+  (content.heading && content.heading.includes(template)) ||
+  (content.paragraphs != null && content.paragraphs[0].includes(template)) ||
+  (content.messageText != null && content.messageText.includes(template));
+
 const testCopyHasTemplate = (test: BannerTest, template: string): boolean =>
   test.variants.some(
     variant =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -24,7 +24,7 @@ import { useStyles } from '../helpers/testEditorStyles';
 
 const copyHasTemplate = (content: BannerContent, template: string): boolean =>
   (content.heading && content.heading.includes(template)) ||
-  (content.paragraphs != null && content.paragraphs[0].includes(template)) ||
+  (content.paragraphs && content.paragraphs.some(para => para.includes(template))) ||
   (content.messageText != null && content.messageText.includes(template));
 
 const testCopyHasTemplate = (test: BannerTest, template: string): boolean =>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -149,7 +149,13 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
   }, [errors.body, errors.heading, errors.highlightedText]);
 
   const onSubmit = ({ heading, body, highlightedText }: FormData): void => {
-    onChange({ ...content, heading, paragraphs: body.split('\n'), highlightedText });
+    onChange({
+      ...content,
+      heading,
+      paragraphs: body.split('\n'),
+      highlightedText,
+      messageText: undefined,
+    });
   };
 
   const updatePrimaryCta = (updatedCta?: Cta): void => {

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -111,7 +111,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
 
   const defaultValues: BannerContent = {
     heading: content.heading || '',
-    messageText: content.messageText,
+    paragraphs: content.paragraphs || [content.messageText] || [],
     highlightedText: content.highlightedText || '',
   };
 
@@ -127,10 +127,13 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.messageText, errors.heading, errors.highlightedText]);
+  }, [errors.paragraphs, errors.heading, errors.highlightedText]);
 
-  const onSubmit = ({ heading, messageText, highlightedText }: BannerContent): void => {
-    onChange({ ...content, heading, messageText, highlightedText });
+  const onSubmit = ({ heading, paragraphs, highlightedText }: BannerContent): void => {
+    if (paragraphs != null && !Array.isArray(paragraphs)) {
+      paragraphs = [paragraphs];
+    }
+    onChange({ ...content, heading, paragraphs, highlightedText });
   };
 
   const updatePrimaryCta = (updatedCta?: Cta): void => {
@@ -148,7 +151,19 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
     ? BODY_COPY_WITH_SECONDARY_CTA_RECOMMENDED_LENGTH
     : BODY_COPY_WITHOUT_SECONDARY_CTA_RECOMMENDED_LENGTH;
 
-  const bodyCopyLength = content.messageText.length + (content.highlightedText?.length ?? 0);
+  const getBodyCopyLength = (paras: string[] | undefined, text: string | undefined): number => {
+    if (paras != null) {
+      return paras.reduce((prev, curr) => prev + curr.length, 0);
+    }
+    if (text != null) {
+      return text.length;
+    }
+    return 0;
+  };
+
+  const bodyCopyLength =
+    getBodyCopyLength(content.paragraphs, content.messageText) +
+    (content.highlightedText?.length ?? 0);
 
   return (
     <>
@@ -184,10 +199,14 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
               required: EMPTY_ERROR_HELPER_TEXT,
               validate: templateValidator,
             })}
-            error={errors.messageText !== undefined}
-            helperText={errors.messageText ? errors.messageText.message : BODY_DEFAULT_HELPER_TEXT}
+            error={errors.paragraphs !== undefined}
+            helperText={
+              errors.paragraphs && errors.paragraphs[0]
+                ? errors.paragraphs[0].message
+                : BODY_DEFAULT_HELPER_TEXT
+            }
             onBlur={handleSubmit(onSubmit)}
-            name="messageText"
+            name="paragraphs"
             label="Body copy"
             margin="normal"
             variant="outlined"
@@ -262,7 +281,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
 
   const content: BannerContent = variant.bannerContent || {
     heading: variant.heading,
-    messageText: variant.body || '',
+    paragraphs: variant.body || '',
     highlightedText: variant.highlightedText,
     cta: variant.cta,
     secondaryCta: variant.secondaryCta,

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -10,7 +10,8 @@ import { useModule } from '../../../hooks/useModule';
 
 export interface BannerContent {
   heading?: string;
-  messageText: string;
+  messageText?: string;
+  paragraphs: string[];
   highlightedText?: string;
   cta?: Cta;
   secondaryCta?: SecondaryCta;

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -18,8 +18,6 @@ const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
   template: BannerTemplate.ContributionsBanner,
   bannerContent: {
     heading: 'We chose a different approach. Will you support it?',
-    messageText:
-      'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
     paragraphs: [
       'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
     ],
@@ -32,7 +30,6 @@ const PROD_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
   template: BannerTemplate.ContributionsBanner,
   bannerContent: {
-    messageText: '',
     paragraphs: [],
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
     cta: DEFAULT_PRIMARY_CTA,

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -20,6 +20,9 @@ const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
     heading: 'We chose a different approach. Will you support it?',
     messageText:
       'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+    paragraphs: [
+      'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+    ],
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
     cta: DEFAULT_PRIMARY_CTA,
   },
@@ -30,6 +33,7 @@ const PROD_DEFAULT_VARIANT: BannerVariant = {
   template: BannerTemplate.ContributionsBanner,
   bannerContent: {
     messageText: '',
+    paragraphs: [''],
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
     cta: DEFAULT_PRIMARY_CTA,
   },

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -33,7 +33,7 @@ const PROD_DEFAULT_VARIANT: BannerVariant = {
   template: BannerTemplate.ContributionsBanner,
   bannerContent: {
     messageText: '',
-    paragraphs: [''],
+    paragraphs: [],
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
     cta: DEFAULT_PRIMARY_CTA,
   },

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { createStyles, List, withStyles, WithStyles } from '@material-ui/core';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 

--- a/public/src/components/channelManagement/testVariantEditorWithPreviewTab.tsx
+++ b/public/src/components/channelManagement/testVariantEditorWithPreviewTab.tsx
@@ -31,7 +31,7 @@ function TestVariantEditorWithPreviewTab({
 
   const [value, setValue] = useState(0);
 
-  const handleChange = (event: React.ChangeEvent<{}>, newValue: number): void => {
+  const handleChange = (event: React.ChangeEvent<unknown>, newValue: number): void => {
     setValue(newValue);
   };
 

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -23,7 +23,8 @@ export enum BannerTemplate {
 
 export interface BannerContent {
   heading?: string;
-  messageText: string;
+  messageText?: string;
+  paragraphs: string[];
   highlightedText?: string;
   cta?: Cta;
   secondaryCta?: SecondaryCta;


### PR DESCRIPTION
## What does this change?
All Banners currently use a `messageText` String field to hold the copy to be used in the Banner's body. Different Banners also use different approaches to adding a sentence of highlighted text to the body copy. Compare this to the situation in Epics, where body copy is supplied in an array of Strings (in a `paragraphs` attribute), which allows Epics to break their body copy into paragraphs.

This PR aims to bring the handling of body copy into alignment between Banners and Epics, with copy supplied in a new `paragraphs` array. It also introduces a shared function to handle the addition of highlighted text to the last paragraph of the body copy.

### Risks
Body copy is generated by Marketing colleagues using the RRCP. This PR is supported by [an equivalent PR in the support.dotcom.components repo](https://github.com/guardian/support-dotcom-components/pull/632) to update the Banner variant forms so that they save their body content as an array of Strings in the new `paragraphs` attribute. (link to SAC PR required)

A major risk for this PR is handling the transition of existing Banner tests from the old way of doing things (using `messageText`) to the new way (using `paragraphs`). We mitigate that risk in this PR by including temporary functionality so that Banner tests that do not include the `paragraphs` copy automatically fall back to using the `messageText` copy.

Once we are satisfied that all Banner tests on the LIVE site have been updated to include their copy in the `paragraphs` attribute we will be able to remove the temporary functionality and simplify the code base.

### Testing
This PR can be tested using the RRCP in DEV or CODE.

### Images
(Add some images to compare existing vs new paragraph functionality)