### PR TITLE
Zio 1.0.14

### DIFF
--- a/app/controllers/AmountsController.scala
+++ b/app/controllers/AmountsController.scala
@@ -4,10 +4,10 @@ import com.gu.googleauth.AuthAction
 import models.ConfiguredAmounts
 import models.ConfiguredAmounts._
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class AmountsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class AmountsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[ConfiguredAmounts](authAction, components, stage, filename = "configured-amounts.json", runtime) {
 }

--- a/app/controllers/CampaignsController.scala
+++ b/app/controllers/CampaignsController.scala
@@ -3,10 +3,10 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.Campaigns._
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class CampaignsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class CampaignsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[Campaigns](authAction, components, stage, filename = "campaigns.json", runtime) {
 }

--- a/app/controllers/ChannelSwitchesController.scala
+++ b/app/controllers/ChannelSwitchesController.scala
@@ -3,10 +3,10 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.ChannelSwitches
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class ChannelSwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class ChannelSwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[ChannelSwitches](authAction, components, stage, filename = "channel-switches.json", runtime) {
 }

--- a/app/controllers/ContributionTypesController.scala
+++ b/app/controllers/ContributionTypesController.scala
@@ -4,10 +4,10 @@ import com.gu.googleauth.AuthAction
 import models.ContributionTypes
 import play.api.mvc.{AnyContent, ControllerComponents}
 import io.circe.generic.auto._
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class ContributionTypesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class ContributionTypesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[ContributionTypes](authAction, components, stage, filename = "contributionTypes.json", runtime) {
 }

