### PR TITLE
Migrate uses of withStyles to makeStyles

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestNewVariantButton.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestNewVariantButton.tsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import {
   Button,
-  createStyles,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   IconButton,
+  makeStyles,
   TextField,
   Theme,
   Typography,
-  WithStyles,
-  withStyles,
 } from '@material-ui/core';
 
 import AddIcon from '@material-ui/icons/Add';
@@ -27,42 +25,40 @@ import {
   createDuplicateValidator,
 } from '../helpers/validation';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing, palette }: Theme) =>
-  createStyles({
-    button: {
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'start',
-      border: `1px dashed ${palette.grey[700]}`,
-      borderRadius: '4px',
-      padding: '12px 16px',
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  button: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'start',
+    border: `1px dashed ${palette.grey[700]}`,
+    borderRadius: '4px',
+    padding: '12px 16px',
+  },
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > * + *': {
+      marginLeft: spacing(1),
     },
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-      '& > * + *': {
-        marginLeft: spacing(1),
-      },
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: 500,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  dialogHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '8px',
+  },
+  input: {
+    '& input': {
+      textTransform: 'uppercase !important',
     },
-    text: {
-      fontSize: 14,
-      fontWeight: 500,
-      letterSpacing: 1,
-      textTransform: 'uppercase',
-    },
-    dialogHeader: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingRight: '8px',
-    },
-    input: {
-      '& input': {
-        textTransform: 'uppercase !important',
-      },
-    },
-  });
+  },
+}));
 
 const NAME_DEFAULT_HELPER_TEXT = "Format: 'control' or 'v1_name'";
 
@@ -70,18 +66,18 @@ interface FormData {
   name: string;
 }
 
-interface BannerTestNewVariantButtonProps extends WithStyles<typeof styles> {
+interface BannerTestNewVariantButtonProps {
   existingNames: string[];
   createVariant: (name: string) => void;
   isDisabled: boolean;
 }
 
 const BannerTestNewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
-  classes,
   existingNames,
   createVariant,
   isDisabled,
 }: BannerTestNewVariantButtonProps) => {
+  const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
 
   const { register, handleSubmit, errors } = useForm<FormData>();
@@ -143,4 +139,4 @@ const BannerTestNewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
   );
 };
 
-export default withStyles(styles)(BannerTestNewVariantButton);
+export default BannerTestNewVariantButton;

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
-import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';
 import { DEFAULT_PRIMARY_CTA, DEFAULT_SECONDARY_CTA } from './utils/defaults';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr',
-      gridGap: spacing(2),
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridGap: spacing(2),
+  },
+}));
 
-interface BannerTestVariantEditorCtasEditorProps extends WithStyles<typeof styles> {
+interface BannerTestVariantEditorCtasEditorProps {
   primaryCta?: Cta;
   secondaryCta?: SecondaryCta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
@@ -26,7 +24,6 @@ interface BannerTestVariantEditorCtasEditorProps extends WithStyles<typeof style
 }
 
 const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEditorProps> = ({
-  classes,
   primaryCta,
   secondaryCta,
   updatePrimaryCta,
@@ -35,6 +32,8 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
   isDisabled,
   supportSecondaryCta,
 }: BannerTestVariantEditorCtasEditorProps) => {
+  const classes = useStyles();
+
   return (
     <div className={classes.container}>
       <VariantEditorCtaEditor
@@ -60,4 +59,4 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
   );
 };
 
-export default withStyles(styles)(BannerTestVariantEditorCtasEditor);
+export default BannerTestVariantEditorCtasEditor;

--- a/public/src/components/channelManagement/batchProcessTestButton.tsx
+++ b/public/src/components/channelManagement/batchProcessTestButton.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Button, createStyles, Typography, WithStyles, withStyles } from '@material-ui/core';
+import { Button, makeStyles, Typography } from '@material-ui/core';
 import { Test } from './helpers/shared';
 import ArchiveIcon from '@material-ui/icons/Archive';
 
 import BatchProcessTestDialog from './batchProcessTestDialog';
 import useOpenable from '../../hooks/useOpenable';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   button: {
     borderStyle: 'dashed',
     justifyContent: 'start',
@@ -19,20 +19,20 @@ const styles = createStyles({
     textTransform: 'uppercase',
     letterSpacing: '1px',
   },
-});
+}));
 
-interface BatchProcessTestButtonProps extends WithStyles<typeof styles> {
+interface BatchProcessTestButtonProps {
   draftTests: Test[];
   onBatchTestDelete: (batchTestNames: string[]) => void;
   onBatchTestArchive: (batchTestNames: string[]) => void;
 }
 
 const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
-  classes,
   draftTests,
   onBatchTestDelete,
   onBatchTestArchive,
 }: BatchProcessTestButtonProps) => {
+  const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
   return (
     <>
@@ -55,4 +55,4 @@ const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
   );
 };
 
-export default withStyles(styles)(BatchProcessTestButton);
+export default BatchProcessTestButton;

--- a/public/src/components/channelManagement/batchProcessTestDialog.tsx
+++ b/public/src/components/channelManagement/batchProcessTestDialog.tsx
@@ -5,7 +5,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  createStyles,
   IconButton,
   List,
   ListItem,
@@ -13,23 +12,22 @@ import {
   ListItemText,
   Checkbox,
   Typography,
-  WithStyles,
-  withStyles,
+  makeStyles,
 } from '@material-ui/core';
 import { Test } from './helpers/shared';
 import CloseIcon from '@material-ui/icons/Close';
 import useOpenable from '../../hooks/useOpenable';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   dialogHeader: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingRight: '8px',
   },
-});
+}));
 
-interface BatchProcessTestDialogProps extends WithStyles<typeof styles> {
+interface BatchProcessTestDialogProps {
   isOpen: boolean;
   close: () => void;
   draftTests: Test[];
@@ -38,13 +36,14 @@ interface BatchProcessTestDialogProps extends WithStyles<typeof styles> {
 }
 
 const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
-  classes,
   isOpen,
   close,
   draftTests,
   onBatchTestDelete,
   onBatchTestArchive,
 }: BatchProcessTestDialogProps) => {
+  const classes = useStyles();
+
   const [selectedBatchProcess, setSelectedBatchProcess] = useState('');
   const [selectedTests, setSelectedTests] = useState<string[]>([]);
   const [isConfirmOpen, confirmOpen, confirmClose] = useOpenable();
@@ -194,4 +193,4 @@ const BatchProcessTestDialog: React.FC<BatchProcessTestDialogProps> = ({
   );
 };
 
-export default withStyles(styles)(BatchProcessTestDialog);
+export default BatchProcessTestDialog;

--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -6,16 +6,14 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  createStyles,
   IconButton,
   TextField,
-  WithStyles,
-  withStyles,
   InputAdornment,
   Select,
   MenuItem,
   InputLabel,
   FormControl,
+  makeStyles,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 
@@ -29,7 +27,7 @@ import { Campaign } from './campaigns/CampaignsEditor';
 import { fetchFrontendSettings, FrontendSettingsType } from '../../utils/requests';
 import { DataFromServer } from '../../hocs/withS3Data';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   dialogHeader: {
     display: 'flex',
     alignItems: 'center',
@@ -45,7 +43,7 @@ const styles = createStyles({
     marginBottom: '20px',
     minWidth: '200px',
   },
-});
+}));
 
 type FormData = {
   name: string;
@@ -56,7 +54,7 @@ const NAME_DEFAULT_HELPER_TEXT = 'Date format: YYYY-MM-DD_TEST_NAME';
 const NICKNAME_DEFAULT_HELPER_TEXT = "Pick a name for your test that's easy to recognise";
 
 type Mode = 'NEW' | 'COPY';
-interface CreateTestDialogProps extends WithStyles<typeof styles> {
+interface CreateTestDialogProps {
   isOpen: boolean;
   close: () => void;
   existingNames: string[];
@@ -67,7 +65,6 @@ interface CreateTestDialogProps extends WithStyles<typeof styles> {
 }
 
 const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
-  classes,
   isOpen,
   close,
   existingNames,
@@ -76,6 +73,8 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
   testNamePrefix,
   createTest,
 }: CreateTestDialogProps) => {
+  const classes = useStyles();
+
   const defaultValues = {
     name: '',
     nickname: '',
@@ -192,4 +191,4 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
   );
 };
 
-export default withStyles(styles)(CreateTestDialog);
+export default CreateTestDialog;

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
-import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';
 import { DEFAULT_PRIMARY_CTA, DEFAULT_SECONDARY_CTA } from './utils/defaults';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr',
-      gridGap: spacing(2),
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridGap: spacing(2),
+  },
+}));
 
