### PR TITLE
Bump aws sdk version to 2.17.188

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.13.7"
 
 val circeVersion = "0.14.1"
-val awsVersion = "2.17.184"
+val awsVersion = "2.17.188"
 val zioVersion = "1.0.14"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
## What does this change?

This PR fixes an 'information exposure' vulnerability identified in the `io.netty:netty-common` library, which is used extensively by the AWS SDK suite of libraries. The recommended fix is to bump the SDK versions to 2.17.188 as they have updated their dependency on io.netty:netty-common to the latest fixed version

## Screenshots

<img width="1048" alt="Screenshot 2022-05-17 at 16 05 52" src="https://user-images.githubusercontent.com/5357530/168853672-cc3f6c29-f147-46d5-bce0-67748b8658d6.png">

<img width="789" alt="Screenshot 2022-05-17 at 16 37 23" src="https://user-images.githubusercontent.com/5357530/168853788-5893e3a8-f882-4044-98a0-03bc6ad4ed3e.png">


