### PR TITLE
Route traffic to new stack

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -1185,7 +1185,10 @@ dpkg -i /tmp/support-admin-console_1.0-SNAPSHOT_all.deb
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
-              "Action": "s3:PutObject",
+              "Action": Array [
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
               "Effect": "Allow",
               "Resource": Array [
                 "arn:aws:s3:::gu-contributions-public/epic/PROD/*",

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -1468,7 +1468,7 @@ dpkg -i /tmp/support-admin-console_1.0-SNAPSHOT_all.deb
         "ResourceRecords": Array [
           Object {
             "Fn::GetAtt": Array [
-              "ElasticLoadBalancer",
+              "LoadBalancerAdminconsole69251694",
               "DNSName",
             ],
           },

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -48,9 +48,13 @@ export class AdminConsole extends GuStack {
         bucketName: 'support-admin-console',
         paths: [`${this.stage}/*`],
       }),
-      new GuPutS3ObjectsPolicy(this, 'PublicSettingsBucketPut', {
-        bucketName: 'gu-contributions-public',
-        paths: [`epic/${this.stage}/*`, `banner/${this.stage}/*`, `header/${this.stage}/*`],
+      new GuAllowPolicy(this, 'PublicSettingsBucketPut', {
+        actions: ['s3:PutObject', 's3:PutObjectAcl'],
+        resources: [
+          `arn:aws:s3:::gu-contributions-public/epic/${this.stage}/*`,
+          `arn:aws:s3:::gu-contributions-public/banner/${this.stage}/*`,
+          `arn:aws:s3:::gu-contributions-public/header/${this.stage}/*`,
+        ],
       }),
     ];
 

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -12,7 +12,6 @@ import {
 import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
-import type { CfnLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancing';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
 
 export interface AdminConsoleProps extends GuStackProps {
@@ -80,17 +79,16 @@ export class AdminConsole extends GuStack {
 
     // TODO Legacy cloudformation stack - to be removed after migration to cdk is complete
     const yamlTemplateFilePath = join(__dirname, '../..', 'cloudformation.yaml');
-    const template = new CfnInclude(this, 'YamlTemplate', {
+    new CfnInclude(this, 'YamlTemplate', {
       templateFile: yamlTemplateFilePath,
     });
 
-    // TODO Migrate to new LB
-    const oldElb = template.getResource('ElasticLoadBalancer') as CfnLoadBalancer;
+    // TODO lower ttl after migration
     new GuCname(this, 'cname', {
       app,
       domainName,
       ttl: Duration.minutes(1),
-      resourceRecord: oldElb.attrDnsName,
+      resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
     });
   }
 }

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -87,7 +87,7 @@ export class AdminConsole extends GuStack {
       templateFile: yamlTemplateFilePath,
     });
 
-    // TODO lower ttl after migration
+    // TODO increase ttl again after migration
     new GuCname(this, 'cname', {
       app,
       domainName,


### PR DESCRIPTION
Also, because this is the first time I've been able to test the app in CODE, I discovered it was missing the `s3:PutObjectAcl` permission on a bucket, so I've added this.

The final step after this is live will be to delete the old stack.