### PR TITLE
Show 'Saving...' during save

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestsForm.tsx
@@ -38,6 +38,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
     editMode,
     regionFilter,
     setRegionFilter,
+    saving,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
       onTestCreate(createDefaultBannerTest(name, nickname));
@@ -91,6 +92,7 @@ const getBannerTestsForm = (isFirstChannel: boolean): React.FC<Props> => {
         save={onTestSave}
         cancel={cancel}
         editMode={editMode}
+        saving={saving}
       />
     );
   };

--- a/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestsForm.tsx
@@ -124,6 +124,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
     editMode,
     regionFilter,
     setRegionFilter,
+    saving,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
       onTestCreate(createDefaultEpicTest(name, nickname));
@@ -179,6 +180,7 @@ const getEpicTestForm = (epicEditorConfig: EpicEditorConfig): React.FC<Props> =>
         save={onTestSave}
         cancel={cancel}
         editMode={editMode}
+        saving={saving}
       />
     );
   };

--- a/public/src/components/channelManagement/headerTests/headerTestsForm.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestsForm.tsx
@@ -37,6 +37,7 @@ const getHeaderTestsForm = (): React.FC<Props> => {
     editMode,
     regionFilter,
     setRegionFilter,
+    saving,
   }: Props) => {
     const createTest = (name: string, nickname: string): void => {
       onTestCreate(createDefaultHeaderTest(name, nickname));
@@ -90,6 +91,7 @@ const getHeaderTestsForm = (): React.FC<Props> => {
         save={onTestSave}
         cancel={cancel}
         editMode={editMode}
+        saving={saving}
       />
     );
   };

--- a/public/src/components/channelManagement/stickyBottomBar.tsx
+++ b/public/src/components/channelManagement/stickyBottomBar.tsx
@@ -52,6 +52,7 @@ interface StickyBottomBarProps {
   requestLock: () => void;
   save: () => void;
   cancel: () => void;
+  saving: boolean;
 }
 
 const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
@@ -63,6 +64,7 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
   requestLock,
   save,
   cancel,
+  saving,
 }: StickyBottomBarProps) => {
   const classes = useStyles();
   const containerClasses = [
@@ -90,6 +92,7 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
           requestLock={requestLock}
           save={save}
           cancel={cancel}
+          saving={saving}
         />
       </div>
     </AppBar>

--- a/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
+++ b/public/src/components/channelManagement/stickyBottomBarActionButtons.tsx
@@ -54,6 +54,7 @@ interface StickyBottomBarActionButtonsProps {
   requestLock: () => void;
   save: () => void;
   cancel: () => void;
+  saving: boolean;
 }
 
 const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> = ({
@@ -64,6 +65,7 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
   requestLock,
   save,
   cancel,
+  saving,
 }: StickyBottomBarActionButtonsProps) => {
   const classes = useStyles();
 
@@ -129,6 +131,12 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
     </Button>
   );
 
+  const SavingButton: React.FC = () => (
+    <Button variant="contained" color="primary" disableElevation startIcon={<SaveIcon />}>
+      <Typography className={classes.buttonText}>Saving...</Typography>
+    </Button>
+  );
+
   const EditButton: React.FC = () => (
     <Button
       variant="outlined"
@@ -187,7 +195,9 @@ const StickyBottomBarActionButtons: React.FC<StickyBottomBarActionButtonsProps> 
       <div className={classes.leftContainer}>{isInEditMode && <CancelButton />}</div>
 
       <div className={classes.rightContainer}>
-        {isInEditMode ? (
+        {saving ? (
+          <SavingButton />
+        ) : isInEditMode ? (
           // Edit mode
           <SaveButton />
         ) : isLocked ? (

--- a/public/src/components/channelManagement/testEditor.tsx
+++ b/public/src/components/channelManagement/testEditor.tsx
@@ -34,6 +34,7 @@ export interface InnerComponentProps<T extends Test> {
   editMode: boolean;
   regionFilter: RegionsAndAll;
   setRegionFilter: (regionValue: RegionsAndAll) => void;
+  saving: boolean;
 }
 
 interface DataFromServer<T extends Test> {
@@ -88,6 +89,7 @@ const TestEditor = <T extends Test>(
     const [editedTestName, setEditedTestName] = useState<string | null>(null);
     const [editedTestIsValid, setEditedTestIsValid] = useState<boolean>(true);
     const [lockStatus, setLockStatus] = useState<LockStatus>({ locked: false });
+    const [saving, setSaving] = useState<boolean>(false);
 
     const [regionFilter, setRegionFilter] = useState<RegionsAndAll>('ALL');
 
@@ -123,8 +125,11 @@ const TestEditor = <T extends Test>(
         },
       };
 
+      setSaving(true);
+
       return saveFrontendSettings(settingsType, postData)
         .then(resp => {
+          setSaving(false);
           if (!resp.ok) {
             resp.text().then(msg => alert(msg));
           }
@@ -313,6 +318,7 @@ const TestEditor = <T extends Test>(
               editMode={editMode}
               regionFilter={regionFilter}
               setRegionFilter={setRegionFilter}
+              saving={saving}
             />
           </>
         ) : (

--- a/public/src/components/channelManagement/testsFormLayout.tsx
+++ b/public/src/components/channelManagement/testsFormLayout.tsx
@@ -49,6 +49,7 @@ interface Props {
   requestLock: () => void;
   save: () => void;
   cancel: () => void;
+  saving: boolean;
 }
 
 const TestsFormLayout: React.FC<Props> = ({
@@ -62,6 +63,7 @@ const TestsFormLayout: React.FC<Props> = ({
   requestTakeControl,
   requestLock,
   lockStatus,
+  saving,
 }: Props) => {
   const classes = useStyles();
 
@@ -93,6 +95,7 @@ const TestsFormLayout: React.FC<Props> = ({
         requestLock={requestLock}
         save={save}
         cancel={cancel}
+        saving={saving}
       />
     </>
   );


### PR DESCRIPTION
Currently in the channel test tools there is no UI feedback after clicking the save button until the save completes.
This PR changes the button to say "Saving..."
![Screen Shot 2022-05-12 at 08 47 31](https://user-images.githubusercontent.com/1513454/168019541-faddea05-aebc-4672-88bf-d6681b71b8bc.png)

I've implemented this by adding a new `saving` boolean state to the `TestEditor` higher-order component.

Saving tests may get a bit slower during the dynamodb migration while we write all tests to S3 + dynamo.