### PR TITLE
Image editor component

### DIFF
--- a/app/models/EpicTests.scala
+++ b/app/models/EpicTests.scala
@@ -55,7 +55,7 @@ case class EpicVariant(
   footer: Option[String] = None,
   showTicker: Boolean = false,  // Deprecated - use tickerSettings instead
   tickerSettings: Option[TickerSettings] = None,
-  backgroundImageUrl: Option[String] = None,
+  image: Option[Image] = None,
   cta: Option[Cta],
   secondaryCta: Option[SecondaryCta],
   separateArticleCount: Option[SeparateArticleCount],

--- a/app/models/Image.scala
+++ b/app/models/Image.scala
@@ -1,0 +1,6 @@
+package models
+
+case class Image(
+  mainUrl: String,
+  altText: String
+)

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
-import { makeStyles, TextField, Theme, Typography } from '@material-ui/core';
+import { makeStyles, Theme, Typography } from '@material-ui/core';
 
 import EpicTestChoiceCardsEditor from './epicTestChoiceCardsEditor';
 import { EpicVariant, SeparateArticleCount } from './epicTestsForm';
@@ -12,6 +12,7 @@ import {
   ContributionFrequency,
   Cta,
   EpicEditorConfig,
+  Image,
   SecondaryCta,
   TickerSettings,
 } from '../helpers/shared';
@@ -27,6 +28,7 @@ import {
   getRteCopyLength,
 } from '../richTextEditor/richTextEditor';
 import VariantEditorSeparateArticleCountEditor from '../variantEditorSeparateArticleCountEditor';
+import { ImageEditorToggle } from '../imageEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const getUseStyles = (shouldAddPadding: boolean) => {
@@ -63,15 +65,13 @@ const PARAGRAPHS_MAX_LENGTH = 2000;
 const HEADER_DEFAULT_HELPER_TEXT = `Assitive text`;
 const BODY_DEFAULT_HELPER_TEXT = `Maximum ${PARAGRAPHS_MAX_LENGTH} characters.`;
 const HIGHTLIGHTED_TEXT_DEFAULT_HELPER_TEXT = `Final sentence of body copy.`;
-const IMAGE_URL_DEFAULT_HELPER_TEXT =
-  'Image ratio should be 2.5:1. This will appear above everything except a ticker';
 const FOOTER_DEFAULT_HELPER_TEXT = `Bold text below the button.`;
 
 interface FormData {
   heading?: string;
   paragraphs: string[];
   highlightedText?: string;
-  backgroundImageUrl?: string;
+  image?: Image;
   footer?: string;
 }
 
@@ -99,11 +99,11 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
     heading: variant.heading,
     paragraphs: variant.paragraphs,
     highlightedText: variant.highlightedText,
-    backgroundImageUrl: variant.backgroundImageUrl,
+    image: variant.image,
     footer: variant.footer,
   };
 
-  const { register, handleSubmit, control, errors, trigger } = useForm<FormData>({
+  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -115,27 +115,15 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [
-    errors.heading,
-    errors.paragraphs,
-    errors.highlightedText,
-    errors.backgroundImageUrl,
-    errors.footer,
-  ]);
+  }, [errors.heading, errors.paragraphs, errors.highlightedText, errors.image, errors.footer]);
 
-  const onSubmit = ({
-    heading,
-    paragraphs,
-    highlightedText,
-    backgroundImageUrl,
-    footer,
-  }: FormData): void => {
+  const onSubmit = ({ heading, paragraphs, highlightedText, image, footer }: FormData): void => {
     onVariantChange({
       ...variant,
       heading,
       paragraphs,
       highlightedText,
-      backgroundImageUrl: backgroundImageUrl || undefined,
+      image,
       footer,
     });
   };
@@ -163,6 +151,9 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   };
   const updateShowSignInLink = (updatedShowSignInLink?: boolean): void => {
     onVariantChange({ ...variant, showSignInLink: updatedShowSignInLink });
+  };
+  const updateImage = (image?: Image): void => {
+    onVariantChange({ ...variant, image });
   };
 
   const getParagraphsHelperText = () => {
@@ -273,23 +264,6 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
         />
       )}
 
-      {epicEditorConfig.allowVariantImageUrl && (
-        <div>
-          <TextField
-            inputRef={register({ validate: templateValidator })}
-            error={errors.backgroundImageUrl !== undefined}
-            helperText={IMAGE_URL_DEFAULT_HELPER_TEXT}
-            onBlur={handleSubmit(onSubmit)}
-            name="backgroundImageUrl"
-            label="Image URL"
-            margin="normal"
-            variant="outlined"
-            disabled={!editMode}
-            fullWidth
-          />
-        </div>
-      )}
-
       {epicEditorConfig.allowVariantFooter && (
         <Controller
           name="footer"
@@ -317,6 +291,17 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
               />
             );
           }}
