### PR TITLE
Add new pricing templates to the Rich Text Editor

### DIFF
--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -341,22 +341,13 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({
               <span className={classes.remirrorButtonSpacer}>&nbsp;</span>
             </>
           )}
-          <button
-            className="remirror-button"
-            onClick={() => insertArticleCount()}
-          >
+          <button className="remirror-button" onClick={() => insertArticleCount()}>
             Articles
           </button>
-          <button
-            className="remirror-button"
-            onClick={() => insertCurrencySymbol()}
-          >
+          <button className="remirror-button" onClick={() => insertCurrencySymbol()}>
             Currency
           </button>
-          <button
-            className="remirror-button"
-            onClick={() => insertCountryName()}
-          >
+          <button className="remirror-button" onClick={() => insertCountryName()}>
             Country
           </button>
           <span className={classes.remirrorButtonSpacer}>&nbsp;</span>
@@ -368,7 +359,11 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({
               {priceButtonsVisible ? 'Prices ↑' : 'Prices ↓'}
             </button>
             <menu
-              className={priceButtonsVisible ? classes.dropdownMenuContent : classes.dropdownMenuContentHidden}
+              className={
+                priceButtonsVisible
+                  ? classes.dropdownMenuContent
+                  : classes.dropdownMenuContentHidden
+              }
             >
               <div className={classes.fieldLabelPrices}>Price templates:</div>
               <button

--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -222,10 +222,10 @@ const FloatingLinkToolbar = () => {
         label: 'Link',
         items: activeLink
           ? [
-              { type: ComponentItem.ToolbarButton, onClick: () => clickEdit(), icon: 'pencilLine' },
-              { type: ComponentItem.ToolbarButton, onClick: onRemove, icon: 'linkUnlink' },
+              { type: ComponentItem.ToolbarButton, onClick: () => clickEdit(), label: 'Edit link' },
+              { type: ComponentItem.ToolbarButton, onClick: onRemove, label: 'Remove link' },
             ]
-          : [{ type: ComponentItem.ToolbarButton, onClick: () => clickEdit(), icon: 'link' }],
+          : [{ type: ComponentItem.ToolbarButton, onClick: () => clickEdit(), label: 'Add link' }],
       },
     ],
     [clickEdit, onRemove, activeLink],
@@ -279,6 +279,42 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({
   const chain = useChainedCommands();
   const active = useActive();
 
+  const [priceButtonsVisible, setPriceButtonsVisible] = useState<boolean>(false);
+
+  const clickBold = () => {
+    chain
+      .toggleBold()
+      .focus()
+      .run();
+  };
+  const clickItalic = () => {
+    chain
+      .toggleItalic()
+      .focus()
+      .run();
+  };
+  const insertArticleCount = () => {
+    chain.insertText('%%ARTICLE_COUNT%%').run();
+  };
+  const insertCurrencySymbol = () => {
+    chain.insertText('%%CURRENCY_SYMBOL%%').run();
+  };
+  const insertCountryName = () => {
+    chain.insertText('%%COUNTRY_NAME%%').run();
+  };
+  const insertPriceDigisubMonthly = () => {
+    chain.insertText('%%PRICE_DIGISUB_MONTHLY%%').run();
+  };
+  const insertPriceDigisubAnnual = () => {
+    chain.insertText('%%PRICE_DIGISUB_ANNUAL%%').run();
+  };
+  const insertPriceGwMonthly = () => {
+    chain.insertText('%%PRICE_GUARDIANWEEKLY_MONTHLY%%').run();
+  };
+  const insertPriceGwAnnual = () => {
+    chain.insertText('%%PRICE_GUARDIANWEEKLY_ANNUAL%%').run();
+  };
+
   return (
     <div>
       <span className={classes.fieldLabel}>{label != null ? label : 'Editable field'}</span>
@@ -290,12 +326,7 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({
                 className={
                   active.bold() ? 'remirror-button remirror-button-active' : 'remirror-button'
                 }
-                onClick={() => {
-                  chain
-                    .toggleBold()
-                    .focus()
-                    .run();
-                }}
+                onClick={() => clickBold()}
               >
                 Bold
               </button>
@@ -303,12 +334,7 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({
                 className={
                   active.italic() ? 'remirror-button remirror-button-active' : 'remirror-button'
                 }
-                onClick={() => {
-                  chain
-                    .toggleItalic()
-                    .focus()
-                    .run();
-                }}
+                onClick={() => clickItalic()}
               >
                 Italic
               </button>
@@ -317,28 +343,60 @@ const RichTextMenu: React.FC<RichTextMenuProps> = ({
           )}
           <button
             className="remirror-button"
-            onClick={() => {
-              chain.insertText('%%ARTICLE_COUNT%%').run();
-            }}
+            onClick={() => insertArticleCount()}
           >
             Articles
           </button>
           <button
             className="remirror-button"
-            onClick={() => {
-              chain.insertText('%%CURRENCY_SYMBOL%%').run();
-            }}
+            onClick={() => insertCurrencySymbol()}
           >
             Currency
           </button>
           <button
             className="remirror-button"
-            onClick={() => {
-              chain.insertText('%%COUNTRY_NAME%%').run();
-            }}
+            onClick={() => insertCountryName()}
           >
             Country
           </button>
+          <span className={classes.remirrorButtonSpacer}>&nbsp;</span>
+          <div className={classes.dropdownMenu}>
+            <button
+              className={`remirror-button ${classes.dropdownMenuToggle}`}
+              onClick={() => setPriceButtonsVisible(!priceButtonsVisible)}
+            >
+              {priceButtonsVisible ? 'Prices ↑' : 'Prices ↓'}
+            </button>
+            <menu
+              className={priceButtonsVisible ? classes.dropdownMenuContent : classes.dropdownMenuContentHidden}
+            >
+              <div className={classes.fieldLabelPrices}>Price templates:</div>
+              <button
+                className={`remirror-button ${classes.dropdownMenuItem}`}
+                onClick={() => insertPriceDigisubMonthly()}
+              >
+                Digisub monthly
+              </button>
+              <button
+                className={`remirror-button ${classes.dropdownMenuItem}`}
+                onClick={() => insertPriceDigisubAnnual()}
+              >
+                Digisub annual
+              </button>
+              <button
+                className={`remirror-button ${classes.dropdownMenuItem}`}
+                onClick={() => insertPriceGwMonthly()}
+              >
+                GW monthly
+              </button>
+              <button
+                className={`remirror-button ${classes.dropdownMenuItem}`}
+                onClick={() => insertPriceGwAnnual()}
+              >
+                GW annual
+              </button>
+            </menu>
+          </div>
         </>
       )}
     </div>

--- a/public/src/components/channelManagement/richTextEditor/richTextEditorStyles.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditorStyles.tsx
@@ -7,6 +7,13 @@ export const useRTEStyles = makeStyles(() => ({
     color: 'rgba(0 0 0 / 0.6)',
     margin: '0 1.5em',
   },
+  fieldLabelPrices: {
+    display: 'inline-block',
+    fontSize: '85%',
+    color: 'rgba(0 0 0 / 0.6)',
+    margin: '0 1.5em',
+    paddingLeft: '10em',
+  },
   helperText: {
     fontSize: '85%',
     color: 'rgba(0 0 0 / 0.6)',
@@ -19,6 +26,28 @@ export const useRTEStyles = makeStyles(() => ({
   },
   remirrorButtonSpacer: {
     paddingLeft: '1em',
+  },
+
+  dropdownMenu: {
+    display: 'inline',
+  },
+
+  dropdownMenuToggle: {
+  },
+
+  dropdownMenuContent: {
+    margin: '0.5em 0 0',
+    padding: '0',
+  },
+
+  dropdownMenuContentHidden: {
+    margin: '0',
+    padding: '0',
+    height: '0',
+    overflowY: 'hidden',
+  },
+
+  dropdownMenuItem: {
   },
 
   // extra css to style remirror components in RRCP:

--- a/public/src/components/channelManagement/richTextEditor/richTextEditorStyles.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditorStyles.tsx
@@ -27,28 +27,21 @@ export const useRTEStyles = makeStyles(() => ({
   remirrorButtonSpacer: {
     paddingLeft: '1em',
   },
-
   dropdownMenu: {
     display: 'inline',
   },
-
-  dropdownMenuToggle: {
-  },
-
+  dropdownMenuToggle: {},
   dropdownMenuContent: {
     margin: '0.5em 0 0',
     padding: '0',
   },
-
   dropdownMenuContentHidden: {
     margin: '0',
     padding: '0',
     height: '0',
     overflowY: 'hidden',
   },
-
-  dropdownMenuItem: {
-  },
+  dropdownMenuItem: {},
 
   // extra css to style remirror components in RRCP:
   remirrorCustom: {


### PR DESCRIPTION
## What does this change?
We've added new pricing copy templates to SDC and SAC repos - see PR #312 for further info.

This PR adds UX to the Rich Text Editor to make it easy for users to add the new templates to their copy

**Screenshots:**
![Screenshot 2022-05-04 at 16 17 48](https://user-images.githubusercontent.com/5357530/166718165-7993fcee-8f29-4c77-983b-ddd78dcf8f3d.png)
![Screenshot 2022-05-04 at 16 18 01](https://user-images.githubusercontent.com/5357530/166718192-7c63af11-467c-45a1-b541-f440bc123822.png)
![Screenshot 2022-05-04 at 16 18 19](https://user-images.githubusercontent.com/5357530/166718240-26919374-c69e-4223-ac4b-6174eec9972c.png)
![Screenshot 2022-05-04 at 16 18 34](https://user-images.githubusercontent.com/5357530/166718268-b6bd4ae7-9af8-48da-ad78-2920e2d91d7d.png)

