### PR TITLE
Targeting by device type

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -46,7 +46,8 @@ case class BannerTest(
   locations: List[Region] = Nil,
   variants: List[BannerVariant],
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
-  controlProportionSettings: Option[ControlProportionSettings] = None
+  controlProportionSettings: Option[ControlProportionSettings] = None,
+  deviceType: Option[DeviceType] = None
 )
 
 case class BannerTests(tests: List[BannerTest])

--- a/app/models/DeviceType.scala
+++ b/app/models/DeviceType.scala
@@ -1,0 +1,16 @@
+package models
+
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{ deriveEnumerationDecoder, deriveEnumerationEncoder }
+import io.circe.{Decoder, Encoder}
+
+sealed trait DeviceType
+case object All extends DeviceType
+case object Desktop extends DeviceType
+case object Mobile extends DeviceType
+
+object DeviceType {
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val decoder: Decoder[DeviceType] = deriveEnumerationDecoder[DeviceType]
+  implicit val encoder: Encoder[DeviceType] = deriveEnumerationEncoder[DeviceType]
+}

--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -80,7 +80,8 @@ case class EpicTest(
   highPriority: Boolean = false, // has been removed from form, but might be used in future
   useLocalViewLog: Boolean = false,
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
-  controlProportionSettings: Option[ControlProportionSettings] = None
+  controlProportionSettings: Option[ControlProportionSettings] = None,
+  deviceType: Option[DeviceType] = None
 )
 
 case class EpicTests(tests: List[EpicTest])

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -27,7 +27,8 @@ case class HeaderTest(
   locations: List[Region] = Nil,
   userCohort: Option[UserCohort] = None,
   variants: List[HeaderVariant],
-  controlProportionSettings: Option[ControlProportionSettings] = None
+  controlProportionSettings: Option[ControlProportionSettings] = None,
+  deviceType: Option[DeviceType] = None
 )
 
 case class HeaderTests(tests: List[HeaderTest])

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
-import { ArticlesViewedSettings, UserCohort } from '../helpers/shared';
+import { ArticlesViewedSettings, DeviceType, UserCohort } from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@material-ui/core';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
@@ -128,6 +128,10 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
     updateTest({ ...test, userCohort: updatedCohort });
   };
 
+  const onDeviceTypeChange = (updatedDeviceType: DeviceType): void => {
+    updateTest({ ...test, deviceType: updatedDeviceType });
+  };
+
   const onArticlesViewedSettingsChange = (
     updatedArticlesViewedSettings?: ArticlesViewedSettings,
   ): void => {
@@ -245,8 +249,11 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
             onRegionsUpdate={onRegionsChange}
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
+            selectedDeviceType={test.deviceType ?? 'All'}
+            onDeviceTypeChange={onDeviceTypeChange}
             isDisabled={!editMode}
             showSupporterStatusSelector={true}
+            showDeviceTypeSelector={true}
           />
         </div>
 

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 import { EpicTest, EpicVariant, MaxEpicViews } from './epicTestsForm';
-import { ArticlesViewedSettings, UserCohort, EpicEditorConfig } from '../helpers/shared';
+import {
+  ArticlesViewedSettings,
+  UserCohort,
+  EpicEditorConfig,
+  DeviceType,
+} from '../helpers/shared';
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
 import TestEditorHeader from '../testEditorHeader';
 import TestVariantsEditor from '../testVariantsEditor';
@@ -151,6 +156,10 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
 
   const onCohortChange = (updatedCohort: UserCohort): void => {
     updateTest({ ...test, userCohort: updatedCohort });
+  };
+
+  const onDeviceTypeChange = (updatedDeviceType: DeviceType): void => {
+    updateTest({ ...test, deviceType: updatedDeviceType });
   };
 
   const onArticlesViewedSettingsChange = (
@@ -310,8 +319,11 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
             supportedRegions={epicEditorConfig.supportedRegions}
+            selectedDeviceType={test.deviceType ?? 'All'}
+            onDeviceTypeChange={onDeviceTypeChange}
             isDisabled={!editMode}
             showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargeting}
+            showDeviceTypeSelector={epicEditorConfig.allowDeviceTypeTargeting}
           />
         </div>
       )}

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -16,6 +16,7 @@ import {
   AMP_EPIC_CONFIG,
   SecondaryCta,
   ContributionFrequency,
+  DeviceType,
 } from '../helpers/shared';
 import { InnerComponentProps } from '../testEditor';
 import TestsForm from '../testEditor';
