### PR TITLE
Improve html validation on AMP/Apple News

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -251,7 +251,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
               required: true,
               validate: (pars: string[]) =>
                 getEmptyParagraphsError(pars) ??
-                pars.map(templateValidator).find(result => result !== true),
+                pars.map(templateValidator).find((result: string | undefined) => !!result),
             }}
             render={data => {
               return (

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -19,6 +19,7 @@ import {
 import {
   EMPTY_ERROR_HELPER_TEXT,
   getEmptyParagraphsError,
+  noHtmlValidator,
   MAXLENGTH_ERROR_HELPER_TEXT,
   templateValidatorForPlatform,
 } from '../helpers/validation';
@@ -95,6 +96,8 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
 
   const templateValidator = templateValidatorForPlatform(epicEditorConfig.platform);
   const allowHtml = epicEditorConfig.platform === 'DOTCOM';
+  const htmlValidator = allowHtml ? () => undefined : noHtmlValidator;
+  const lineValidator = (text: string) => templateValidator(text) ?? htmlValidator(text);
 
   const defaultValues: FormData = {
     heading: variant.heading,
@@ -177,7 +180,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
           control={control}
           rules={{
             required: epicEditorConfig.requireVariantHeader ? EMPTY_ERROR_HELPER_TEXT : undefined,
-            validate: templateValidator,
+            validate: lineValidator,
           }}
           render={data => {
             return (
@@ -210,7 +213,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
           required: true,
           validate: (pars: string[]) =>
             getEmptyParagraphsError(pars) ??
-            pars.map(templateValidator).find(result => result !== true),
+            pars.map(lineValidator).find((result: string | undefined) => !!result),
         }}
         render={data => {
           return (
@@ -242,7 +245,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
           control={control}
           rules={{
             required: false,
-            validate: templateValidator,
+            validate: lineValidator,
           }}
           render={data => {
             return (
@@ -273,7 +276,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
           name="footer"
           control={control}
           rules={{
-            validate: templateValidator,
+            validate: lineValidator,
           }}
           render={data => {
             return (

--- a/public/src/components/channelManagement/helpers/validation.test.ts
+++ b/public/src/components/channelManagement/helpers/validation.test.ts
@@ -4,14 +4,14 @@ describe('templateValidatorForPlatform', () => {
   describe('When platform is dotcom', () => {
     const templateValidator = templateValidatorForPlatform('DOTCOM');
 
-    it('should return true if no templates are present', () => {
-      expect(templateValidator('Blah blah')).toBeTruthy();
+    it('should return undefined if no templates are present', () => {
+      expect(templateValidator('Blah blah')).toBeUndefined();
     });
 
-    it('should return true if a valid template is present', () => {
-      expect(templateValidator('%%CURRENCY_SYMBOL%%')).toBeTruthy();
-      expect(templateValidator('%%COUNTRY_NAME%%')).toBeTruthy();
-      expect(templateValidator('%%ARTICLE_COUNT%%')).toBeTruthy();
+    it('should return undefined if a valid template is present', () => {
+      expect(templateValidator('%%CURRENCY_SYMBOL%%')).toBeUndefined();
+      expect(templateValidator('%%COUNTRY_NAME%%')).toBeUndefined();
+      expect(templateValidator('%%ARTICLE_COUNT%%')).toBeUndefined();
     });
 
     it('should return an error message if template text is not valid', () => {
@@ -33,13 +33,13 @@ describe('templateValidatorForPlatform', () => {
   describe('When platform is an AMP article', () => {
     const templateValidator = templateValidatorForPlatform('AMP');
 
-    it('should return true if no templates are present', () => {
-      expect(templateValidator('Blah blah')).toBeTruthy();
+    it('should return undefined if no templates are present', () => {
+      expect(templateValidator('Blah blah')).toBeUndefined();
     });
 
-    it('should return true if a valid template is present', () => {
-      expect(templateValidator('%%CURRENCY_SYMBOL%%')).toBeTruthy();
-      expect(templateValidator('%%COUNTRY_NAME%%')).toBeTruthy();
+    it('should return undefined if a valid template is present', () => {
+      expect(templateValidator('%%CURRENCY_SYMBOL%%')).toBeUndefined();
+      expect(templateValidator('%%COUNTRY_NAME%%')).toBeUndefined();
     });
 
     it('should return an error message if template is unsupported by platform', () => {
@@ -67,12 +67,12 @@ describe('templateValidatorForPlatform', () => {
   describe('When platform is an Apple News article', () => {
     const templateValidator = templateValidatorForPlatform('APPLE_NEWS');
 
-    it('should return true if no templates are present', () => {
-      expect(templateValidator('Blah blah')).toBeTruthy();
+    it('should return undefined if no templates are present', () => {
+      expect(templateValidator('Blah blah')).toBeUndefined();
     });
 
-    it('should return true if a valid template is present', () => {
-      expect(templateValidator('%%CURRENCY_SYMBOL%%')).toBeTruthy();
+    it('should return undefined if a valid template is present', () => {
+      expect(templateValidator('%%CURRENCY_SYMBOL%%')).toBeUndefined();
     });
 
     it('should return an error message if template is unsupported by platform', () => {

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -1,34 +1,4 @@
-import React from 'react';
 import { TestPlatform } from './shared';
-
-/**
- * Helper for tracking validation of multiple child components.
- * Calls onValidationChange with 'true' only when all child components are valid.
- *
- * E.g.
- *
- * type Props = ValidationComponentProps & {}
- * type State = ValidationComponentState & {}
- *
- * class MyComponent extends React.Component<Props,State> {
- *   state: State = {
- *     validationStatus: {}
- *   };
- *
- *   <Input
- *     label="email"
- *     onChange={value => {
- *       const isValid = value !== '';
- *       onFieldValidationChange(this)('email')(isValid)
- *      }}
- *   />
- * }
- *
- */
-
-export interface ValidationComponentProps {
-  onValidationChange: (isValid: boolean) => void;
-}
 
 export type ValidationStatus = {
   [fieldName: string]: boolean;
@@ -36,64 +6,36 @@ export type ValidationStatus = {
 
 export const INVALID_CHARACTERS_ERROR_HELPER_TEXT =
   'Only letters, numbers, underscores and hyphens are allowed';
-const INVALID_CHARACTERS_REGEX = /[^\w-]/;
 export const VALID_CHARACTERS_REGEX = /^[\w-]+$/;
-
-export const getInvalidCharactersError = (text: string): string | null => {
-  if (INVALID_CHARACTERS_REGEX.test(text)) {
-    return INVALID_CHARACTERS_ERROR_HELPER_TEXT;
-  }
-  return null;
-};
 
 export const EMPTY_ERROR_HELPER_TEXT = 'Field cannot be empty - please enter some text';
 export const MAXLENGTH_ERROR_HELPER_TEXT =
   'This copy is longer than the recommended length. Please preview across breakpoints before publishing.';
 
-export const getEmptyError = (text: string): string | null => {
-  if (text.trim() === '') {
-    return EMPTY_ERROR_HELPER_TEXT;
-  }
-  return null;
-};
-
-export const getEmptyParagraphsError = (pars: string[]): string | null => {
+export const getEmptyParagraphsError = (pars: string[]): string | undefined => {
   if (pars.filter(p => p).join('').length <= 0) {
     return EMPTY_ERROR_HELPER_TEXT;
   }
-  return null;
+  return undefined;
 };
 
 const NOT_NUMBER_ERROR_HELPER_TEXT = 'Must be a number';
 
-export const getNotNumberError = (text: string): string | null =>
-  Number.isNaN(Number(text)) ? NOT_NUMBER_ERROR_HELPER_TEXT : null;
-
-export const notNumberValidator = (text: string): string | boolean =>
-  Number.isNaN(Number(text)) ? NOT_NUMBER_ERROR_HELPER_TEXT : true;
+export const notNumberValidator = (text: string): string | undefined =>
+  Number.isNaN(Number(text)) ? NOT_NUMBER_ERROR_HELPER_TEXT : undefined;
 
 export const DUPLICATE_ERROR_HELPER_TEXT = 'Name already exists - please try another';
-
-export const createGetDuplicateError = (existing: string[]): ((text: string) => string | null) => {
-  const existingLowerCased = existing.map(value => value.toLowerCase());
-  return (text: string): string | null => {
-    if (existingLowerCased.includes(text.toLowerCase())) {
-      return DUPLICATE_ERROR_HELPER_TEXT;
-    }
-    return null;
-  };
-};
 
 export const createDuplicateValidator = (
   existing: string[],
   testNamePrefix?: string,
-): ((text: string) => string | boolean) => {
+): ((text: string) => string | undefined) => {
   const existingLowerCased = existing.map(value => value.toLowerCase());
-  return (text: string): string | boolean => {
+  return (text: string): string | undefined => {
     if (existingLowerCased.includes(`${testNamePrefix || ''}${text}`.toLowerCase())) {
       return DUPLICATE_ERROR_HELPER_TEXT;
     }
-    return true;
+    return undefined;
   };
 };
 
@@ -109,7 +51,7 @@ const VALID_TEMPLATES = {
 
 export const templateValidatorForPlatform = (platform: TestPlatform) => (
   text?: string,
-): string | boolean => {
+): string | undefined => {
   if (text) {
     const templates: string[] | null = text.match(/%\S*%/g);
 
@@ -122,35 +64,8 @@ export const templateValidatorForPlatform = (platform: TestPlatform) => (
       }
     }
   }
-  return true;
+  return undefined;
 };
 
-export interface ValidationComponentState {
-  validationStatus: ValidationStatus;
-}
-
-// Call this when a single field in the component updates
-export const onFieldValidationChange = <
-  P extends ValidationComponentProps,
-  S extends ValidationComponentState
->(
-  component: React.Component<P, S>,
-) => (fieldName: string) => (isValid: boolean): void => {
-  component.setState(
-    state => {
-      const newValidationStatus: ValidationStatus = Object.assign({}, state.validationStatus);
-      newValidationStatus[fieldName] = isValid;
-      return { validationStatus: newValidationStatus };
-    },
-    () => {
-      const hasInvalidField = Object.keys(component.state.validationStatus).some(
-        name => !component.state.validationStatus[name],
-      );
-
-      component.props.onValidationChange(!hasInvalidField);
-    },
-  );
-};
-
-// const onFieldValidationChangeTemp = (setValidation, )
-export const isNumber = (value: string): boolean => !Number.isNaN(Number(value));
+export const noHtmlValidator = (s: string): string | undefined =>
+  /<\/?[a-z][\s\S]*>/i.test(s) ? 'HTML is not allowed' : undefined;

--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -45,6 +45,7 @@ interface RichTextEditorProps<T> {
 interface RichTextMenuProps {
   disabled: boolean;
   label: string | undefined;
+  allowHtml: boolean;
 }
 
 /**
@@ -258,7 +259,11 @@ const FloatingLinkToolbar = () => {
 };
 
 // ReMirror/ProseMirror TOP MENU BUTTONS
-const RichTextMenu: React.FC<RichTextMenuProps> = ({ disabled, label }: RichTextMenuProps) => {
+const RichTextMenu: React.FC<RichTextMenuProps> = ({
+  disabled,
+  label,
+  allowHtml,
+}: RichTextMenuProps) => {
   const classes = useRTEStyles();
   const chain = useChainedCommands();
   const active = useActive();
@@ -268,31 +273,37 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({ disabled, label }: RichText
       <span className={classes.fieldLabel}>{label != null ? label : 'Editable field'}</span>
       {!disabled && (
         <>
-          <button
-            className={active.bold() ? 'remirror-button remirror-button-active' : 'remirror-button'}
-            onClick={() => {
-              chain
-                .toggleBold()
-                .focus()
-                .run();
-            }}
-          >
-            Bold
-          </button>
-          <button
-            className={
-              active.italic() ? 'remirror-button remirror-button-active' : 'remirror-button'
-            }
-            onClick={() => {
-              chain
-                .toggleItalic()
-                .focus()
-                .run();
-            }}
-          >
-            Italic
-          </button>
-          <span className={classes.remirrorButtonSpacer}>&nbsp;</span>
+          {allowHtml && (
+            <>
+              <button
+                className={
+                  active.bold() ? 'remirror-button remirror-button-active' : 'remirror-button'
+                }
+                onClick={() => {
+                  chain
+                    .toggleBold()
+                    .focus()
+                    .run();
+                }}
+              >
+                Bold
+              </button>
+              <button
+                className={
+                  active.italic() ? 'remirror-button remirror-button-active' : 'remirror-button'
+                }
+                onClick={() => {
+                  chain
+                    .toggleItalic()
+                    .focus()
+                    .run();
+                }}
+              >
+                Italic
+              </button>
+              <span className={classes.remirrorButtonSpacer}>&nbsp;</span>
+            </>
+          )}
           <button
             className="remirror-button"
             onClick={() => {
@@ -422,7 +433,7 @@ const RichTextEditor: React.FC<RichTextEditorProps<string[]>> = ({
     <div className={classes.remirrorCustom}>
       <div id={`RTE-${name}`} className={wrapperClasses}>
         <Remirror manager={manager} initialContent={state} editable={!disabled} hooks={hooks}>
-          <RichTextMenu disabled={disabled} label={label} />
+          <RichTextMenu disabled={disabled} label={label} allowHtml={allowHtml} />
           <EditorComponent />
           {!disabled && <FloatingLinkToolbar />}
           <p className={error ? classes.errorText : classes.helperText}>{helperText}</p>


### PR DESCRIPTION
A previous change to pass an `allowHtml` prop into the RTE prevents users from adding styling, by using `getText` instead of `getHTML`. But I've noticed it doesn't actually prevent them from typing in their own html.

This PR:
1. adds a validator to check for html if the epic is on AMP/AN
2. Hides the bold/italics buttons on the RTE if `!allowHtml` (to avoid confusion)
3. Tidies up validation.ts by removing unused code
4. Makes the return type of the validator functions consistant.  They now all return `string | undefined`, where a `string` contains an error message and `undefined` means no error. ([expected type](https://github.com/react-hook-form/react-hook-form/blob/master/src/types/validator.ts#L18))