### PR TITLE
Improve RRCP test variant 'live' previews

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -211,7 +211,11 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
         />
       }
       variantPreview={
-        <EpicVariantPreview variant={variant} moduleName={epicEditorConfig.moduleName} />
+        epicEditorConfig.allowVariantPreview ? (
+          <EpicVariantPreview variant={variant} moduleName={epicEditorConfig.moduleName} />
+        ) : (
+          undefined
+        )
       }
     />
   );

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -14,31 +14,38 @@ export interface ArticleCounts {
 }
 
 // Choice card TS defs and object generation
-interface ChoiceCardAmounts {
+// - Matches the TS set out in SDC file `/packages/shared/src/types/abTests/epic.ts`
+interface AmountSelection {
   amounts: number[];
   defaultAmount: number;
 }
 
-interface ChoiceCardVariant {
+type ContributionAmounts = {
+  [index: string]: AmountSelection;
+};
+
+interface AmountsTestVariant {
   name: string;
-  amounts: {
-    [index: string]: ChoiceCardAmounts;
-  };
+  amounts: ContributionAmounts;
 }
 
-interface RegionalChoiceCard {
-  control: {
-    [index: string]: ChoiceCardAmounts;
-  };
-  test: {
-    name: string;
-    isLive: boolean;
-    variants: ChoiceCardVariant[];
-    seed: number;
-  };
+interface AmountsTest {
+  name: string;
+  isLive: boolean;
+  variants: AmountsTestVariant[];
+  seed: number;
 }
 
-const generateChoiceCardObject = (): ChoiceCardAmounts => {
+type ConfiguredRegionAmounts = {
+  control: ContributionAmounts;
+  test?: AmountsTest;
+};
+
+type ChoiceCardAmounts = {
+  [index: string]: ConfiguredRegionAmounts;
+};
+
+const generateChoiceCardObject = (): AmountSelection => {
   return {
     amounts: [30, 60, 120, 240],
     defaultAmount: 60,
@@ -53,7 +60,7 @@ const generateChoiceCardAmounts = () => {
   };
 };
 
-const generateRegionalChoiceCard = (name: string): RegionalChoiceCard => {
+const generateRegionalChoiceCard = (name: string): ConfiguredRegionAmounts => {
   return {
     control: generateChoiceCardAmounts(),
     test: {
@@ -89,9 +96,7 @@ interface ShowReminderFields {
 
 // Extend EpicVariant to include choice cards and tickers
 interface EpicVariantWithAdditionalData extends EpicVariant {
-  choiceCardAmounts: {
-    [index: string]: RegionalChoiceCard;
-  };
+  choiceCardAmounts: ChoiceCardAmounts;
   tickerSettings?: TickerSettingsWithData;
   showReminderFields?: ShowReminderFields;
 }
@@ -132,11 +137,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
 
     separateArticleCount: variant.separateArticleCount,
 
-    // There's some weird stuff going on around the sign-in link
-    // - we have an 'enable sign-in link' checkbox in RRCP
-    // - but no indication that the checkbox setting gets set in variant data
-    // - for now, always show the link for the purposes of LIVE preview
-    showSignInLink: true,
+    showSignInLink: variant.showSignInLink,
 
     image: variant.image,
 

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -10,8 +10,70 @@ export interface ArticleCounts {
   forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
 }
 
+interface ChoiceCardAmounts {
+  amounts: number[];
+  defaultAmount: number;
+}
+
+interface ChoiceCardVariant {
+  name: string;
+  amounts: {
+    [index: string]: ChoiceCardAmounts;
+  };
+}
+
+interface RegionalChoiceCard {
+  control: {
+    [index: string]: ChoiceCardAmounts;
+  };
+  test: {
+    name: string;
+    isLive: boolean;
+    variants: ChoiceCardVariant[];
+    seed: number;
+  };
+}
+
+interface EpicVariantWithChoiceCard extends EpicVariant {
+  choiceCardAmounts: {
+    [index: string]: RegionalChoiceCard;
+  };
+}
+
+const generateChoiceCardObject = (): ChoiceCardAmounts => {
+  return {
+    amounts: [30, 60, 120, 240],
+    defaultAmount: 60,
+  };
+};
+
+const generateChoiceCardAmounts = () => {
+  return {
+    ONE_OFF: generateChoiceCardObject(),
+    MONTHLY: generateChoiceCardObject(),
+    ANNUAL: generateChoiceCardObject(),
+  };
+};
+
+const generateRegionalChoiceCard = (name: string): RegionalChoiceCard => {
+  return {
+    control: generateChoiceCardAmounts(),
+    test: {
+      name,
+      isLive: false,
+      variants: [
+        {
+          name: 'V2_LOWER',
+          amounts: generateChoiceCardAmounts(),
+        },
+      ],
+      seed: 917618,
+    },
+  };
+};
+
 interface EpicProps {
-  variant: EpicVariant;
+  variant: EpicVariantWithChoiceCard;
   tracking: {
     ophanPageId: string;
     platformId: string;
@@ -40,6 +102,16 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     separateArticleCount: variant.separateArticleCount,
     showSignInLink: variant.showSignInLink,
     image: variant.image,
+    showChoiceCards: variant.showChoiceCards,
+    choiceCardAmounts: {
+      GBPCountries: generateRegionalChoiceCard('2021-09-02_AMOUNTS_R5__UK'),
+      UnitedStates: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__US'),
+      EURCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__EU'),
+      AUDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__AU'),
+      International: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__INT'),
+      NZDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__NZ'),
+      Canada: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__CA'),
+    },
   },
   tracking: {
     ophanPageId: 'ophanPageId',

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -114,8 +114,18 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     paragraphs: variant.paragraphs,
     highlightedText: variant.highlightedText,
     cta: variant.cta,
+
+    // Secondary CTA needs to have additional data added to it - like done for ticker
+    secondaryCta: variant.secondaryCta,
+
     separateArticleCount: variant.separateArticleCount,
-    showSignInLink: variant.showSignInLink,
+
+    // There's some weird stuff going on around the sign-in link
+    // - we have an 'enable sign-in link' checkbox in RRCP
+    // - but no indication that the checkbox setting gets set in variant data
+    // - for now, always show the link for the purposes of LIVE preview
+    showSignInLink: true,
+
     image: variant.image,
     showChoiceCards: variant.showChoiceCards,
     choiceCardAmounts: {

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Theme, makeStyles } from '@material-ui/core';
 import { EpicVariant } from './epicTestsForm';
 
-import { EpicModuleName } from '../helpers/shared';
+import { EpicModuleName, TickerSettings } from '../helpers/shared';
 import { useModule } from '../../../hooks/useModule';
 
 // Article count TS defs
@@ -70,33 +70,13 @@ const generateRegionalChoiceCard = (name: string): RegionalChoiceCard => {
   };
 };
 
-// Ticker TS defs
-enum TickerEndType {
-  unlimited = 'unlimited',
-  hardstop = 'hardstop', // currently unsupported
-}
-
-enum TickerCountType {
-  money = 'money',
-  people = 'people',
-}
-
-interface TickerCopy {
-  countLabel: string;
-  goalReachedPrimary: string;
-  goalReachedSecondary: string;
-}
-
+// Ticker additional TS defs
 interface TickerData {
   total: number;
   goal: number;
 }
 
-interface TickerSettings {
-  endType: TickerEndType;
-  countType: TickerCountType;
-  currencySymbol: string;
-  copy: TickerCopy;
+interface TickerSettingsWithData extends TickerSettings {
   tickerData?: TickerData;
 }
 
@@ -105,7 +85,7 @@ interface EpicVariantWithAdditionalData extends EpicVariant {
   choiceCardAmounts: {
     [index: string]: RegionalChoiceCard;
   };
-  tickerSettings: TickerSettings;
+  tickerSettings?: TickerSettingsWithData;
 }
 
 interface EpicProps {
@@ -133,7 +113,6 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     heading: variant.heading,
     paragraphs: variant.paragraphs,
     highlightedText: variant.highlightedText,
-    showTicker: variant.showTicker,
     cta: variant.cta,
     separateArticleCount: variant.separateArticleCount,
     showSignInLink: variant.showSignInLink,
@@ -148,20 +127,19 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
       NZDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__NZ'),
       Canada: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__CA'),
     },
-    tickerSettings: {
-      countType: TickerCountType.money,
-      endType: TickerEndType.unlimited,
-      currencySymbol: '£',
-      copy: {
-        countLabel: 'contributed',
-        goalReachedPrimary: "We've met our goal - thank you",
-        goalReachedSecondary: 'Contributions are still being accepted',
-      },
-      tickerData: {
-        total: 10000,
-        goal: 100000,
-      },
-    },
+    showTicker: variant.showTicker,
+    tickerSettings: variant.tickerSettings
+      ? {
+          countType: variant.tickerSettings.countType,
+          endType: variant.tickerSettings.endType,
+          currencySymbol: variant.tickerSettings.currencySymbol,
+          copy: variant.tickerSettings.copy,
+          tickerData: {
+            total: 50000,
+            goal: 100000,
+          },
+        }
+      : undefined,
   },
   tracking: {
     ophanPageId: 'ophanPageId',

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -5,11 +5,15 @@ import { EpicVariant } from './epicTestsForm';
 import { EpicModuleName } from '../helpers/shared';
 import { useModule } from '../../../hooks/useModule';
 
+// Article count TS defs
 export interface ArticleCounts {
-  for52Weeks: number; // The user's total article view count, which currently goes back as far as 52 weeks
-  forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
+  // The user's total article view count, which currently goes back as far as 52 weeks
+  for52Weeks: number;
+  // The user's article view count for the configured periodInWeeks
+  forTargetedWeeks: number;
 }
 
+// Choice card TS defs and object generation
 interface ChoiceCardAmounts {
   amounts: number[];
   defaultAmount: number;
@@ -31,12 +35,6 @@ interface RegionalChoiceCard {
     isLive: boolean;
     variants: ChoiceCardVariant[];
     seed: number;
-  };
-}
-
-interface EpicVariantWithChoiceCard extends EpicVariant {
-  choiceCardAmounts: {
-    [index: string]: RegionalChoiceCard;
   };
 }
 
@@ -72,8 +70,46 @@ const generateRegionalChoiceCard = (name: string): RegionalChoiceCard => {
   };
 };
 
+// Ticker TS defs
+enum TickerEndType {
+  unlimited = 'unlimited',
+  hardstop = 'hardstop', // currently unsupported
+}
+
+enum TickerCountType {
+  money = 'money',
+  people = 'people',
+}
+
+interface TickerCopy {
+  countLabel: string;
+  goalReachedPrimary: string;
+  goalReachedSecondary: string;
+}
+
+interface TickerData {
+  total: number;
+  goal: number;
+}
+
+interface TickerSettings {
+  endType: TickerEndType;
+  countType: TickerCountType;
+  currencySymbol: string;
+  copy: TickerCopy;
+  tickerData?: TickerData;
+}
+
+// Extend EpicVariant to include choice cards and tickers
+interface EpicVariantWithAdditionalData extends EpicVariant {
+  choiceCardAmounts: {
+    [index: string]: RegionalChoiceCard;
+  };
+  tickerSettings: TickerSettings;
+}
+
 interface EpicProps {
-  variant: EpicVariantWithChoiceCard;
+  variant: EpicVariantWithAdditionalData;
   tracking: {
     ophanPageId: string;
     platformId: string;
@@ -97,7 +133,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     heading: variant.heading,
     paragraphs: variant.paragraphs,
     highlightedText: variant.highlightedText,
-    showTicker: false,
+    showTicker: variant.showTicker,
     cta: variant.cta,
     separateArticleCount: variant.separateArticleCount,
     showSignInLink: variant.showSignInLink,
@@ -111,6 +147,20 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
       International: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__INT'),
       NZDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__NZ'),
       Canada: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__CA'),
+    },
+    tickerSettings: {
+      countType: TickerCountType.money,
+      endType: TickerEndType.unlimited,
+      currencySymbol: '£',
+      copy: {
+        countLabel: 'contributed',
+        goalReachedPrimary: "We've met our goal - thank you",
+        goalReachedSecondary: 'Contributions are still being accepted',
+      },
+      tickerData: {
+        total: 10000,
+        goal: 100000,
+      },
     },
   },
   tracking: {

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -80,12 +80,20 @@ interface TickerSettingsWithData extends TickerSettings {
   tickerData?: TickerData;
 }
 
+// Secondary CTA TS defs
+interface ShowReminderFields {
+  reminderCta: string;
+  reminderPeriod: string;
+  reminderLabel: string;
+}
+
 // Extend EpicVariant to include choice cards and tickers
 interface EpicVariantWithAdditionalData extends EpicVariant {
   choiceCardAmounts: {
     [index: string]: RegionalChoiceCard;
   };
   tickerSettings?: TickerSettingsWithData;
+  showReminderFields?: ShowReminderFields;
 }
 
 interface EpicProps {
@@ -115,8 +123,12 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     highlightedText: variant.highlightedText,
     cta: variant.cta,
 
-    // Secondary CTA needs to have additional data added to it - like done for ticker
     secondaryCta: variant.secondaryCta,
+    showReminderFields: {
+      reminderCta: 'Remind me in October',
+      reminderPeriod: '2021-10-01',
+      reminderLabel: 'October',
+    },
 
     separateArticleCount: variant.separateArticleCount,
 
@@ -127,6 +139,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     showSignInLink: true,
 
     image: variant.image,
+
     showChoiceCards: variant.showChoiceCards,
     choiceCardAmounts: {
       GBPCountries: generateRegionalChoiceCard('2021-09-02_AMOUNTS_R5__UK'),
@@ -137,6 +150,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
       NZDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__NZ'),
       Canada: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__CA'),
     },
+
     showTicker: variant.showTicker,
     tickerSettings: variant.tickerSettings
       ? {

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -45,6 +45,7 @@ export interface EpicEditorConfig {
   allowVariantTicker: boolean;
   allowVariantChoiceCards: boolean;
   allowVariantSignInLink: boolean;
+  allowVariantPreview: boolean;
   requireVariantHeader: boolean;
   moduleName: EpicModuleName;
 }
@@ -68,6 +69,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: true,
+  allowVariantPreview: true,
   requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'DOTCOM',
@@ -93,6 +95,7 @@ export const ARTICLE_EPIC_HOLDBACK_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: true,
+  allowVariantPreview: true,
   requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'DOTCOM',
@@ -117,6 +120,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: false,
   allowVariantChoiceCards: false,
   allowVariantSignInLink: false,
+  allowVariantPreview: true,
   requireVariantHeader: false,
   moduleName: 'ContributionsLiveblogEpic',
   platform: 'DOTCOM',
@@ -142,6 +146,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: false,
   allowVariantChoiceCards: false,
   allowVariantSignInLink: false,
+  allowVariantPreview: false,
   requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'APPLE_NEWS',
@@ -166,6 +171,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: false,
+  allowVariantPreview: false,
   requireVariantHeader: false,
   moduleName: 'ContributionsEpic',
   platform: 'AMP',

--- a/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
@@ -8,19 +8,22 @@ const BASE_ARTICLE_URL = {
   PROD: {
     DOTCOM:
       'https://theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
-    AMP: '',
+    AMP:
+      'https://amp.theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
     APPLE_NEWS: '',
   },
   CODE: {
     DOTCOM:
       'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
-    AMP: '',
+    AMP:
+      'https://amp.code.dev-theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-findshttps://amp.theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
     APPLE_NEWS: '',
   },
   DEV: {
     DOTCOM:
       'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
-    AMP: '',
+    AMP:
+      'https://amp.code.dev-theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
     APPLE_NEWS: '',
   },
 };
@@ -52,7 +55,7 @@ const TestEditorVariantSummaryWebPreviewButton: React.FC<TestEditorVariantSummar
   platform,
   isDisabled,
 }: TestEditorVariantSummaryPreviewButtonProps) => {
-  const isIncompatiblePlatform = ['AMP', 'APPLE_NEWS'].includes(platform);
+  const isIncompatiblePlatform = ['APPLE_NEWS'].includes(platform);
 
   const checkForDisabledButton = (): boolean => {
     if (isIncompatiblePlatform) {

--- a/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
@@ -16,7 +16,7 @@ const BASE_ARTICLE_URL = {
     DOTCOM:
       'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
     AMP:
-      'https://amp.code.dev-theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-findshttps://amp.theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
+      'https://amp.code.dev-theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
     APPLE_NEWS: '',
   },
   DEV: {

--- a/public/src/components/channelManagement/testVariantEditorWithPreviewTab.tsx
+++ b/public/src/components/channelManagement/testVariantEditorWithPreviewTab.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 
 interface TestVariantEditorProps {
   variantEditor: React.ReactElement;
-  variantPreview: React.ReactElement;
+  variantPreview?: React.ReactElement;
 }
 
 function TestVariantEditorWithPreviewTab({
@@ -45,12 +45,12 @@ function TestVariantEditorWithPreviewTab({
         aria-label="disabled tabs example"
       >
         <Tab label="Form" />
-        <Tab label="Preview" />
+        {variantPreview && <Tab label="Preview" />}
       </Tabs>
 
       <div>
         {value === 0 && variantEditor}
-        {value === 1 && variantPreview}
+        {value === 1 && variantPreview && variantPreview}
       </div>
     </div>
   );


### PR DESCRIPTION
## What does this change?
Existing 'live' preview functionality does not accurately display Banner and Epic test variants to the user - some critical parts of the tests are missing (eg choice cards). Marketing colleagues have to rely on the Web preview (where available) to capture screenshots of their work, which is inefficient and not particularly 'real-time live'.

This PR attempts to fix these issues for the various Epic channel 'live' previews. 

It also removes the 'live' preview panel in the AMP Epic channel, and enables the 'web' preview for that channel

### Screenshots

Epic LIVE preview:

<img width="905" alt="Screenshot 2022-05-17 at 13 34 57" src="https://user-images.githubusercontent.com/5357530/168817961-08a2b6eb-f25a-44b8-8d99-45c035f99181.png">

<img width="465" alt="Screenshot 2022-05-17 at 13 42 08" src="https://user-images.githubusercontent.com/5357530/168818132-a146d619-57b4-43d5-982c-455e5f7f1436.png">

AMP Epic channel page (live preview panel removed):

<img width="831" alt="Screenshot 2022-05-17 at 13 47 17" src="https://user-images.githubusercontent.com/5357530/168818371-c0144351-2798-4efc-927e-c3004ab5de13.png">

AMP Epic WEB preview enabled - preview result:

<img width="593" alt="Screenshot 2022-05-17 at 13 54 45" src="https://user-images.githubusercontent.com/5357530/168818565-75af7c66-bee8-4979-b233-f1b1f046011d.png">

