### PR TITLE
Fix epic holdback access

### DIFF
--- a/app/controllers/epic/EpicHoldbackTestsController.scala
+++ b/app/controllers/epic/EpicHoldbackTestsController.scala
@@ -29,7 +29,7 @@ class EpicHoldbackTestsController(
     dataObjectSettings = S3ObjectSettings(
       bucket = "gu-contributions-public",
       key = s"epic/$stage/${EpicHoldbackTestsController.name}.json",
-      publicRead = false,
+      publicRead = true,
       cacheControl = None,
       surrogateControl = None
     ),


### PR DESCRIPTION
Test config files are public in s3 (for historical reasons - dotcom used to fetch them directly).
Currently when the Holdback epic config is updated in S3, it removes read access. This doesn't affect SDC (which has full read permissions), but prevents the RRCP from reading the data again.

None of this is relevant once we've finished migrating to dynamodb...