-interface EpicTestVariantEditorButtonsEditorProps extends WithStyles<typeof styles> {
+interface EpicTestVariantEditorButtonsEditorProps {
   primaryCta?: Cta;
   secondaryCta?: SecondaryCta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
@@ -26,7 +24,6 @@ interface EpicTestVariantEditorButtonsEditorProps extends WithStyles<typeof styl
 }
 
 const EpicTestVariantEditorButtonsEditor: React.FC<EpicTestVariantEditorButtonsEditorProps> = ({
-  classes,
   primaryCta,
   secondaryCta,
   updatePrimaryCta,
@@ -35,6 +32,8 @@ const EpicTestVariantEditorButtonsEditor: React.FC<EpicTestVariantEditorButtonsE
   isDisabled,
   supportSecondaryCta,
 }: EpicTestVariantEditorButtonsEditorProps) => {
+  const classes = useStyles();
+
   return (
     <div className={classes.container}>
       <VariantEditorCtaEditor
@@ -60,4 +59,4 @@ const EpicTestVariantEditorButtonsEditor: React.FC<EpicTestVariantEditorButtonsE
   );
 };
 
-export default withStyles(styles)(EpicTestVariantEditorButtonsEditor);
+export default EpicTestVariantEditorButtonsEditor;

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditorCtasEditor.tsx
@@ -1,22 +1,20 @@
 import React from 'react';
-import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 
 import { Cta } from '../helpers/shared';
 
 import { DEFAULT_PRIMARY_CTA, DEFAULT_SECONDARY_CTA } from './utils/defaults';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr',
-      gridGap: spacing(2),
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridGap: spacing(2),
+  },
+}));
 
-interface HeaderTestVariantEditorCtasEditorProps extends WithStyles<typeof styles> {
+interface HeaderTestVariantEditorCtasEditorProps {
   primaryCta?: Cta;
   secondaryCta?: Cta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
@@ -27,7 +25,6 @@ interface HeaderTestVariantEditorCtasEditorProps extends WithStyles<typeof style
 }
 
 const HeaderTestVariantEditorCtasEditor: React.FC<HeaderTestVariantEditorCtasEditorProps> = ({
-  classes,
   primaryCta,
   secondaryCta,
   updatePrimaryCta,
@@ -36,6 +33,8 @@ const HeaderTestVariantEditorCtasEditor: React.FC<HeaderTestVariantEditorCtasEdi
   isDisabled,
   supportSecondaryCta,
 }: HeaderTestVariantEditorCtasEditorProps) => {
+  const classes = useStyles();
+
   return (
     <div className={classes.container}>
       <VariantEditorCtaEditor
@@ -61,4 +60,4 @@ const HeaderTestVariantEditorCtasEditor: React.FC<HeaderTestVariantEditorCtasEdi
   );
 };
 
-export default withStyles(styles)(HeaderTestVariantEditorCtasEditor);
+export default HeaderTestVariantEditorCtasEditor;

--- a/public/src/components/channelManagement/newTestButton.tsx
+++ b/public/src/components/channelManagement/newTestButton.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Button, createStyles, Typography, WithStyles, withStyles } from '@material-ui/core';
+import { Button, makeStyles, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 
 import CreateTestDialog from './createTestDialog';
 import useOpenable from '../../hooks/useOpenable';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   button: {
     borderStyle: 'dashed',
     justifyContent: 'start',
@@ -17,9 +17,9 @@ const styles = createStyles({
     textTransform: 'uppercase',
     letterSpacing: '1px',
   },
-});
+}));
 
-interface NewTestButtonProps extends WithStyles<typeof styles> {
+interface NewTestButtonProps {
   existingNames: string[];
   existingNicknames: string[];
   testNamePrefix?: string;
@@ -27,12 +27,12 @@ interface NewTestButtonProps extends WithStyles<typeof styles> {
 }
 
 const NewTestButton: React.FC<NewTestButtonProps> = ({
-  classes,
   existingNames,
   existingNicknames,
   testNamePrefix,
   createTest,
 }: NewTestButtonProps) => {
+  const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
   return (
     <>
@@ -52,4 +52,4 @@ const NewTestButton: React.FC<NewTestButtonProps> = ({
   );
 };
 
-export default withStyles(styles)(NewTestButton);
+export default NewTestButton;

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createStyles, Typography, withStyles, WithStyles } from '@material-ui/core';
+import { makeStyles, Typography } from '@material-ui/core';
 import { Test } from './helpers/shared';
 import TestList from './testList';
 import TestPriorityLabelList from './testPriorityLabelList';
@@ -9,7 +9,7 @@ import BatchProcessTestButton from './batchProcessTestButton';
 import TestListSidebarFilterSelector from './testListSidebarFilterSelector';
 import { RegionsAndAll } from '../../utils/models';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
@@ -28,7 +28,7 @@ const styles = createStyles({
     position: 'absolute',
     left: '-32px',
   },
-});
+}));
 
 interface SidebarProps<T extends Test> {
   tests: T[];
@@ -46,7 +46,6 @@ interface SidebarProps<T extends Test> {
 }
 
 function Sidebar<T extends Test>({
-  classes,
   tests,
   isInEditMode,
   selectedTestName,
@@ -59,7 +58,9 @@ function Sidebar<T extends Test>({
   setRegionFilter,
   onBatchTestDelete,
   onBatchTestArchive,
-}: SidebarProps<T> & WithStyles<typeof styles>): React.ReactElement<SidebarProps<T>> {
+}: SidebarProps<T>): React.ReactElement<SidebarProps<T>> {
+  const classes = useStyles();
+
   const filterTests = function(testsToFilter: Test[]): Test[] {
     if (isInEditMode || 'ALL' === regionFilter) {
       return testsToFilter;
@@ -108,12 +109,4 @@ function Sidebar<T extends Test>({
   );
 }
 
-// Hack to work around material UI breaking type checking when class has type parameters - https://stackoverflow.com/q/52567697
-export default function WrappedTestListContainer<T extends Test>(
-  props: SidebarProps<T>,
-): React.ReactElement<SidebarProps<T>> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const wrapper = withStyles(styles)(Sidebar) as any;
-
-  return React.createElement(wrapper, props);
-}
+export default Sidebar;

--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 import AppBar from '@material-ui/core/AppBar';
 import { LockStatus } from './helpers/shared';
 
@@ -7,45 +7,43 @@ import StickyBottomBarStatus from './stickyBottomBarStatus';
 import StickyBottomBarDetail from './stickyBottomBarDetail';
 import StickyBottomBarActionButtons from './stickyBottomBarActionButtons';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette, spacing }: Theme) =>
-  createStyles({
-    appBar: {
-      top: 'auto',
-      bottom: 0,
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  appBar: {
+    top: 'auto',
+    bottom: 0,
+  },
+  container: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'center',
+    padding: `${spacing(2)}px 0`,
+    '& > * + *': {
+      marginLeft: '4px',
     },
-    container: {
-      display: 'flex',
-      alignItems: 'baseline',
-      justifyContent: 'center',
-      padding: `${spacing(2)}px 0`,
-      '& > * + *': {
-        marginLeft: '4px',
-      },
-    },
-    containerEditMode: {
-      background: palette.grey[800],
-    },
-    containerReadOnlyMode: {
-      background: palette.grey[900],
-    },
-    actionButtonContainer: {
-      position: 'absolute',
-      top: 0,
-      bottom: 0,
-      left: '100px',
-      right: '100px',
-      display: 'flex',
-      alignItems: 'center',
-    },
-    helpButtonContainer: {
-      position: 'absolute',
-      top: '-62px',
-      right: '24px',
-    },
-  });
+  },
+  containerEditMode: {
+    background: palette.grey[800],
+  },
+  containerReadOnlyMode: {
+    background: palette.grey[900],
+  },
+  actionButtonContainer: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: '100px',
+    right: '100px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  helpButtonContainer: {
+    position: 'absolute',
+    top: '-62px',
+    right: '24px',
+  },
+}));
 
