### PR TITLE
Single dynamo table for channel tests

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -158,70 +158,6 @@ Object {
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
-    "BannerTestsDynamoTable": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "AttributeDefinitions": Array [
-          Object {
-            "AttributeName": "name",
-            "AttributeType": "S",
-          },
-          Object {
-            "AttributeName": "status",
-            "AttributeType": "S",
-          },
-        ],
-        "GlobalSecondaryIndexes": Array [
-          Object {
-            "IndexName": "status-index",
-            "KeySchema": Array [
-              Object {
-                "AttributeName": "status",
-                "KeyType": "HASH",
-              },
-            ],
-            "Projection": Object {
-              "ProjectionType": "ALL",
-            },
-            "ProvisionedThroughput": Object {
-              "ReadCapacityUnits": 4,
-              "WriteCapacityUnits": 4,
-            },
-          },
-        ],
-        "KeySchema": Array [
-          Object {
-            "AttributeName": "name",
-            "KeyType": "HASH",
-          },
-        ],
-        "ProvisionedThroughput": Object {
-          "ReadCapacityUnits": 4,
-          "WriteCapacityUnits": 4,
-        },
-        "TableName": "banner-tests-PROD",
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/support-admin-console",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::DynamoDB::Table",
-      "UpdateReplacePolicy": "Retain",
-    },
     "CertificateAdminconsole74B584AB": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -251,6 +187,56 @@ Object {
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ChannelTestsDynamoTable": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AttributeDefinitions": Array [
+          Object {
+            "AttributeName": "channel",
+            "AttributeType": "S",
+          },
+          Object {
+            "AttributeName": "name",
+            "AttributeType": "S",
+          },
+        ],
+        "KeySchema": Array [
+          Object {
+            "AttributeName": "channel",
+            "KeyType": "HASH",
+          },
+          Object {
+            "AttributeName": "name",
+            "KeyType": "RANGE",
+          },
+        ],
+        "ProvisionedThroughput": Object {
+          "ReadCapacityUnits": 4,
+          "WriteCapacityUnits": 4,
+        },
+        "TableName": "channel-tests-PROD",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-admin-console",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
     "CloudwatchA324BFA2": Object {
@@ -304,7 +290,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DynamoReadBannerTestsDynamoTable7D8ADE8F": Object {
+    "DynamoReadChannelTestsDynamoTable934E3DAF": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -331,7 +317,7 @@ Object {
                     },
                     ":table/",
                     Object {
-                      "Ref": "BannerTestsDynamoTable",
+                      "Ref": "ChannelTestsDynamoTable",
                     },
                   ],
                 ],
