### PR TITLE
Increase dynamodb capacity

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -213,8 +213,8 @@ Object {
           },
         ],
         "ProvisionedThroughput": Object {
-          "ReadCapacityUnits": 4,
-          "WriteCapacityUnits": 4,
+          "ReadCapacityUnits": 8,
+          "WriteCapacityUnits": 8,
         },
         "TableName": "support-admin-console-channel-tests-PROD",
         "Tags": Array [

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -27,8 +27,8 @@ export class AdminConsole extends GuStack {
     const table = new Table(this, id, {
       tableName: `support-admin-console-channel-tests-${this.stage}`,
       removalPolicy: RemovalPolicy.RETAIN,
-      readCapacity: 4,
-      writeCapacity: 4,
+      readCapacity: 8,
+      writeCapacity: 8,
       partitionKey: {
         name: 'channel',
         type: AttributeType.STRING,


### PR DESCRIPTION
I've noticed we're slightly exceeding the write capacity of 4 units/second. This is probably because the list of epic tests is huge and we're currently writing the whole lot when a user saves (in the long term this will not be the case).
The AWS sdk does automatically take care of retries if there's any throttling but I think it's good to have a correct capacity set.