-interface StickyBottomBarProps extends WithStyles<typeof styles> {
+interface StickyBottomBarProps {
   isInEditMode: boolean;
   selectedTestName: string | null;
   editedTestName: string | null;
@@ -57,7 +55,6 @@ interface StickyBottomBarProps extends WithStyles<typeof styles> {
 }
 
 const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
-  classes,
   isInEditMode,
   selectedTestName,
   editedTestName,
@@ -67,6 +64,7 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
   save,
   cancel,
 }: StickyBottomBarProps) => {
+  const classes = useStyles();
   const containerClasses = [
     classes.container,
     isInEditMode ? classes.containerEditMode : classes.containerReadOnlyMode,
@@ -98,4 +96,4 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
   );
 };
 
-export default withStyles(styles)(StickyBottomBar);
+export default StickyBottomBar;

--- a/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import {
   Button,
-  createStyles,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  makeStyles,
   Theme,
   Typography,
-  WithStyles,
-  withStyles,
 } from '@material-ui/core';
 
 import CloseIcon from '@material-ui/icons/Close';
@@ -20,37 +18,35 @@ import LockIcon from '@material-ui/icons/Lock';
 
 import useOpenable from '../../hooks/useOpenable';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      width: '100%',
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+  leftContainer: {},
+  rightContainer: {
+    '& > * + *': {
+      marginLeft: spacing(1),
     },
-    leftContainer: {},
-    rightContainer: {
-      '& > * + *': {
-        marginLeft: spacing(1),
-      },
-    },
-    button: {
-      color: 'white',
-      borderColor: 'white',
-    },
-    buttonText: {
-      fontSize: '14px',
-      fontWeight: 500,
-      textTransform: 'uppercase',
-      letterSpacing: '1px',
-    },
-  });
+  },
+  button: {
+    color: 'white',
+    borderColor: 'white',
+  },
+  buttonText: {
+    fontSize: '14px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+  },
+}));
 
 const SAVE_BUTTON_TEST_SELECTED_TEXT = 'Save test';
 const SAVE_BUTTON_TEST_NOT_SELECTED_TEXT = 'Save changes';
 
-interface StickyBottomBarActionButtonsProps extends WithStyles<typeof styles> {
+interface StickyBottomBarActionButtonsProps {
   isInEditMode: boolean;
   selectedTestIsBeingEdited: boolean;
   isLocked: boolean;
@@ -61,7 +57,6 @@ interface StickyBottomBarActionButtonsProps extends WithStyles<typeof styles> {
 }
 
 const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> = ({
-  classes,
   isInEditMode,
   selectedTestIsBeingEdited,
   isLocked,
@@ -70,6 +65,8 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
   save,
   cancel,
 }: StickyBottomBarActionButtonsProps) => {
+  const classes = useStyles();
+
   const CancelButton: React.FC = () => {
     const [isOpen, open, close] = useOpenable();
 
@@ -205,4 +202,4 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
   );
 };
 
-export default withStyles(styles)(StickyBottomBarActionButtons);
+export default StickyBottomBarActionButtons;

--- a/public/src/components/channelManagement/stickyBottomBarDetail.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarDetail.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import { createStyles, Typography, WithStyles, withStyles } from '@material-ui/core';
+import { makeStyles, Typography } from '@material-ui/core';
 import { LockStatus } from './helpers/shared';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   text: {
     fontSize: '14px',
     fontWeight: 500,
     textTransform: 'uppercase',
     letterSpacing: '1px',
   },
-});
+}));
 
-interface StickyBottomBarDetailProps extends WithStyles<typeof styles> {
+interface StickyBottomBarDetailProps {
   isInEditMode: boolean;
   editedTestName: string | null;
   lockStatus: LockStatus;
@@ -56,11 +56,11 @@ const formattedTimestamp = (timestamp: string): string => {
 };
 
 const StickyBottomBarDetail: React.FC<StickyBottomBarDetailProps> = ({
-  classes,
   isInEditMode,
   editedTestName,
   lockStatus,
 }: StickyBottomBarDetailProps) => {
+  const classes = useStyles();
   let text = editedTestName == null ? '' : `- ${editedTestName}`;
 
   if (!isInEditMode && lockStatus.locked && lockStatus.email && lockStatus.timestamp) {
@@ -77,4 +77,4 @@ const StickyBottomBarDetail: React.FC<StickyBottomBarDetailProps> = ({
   );
 };
 
-export default withStyles(styles)(StickyBottomBarDetail);
+export default StickyBottomBarDetail;

--- a/public/src/components/channelManagement/stickyBottomBarStatus.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarStatus.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { createStyles, Typography, WithStyles, withStyles } from '@material-ui/core';
+import { makeStyles, Typography } from '@material-ui/core';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   text: {
     fontSize: '14px',
     fontWeight: 900,
     textTransform: 'uppercase',
     letterSpacing: '1px',
   },
-});
+}));
 
-interface StickyBottomBarStatusProps extends WithStyles<typeof styles> {
+interface StickyBottomBarStatusProps {
   isInEditMode: boolean;
   isLocked: boolean;
 }
@@ -20,10 +20,11 @@ const READ_ONLY_MODE_TEXT = 'Read only mode';
 const EDIT_MODE_TEXT = 'Editing';
 
 const StickyBottomBarStatus: React.FC<StickyBottomBarStatusProps> = ({
-  classes,
   isInEditMode,
   isLocked,
 }: StickyBottomBarStatusProps) => {
+  const classes = useStyles();
+
   let text = '';
   if (isInEditMode) {
     text = EDIT_MODE_TEXT;
@@ -40,4 +41,4 @@ const StickyBottomBarStatus: React.FC<StickyBottomBarStatusProps> = ({
   );
 };
 
-export default withStyles(styles)(StickyBottomBarStatus);
+export default StickyBottomBarStatus;

--- a/public/src/components/channelManagement/testEditorActionButtons.tsx
+++ b/public/src/components/channelManagement/testEditorActionButtons.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import {
   Button,
-  createStyles,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-  withStyles,
-  WithStyles,
   Theme,
   Typography,
+  makeStyles,
 } from '@material-ui/core';
 import { grey } from '@material-ui/core/colors';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -19,29 +17,27 @@ import FileCopyIcon from '@material-ui/icons/FileCopy';
 import CreateTestDialog from './createTestDialog';
 import useOpenable from '../../hooks/useOpenable';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing, palette }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  copyAndArchiveContainer: {
+    '& > * + *': {
+      marginLeft: spacing(2),
     },
-    copyAndArchiveContainer: {
-      '& > * + *': {
-        marginLeft: spacing(2),
-      },
-    },
-    buttonText: {
-      fontSize: '14px',
-      fontWeight: 500,
-      textTransform: 'uppercase',
-      letterSpacing: '1px',
-      color: palette.grey[800],
-    },
-  });
+  },
+  buttonText: {
+    fontSize: '14px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    color: palette.grey[800],
+  },
+}));
 
-interface TestEditorActionButtonsProps extends WithStyles<typeof styles> {
+interface TestEditorActionButtonsProps {
   existingNames: string[];
   existingNicknames: string[];
   testNamePrefix?: string;
@@ -52,7 +48,6 @@ interface TestEditorActionButtonsProps extends WithStyles<typeof styles> {
 }
 
 const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
-  classes,
   existingNames,
   existingNicknames,
   testNamePrefix,
@@ -61,6 +56,8 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
   isDisabled,
   onCopy,
 }: TestEditorActionButtonsProps) => {
+  const classes = useStyles();
+
   const DeleteButton: React.FC = () => {
     const [isOpen, open, close] = useOpenable();
 
@@ -179,4 +176,4 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
   );
 };
 
-export default withStyles(styles)(TestEditorActionButtons);
+export default TestEditorActionButtons;

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -8,29 +8,25 @@ import {
   FormControlLabel,
   TextField,
   Theme,
-  WithStyles,
-  createStyles,
-  withStyles,
+  makeStyles,
 } from '@material-ui/core';
 import { ArticlesViewedSettings } from './helpers/shared';
 import { notNumberValidator, EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(2),
-      },
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(2),
     },