@@ -340,7 +326,7 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DynamoReadBannerTestsDynamoTable7D8ADE8F",
+        "PolicyName": "DynamoReadChannelTestsDynamoTable934E3DAF",
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleAdminconsole347DA627",
@@ -349,97 +335,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DynamoReadEpicTestsDynamoTable0344F8D9": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "dynamodb:BatchGetItem",
-                "dynamodb:GetItem",
-                "dynamodb:Scan",
-                "dynamodb:Query",
-                "dynamodb:GetRecords",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:dynamodb:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":table/",
-                    Object {
-                      "Ref": "EpicTestsDynamoTable",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DynamoReadEpicTestsDynamoTable0344F8D9",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleAdminconsole347DA627",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "DynamoReadHeaderTestsDynamoTable43CCFF7E": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "dynamodb:BatchGetItem",
-                "dynamodb:GetItem",
-                "dynamodb:Scan",
-                "dynamodb:Query",
-                "dynamodb:GetRecords",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:dynamodb:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":table/",
-                    Object {
-                      "Ref": "HeaderTestsDynamoTable",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DynamoReadHeaderTestsDynamoTable43CCFF7E",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleAdminconsole347DA627",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "DynamoWriteBannerTestsDynamoTable1653F178": Object {
+    "DynamoWriteChannelTestsDynamoTable593B6212": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -465,7 +361,7 @@ Object {
                     },
                     ":table/",
                     Object {
-                      "Ref": "BannerTestsDynamoTable",
+                      "Ref": "ChannelTestsDynamoTable",
                     },
                   ],
                 ],
@@ -474,7 +370,7 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DynamoWriteBannerTestsDynamoTable1653F178",
+        "PolicyName": "DynamoWriteChannelTestsDynamoTable593B6212",
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleAdminconsole347DA627",
@@ -482,158 +378,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "DynamoWriteEpicTestsDynamoTable3BEEE8A5": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "dynamodb:BatchWriteItem",
-                "dynamodb:PutItem",
-                "dynamodb:DeleteItem",
-                "dynamodb:UpdateItem",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:dynamodb:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":table/",
-                    Object {
-                      "Ref": "EpicTestsDynamoTable",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DynamoWriteEpicTestsDynamoTable3BEEE8A5",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleAdminconsole347DA627",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "DynamoWriteHeaderTestsDynamoTableBA567E40": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "dynamodb:BatchWriteItem",
-                "dynamodb:PutItem",
-                "dynamodb:DeleteItem",
-                "dynamodb:UpdateItem",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:dynamodb:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":table/",
-                    Object {
-                      "Ref": "HeaderTestsDynamoTable",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DynamoWriteHeaderTestsDynamoTableBA567E40",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleAdminconsole347DA627",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "EpicTestsDynamoTable": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "AttributeDefinitions": Array [
-          Object {
-            "AttributeName": "name",
-            "AttributeType": "S",
-          },
-          Object {
-            "AttributeName": "status",
-            "AttributeType": "S",
-          },
-        ],
-        "GlobalSecondaryIndexes": Array [
-          Object {
-            "IndexName": "status-index",
-            "KeySchema": Array [
-              Object {
-                "AttributeName": "status",
-                "KeyType": "HASH",
-              },
-            ],
-            "Projection": Object {
-              "ProjectionType": "ALL",
-            },
-            "ProvisionedThroughput": Object {
-              "ReadCapacityUnits": 4,
-              "WriteCapacityUnits": 4,
-            },
-          },
-        ],
-        "KeySchema": Array [
-          Object {
-            "AttributeName": "name",
-            "KeyType": "HASH",
-          },
-        ],
-        "ProvisionedThroughput": Object {
-          "ReadCapacityUnits": 4,
-          "WriteCapacityUnits": 4,
-        },
-        "TableName": "epic-tests-PROD",
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/support-admin-console",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::DynamoDB::Table",
-      "UpdateReplacePolicy": "Retain",
     },
     "GetDistributablePolicyAdminconsole6DA8CA46": Object {
       "Properties": Object {
@@ -769,70 +513,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "HeaderTestsDynamoTable": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "AttributeDefinitions": Array [
-          Object {
-            "AttributeName": "name",
-            "AttributeType": "S",
-          },
-          Object {
-            "AttributeName": "status",
-            "AttributeType": "S",
-          },
-        ],
-        "GlobalSecondaryIndexes": Array [
-          Object {
-            "IndexName": "status-index",
-            "KeySchema": Array [
-              Object {
-                "AttributeName": "status",
-                "KeyType": "HASH",
-              },
-            ],
-            "Projection": Object {
-              "ProjectionType": "ALL",
-            },
-            "ProvisionedThroughput": Object {
-              "ReadCapacityUnits": 4,
-              "WriteCapacityUnits": 4,
-            },
-          },
-        ],
-        "KeySchema": Array [
-          Object {
-            "AttributeName": "name",
-            "KeyType": "HASH",
-          },
-        ],
-        "ProvisionedThroughput": Object {
-          "ReadCapacityUnits": 4,
-          "WriteCapacityUnits": 4,
-        },
-        "TableName": "header-tests-PROD",
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/support-admin-console",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::DynamoDB::Table",
-      "UpdateReplacePolicy": "Retain",
     },
     "InstanceRoleAdminconsole347DA627": Object {
       "Properties": Object {


### PR DESCRIPTION
In the 1st PR I added dynamodb tables for epic, banner, and header. In the world of relational databases this feels a normal thing to do.
I then thought about it a bit harder and realised that with dynamo, a table per channel does not make sense.
Firstly, we'd need a lot of tables (apple news epics, liveblog epics, banner1, banner2...).
Secondly, with dynamo there are typically no benefits to defining lots of tables (no joins/normalisation).

With this PR we have just one table: `channel-tests`.
It has a composite primary key:
- the partition key is `channel` (e.g. "epic", "banner1", "banner2"...)
- the sort key is `name`

This means:
1. The test name is still unique within a channel.
2. Querying for tests is efficient because the data is partitioned by channel. Typically SDC/SAC query for tests in a single channel. (Dynamodb uses the partition key value as the input to a hash function).
3. In the future we can add secondary indexes for new use cases, for example for querying by `campaign` across all channels.

See [this article](https://aws.amazon.com/blogs/database/choosing-the-right-dynamodb-partition-key/) for an explanation of dynamodb primary keys.