### PR TITLE
Point-in-time backups

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -213,6 +213,9 @@ Object {
             "KeyType": "RANGE",
           },
         ],
+        "PointInTimeRecoverySpecification": Object {
+          "PointInTimeRecoveryEnabled": true,
+        },
         "TableName": "support-admin-console-channel-tests-PROD",
         "Tags": Array [
           Object {

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -12,8 +12,7 @@ import {
 } from '@guardian/cdk/lib/constructs/iam';
 import type { App, CfnElement } from 'aws-cdk-lib';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
-import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
-import { BillingMode } from 'aws-cdk-lib/aws-dynamodb';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
 export interface AdminConsoleProps extends GuStackProps {

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -28,6 +28,7 @@ export class AdminConsole extends GuStack {
     const table = new Table(this, id, {
       tableName: `support-admin-console-channel-tests-${this.stage}`,
       removalPolicy: RemovalPolicy.RETAIN,
+      pointInTimeRecovery: this.stage === 'PROD',
       // Use on-demand billing during migration from S3, because we have infrequent spikes when users click save. We can switch to provisioned after
       billingMode: BillingMode.PAY_PER_REQUEST,
       partitionKey: {


### PR DESCRIPTION
This PR enables continuous backups in PROD only.
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html
The table isn't very write-heavy so I don't expect this to cost much, but I'll keep any eye on this