-    formContainer: {
-      maxWidth: '250px',
+  },
+  formContainer: {
+    maxWidth: '250px',
 
-      '& > * + *': {
-        marginTop: spacing(1),
-      },
+    '& > * + *': {
+      marginTop: spacing(1),
     },
-  });
+  },
+}));
 
 export const DEFAULT_ARTICLES_VIEWED_SETTINGS: ArticlesViewedSettings = {
   minViews: 5,
@@ -44,7 +40,7 @@ interface FormData {
   periodInWeeks: string;
 }
 
-interface TestEditorArticleCountEditorProps extends WithStyles<typeof styles> {
+interface TestEditorArticleCountEditorProps {
   articlesViewedSettings?: ArticlesViewedSettings;
   onArticlesViewedSettingsChanged: (updatedArticlesViewedSettings?: ArticlesViewedSettings) => void;
   onValidationChange: (isValid: boolean) => void;
@@ -52,12 +48,13 @@ interface TestEditorArticleCountEditorProps extends WithStyles<typeof styles> {
 }
 
 const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> = ({
-  classes,
   articlesViewedSettings,
   onArticlesViewedSettingsChanged,
   onValidationChange,
   isDisabled,
 }: TestEditorArticleCountEditorProps) => {
+  const classes = useStyles();
+
   const defaultValues: FormData = {
     minViews: articlesViewedSettings?.minViews?.toString() || '',
     maxViews: articlesViewedSettings?.maxViews?.toString() || '',
@@ -171,4 +168,4 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
   );
 };
 
-export default withStyles(styles)(TestEditorArticleCountEditor);
+export default TestEditorArticleCountEditor;

--- a/public/src/components/channelManagement/testEditorHeader.tsx
+++ b/public/src/components/channelManagement/testEditorHeader.tsx
@@ -1,34 +1,32 @@
 import React from 'react';
-import { createStyles, withStyles, WithStyles, Theme, Typography } from '@material-ui/core';
+import { Theme, Typography, makeStyles } from '@material-ui/core';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      alignItems: 'flex-start',
-      justifyContent: 'space-between',
-    },
-    mainHeader: {
-      fontSize: '32px',
-      fontWeight: 'normal',
-    },
-    secondaryHeader: {
-      fontSize: '14px',
-      color: palette.grey[700],
-    },
-  });
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+  },
+  mainHeader: {
+    fontSize: '32px',
+    fontWeight: 'normal',
+  },
+  secondaryHeader: {
+    fontSize: '14px',
+    color: palette.grey[700],
+  },
+}));
 
-interface TestEditorHeaderProps extends WithStyles<typeof styles> {
+interface TestEditorHeaderProps {
   name: string;
   nickname?: string;
 }
 
 const TestEditorHeader: React.FC<TestEditorHeaderProps> = ({
-  classes,
   name,
   nickname,
 }: TestEditorHeaderProps) => {
+  const classes = useStyles();
   const mainHeader = nickname ? nickname : name;
   const secondaryHeader = nickname ? name : null;
 
@@ -42,4 +40,4 @@ const TestEditorHeader: React.FC<TestEditorHeaderProps> = ({
   );
 };
 
-export default withStyles(styles)(TestEditorHeader);
+export default TestEditorHeader;

--- a/public/src/components/channelManagement/testEditorMinArticlesViewedInput.tsx
+++ b/public/src/components/channelManagement/testEditorMinArticlesViewedInput.tsx
@@ -1,33 +1,24 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import {
-  createStyles,
-  withStyles,
-  WithStyles,
-  TextField,
-  Theme,
-  Typography,
-} from '@material-ui/core';
+import { TextField, Theme, Typography, makeStyles } from '@material-ui/core';
 import { notNumberValidator } from './helpers/validation';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-    },
-    text: {
-      marginLeft: spacing(1),
-      fontSize: 14,
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  text: {
+    marginLeft: spacing(1),
+    fontSize: 14,
+  },
+}));
 
 interface FormData {
   minArticles: string;
 }
 
-interface TestEditorMinArticlesViewedInputProps extends WithStyles<typeof styles> {
+interface TestEditorMinArticlesViewedInputProps {
   minArticles: number;
   isDisabled: boolean;
   onValidationChange: (isValid: boolean) => void;
@@ -35,12 +26,13 @@ interface TestEditorMinArticlesViewedInputProps extends WithStyles<typeof styles
 }
 
 const TestEditorMinArticlesViewedInput: React.FC<TestEditorMinArticlesViewedInputProps> = ({
-  classes,
   minArticles,
   isDisabled,
   onValidationChange,
   onUpdate,
 }: TestEditorMinArticlesViewedInputProps) => {
+  const classes = useStyles();
+
   const defaultValues: FormData = {
     minArticles: minArticles.toString(),
   };
@@ -81,4 +73,4 @@ const TestEditorMinArticlesViewedInput: React.FC<TestEditorMinArticlesViewedInpu
   );
 };
 
-export default withStyles(styles)(TestEditorMinArticlesViewedInput);
+export default TestEditorMinArticlesViewedInput;

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Theme, WithStyles, createStyles, withStyles, Typography } from '@material-ui/core';
+import { Theme, Typography, makeStyles } from '@material-ui/core';
 import { Region } from '../../utils/models';
 import { DeviceType, UserCohort } from './helpers/shared';
 
@@ -8,29 +8,27 @@ import TestEditorTargetRegionsSelector from './testEditorTargetRegionsSelector';
 import TestEditorTargetSupporterStatusSelector from './testEditorTargetSupporterStatusSelector';
 import TestEditorTargetDeviceType from './testEditorTargetDeviceType';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing, palette }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  container: {
+    display: 'flex',
 
-      '& > * + *': {
-        marginLeft: spacing(12),
-      },
+    '& > * + *': {
+      marginLeft: spacing(12),
     },
-    sectionContainer: {
-      '& > * + *': {
-        marginTop: spacing(2),
-      },
+  },
+  sectionContainer: {
+    '& > * + *': {
+      marginTop: spacing(2),
     },
-    heading: {
-      fontSize: 16,
-      color: palette.grey[900],
-      fontWeight: 500,
-    },
-  });
+  },
+  heading: {
+    fontSize: 16,
+    color: palette.grey[900],
+    fontWeight: 500,
+  },
+}));
 
-interface TestEditorTargetAudienceSelectorProps extends WithStyles<typeof styles> {
+interface TestEditorTargetAudienceSelectorProps {
   selectedRegions: Region[];
   onRegionsUpdate: (selectedRegions: Region[]) => void;
   selectedCohort: UserCohort;
@@ -43,7 +41,6 @@ interface TestEditorTargetAudienceSelectorProps extends WithStyles<typeof styles
   showDeviceTypeSelector: boolean;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
-  classes,
   selectedRegions,
   onRegionsUpdate,
   selectedCohort,
@@ -55,6 +52,8 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   showSupporterStatusSelector,
   showDeviceTypeSelector,
 }: TestEditorTargetAudienceSelectorProps) => {
+  const classes = useStyles();
+
   return (
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
@@ -92,4 +91,4 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   );
 };
 
-export default withStyles(styles)(TestEditorTargetAudienceSelector);
+export default TestEditorTargetAudienceSelector;

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
 