--- a/app/controllers/HeaderTestArchiveController.scala
+++ b/app/controllers/HeaderTestArchiveController.scala
@@ -5,7 +5,7 @@ import models.HeaderTest
 import models.HeaderTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -13,7 +13,7 @@ class HeaderTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[HeaderTest](
   authAction,
   components,

--- a/app/controllers/HeaderTestsController.scala
+++ b/app/controllers/HeaderTestsController.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
 import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -19,9 +19,9 @@ object HeaderTestsController {
 class HeaderTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
-  ws: WSClient, 
+  ws: WSClient,
   stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[HeaderTests](
     authAction,
     components,

--- a/app/controllers/LockableS3ObjectController.scala
+++ b/app/controllers/LockableS3ObjectController.scala
@@ -12,7 +12,7 @@ import play.api.mvc._
 import services.S3Client.{S3ClientError, S3ObjectSettings}
 import services.{FastlyPurger, S3Json, VersionedS3Data}
 import zio.blocking.Blocking
-import zio.{DefaultRuntime, IO, ZIO}
+import zio.{IO, ZEnv, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -38,7 +38,7 @@ abstract class LockableS3ObjectController[T : Decoder : Encoder](
   name: String,
   dataObjectSettings: S3ObjectSettings,
   fastlyPurger: Option[FastlyPurger],
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   private val lockObjectSettings = S3ObjectSettings(

--- a/app/controllers/S3ObjectController.scala
+++ b/app/controllers/S3ObjectController.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{AbstractController, AnyContent, ControllerComponents, Resul
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
 import zio.blocking.Blocking
-import zio.{DefaultRuntime, IO, ZIO}
+import zio.{IO, ZEnv, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -23,7 +23,7 @@ abstract class S3ObjectController[T : Decoder : Encoder](
   components: ControllerComponents,
   stage: String,
   filename: String,
-  val runtime: DefaultRuntime)(implicit ec: ExecutionContext) extends AbstractController(components) with Circe {
+  val runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   private val dataObjectSettings = S3ObjectSettings(
     bucket = "support-admin-console",

--- a/app/controllers/S3ObjectsController.scala
+++ b/app/controllers/S3ObjectsController.scala
@@ -8,7 +8,7 @@ import play.api.mvc._
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
 import zio.blocking.Blocking
-import zio.{DefaultRuntime, IO, ZIO}
+import zio.{IO, ZEnv, ZIO}
 import S3ObjectsController.extractFilename
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,7 +33,7 @@ abstract class S3ObjectsController[T : Decoder : Encoder](
   stage: String,
   path: String,
   nameGenerator: T => String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   val s3Client = services.S3

--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -3,10 +3,10 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc.{AnyContent, ControllerComponents}
 import models.SupportFrontendSwitches.{SupportFrontendSwitches, SupportFrontendSwitchesDecoder, SupportFrontendSwitchesEncoder}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class SwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class SwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[SupportFrontendSwitches](authAction, components, stage, filename = "switches_v2.json", runtime) {
 }

--- a/app/controllers/banner/BannerDeployController.scala
+++ b/app/controllers/banner/BannerDeployController.scala
@@ -5,10 +5,10 @@ import controllers.S3ObjectController
 import io.circe.generic.auto._
 import models.BannerDeploys
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class BannerDeployController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class BannerDeployController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel1.json", runtime) {
 }

--- a/app/controllers/banner/BannerDeployController2.scala
+++ b/app/controllers/banner/BannerDeployController2.scala
@@ -5,10 +5,10 @@ import controllers.S3ObjectController
 import io.circe.generic.auto._
 import models.BannerDeploys
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class BannerDeployController2(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: DefaultRuntime)(implicit ec: ExecutionContext)
+class BannerDeployController2(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel2.json", runtime) {
 }

--- a/app/controllers/banner/BannerTestArchiveController.scala
+++ b/app/controllers/banner/BannerTestArchiveController.scala
@@ -6,7 +6,7 @@ import models.BannerTest
 import models.BannerTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class BannerTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[BannerTest](
   authAction,
   components,

--- a/app/controllers/banner/BannerTestArchiveController2.scala
+++ b/app/controllers/banner/BannerTestArchiveController2.scala
@@ -6,7 +6,7 @@ import models.BannerTest
 import models.BannerTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class BannerTestArchiveController2(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[BannerTest](
   authAction,
   components,

--- a/app/controllers/banner/BannerTestsController.scala
+++ b/app/controllers/banner/BannerTestsController.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
 import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +20,7 @@ class BannerTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[BannerTests](
     authAction,
     components,

--- a/app/controllers/banner/BannerTestsController2.scala
+++ b/app/controllers/banner/BannerTestsController2.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
 import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +20,7 @@ class BannerTestsController2(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[BannerTests](
     authAction,
     components,

--- a/app/controllers/epic/AMPEpicTestArchiveController.scala
+++ b/app/controllers/epic/AMPEpicTestArchiveController.scala
@@ -6,7 +6,7 @@ import models.EpicTest
 import models.EpicTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class AMPEpicTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
   authAction,
   components,

--- a/app/controllers/epic/AMPEpicTestsController.scala
+++ b/app/controllers/epic/AMPEpicTestsController.scala
@@ -7,7 +7,7 @@ import play.api.libs.circe.Circe
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -19,7 +19,7 @@ class AMPEpicTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
   authAction,
   components,

--- a/app/controllers/epic/AppleNewsEpicTestArchiveController.scala
+++ b/app/controllers/epic/AppleNewsEpicTestArchiveController.scala
@@ -6,7 +6,7 @@ import models.EpicTest
 import models.EpicTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class AppleNewsEpicTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
   authAction,
   components,

--- a/app/controllers/epic/AppleNewsEpicTestsController.scala
+++ b/app/controllers/epic/AppleNewsEpicTestsController.scala
@@ -7,7 +7,7 @@ import play.api.libs.circe.Circe
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -19,7 +19,7 @@ class AppleNewsEpicTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
   authAction,
   components,

--- a/app/controllers/epic/EpicHoldbackTestArchiveController.scala
+++ b/app/controllers/epic/EpicHoldbackTestArchiveController.scala
@@ -6,7 +6,7 @@ import models.EpicTest
 import models.EpicTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class EpicHoldbackTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
   authAction,
   components,

--- a/app/controllers/epic/EpicHoldbackTestsController.scala
+++ b/app/controllers/epic/EpicHoldbackTestsController.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +20,7 @@ class EpicHoldbackTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
     authAction,
     components,

--- a/app/controllers/epic/EpicTestArchiveController.scala
+++ b/app/controllers/epic/EpicTestArchiveController.scala
@@ -6,7 +6,7 @@ import models.EpicTest
 import models.EpicTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class EpicTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
   authAction,
   components,

--- a/app/controllers/epic/EpicTestsController.scala
+++ b/app/controllers/epic/EpicTestsController.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +20,7 @@ class EpicTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
     authAction,
     components,

--- a/app/controllers/epic/LiveblogEpicTestArchiveController.scala
+++ b/app/controllers/epic/LiveblogEpicTestArchiveController.scala
@@ -6,7 +6,7 @@ import models.EpicTest
 import models.EpicTests._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, ControllerComponents}
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -14,7 +14,7 @@ class LiveblogEpicTestArchiveController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends S3ObjectsController[EpicTest](
   authAction,
   components,

--- a/app/controllers/epic/LiveblogEpicTestsController.scala
+++ b/app/controllers/epic/LiveblogEpicTestsController.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.FastlyPurger
 import services.S3Client.S3ObjectSettings
-import zio.DefaultRuntime
+import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +20,7 @@ class LiveblogEpicTestsController(
   authAction: AuthAction[AnyContent],
   components: ControllerComponents,
   ws: WSClient, stage: String,
-  runtime: DefaultRuntime
+  runtime: zio.Runtime[ZEnv]
 )(implicit ec: ExecutionContext) extends LockableS3ObjectController[EpicTests](
     authAction,
     components,

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -13,7 +13,6 @@ import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
 import services.{CapiService, S3}
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import zio.DefaultRuntime
 
 class AppComponents(context: Context, stage: String) extends BuiltInComponentsFromContext(context) with AhcWSComponents with NoHttpFiltersComponents with AssetsComponents {
 
@@ -52,7 +51,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
 
   private val authAction = new AuthAction[AnyContent](authConfig, controllers.routes.Login.loginAction, controllerComponents.parsers.default)(executionContext)
 
-  private val runtime = new DefaultRuntime {}
+  private val runtime = zio.Runtime.default
 
   val capiService = new CapiService(configuration.get[String]("capi.apiKey"), wsClient)
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.beachape" %% "enumeratum" % "1.7.0",
   "com.beachape" %% "enumeratum-circe" % "1.7.0",
   ws,
-  "dev.zio" %% "zio" % "1.0.0-RC17",
+  "dev.zio" %% "zio" % "1.0.14",
   "org.scalatest" %% "scalatest" % "3.2.10" % "test",
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -7,14 +7,14 @@ import services.S3Client.{RawVersionedS3Data, S3Action, S3ObjectSettings}
 import models.SupportFrontendSwitches.{SupportFrontendSwitches, Switch, SwitchGroup}
 import models._
 import org.scalatest.matchers.should.Matchers
-import zio.{DefaultRuntime, IO}
+import zio.IO
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
 
-  val runtime = new DefaultRuntime {}
+  val runtime = zio.Runtime.default
 
   val expectedJson: String =
     """


### PR DESCRIPTION
An [upcoming PR](https://github.com/guardian/support-admin-console/pull/327) to add dynamodb support uses a newer version of zio, and zio streams.

This PR updates to the newest version of zio v1, to make that PR's diff easier to read.
The only code changes relate to the imports/types of the zio `Runtime`

Note - there is a zio v2, but I don't want to go that far just yet!