+        />
+      )}
+
+      {epicEditorConfig.allowVariantImageUrl && (
+        <ImageEditorToggle
+          image={variant.image}
+          updateImage={updateImage}
+          isDisabled={!editMode}
+          onValidationChange={onValidationChange}
+          label={'Image - appears below the article count badge and ticker'}
+          guidance={'Ratio should be 2.5:1'}
         />
       )}
 

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -3,23 +3,23 @@ import EpicTestEditor from './epicTestEditor';
 import { Region } from '../../../utils/models';
 
 import {
-  UserCohort,
-  Cta,
-  ArticlesViewedSettings,
-  Test,
-  Variant,
-  EpicEditorConfig,
+  AMP_EPIC_CONFIG,
+  APPLE_NEWS_EPIC_CONFIG,
   ARTICLE_EPIC_CONFIG,
   ARTICLE_EPIC_HOLDBACK_CONFIG,
-  LIVEBLOG_EPIC_CONFIG,
-  APPLE_NEWS_EPIC_CONFIG,
-  AMP_EPIC_CONFIG,
-  SecondaryCta,
+  ArticlesViewedSettings,
   ContributionFrequency,
+  Cta,
   DeviceType,
+  EpicEditorConfig,
+  Image,
+  LIVEBLOG_EPIC_CONFIG,
+  SecondaryCta,
+  Test,
+  UserCohort,
+  Variant,
 } from '../helpers/shared';
-import { InnerComponentProps } from '../testEditor';
-import TestsForm from '../testEditor';
+import TestsForm, { InnerComponentProps } from '../testEditor';
 import TestsFormLayout from '../testsFormLayout';
 import Sidebar from '../sidebar';
 import { FrontendSettingsType } from '../../../utils/requests';
@@ -57,7 +57,7 @@ export interface EpicVariant extends Variant {
   footer?: string;
   showTicker: boolean;
   tickerSettings?: TickerSettings;
-  backgroundImageUrl?: string;
+  image?: Image;
   cta?: Cta;
   secondaryCta?: SecondaryCta;
   separateArticleCount?: SeparateArticleCount;

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -39,7 +39,6 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     cta: variant.cta,
     separateArticleCount: variant.separateArticleCount,
     showSignInLink: variant.showSignInLink,
-    backgroundImageUrl: variant.backgroundImageUrl,
   },
   tracking: {
     ophanPageId: 'ophanPageId',

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -39,6 +39,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     cta: variant.cta,
     separateArticleCount: variant.separateArticleCount,
     showSignInLink: variant.showSignInLink,
+    image: variant.image,
   },
   tracking: {
     ophanPageId: 'ophanPageId',

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -250,3 +250,8 @@ export interface TickerSettings {
 export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
 
 export type DeviceType = 'Mobile' | 'Desktop' | 'All';
+
+export interface Image {
+  mainUrl: string;
+  altText: string;
+}

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -19,7 +19,7 @@ interface ImageEditorProps {
   guidance: string; // helper text to suggest e.g. image ratio
 }
 
-interface ImageEditorContainerProps {
+interface ImageEditorToggleProps {
   image?: Image;
   updateImage: (image?: Image) => void;
   isDisabled: boolean;
@@ -94,14 +94,14 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
  * Component for toggling the use of an image.
  * Renders the ImageEditor component if the checkbox is checked.
  */
-const ImageEditorToggle: React.FC<ImageEditorContainerProps> = ({
+const ImageEditorToggle: React.FC<ImageEditorToggleProps> = ({
   image,
   updateImage,
   isDisabled,
   onValidationChange,
   label,
   guidance,
-}: ImageEditorContainerProps) => {
+}: ImageEditorToggleProps) => {
   const classes = useStyles();
 
   const onCheckboxChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -1,0 +1,143 @@
+import { Image } from './helpers/shared';
+import React, { useEffect } from 'react';
+import { Checkbox, makeStyles, TextField, Theme } from '@material-ui/core';
+import { useForm } from 'react-hook-form';
+import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    marginBottom: spacing(3),
+  },
+}));
+
+interface ImageEditorProps {
+  image: Image;
+  updateImage: (image?: Image) => void;
+  isDisabled: boolean;
+  onValidationChange: (isValid: boolean) => void;
+  guidance: string;
+}
+
+type ImageEditorContainerProps = Omit<ImageEditorProps, 'image'> & {
+  image?: Image;
+  label: string;
+};
+
+const DEFAULT_IMAGE: Image = {
+  mainUrl: '',
+  altText: '',
+};
+
+const ImageEditor: React.FC<ImageEditorProps> = ({
+  image,
+  updateImage,
+  isDisabled,
+  onValidationChange,
+  guidance,
+}: ImageEditorProps) => {
+  const defaultValues: Image = image;
+
+  const { register, handleSubmit, errors, trigger } = useForm<Image>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    trigger(); // validate immediately
+  }, []);
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange(isValid);
+  }, [errors]);
+
+  const onUpdate = (updatedImage: Image): void => {
+    updateImage(updatedImage);
+  };
+
+  return (
+    <div>
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        error={errors.mainUrl !== undefined}
+        helperText={errors.mainUrl?.message ?? guidance}
+        onBlur={handleSubmit(onUpdate)}
+        name="mainUrl"
+        label="Image URL"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        error={errors.altText !== undefined}
+        helperText={errors.altText?.message}
+        onBlur={handleSubmit(onUpdate)}
+        name="altText"
+        label="Image alt-text"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+    </div>
+  );
+};
+
+/**
+ * Component for toggling the use of an image.
+ * Renders the ImageEditor component if the checkbox is checked.
+ */
+const ImageEditorToggle: React.FC<ImageEditorContainerProps> = ({
+  image,
+  updateImage,
+  isDisabled,
+  onValidationChange,
+  label,
+  guidance,
+}: ImageEditorContainerProps) => {
+  const classes = useStyles();
+
+  const onCheckboxChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const isChecked = event.target.checked;
+    if (isChecked) {
+      updateImage(DEFAULT_IMAGE);
+    } else {
+      updateImage(undefined);
+      onValidationChange(true);
+    }
+  };
+
+  return (
+    <div className={classes.container}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={!!image}
+            onChange={onCheckboxChanged}
+            color="primary"
+            disabled={isDisabled}
+          />
+        }
+        label={label}
+      />
+      {image && (
+        <ImageEditor
+          image={image}
+          updateImage={updateImage}
+          isDisabled={isDisabled}
+          onValidationChange={onValidationChange}
+          guidance={guidance}
+        />
+      )}
+    </div>
+  );
+};
+
+export { ImageEditorToggle };

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -16,7 +16,7 @@ interface ImageEditorProps {
   updateImage: (image: Image) => void;
   isDisabled: boolean;
   onValidationChange: (isValid: boolean) => void;
-  guidance: string;
+  guidance: string; // helper text to suggest e.g. image ratio
 }
 
 interface ImageEditorContainerProps {

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -13,16 +13,20 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 
 interface ImageEditorProps {
   image: Image;
-  updateImage: (image?: Image) => void;
+  updateImage: (image: Image) => void;
   isDisabled: boolean;
   onValidationChange: (isValid: boolean) => void;
   guidance: string;
 }
 
-type ImageEditorContainerProps = Omit<ImageEditorProps, 'image'> & {
+interface ImageEditorContainerProps {
   image?: Image;
+  updateImage: (image?: Image) => void;
+  isDisabled: boolean;
+  onValidationChange: (isValid: boolean) => void;
+  guidance: string;
   label: string;
-};
+}
 
 const DEFAULT_IMAGE: Image = {
   mainUrl: '',
@@ -52,10 +56,6 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
     onValidationChange(isValid);
   }, [errors]);
 
