### PR TITLE
Preview all epic variants

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -31,6 +31,7 @@ import {
   ControlProportionSettings,
 } from '../helpers/controlProportionSettings';
 import { useStyles } from '../helpers/testEditorStyles';
+import { EpicTestPreviewButton } from './epicTestPreview';
 
 const copyHasTemplate = (test: EpicTest, template: string): boolean =>
   test.variants.some(
@@ -235,12 +236,17 @@ const EpicTestEditor: React.FC<EpicTestEditorProps> = ({
       <div className={classes.headerAndSwitchContainer}>
         <TestEditorHeader name={test.name} nickname={test.nickname} />
 
-        <LiveSwitch
-          label="Live on Guardian.com"
-          isLive={test.isOn}
-          isDisabled={!editMode}
-          onChange={onLiveSwitchChange}
-        />
+        <div className={classes.switchContainer}>
+          <LiveSwitch
+            label="Live on Guardian.com"
+            isLive={test.isOn}
+            isDisabled={!editMode}
+            onChange={onLiveSwitchChange}
+          />
+          <div>
+            <EpicTestPreviewButton test={test} />
+          </div>
+        </div>
       </div>
 
       {epicEditorConfig.allowMultipleVariants && (

--- a/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
@@ -38,13 +38,7 @@ export const EpicTestPreviewButton: React.FC<EpicTestPreviewProps> = ({
         Preview all variants
       </Button>
 
-      <Dialog
-        open={isOpen}
-        onClose={close}
-        fullWidth
-        maxWidth="xl"
-        className={classes.dialog}
-      >
+      <Dialog open={isOpen} onClose={close} fullWidth maxWidth="xl" className={classes.dialog}>
         <div className={classes.variantPreviewsContainer}>
           {test.variants.map(variant => (
             <div

--- a/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Button, Dialog, makeStyles, Theme, Typography } from '@material-ui/core';
+import { EpicTest } from './epicTestsForm';
+import useOpenable from '../../../hooks/useOpenable';
+import EpicVariantPreview from './epicVariantPreview';
+
+const useStyles = makeStyles(({}: Theme) => ({
+  dialog: {
+    padding: '10px',
+  },
+  variantPreviewsContainer: {
+    display: 'flex',
+    margin: '5px',
+  },
+  variantPreviewContainer: {
+    margin: '5px',
+  },
+  variantName: {
+    marginBottom: '10px',
+    fontSize: 26,
+    fontWeight: 500,
+  },
+}));
+
+interface EpicTestPreviewProps {
+  test: EpicTest;
+}
+
+export const EpicTestPreviewButton: React.FC<EpicTestPreviewProps> = ({
+  test,
+}: EpicTestPreviewProps) => {
+  const classes = useStyles();
+  const [isOpen, open, close] = useOpenable();
+
+  return (
+    <>
+      <Button variant="outlined" onClick={open}>
+        Preview all variants
+      </Button>
+
+      <Dialog
+        open={isOpen}
+        onClose={close}
+        fullWidth
+        maxWidth="xl"
+        className={classes.dialog}
+      >
+        <div className={classes.variantPreviewsContainer}>
+          {test.variants.map(variant => (
+            <div
+              className={classes.variantPreviewContainer}
+              key={`variant-preview-${variant.name}`}
+            >
+              <Typography variant={'h3'} className={classes.variantName}>
+                {variant.name}
+              </Typography>
+              <EpicVariantPreview variant={variant} moduleName="ContributionsEpic" />
+            </div>
+          ))}
+        </div>
+      </Dialog>
+    </>
+  );
+};

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -188,7 +188,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
 
 const useStyles = makeStyles(({}: Theme) => ({
   container: {
-    maxWidth: '620px',
+    width: '620px',
   },
 }));
 

--- a/public/src/components/channelManagement/helpers/testEditorStyles.ts
+++ b/public/src/components/channelManagement/helpers/testEditorStyles.ts
@@ -17,6 +17,10 @@ export const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
       marginTop: spacing(2),
     },
   },
+  switchContainer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
   sectionContainer: {
     paddingTop: spacing(1),
     paddingBottom: spacing(6),


### PR DESCRIPTION
Adds a button at the top of the epic editor to live preview all variants at once in a modal.
Primarily to help Marketing to screenshot variants before going live.

TODO - get UX feedback
Other things to consider:
- ability to easily preview across breakpoints
- campaigns page
- banner previews?

![Screen Shot 2022-05-25 at 13 58 19](https://user-images.githubusercontent.com/1513454/170267674-15735552-4bd4-49d6-bab6-537e4ffbf1bd.png)
![Screen Shot 2022-05-25 at 13 58 35](https://user-images.githubusercontent.com/1513454/170267679-e078fa98-cfeb-47a6-9eba-8155daa209eb.png)