@@ -89,6 +90,7 @@ export interface EpicTest extends Test {
   useLocalViewLog: boolean;
   articlesViewedSettings?: ArticlesViewedSettings;
   controlProportionSettings?: ControlProportionSettings;
+  deviceType?: DeviceType;
 }
 
 type Props = InnerComponentProps<EpicTest>;

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 
-import { UserCohort } from '../helpers/shared';
+import { DeviceType, UserCohort } from '../helpers/shared';
 
 import { Typography } from '@material-ui/core';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
@@ -89,6 +89,10 @@ const HeaderTestEditor: React.FC<HeaderTestEditorProps> = ({
 
   const onCohortChange = (updatedCohort: UserCohort): void => {
     updateTest({ ...test, userCohort: updatedCohort });
+  };
+
+  const onDeviceTypeChange = (updatedDeviceType: DeviceType): void => {
+    updateTest({ ...test, deviceType: updatedDeviceType });
   };
 
   const onCopy = (name: string, nickname: string): void => {
@@ -186,8 +190,11 @@ const HeaderTestEditor: React.FC<HeaderTestEditorProps> = ({
             onRegionsUpdate={onRegionsChange}
             selectedCohort={test.userCohort}
             onCohortChange={onCohortChange}
+            selectedDeviceType={test.deviceType ?? 'All'}
+            onDeviceTypeChange={onDeviceTypeChange}
             isDisabled={!editMode}
             showSupporterStatusSelector={true}
+            showDeviceTypeSelector={true}
           />
         </div>
 

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -28,6 +28,7 @@ export interface EpicEditorConfig {
   allowLocationTargeting: boolean;
   supportedRegions?: Region[];
   allowSupporterStatusTargeting: boolean;
+  allowDeviceTypeTargeting: boolean;
   allowViewFrequencySettings: boolean;
   allowArticleCount: boolean;
   testNamePrefix?: string;
@@ -54,6 +55,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowContentTargeting: true,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
+  allowDeviceTypeTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: true,
@@ -77,6 +79,7 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowContentTargeting: true,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
+  allowDeviceTypeTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   testNamePrefix: 'HOLDBACK__',
@@ -101,6 +104,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowContentTargeting: true,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
+  allowDeviceTypeTargeting: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: true,
@@ -125,6 +129,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowLocationTargeting: true,
   supportedRegions: [Region.UnitedStates, Region.AUDCountries],
   allowSupporterStatusTargeting: false,
+  allowDeviceTypeTargeting: false,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,
@@ -148,6 +153,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowContentTargeting: false,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: false,
+  allowDeviceTypeTargeting: false,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,
@@ -242,3 +248,5 @@ export interface TickerSettings {
 }
 
 export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
+
+export type DeviceType = 'Mobile' | 'Desktop' | 'All';

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -1,21 +1,32 @@
 import React from 'react';
 
-import { Theme, WithStyles, createStyles, withStyles } from '@material-ui/core';
+import { Theme, WithStyles, createStyles, withStyles, Typography } from '@material-ui/core';
 import { Region } from '../../utils/models';
-import { UserCohort } from './helpers/shared';
+import { DeviceType, UserCohort } from './helpers/shared';
 
 import TestEditorTargetRegionsSelector from './testEditorTargetRegionsSelector';
 import TestEditorTargetSupporterStatusSelector from './testEditorTargetSupporterStatusSelector';
+import TestEditorTargetDeviceType from './testEditorTargetDeviceType';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
+const styles = ({ spacing, palette }: Theme) =>
   createStyles({
     container: {
       display: 'flex',
 
       '& > * + *': {
-        marginLeft: spacing(30),
+        marginLeft: spacing(12),
       },
+    },
+    sectionContainer: {
+      '& > * + *': {
+        marginTop: spacing(2),
+      },
+    },
+    heading: {
+      fontSize: 16,
+      color: palette.grey[900],
+      fontWeight: 500,
     },
   });
 
@@ -25,8 +36,11 @@ interface TestEditorTargetAudienceSelectorProps extends WithStyles<typeof styles
   selectedCohort: UserCohort;
   onCohortChange: (updatedCohort: UserCohort) => void;
   supportedRegions?: Region[];
+  selectedDeviceType: DeviceType;
+  onDeviceTypeChange: (deviceType: DeviceType) => void;
   isDisabled: boolean;
   showSupporterStatusSelector: boolean;
+  showDeviceTypeSelector: boolean;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
   classes,
@@ -35,24 +49,44 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   selectedCohort,
   onCohortChange,
   supportedRegions,
+  selectedDeviceType,
+  onDeviceTypeChange,
   isDisabled,
   showSupporterStatusSelector,
+  showDeviceTypeSelector,
 }: TestEditorTargetAudienceSelectorProps) => {
   return (
     <div className={classes.container}>
-      <TestEditorTargetRegionsSelector
-        selectedRegions={selectedRegions}
-        onRegionsUpdate={onRegionsUpdate}
-        supportedRegions={supportedRegions}
-        isDisabled={isDisabled}
-      />
-
-      {showSupporterStatusSelector && (
-        <TestEditorTargetSupporterStatusSelector
-          selectedCohort={selectedCohort}
-          onCohortChange={onCohortChange}
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.heading}>Region</Typography>
+        <TestEditorTargetRegionsSelector
+          selectedRegions={selectedRegions}
+          onRegionsUpdate={onRegionsUpdate}
+          supportedRegions={supportedRegions}
           isDisabled={isDisabled}
         />
+      </div>
+
+      {showSupporterStatusSelector && (
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.heading}>Supporter Status</Typography>
+          <TestEditorTargetSupporterStatusSelector
+            selectedCohort={selectedCohort}
+            onCohortChange={onCohortChange}
+            isDisabled={isDisabled}
+          />
+        </div>
+      )}
+
+      {showDeviceTypeSelector && (
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.heading}>Device Type</Typography>
+          <TestEditorTargetDeviceType
+            selectedDeviceType={selectedDeviceType}
+            onChange={onDeviceTypeChange}
+            isDisabled={isDisabled}
+          />
+        </div>
       )}
     </div>
   );

--- a/public/src/components/channelManagement/testEditorTargetDeviceType.tsx
+++ b/public/src/components/channelManagement/testEditorTargetDeviceType.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { Checkbox, FormControlLabel, FormGroup, Theme, makeStyles } from '@material-ui/core';
+import { DeviceType } from './helpers/shared';
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  indentedContainer: {
+    marginLeft: spacing(3),
+  },
+}));
+
+interface TestEditorTargetDeviceTypeProps {
+  selectedDeviceType: DeviceType;
+  onChange: (updatedDeviceType: DeviceType) => void;
+  isDisabled: boolean;
+}
+const TestEditorTargetDeviceType: React.FC<TestEditorTargetDeviceTypeProps> = ({
+  selectedDeviceType,
+  onChange,
+  isDisabled,
+}: TestEditorTargetDeviceTypeProps) => {
+  const classes = useStyles();
+
+  const onSelect = (deviceType: DeviceType) => (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    if (event.target.checked) {
+      // It's impossible to have had neither checked, so it must now be both
+      onChange('All');
+    } else if (selectedDeviceType === 'All') {
+      if (deviceType === 'Desktop') {
+        onChange('Mobile');
+      } else if (deviceType === 'Mobile') {
+        onChange('Desktop');
+      }
+    }
+  };
+
+  return (
+    <FormGroup>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={selectedDeviceType === 'All'}
+            onChange={onSelect('All')}
+            disabled={isDisabled}
+          />
+        }
+        label="Everyone"
+      />
+      <FormGroup className={classes.indentedContainer}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={selectedDeviceType === 'All' || selectedDeviceType === 'Desktop'}
+              onChange={onSelect('Desktop')}
+              disabled={isDisabled}
+            />
+          }
+          label="Desktop"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={selectedDeviceType === 'All' || selectedDeviceType === 'Mobile'}
+              onChange={onSelect('Mobile')}
+              disabled={isDisabled}
+            />
+          }
+          label="Mobile"
+        />
+      </FormGroup>
+    </FormGroup>
+  );
+};
+
+export default TestEditorTargetDeviceType;

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -5,7 +5,6 @@ import {
   FormControlLabel,
   FormGroup,
   Theme,
-  Typography,
   WithStyles,
   createStyles,
   withStyles,
@@ -15,11 +14,6 @@ import { Region } from '../../utils/models';
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
   createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(2),
-      },
-    },
     indentedContainer: {
       marginLeft: spacing(3),
     },
