### PR TITLE
Do not allow html on AMP/Apple News

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -236,6 +236,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
                   name="heading"
                   label="Header"
                   disabled={!editMode}
+                  allowHtml={true}
                 />
               );
             }}
@@ -270,6 +271,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
                   name="paragraphs"
                   label="Body copy"
                   disabled={!editMode}
+                  allowHtml={true}
                 />
               );
             }}
@@ -300,6 +302,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
                     name="highlightedText"
                     label="Highlighted text"
                     disabled={!editMode}
+                    allowHtml={true}
                   />
                 );
               }}

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -94,6 +94,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   const classes = getUseStyles(epicEditorConfig.allowMultipleVariants)();
 
   const templateValidator = templateValidatorForPlatform(epicEditorConfig.platform);
+  const allowHtml = epicEditorConfig.platform === 'DOTCOM';
 
   const defaultValues: FormData = {
     heading: variant.heading,
@@ -195,6 +196,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                 name="heading"
                 label="Header"
                 disabled={!editMode}
+                allowHtml={allowHtml}
               />
             );
           }}
@@ -228,6 +230,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
               name="paragraphs"
               label="Body copy"
               disabled={!editMode}
+              allowHtml={allowHtml}
             />
           );
         }}
@@ -258,6 +261,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                 name="highlightedText"
                 label="Highlighted text"
                 disabled={!editMode}
+                allowHtml={allowHtml}
               />
             );
           }}
@@ -288,6 +292,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                 name="footer"
                 label="Footer"
                 disabled={!editMode}
+                allowHtml={allowHtml}
               />
             );
           }}


### PR DESCRIPTION
The Rich Text Editor allows arbitrary html. If a user pastes text from a google doc then it may include html.
AMP + Apple News do not support html.
This PR adds a `allowHtml` flag to the RTE to prevent html accidentally being published on these platforms.

Separately, we should explore how we can prevent copying of markup from google docs.