### PR TITLE
Make epic heading optional

### DIFF
--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -21,7 +21,6 @@ export const DEFAULT_SECONDARY_CTA: Cta = {
 
 const DEV_AND_CODE_DEFAULT_VARIANT: EpicVariant = {
   name: 'CONTROL',
-  heading: "Since you're here ...",
   paragraphs: [
     "… we have a small favour to ask. You've read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; millions are flocking to the Guardian for quality news every day. We believe everyone deserves access to factual information, and analysis that has authority and integrity. That’s why, unlike many others, we made a choice: to keep Guardian reporting open for all, regardless of where they live or what they can afford to pay.",
     'As an open, independent news organisation we investigate, interrogate and expose the actions of those in power, without fear. With no shareholders or billionaire owner, our journalism is free from political and commercial bias – this makes us different. We can give a voice to the oppressed and neglected, and stand in solidarity with those who are calling for a fairer future. With your help we can make a difference.',

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -68,7 +68,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: true,
-  requireVariantHeader: true,
+  requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'DOTCOM',
 };
@@ -93,7 +93,7 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: true,
-  requireVariantHeader: true,
+  requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'DOTCOM',
 };
@@ -142,7 +142,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: false,
   allowVariantChoiceCards: false,
   allowVariantSignInLink: false,
-  requireVariantHeader: true,
+  requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'APPLE_NEWS',
 };
@@ -166,7 +166,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: false,
-  requireVariantHeader: true,
+  requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'AMP',
 };


### PR DESCRIPTION
The heading field is optional in the model, and these days it's mostly left empty. Currently users have to enter a space because the form requires it to be non-empty.

Tested with AMP and Apple News to ensure they're happy with `undefined` heading