@@ -69,38 +63,35 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
   };
 
   return (
-    <div className={classes.container}>
-      <Typography>Region</Typography>
-      <FormGroup>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={selectedRegions.length === allRegions.length}
-              value={'allRegions'}
-              onChange={onAllRegionsChange}
-              disabled={isDisabled}
-            />
-          }
-          label={'All regions'}
-        />
-        <FormGroup className={classes.indentedContainer}>
-          {allRegions.map(region => (
-            <FormControlLabel
-              key={region}
-              control={
-                <Checkbox
-                  checked={selectedRegions.includes(region)}
-                  onChange={onSingleRegionChange}
-                  value={region}
-                  disabled={isDisabled}
-                />
-              }
-              label={regionLabels[region]}
-            />
-          ))}
-        </FormGroup>
+    <FormGroup>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={selectedRegions.length === allRegions.length}
+            value={'allRegions'}
+            onChange={onAllRegionsChange}
+            disabled={isDisabled}
+          />
+        }
+        label={'All regions'}
+      />
+      <FormGroup className={classes.indentedContainer}>
+        {allRegions.map(region => (
+          <FormControlLabel
+            key={region}
+            control={
+              <Checkbox
+                checked={selectedRegions.includes(region)}
+                onChange={onSingleRegionChange}
+                value={region}
+                disabled={isDisabled}
+              />
+            }
+            label={regionLabels[region]}
+          />
+        ))}
       </FormGroup>