-import {
-  Checkbox,
-  FormControlLabel,
-  FormGroup,
-  Theme,
-  WithStyles,
-  createStyles,
-  withStyles,
-} from '@material-ui/core';
+import { Checkbox, FormControlLabel, FormGroup, Theme, makeStyles } from '@material-ui/core';
 import { Region } from '../../utils/models';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    indentedContainer: {
-      marginLeft: spacing(3),
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  indentedContainer: {
+    marginLeft: spacing(3),
+  },
+}));
 
 const regionLabels = {
   AUDCountries: 'Australia',
@@ -31,19 +21,19 @@ const regionLabels = {
 
 const ALL_REGIONS = Object.values(Region);
 
-interface TestEditorTargetRegionsSelectorProps extends WithStyles<typeof styles> {
+interface TestEditorTargetRegionsSelectorProps {
   selectedRegions: Region[];
   onRegionsUpdate: (selectedRegions: Region[]) => void;
   supportedRegions?: Region[];
   isDisabled: boolean;
 }
 const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorProps> = ({
-  classes,
   selectedRegions,
   onRegionsUpdate,
   supportedRegions,
   isDisabled,
 }: TestEditorTargetRegionsSelectorProps) => {
+  const classes = useStyles();
   const allRegions = supportedRegions || ALL_REGIONS;
 
   const onAllRegionsChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -95,4 +85,4 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
   );
 };
 
-export default withStyles(styles)(TestEditorTargetRegionsSelector);
+export default TestEditorTargetRegionsSelector;

--- a/public/src/components/channelManagement/testEditorTargetSupporterStatusSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetSupporterStatusSelector.tsx
@@ -1,35 +1,26 @@
 import React from 'react';
 
-import {
-  Checkbox,
-  FormControlLabel,
-  FormGroup,
-  Theme,
-  WithStyles,
-  createStyles,
-  withStyles,
-} from '@material-ui/core';
+import { Checkbox, FormControlLabel, FormGroup, Theme, makeStyles } from '@material-ui/core';
 import { UserCohort } from './helpers/shared';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    indentedContainer: {
-      marginLeft: spacing(3),
-    },
-  });
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  indentedContainer: {
+    marginLeft: spacing(3),
+  },
+}));
 
-interface TestEditorTargetSupporterStatusSelectorProps extends WithStyles<typeof styles> {
+interface TestEditorTargetSupporterStatusSelectorProps {
   selectedCohort: UserCohort;
   onCohortChange: (updatedCohort: UserCohort) => void;
   isDisabled: boolean;
 }
 const TestEditorTargetSupporterStatusSelector: React.FC<TestEditorTargetSupporterStatusSelectorProps> = ({
-  classes,
   selectedCohort,
   onCohortChange,
   isDisabled,
 }: TestEditorTargetSupporterStatusSelectorProps) => {
+  const classes = useStyles();
+
   const onEveryoneSelected = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const checked = event.target.checked;
     if (checked) {
@@ -99,4 +90,4 @@ const TestEditorTargetSupporterStatusSelector: React.FC<TestEditorTargetSupporte
   );
 };
 
-export default withStyles(styles)(TestEditorTargetSupporterStatusSelector);
+export default TestEditorTargetSupporterStatusSelector;

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -1,54 +1,45 @@
 import React from 'react';
-import {
-  createStyles,
-  withStyles,
-  WithStyles,
-  Theme,
-  Typography,
-  AccordionSummary,
-} from '@material-ui/core';
+import { Theme, Typography, AccordionSummary, makeStyles } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
 import TestEditorVariantSummaryWebPreviewButton from './testEditorVariantSummaryWebPreviewButton';
 import { TestPlatform, TestType } from './helpers/shared';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing, palette }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      width: '100%',
-    },
-    nameContainer: {
-      display: 'flex',
-      alignItems: 'center',
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+  nameContainer: {
+    display: 'flex',
+    alignItems: 'center',
 
-      '& > * + *': {
-        marginLeft: spacing(1),
-      },
+    '& > * + *': {
+      marginLeft: spacing(1),
     },
-    icon: {
-      display: 'inline-block',
-      fill: palette.grey[700],
+  },
+  icon: {
+    display: 'inline-block',
+    fill: palette.grey[700],
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: 500,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  buttonsContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    '& > *': {
+      marginLeft: '20px',
     },
-    text: {
-      fontSize: 14,
-      fontWeight: 500,
-      letterSpacing: 1,
-      textTransform: 'uppercase',
-    },
-    buttonsContainer: {
-      display: 'flex',
-      flexDirection: 'row',
-      '& > *': {
-        marginLeft: '20px',
-      },
-    },
-  });
+  },
+}));
 
-interface TestEditorVariantSummaryProps extends WithStyles<typeof styles> {
+interface TestEditorVariantSummaryProps {
   name: string;
   testName: string;
   testType: TestType;
@@ -58,7 +49,6 @@ interface TestEditorVariantSummaryProps extends WithStyles<typeof styles> {
 }
 
 const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
-  classes,
   name,
   testName,
   testType,
@@ -66,6 +56,8 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
   topButton,
   platform,
 }: TestEditorVariantSummaryProps) => {
+  const classes = useStyles();
+
   return (
     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
       <div className={classes.container}>
@@ -91,4 +83,4 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
   );
 };
 
-export default withStyles(styles)(TestEditorVariantSummary);
+export default TestEditorVariantSummary;

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { createStyles, List, withStyles, WithStyles } from '@material-ui/core';
+import { List, makeStyles } from '@material-ui/core';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 
 import { Test } from './helpers/shared';
 import TestListTest from './testListTest';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   container: {},
   list: {
     marginTop: 0,
@@ -14,7 +14,7 @@ const styles = createStyles({
       marginTop: '8px',
     },
   },
-});
+}));
 
 interface TestListProps<T extends Test> {
   tests: T[];
@@ -26,14 +26,15 @@ interface TestListProps<T extends Test> {
 }
 
 const TestList = <T extends Test>({
-  classes,
   tests,
   isInEditMode,
   selectedTestName,
   editedTestName,
   onTestPriorityChange,
   onTestSelected,
-}: TestListProps<T> & WithStyles<typeof styles>): React.ReactElement => {
+}: TestListProps<T>): React.ReactElement => {
+  const classes = useStyles();
+
   const onDragEnd = ({ destination, source }: DropResult): void => {
     if (destination) {
       onTestPriorityChange(destination.index, source.index);
@@ -82,12 +83,4 @@ const TestList = <T extends Test>({
   );
 };
 
-// Hack to work around material UI breaking type checking when class has type parameters - https://stackoverflow.com/q/52567697
-export default function WrappedTestsList<T extends Test>(
-  props: TestListProps<T>,
-): React.ReactElement<TestListProps<T>> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const wrapper = withStyles(styles)(TestList) as any;
-
-  return React.createElement(wrapper, props);
-}
+export default TestList;

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ListItem, createStyles, withStyles, WithStyles, Theme } from '@material-ui/core';
+import { ListItem, Theme, makeStyles } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
 import { Test } from './helpers/shared';
 import TestListTestLiveLabel from './testListTestLiveLabel';
@@ -8,59 +8,57 @@ import TestListTestArticleCountLabel from './testListTestArticleCountLabel';
 import useHover from '../../hooks/useHover';
 import EditIcon from '@material-ui/icons/Edit';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette }: Theme) =>
-  createStyles({
-    test: {
-      position: 'relative',
-      height: '50px',
-      width: '290px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      background: 'white',
-      borderRadius: '4px',
-      padding: '0 12px',
-    },
-    live: {
-      border: `1px solid ${red[500]}`,
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  test: {
+    position: 'relative',
+    height: '50px',
+    width: '290px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    background: 'white',
+    borderRadius: '4px',
+    padding: '0 12px',
+  },
+  live: {
+    border: `1px solid ${red[500]}`,
 
-      '&:hover': {
-        background: `${red[500]}`,
-      },
-    },
-    liveInverted: {
+    '&:hover': {
       background: `${red[500]}`,
     },
-    draft: {
-      border: `1px solid ${palette.grey[700]}`,
+  },
+  liveInverted: {
+    background: `${red[500]}`,
+  },
+  draft: {
+    border: `1px solid ${palette.grey[700]}`,
 
-      '&:hover': {
-        background: `${palette.grey[700]}`,
-      },
-    },
-    draftInverted: {
+    '&:hover': {
       background: `${palette.grey[700]}`,
     },
-    priorityLabelContainer: {
-      position: 'absolute',
-      top: '0',
-      bottom: '0',
-      left: '-36px',
+  },
+  draftInverted: {
+    background: `${palette.grey[700]}`,
+  },
+  priorityLabelContainer: {
+    position: 'absolute',
+    top: '0',
+    bottom: '0',
+    left: '-36px',
+  },
+  labelAndNameContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > * + *': {
+      marginLeft: '4px',
     },
-    labelAndNameContainer: {
-      display: 'flex',
-      alignItems: 'center',
-      '& > * + *': {
-        marginLeft: '4px',
-      },
-    },
-    whitePencil: {
-      color: 'white',
-    },
-  });
+  },
+  whitePencil: {
+    color: 'white',
+  },
+}));
 
