### PR TITLE
Use on-demand billing for dynamodb during migration

### DIFF
--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 import models.{Channel, ChannelTest}
 import DynamoChannelTests._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, BatchWriteItemRequest, DeleteRequest, PutRequest, QueryRequest, WriteRequest}
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, BatchWriteItemRequest, DeleteRequest, PutRequest, QueryRequest, ReturnConsumedCapacity, WriteRequest}
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
 import zio.{ZEnv, ZIO}
 import zio.blocking.effectBlocking
@@ -56,6 +56,7 @@ class DynamoChannelTests(stage: String) extends StrictLogging {
         BatchWriteItemRequest
           .builder
           .requestItems(Map(tableName -> writeRequests.asJava).asJava)
+          .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
           .build()
 
       val result = client.batchWriteItem(batchWriteRequest)

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -202,6 +202,7 @@ Object {
             "AttributeType": "S",
           },
         ],
+        "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": Array [
           Object {
             "AttributeName": "channel",
@@ -212,10 +213,6 @@ Object {
             "KeyType": "RANGE",
           },
         ],
-        "ProvisionedThroughput": Object {
-          "ReadCapacityUnits": 8,
-          "WriteCapacityUnits": 8,
-        },
         "TableName": "support-admin-console-channel-tests-PROD",
         "Tags": Array [
           Object {

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -13,7 +13,7 @@ import {
 import type { App, CfnElement } from 'aws-cdk-lib';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
-import { BillingMode } from 'aws-cdk-lib/aws-dynamodb/lib/table';
+import { BillingMode } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
 export interface AdminConsoleProps extends GuStackProps {

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -13,6 +13,7 @@ import {
 import type { App, CfnElement } from 'aws-cdk-lib';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { BillingMode } from 'aws-cdk-lib/aws-dynamodb/lib/table';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
 export interface AdminConsoleProps extends GuStackProps {
@@ -27,8 +28,8 @@ export class AdminConsole extends GuStack {
     const table = new Table(this, id, {
       tableName: `support-admin-console-channel-tests-${this.stage}`,
       removalPolicy: RemovalPolicy.RETAIN,
-      readCapacity: 8,
-      writeCapacity: 8,
+      // Use on-demand billing during migration from S3, because we have infrequent spikes when users click save. We can switch to provisioned after
+      billingMode: BillingMode.PAY_PER_REQUEST,
       partitionKey: {
         name: 'channel',
         type: AttributeType.STRING,


### PR DESCRIPTION
We are in the process of migrating from S3 to dynamodb for channel tests data.
While this is happening, we're batch writing updates for all tests in a channel when a user clicks save. In the long term we can just update the test that a user has changed.
Because of this, the writes to dynamo use a lot of capacity units when a user clicks save. This is infrequent, but can use hundreds of units at a time:
![Screen Shot 2022-05-23 at 15 17 51](https://user-images.githubusercontent.com/1513454/169985613-a1fd1a21-8f8d-4800-86c7-528c22d7f5b0.png)

This PR switches to on-demand rather than provisioned capacity. We can go back to provisioned when the migration is over, and we have more predictable writes.

Docs: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html