-    </div>
+    </FormGroup>
   );
 };
 

--- a/public/src/components/channelManagement/testEditorTargetSupporterStatusSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetSupporterStatusSelector.tsx
@@ -5,7 +5,6 @@ import {
   FormControlLabel,
   FormGroup,
   Theme,
-  Typography,
   WithStyles,
   createStyles,
   withStyles,
@@ -15,11 +14,6 @@ import { UserCohort } from './helpers/shared';
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const styles = ({ spacing }: Theme) =>
   createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(2),
-      },
-    },
     indentedContainer: {
       marginLeft: spacing(3),
     },
@@ -62,49 +56,46 @@ const TestEditorTargetSupporterStatusSelector: React.FC<TestEditorTargetSupporte
   };
 
   return (
-    <div className={classes.container}>
-      <Typography>Supporter status</Typography>
-      <FormGroup>
+    <FormGroup>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={selectedCohort === 'Everyone'}
+            onChange={onEveryoneSelected}
+            disabled={isDisabled}
+          />
+        }
+        label="Everyone"
+      />
+      <FormGroup className={classes.indentedContainer}>
         <FormControlLabel
           control={
             <Checkbox
-              checked={selectedCohort === 'Everyone'}
-              onChange={onEveryoneSelected}
+              checked={
+                selectedCohort === UserCohort['Everyone'] ||
+                selectedCohort === UserCohort['AllNonSupporters']
+              }
+              onChange={onNonSupportersSelected}
               disabled={isDisabled}
             />
           }
-          label="Everyone"
+          label="Non-supporters"
         />
-        <FormGroup className={classes.indentedContainer}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={
-                  selectedCohort === UserCohort['Everyone'] ||
-                  selectedCohort === UserCohort['AllNonSupporters']
-                }
-                onChange={onNonSupportersSelected}
-                disabled={isDisabled}
-              />
-            }
-            label="Non-supporters"
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={
-                  selectedCohort === UserCohort['Everyone'] ||
-                  selectedCohort === UserCohort['AllExistingSupporters']
-                }
-                onChange={onAllSupportersSelected}
-                disabled={isDisabled}
-              />
-            }
-            label="Existing supporters"
-          />
-        </FormGroup>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={
+                selectedCohort === UserCohort['Everyone'] ||
+                selectedCohort === UserCohort['AllExistingSupporters']
+              }
+              onChange={onAllSupportersSelected}
+              disabled={isDisabled}
+            />
+          }
+          label="Existing supporters"
+        />
       </FormGroup>
-    </div>
+    </FormGroup>
   );
 };
 

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -5,6 +5,7 @@ import {
   Variant,
   UserCohort,
   SecondaryCta,
+  DeviceType,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
@@ -43,4 +44,5 @@ export interface BannerTest extends Test {
   variants: BannerVariant[];
   articlesViewedSettings?: ArticlesViewedSettings;
   controlProportionSettings?: ControlProportionSettings;
+  deviceType?: DeviceType;
 }

--- a/public/src/models/header.ts
+++ b/public/src/models/header.ts
@@ -1,4 +1,10 @@
-import { Cta, Test, Variant, UserCohort } from '../components/channelManagement/helpers/shared';
+import {
+  Cta,
+  Test,
+  Variant,
+  UserCohort,
+  DeviceType,
+} from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
 
@@ -23,4 +29,5 @@ export interface HeaderTest extends Test {
   locations: Region[];
   variants: HeaderVariant[];
   controlProportionSettings?: ControlProportionSettings;
+  deviceType?: DeviceType;
 }


### PR DESCRIPTION
We're adding the ability to target by mobile/desktop - https://github.com/guardian/support-dotcom-components/pull/640

This PR adds a new sub-section in the audience section for epic/banner/header tools:
![Screen Shot 2022-03-01 at 14 04 50](https://user-images.githubusercontent.com/1513454/156186260-97d6d285-8156-4133-a0e5-7cfdfd79b636.png)

I've also slightly restructured the audience component to share common styling.
