### PR TITLE
Allow pasting of paragraphs

### DIFF
--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -90,9 +90,18 @@ class RemovePastedHtmlExtension extends PlainExtension {
       props: {
         transformPastedHTML: html => {
           const doc = new DOMParser().parseFromString(html, 'text/html');
-          return Array.from(doc.getElementsByTagName('p'))
-            .map(p => `<p>${p.textContent}</p>`)
-            .join(' ');
+          const paras = Array.from(doc.getElementsByTagName('p'));
+          /**
+           * It's important to remove all pasted html.
+           * If the html contains any paras then assume all content is in <p> tags.
+           */
+          if (paras.length > 0) {
+            return Array.from(doc.getElementsByTagName('p'))
+              .map(p => `<p>${p.textContent}</p>`)
+              .join(' ');
+          } else {
+            return doc.body.textContent || '';
+          }
         },
       },
     });


### PR DESCRIPTION
When users copy from google docs into the Rich Text Editor (RTE), it tends to bring a load of html with it, which we really don't want. E.g.
![Screen Shot 2022-04-27 at 16 05 45](https://user-images.githubusercontent.com/1513454/165549999-e420d065-cbd4-4aa3-93d8-8bb9d3a70bb3.png)
comes over as:
```
<meta charset="utf-8"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" id="docs-internal-guid-534fbcd6-7fff-a07b-a0f8-a09f82528c5a"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Para1</span></p><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Para2</span></p><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Para 3</span></p>
```

Currently we strip out all html when pasting into the RTE (and this is good).
But users want to preserve paragraphs. With this change it now takes the `textContent` of any `<p>` tags, wrapping each in `<p>`. If there are no `<p>` tags then it still takes `body.textContent`.