### PR TITLE
Populate new test modal fields with copied test data

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -284,7 +284,9 @@ const BannerTestEditor: React.FC<BannerTestEditorProps> = ({
         <div className={classes.buttonsContainer}>
           <TestEditorActionButtons
             existingNames={testNames}
+            sourceName={test.name}
             existingNicknames={testNicknames}
+            sourceNickname={test.nickname}
             isDisabled={!editMode}
             onArchive={onArchive}
             onDelete={onDelete}

--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -58,7 +58,9 @@ interface CreateTestDialogProps {
   isOpen: boolean;
   close: () => void;
   existingNames: string[];
+  sourceName?: string | void;
   existingNicknames: string[];
+  sourceNickname?: string | void;
   mode: Mode;
   testNamePrefix?: string; // set if all tests must have the same prefix
   createTest: (name: string, nickname: string) => void;
@@ -68,7 +70,9 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
   isOpen,
   close,
   existingNames,
+  sourceName,
   existingNicknames,
+  sourceNickname,
   mode,
   testNamePrefix,
   createTest,
@@ -76,8 +80,8 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
   const classes = useStyles();
 
   const defaultValues = {
-    name: '',
-    nickname: '',
+    name: sourceName || '',
+    nickname: sourceNickname || '',
   };
 
   const { register, handleSubmit, errors } = useForm<FormData>({

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -380,7 +380,9 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
       <div className={classes.buttonsContainer}>
         <TestEditorActionButtons
           existingNames={testNames}
+          sourceName={test.name}
           existingNicknames={testNicknames}
+          sourceNickname={test.nickname}
           testNamePrefix={testNamePrefix}
           isDisabled={!editMode}
           onArchive={onArchive}

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -210,7 +210,9 @@ const HeaderTestEditor: React.FC<HeaderTestEditorProps> = ({
         <div className={classes.buttonsContainer}>
           <TestEditorActionButtons
             existingNames={testNames}
+            sourceName={test.name}
             existingNicknames={testNicknames}
+            sourceNickname={test.nickname}
             isDisabled={!editMode}
             onArchive={onArchive}
             onDelete={onDelete}

--- a/public/src/components/channelManagement/testEditorActionButtons.tsx
+++ b/public/src/components/channelManagement/testEditorActionButtons.tsx
@@ -39,7 +39,9 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
 
 interface TestEditorActionButtonsProps {
   existingNames: string[];
+  sourceName?: string | void;
   existingNicknames: string[];
+  sourceNickname?: string | void;
   testNamePrefix?: string;
   onArchive: () => void;
   onDelete: () => void;
@@ -49,7 +51,9 @@ interface TestEditorActionButtonsProps {
 
 const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
   existingNames,
+  sourceName,
   existingNicknames,
+  sourceNickname,
   testNamePrefix,
   onArchive,
   onDelete,
@@ -157,7 +161,9 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
           isOpen={isOpen}
           close={close}
           existingNames={existingNames}
+          sourceName={sourceName}
           existingNicknames={existingNicknames}
+          sourceNickname={sourceNickname}
           testNamePrefix={testNamePrefix}
           mode="COPY"
           createTest={onCopy}


### PR DESCRIPTION
## What does this change?
This is a small PR which will pre-populate the 'new test' modal's form fields with data when the user copies an existing test to create a new one.

**Screenshots: creating a new test with default values**
![Screenshot 2022-04-05 at 14 30 23](https://user-images.githubusercontent.com/5357530/161765246-61c95768-4a68-4b1b-963b-ffd5bf2d9545.png)

![Screenshot 2022-04-05 at 14 30 38](https://user-images.githubusercontent.com/5357530/161765271-1698a28a-d875-4e9c-99b2-50c47e899c06.png)

**Screenshots: creating a test from an existing test's data**
![Screenshot 2022-04-05 at 14 30 56](https://user-images.githubusercontent.com/5357530/161765457-e3967348-4f36-4c85-8e69-419efda5a7cb.png)

![Screenshot 2022-04-05 at 14 31 10](https://user-images.githubusercontent.com/5357530/161765485-f00728b7-3227-4acb-8ef9-394c51c9d7c5.png)