-interface TestListTestProps extends WithStyles<typeof styles> {
+interface TestListTestProps {
   test: Test;
   isSelected: boolean;
   isEdited: boolean;
@@ -68,12 +66,13 @@ interface TestListTestProps extends WithStyles<typeof styles> {
 }
 
 const TestListTest: React.FC<TestListTestProps> = ({
-  classes,
   test,
   isSelected,
   isEdited,
   onClick,
 }: TestListTestProps) => {
+  const classes = useStyles();
+
   const hasArticleCount = test.articlesViewedSettings !== undefined;
 
   const [ref, isHovered] = useHover<HTMLDivElement>();
@@ -103,4 +102,4 @@ const TestListTest: React.FC<TestListTestProps> = ({
   );
 };
 
-export default withStyles(styles)(TestListTest);
+export default TestListTest;

--- a/public/src/components/channelManagement/testListTestArticleCountLabel.tsx
+++ b/public/src/components/channelManagement/testListTestArticleCountLabel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Typography, createStyles, withStyles, WithStyles } from '@material-ui/core';
+import { Typography, makeStyles } from '@material-ui/core';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   container: {
     padding: '3px',
     background: '#FFC107',
@@ -12,13 +12,10 @@ const styles = createStyles({
     fontWeight: 500,
     textTransform: 'uppercase',
   },
-});
+}));
 
-type TestListTestArticleCountLabel = WithStyles<typeof styles>;
-
-const TestListTestArticleCountLabel: React.FC<TestListTestArticleCountLabel> = ({
-  classes,
-}: TestListTestArticleCountLabel) => {
+const TestListTestArticleCountLabel = (): JSX.Element => {
+  const classes = useStyles();
   return (
     <div className={classes.container}>
       <Typography className={classes.text} noWrap={true}>
@@ -28,4 +25,4 @@ const TestListTestArticleCountLabel: React.FC<TestListTestArticleCountLabel> = (
   );
 };
 
-export default withStyles(styles)(TestListTestArticleCountLabel);
+export default TestListTestArticleCountLabel;

--- a/public/src/components/channelManagement/testListTestLiveLabel.tsx
+++ b/public/src/components/channelManagement/testListTestLiveLabel.tsx
@@ -1,42 +1,40 @@
 import React from 'react';
-import { Typography, createStyles, withStyles, WithStyles, Theme } from '@material-ui/core';
+import { Typography, Theme, makeStyles } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      justifyContent: 'center',
-      width: '35px',
-      padding: '2px',
-      borderRadius: '2px',
-      backgroundColor: '#F2453D',
-    },
-    live: {
-      color: '#FFFFFF',
-      backgroundColor: `${red[500]}`,
-    },
-    liveInverted: {
-      color: `${red[500]}`,
-      backgroundColor: '#FFFFFF',
-    },
-    draft: {
-      color: '#FFFFFF',
-      backgroundColor: `${palette.grey[700]}`,
-    },
-    draftInverted: {
-      color: `${palette.grey[700]}`,
-      backgroundColor: '#FFFFFF',
-    },
-    text: {
-      fontSize: '9px',
-      fontWeight: 500,
-      textTransform: 'uppercase',
-    },
-  });
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+    width: '35px',
+    padding: '2px',
+    borderRadius: '2px',
+    backgroundColor: '#F2453D',
+  },
+  live: {
+    color: '#FFFFFF',
+    backgroundColor: `${red[500]}`,
+  },
+  liveInverted: {
+    color: `${red[500]}`,
+    backgroundColor: '#FFFFFF',
+  },
+  draft: {
+    color: '#FFFFFF',
+    backgroundColor: `${palette.grey[700]}`,
+  },
+  draftInverted: {
+    color: `${palette.grey[700]}`,
+    backgroundColor: '#FFFFFF',
+  },
+  text: {
+    fontSize: '9px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+  },
+}));
 
-interface TestListTestLiveLabelProps extends WithStyles<typeof styles> {
+interface TestListTestLiveLabelProps {
   isLive: boolean;
   shouldInvertColor: boolean;
 }
@@ -44,8 +42,8 @@ interface TestListTestLiveLabelProps extends WithStyles<typeof styles> {
 const TestListTestLiveLabel: React.FC<TestListTestLiveLabelProps> = ({
   isLive,
   shouldInvertColor,
-  classes,
 }: TestListTestLiveLabelProps) => {
+  const classes = useStyles();
   const containerClasses = [classes.container];
   if (isLive) {
     containerClasses.push(shouldInvertColor ? classes.liveInverted : classes.live);
@@ -60,4 +58,4 @@ const TestListTestLiveLabel: React.FC<TestListTestLiveLabelProps> = ({
   );
 };
 
-export default withStyles(styles)(TestListTestLiveLabel);
+export default TestListTestLiveLabel;

--- a/public/src/components/channelManagement/testListTestName.tsx
+++ b/public/src/components/channelManagement/testListTestName.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Typography, createStyles, withStyles, WithStyles } from '@material-ui/core';
+import { Typography, makeStyles } from '@material-ui/core';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   text: {
     maxWidth: '190px',
     fontSize: '12px',
@@ -12,9 +12,9 @@ const styles = createStyles({
   textInverted: {
     color: '#FFFFFF',
   },
-});
+}));
 
-interface TestListTestNameProps extends WithStyles<typeof styles> {
+interface TestListTestNameProps {
   name: string;
   nickname?: string;
   shouldInverColor: boolean;
@@ -23,11 +23,12 @@ interface TestListTestNameProps extends WithStyles<typeof styles> {
 const TEST_NAME_CHARACTERS_TO_STRIP_REGEX = /^\d{4}-\d{2}-\d{2}_(contribs*_|moment_)*/;
 
 const TestListTestName: React.FC<TestListTestNameProps> = ({
-  classes,
   name,
   nickname,
   shouldInverColor,
 }: TestListTestNameProps) => {
+  const classes = useStyles();
+
   const textClasses = [classes.text];
   if (shouldInverColor) {
     textClasses.push(classes.textInverted);
@@ -40,4 +41,4 @@ const TestListTestName: React.FC<TestListTestNameProps> = ({
   );
 };
 
-export default withStyles(styles)(TestListTestName);
+export default TestListTestName;

--- a/public/src/components/channelManagement/testNewVariantButton.tsx
+++ b/public/src/components/channelManagement/testNewVariantButton.tsx
@@ -1,47 +1,46 @@
 import React from 'react';
-import { Button, createStyles, Theme, Typography, WithStyles, withStyles } from '@material-ui/core';
+import { Button, makeStyles, Theme, Typography } from '@material-ui/core';
+
 import AddIcon from '@material-ui/icons/Add';
 import useOpenable from '../../hooks/useOpenable';
 import CreateVariantDialog from './createVariantDialog';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing, palette }: Theme) =>
-  createStyles({
-    button: {
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'start',
-      border: `1px dashed ${palette.grey[700]}`,
-      borderRadius: '4px',
-      padding: '12px 16px',
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  button: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'start',
+    border: `1px dashed ${palette.grey[700]}`,
+    borderRadius: '4px',
+    padding: '12px 16px',
+  },
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > * + *': {
+      marginLeft: spacing(1),
     },
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-      '& > * + *': {
-        marginLeft: spacing(1),
-      },
-    },
-    text: {
-      fontSize: 14,
-      fontWeight: 500,
-      letterSpacing: 1,
-      textTransform: 'uppercase',
-    },
-  });
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: 500,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+}));
 
-interface BannerTestNewVariantButtonProps extends WithStyles<typeof styles> {
+interface BannerTestNewVariantButtonProps {
   existingNames: string[];
   createVariant: (name: string) => void;
   isDisabled: boolean;
 }
 
 const BannerTestNewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
-  classes,
   existingNames,
   createVariant,
   isDisabled,
 }: BannerTestNewVariantButtonProps) => {
+  const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
 
   return (
@@ -63,4 +62,4 @@ const BannerTestNewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
   );
 };
 