-  const onUpdate = (updatedImage: Image): void => {
-    updateImage(updatedImage);
-  };
-
   return (
     <div>
       <TextField
@@ -64,7 +64,7 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
         })}
         error={errors.mainUrl !== undefined}
         helperText={errors.mainUrl?.message ?? guidance}
-        onBlur={handleSubmit(onUpdate)}
+        onBlur={handleSubmit(updateImage)}
         name="mainUrl"
         label="Image URL"
         margin="normal"
@@ -78,7 +78,7 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
         })}
         error={errors.altText !== undefined}
         helperText={errors.altText?.message}
-        onBlur={handleSubmit(onUpdate)}
+        onBlur={handleSubmit(updateImage)}
         name="altText"
         label="Image alt-text"
         margin="normal"


### PR DESCRIPTION
See accompanying [SDC PR](https://github.com/guardian/support-dotcom-components/pull/663) for context.

This PR:
1. Removes the `backgroundImageUrl` field, which hasn't been used for a while
2. Adds `image` field to the epic model, with a new `Image` type which requires an altText
3. Adds a new generic component for toggling the image and setting the url/altText

Note - we have bigger ambitions for images in the RRCP:
1. [support multiple images](https://github.com/guardian/support-dotcom-components/pull/663#discussion_r834141405) for different breakpoints
2. integrate with the Grid

### A checkbox appears above the CTAs editor in the variant editor:
![Screen Shot 2022-03-24 at 14 11 52](https://user-images.githubusercontent.com/1513454/160081234-419bf07e-5d87-4dba-a380-cec190d94fda.png)

### Both fields are mandatory:
![Screen Shot 2022-03-24 at 14 11 10](https://user-images.githubusercontent.com/1513454/160081286-11299001-9719-4c7b-92c3-357130b0858d.png)

![Screen Shot 2022-03-24 at 14 11 40](https://user-images.githubusercontent.com/1513454/160081314-4b5997f9-625c-4423-91fd-b7eafbf6b074.png)