-export default withStyles(styles)(BannerTestNewVariantButton);
+export default BannerTestNewVariantButton;

--- a/public/src/components/channelManagement/testPriorityLabelList.tsx
+++ b/public/src/components/channelManagement/testPriorityLabelList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { createStyles, List, withStyles, WithStyles } from '@material-ui/core';
+import { List, makeStyles } from '@material-ui/core';
 
 import TestPriorityLabelListLabel from './testPriorityLabelListLabel';
 
-const styles = createStyles({
+const useStyles = makeStyles(() => ({
   list: {
     marginTop: 0,
     padding: 0,
@@ -11,18 +11,18 @@ const styles = createStyles({
       marginTop: '8px',
     },
   },
-});
+}));
 
-interface TestPriorityLabelListProps extends WithStyles<typeof styles> {
+interface TestPriorityLabelListProps {
   numTests: number;
 }
 
 const MAX_PRIORITY_TO_DISPLAY_LABEL_FOR = 5;
 
 const TestPriorityLabelList: React.FC<TestPriorityLabelListProps> = ({
-  classes,
   numTests,
 }: TestPriorityLabelListProps) => {
+  const classes = useStyles();
   const maxPriorityLabel = Math.min(numTests, MAX_PRIORITY_TO_DISPLAY_LABEL_FOR);
 
   return (
@@ -34,4 +34,4 @@ const TestPriorityLabelList: React.FC<TestPriorityLabelListProps> = ({
   );
 };
 
-export default withStyles(styles)(TestPriorityLabelList);
+export default TestPriorityLabelList;

--- a/public/src/components/channelManagement/testPriorityLabelListLabel.tsx
+++ b/public/src/components/channelManagement/testPriorityLabelListLabel.tsx
@@ -1,39 +1,38 @@
 import React from 'react';
-import { Typography, createStyles, withStyles, WithStyles, Theme } from '@material-ui/core';
+import { Typography, Theme, makeStyles } from '@material-ui/core';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette }: Theme) =>
-  createStyles({
-    container: {
-      display: 'flex',
-      height: '50px',
-      padding: '4px 0',
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    height: '50px',
+    padding: '4px 0',
+  },
+  text: {
+    fontSize: '12px',
+    color: palette.grey[700],
+  },
+  dashedLinesContainer: {
+    display: 'flex',
+    marginLeft: '4px',
+    '& > * + *': {
+      marginLeft: '2px',
     },
-    text: {
-      fontSize: '12px',
-      color: palette.grey[700],
-    },
-    dashedLinesContainer: {
-      display: 'flex',
-      marginLeft: '4px',
-      '& > * + *': {
-        marginLeft: '2px',
-      },
-    },
-    dashedLine: {
-      height: '100%',
-      borderLeft: '1px dashed #9E9E9E',
-    },
-  });
+  },
+  dashedLine: {
+    height: '100%',
+    borderLeft: '1px dashed #9E9E9E',
+  },
+}));
 
-interface TestPriorityLabelListLabelProps extends WithStyles<typeof styles> {
+interface TestPriorityLabelListLabelProps {
   priority: number;
 }
 
 const TestPriorityLabelListLabel: React.FC<TestPriorityLabelListLabelProps> = ({
-  classes,
   priority,
 }: TestPriorityLabelListLabelProps) => {
+  const classes = useStyles();
+
   return (
     <div className={classes.container}>
       <Typography className={classes.text} noWrap={true}>
@@ -47,4 +46,4 @@ const TestPriorityLabelListLabel: React.FC<TestPriorityLabelListLabelProps> = ({
   );
 };
 
-export default withStyles(styles)(TestPriorityLabelListLabel);
+export default TestPriorityLabelListLabel;

--- a/public/src/components/channelManagement/testsFormLayout.tsx
+++ b/public/src/components/channelManagement/testsFormLayout.tsx
@@ -1,46 +1,44 @@
 import * as React from 'react';
-import { createStyles, Theme, Typography, withStyles, WithStyles } from '@material-ui/core';
+import { makeStyles, Theme, Typography } from '@material-ui/core';
 import StickyBottomBar from './stickyBottomBar';
 import { LockStatus } from './helpers/shared';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing, typography }: Theme) =>
-  createStyles({
-    viewTextContainer: {
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      alignItems: 'center',
-      marginTop: '-50px',
-    },
-    viewText: {
-      fontSize: typography.pxToRem(16),
-    },
-    body: {
-      display: 'flex',
-      overflow: 'hidden',
-      flexGrow: 1,
-      width: '100%',
-      height: '100%',
-    },
-    leftCol: {
-      height: '100%',
-      flexShrink: 0,
-      overflowY: 'auto',
-      background: 'white',
-      paddingTop: spacing(6),
-      paddingLeft: spacing(6),
-      paddingRight: spacing(6),
-    },
-    rightCol: {
-      overflowY: 'auto',
-      flexGrow: 1,
-      display: 'flex',
-      justifyContent: 'center',
-    },
-  });
+const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
+  viewTextContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: '-50px',
+  },
+  viewText: {
+    fontSize: typography.pxToRem(16),
+  },
+  body: {
+    display: 'flex',
+    overflow: 'hidden',
+    flexGrow: 1,
+    width: '100%',
+    height: '100%',
+  },
+  leftCol: {
+    height: '100%',
+    flexShrink: 0,
+    overflowY: 'auto',
+    background: 'white',
+    paddingTop: spacing(6),
+    paddingLeft: spacing(6),
+    paddingRight: spacing(6),
+  },
+  rightCol: {
+    overflowY: 'auto',
+    flexGrow: 1,
+    display: 'flex',
+    justifyContent: 'center',
+  },
+}));
 
-interface Props extends WithStyles<typeof styles> {
+interface Props {
   sidebar: JSX.Element;
   testEditor: JSX.Element | null;
   selectedTestName: string | null;
@@ -54,7 +52,6 @@ interface Props extends WithStyles<typeof styles> {
 }
 
 const TestsFormLayout: React.FC<Props> = ({
-  classes,
   sidebar,
   testEditor,
   selectedTestName,
@@ -66,6 +63,8 @@ const TestsFormLayout: React.FC<Props> = ({
   requestLock,
   lockStatus,
 }: Props) => {
+  const classes = useStyles();
+
   return (
     <>
       <div className={classes.body}>
@@ -99,4 +98,4 @@ const TestsFormLayout: React.FC<Props> = ({
   );
 };
 
-export default withStyles(styles)(TestsFormLayout);
+export default TestsFormLayout;

--- a/public/src/components/channelManagement/variantEditorCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorCtaEditor.tsx
@@ -1,34 +1,25 @@
 import React from 'react';
-import {
-  Checkbox,
-  createStyles,
-  FormControlLabel,
-  Theme,
-  WithStyles,
-  withStyles,
-} from '@material-ui/core';
+import { Checkbox, FormControlLabel, makeStyles, Theme } from '@material-ui/core';
 import { Cta } from './helpers/shared';
 import VariantEditorCtaFieldsEditor from './variantEditorCtaFieldsEditor';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(1),
-      },
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(1),
     },
-    checkboxContainer: {
-      height: '50px',
+  },
+  checkboxContainer: {
+    height: '50px',
+  },
+  fieldsContainer: {
+    '& > * + *': {
+      marginTop: spacing(3),
     },
-    fieldsContainer: {
-      '& > * + *': {
-        marginTop: spacing(3),
-      },
-    },
-  });
+  },
+}));
 
-interface VariantEditorCtaEditorProps extends WithStyles<typeof styles> {
+interface VariantEditorCtaEditorProps {
   label: string;
   cta?: Cta;
   updateCta: (updatedCta?: Cta) => void;
@@ -38,7 +29,6 @@ interface VariantEditorCtaEditorProps extends WithStyles<typeof styles> {
 }
 
 const VariantEditorCtaEditor: React.FC<VariantEditorCtaEditorProps> = ({
-  classes,
   label,
   cta,
   updateCta,
@@ -46,6 +36,7 @@ const VariantEditorCtaEditor: React.FC<VariantEditorCtaEditorProps> = ({
   defaultCta,
   isDisabled,
 }: VariantEditorCtaEditorProps) => {
+  const classes = useStyles();
   const isChecked = cta !== undefined;
 
   const onCheckboxChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -83,4 +74,4 @@ const VariantEditorCtaEditor: React.FC<VariantEditorCtaEditorProps> = ({
   );
 };
 
-export default withStyles(styles)(VariantEditorCtaEditor);
+export default VariantEditorCtaEditor;

--- a/public/src/components/channelManagement/variantEditorCtaFieldsEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorCtaFieldsEditor.tsx
@@ -1,30 +1,15 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { createStyles, TextField, Theme, WithStyles, withStyles } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 import { Cta } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(1),
-      },
-    },
-    fieldsContainer: {
-      '& > * + *': {
-        marginTop: spacing(3),
-      },
-    },
-  });
 
 interface FormData {
   text: string;
   baseUrl: string;
 }
 
-interface VariantEditorCtaFieldsEditorProps extends WithStyles<typeof styles> {
+interface VariantEditorCtaFieldsEditorProps {
   cta: Cta;
   updateCta: (updatedCta: Cta) => void;
   onValidationChange: (isValid: boolean) => void;
@@ -88,4 +73,4 @@ const VariantEditorCtaFieldsEditor: React.FC<VariantEditorCtaFieldsEditorProps> 
   );
 };
 
-export default withStyles(styles)(VariantEditorCtaFieldsEditor);
+export default VariantEditorCtaFieldsEditor;

--- a/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
@@ -1,34 +1,23 @@
 import React from 'react';
-import {
-  createStyles,
-  Theme,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  WithStyles,
-  withStyles,
-} from '@material-ui/core';
+import { Theme, FormControl, InputLabel, Select, MenuItem, makeStyles } from '@material-ui/core';
 import { Cta, SecondaryCta, SecondaryCtaType } from './helpers/shared';
 import VariantEditorCtaFieldsEditor from './variantEditorCtaFieldsEditor';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ spacing }: Theme) =>
-  createStyles({
-    container: {
-      '& > * + *': {
-        marginTop: spacing(1),
-      },
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(1),
     },
-    selectContainer: {
-      height: '50px',
-    },
-    formControl: {
-      minWidth: 240,
-    },
-  });
+  },
+  selectContainer: {
+    height: '50px',
+  },
+  formControl: {
+    minWidth: 240,
+  },
+}));
 
-interface VariantEditorSecondaryCtaEditorProps extends WithStyles<typeof styles> {
+interface VariantEditorSecondaryCtaEditorProps {
   label: string;
   cta?: SecondaryCta;
   updateCta: (updatedCta?: SecondaryCta) => void;
@@ -38,7 +27,6 @@ interface VariantEditorSecondaryCtaEditorProps extends WithStyles<typeof styles>
 }
 
 const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorProps> = ({
-  classes,
   label,
   cta,
   updateCta,
@@ -46,6 +34,8 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
   isDisabled,
   defaultCta,
 }: VariantEditorSecondaryCtaEditorProps) => {
+  const classes = useStyles();
+
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     const value = event.target.value as SecondaryCtaType | 'None';
 
@@ -89,4 +79,4 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
   );
 };
 
-export default withStyles(styles)(VariantEditorSecondaryCtaEditor);
+export default VariantEditorSecondaryCtaEditor;

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -20,13 +20,7 @@ import {
 
 import { HeaderTestsForm } from './components/channelManagement/headerTests/headerTestsForm';
 
-import {
-  createStyles,
-  Theme,
-  ThemeProvider,
-  WithStyles,
-  withStyles,
-} from '@material-ui/core/styles';
+import { Theme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
@@ -39,6 +33,7 @@ import { getTheme } from './utils/theme';
 import ChannelSwitches from './components/channelManagement/ChannelSwitches';
 import CampaignsEditor from './components/channelManagement/campaigns/CampaignsEditor';
 import { FontWeightProperty } from 'csstype';
+import { makeStyles } from '@material-ui/core';
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
@@ -72,57 +67,55 @@ const initialiseDynamicImport = (): void => {
 
 initialiseDynamicImport();
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = ({ palette, mixins, typography, transitions }: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-    },
-    appContainer: {
-      display: 'flex',
-      flexDirection: 'column',
-      width: '100vw',
-      height: '100vh',
-    },
-    appBar: {
-      transition: transitions.create(['margin', 'width'], {
-        easing: transitions.easing.sharp,
-        duration: transitions.duration.leavingScreen,
-      }),
-    },
-    appContent: {
-      display: 'flex',
-      flexDirection: 'column',
-      overflow: 'hidden',
-      flexGrow: 1,
-      backgroundColor: palette.grey[100],
-    },
-    toolbar: mixins.toolbar as CSSProperties, // createStyles expects material-ui's CSSProperties type, not react's
-    heading: {
-      fontSize: typography.pxToRem(24),
-      fontWeight: typography.fontWeightMedium as FontWeightProperty,
-    },
-    toolbarContent: {
-      width: '100%',
-      justifyContent: 'space-between',
-    },
-    link: {
-      fontSize: typography.pxToRem(12),
-      fontWeight: typography.fontWeightMedium as FontWeightProperty,
-      textDecoration: 'none',
-    },
-    guideButton: {
-      borderColor: palette.grey[100],
-      color: palette.grey[100],
-    },
-  });
-
-type Props = WithStyles<typeof styles>;
+const useStyles = makeStyles(({ palette, mixins, typography, transitions }: Theme) => ({
+  root: {
+    display: 'flex',
+  },
+  appContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100vw',
+    height: '100vh',
+  },
+  appBar: {
+    transition: transitions.create(['margin', 'width'], {
+      easing: transitions.easing.sharp,
+      duration: transitions.duration.leavingScreen,
+    }),
+  },
+  appContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    flexGrow: 1,
+    backgroundColor: palette.grey[100],
+  },
+  toolbar: mixins.toolbar as CSSProperties, // createStyles expects material-ui's CSSProperties type, not react's
+  heading: {
+    fontSize: typography.pxToRem(24),
+    fontWeight: typography.fontWeightMedium as FontWeightProperty,
+  },
+  toolbarContent: {
+    width: '100%',
+    justifyContent: 'space-between',
+  },
+  link: {
+    fontSize: typography.pxToRem(12),
+    fontWeight: typography.fontWeightMedium as FontWeightProperty,
+    textDecoration: 'none',
+  },
+  guideButton: {
+    borderColor: palette.grey[100],
+    color: palette.grey[100],
+  },
+}));
 
 const HELP_GUIDE_URL =
   'https://docs.google.com/document/d/1ErgEoQJRpiVMHZZpUmAnq3MGY8tJCaHTun0INzLcLRc/edit';
 
-const AppRouter = withStyles(styles)(({ classes }: Props) => {
+const AppRouter = () => {
+  const classes = useStyles();
+
   const createComponent = (component: JSX.Element, displayName: string): React.ReactElement => (
     <div className={classes.appContainer}>
       <AppBar position="relative" className={classes.appBar}>
@@ -237,6 +230,6 @@ const AppRouter = withStyles(styles)(({ classes }: Props) => {
       </Router>
     </ThemeProvider>
   );
-});
+};
 
 ReactDOM.render(<AppRouter />, document.getElementById('root'));

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -71,7 +71,7 @@ export function fetchSupportFrontendSettings(
 
 export function saveSupportFrontendSettings(
   settingsType: SupportFrontendSettingsType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   data: any,
 ): Promise<Response> {
   return saveSettings(`/support-frontend/${settingsType}/update`, data);
@@ -84,7 +84,7 @@ export function fetchFrontendSettings(settingsType: FrontendSettingsType): Promi
 
 export function saveFrontendSettings(
   settingsType: FrontendSettingsType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   data: any,
 ): Promise<Response> {
   return saveSettings(`/frontend/${settingsType}/update`, data);


### PR DESCRIPTION
There are 2 ways to do css-in-js with MUI:
- higher-order component API (`withStyles`)
- hook API (`makeStyles`)

Currently the codebase uses a mix of the two, which is confusing.
We now prefer `makeStyles`. This is because `withStyles` creates more complexity - we have to wrap our components, and this can confuse the TS compiler when type parameters are involved.

This PR replaces all instances of `withStyles` with `makeStyles`.