### PR TITLE
Local dynamodb tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 .metals/
 .bsp/
 project
+dynamodb-local/

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -25,15 +25,9 @@ object DynamoChannelTests {
   }
 }
 
-class DynamoChannelTests(stage: String) extends StrictLogging {
+class DynamoChannelTests(stage: String, client: DynamoDbClient) extends StrictLogging {
 
   private val tableName = s"support-admin-console-channel-tests-$stage"
-
-  private val client = DynamoDbClient
-    .builder
-    .region(Aws.region)
-    .credentialsProvider(Aws.credentialsProvider.build)
-    .build
 
   private def getAll(channel: Channel): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
     effectBlocking {

--- a/build.sbt
+++ b/build.sbt
@@ -29,11 +29,10 @@ libraryDependencies ++= Seq(
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )
 
-startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value
-test in Test := (test in Test).dependsOn(startDynamoDBLocal).value
-testOnly in Test := (testOnly in Test).dependsOn(startDynamoDBLocal).evaluated
-testOptions in Test += dynamoDBLocalTestCleanup.value
-
+startDynamoDBLocal := {startDynamoDBLocal.dependsOn(Test / compile).value}
+Test / testQuick := {(Test / testQuick).dependsOn(startDynamoDBLocal).evaluated}
+Test / test := {(Test / test).dependsOn(startDynamoDBLocal).value}
+Test / testOptions += {dynamoDBLocalTestCleanup.value}
 
 sources in(Compile, doc) := Seq.empty
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,12 @@ libraryDependencies ++= Seq(
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )
 
+startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value
+test in Test := (test in Test).dependsOn(startDynamoDBLocal).value
+testOnly in Test := (testOnly in Test).dependsOn(startDynamoDBLocal).evaluated
+testOptions in Test += dynamoDBLocalTestCleanup.value
+
+
 sources in(Compile, doc) := Seq.empty
 
 publishArtifact in(Compile, packageDoc) := false

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ libraryDependencies ++= Seq(
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )
 
+dynamoDBLocalPort := 8083
 startDynamoDBLocal := {startDynamoDBLocal.dependsOn(Test / compile).value}
 Test / testQuick := {(Test / testQuick).dependsOn(startDynamoDBLocal).evaluated}
 Test / test := {(Test / test).dependsOn(startDynamoDBLocal).value}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.5" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -19,7 +19,7 @@ class DynamoChannelTestsSpec extends AnyFlatSpec with Matchers {
     .builder
     .region(Aws.region)
     .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("id", "secret")))
-    .endpointOverride(new URI("http://localhost:8000"))
+    .endpointOverride(new URI("http://localhost:8083"))
     .build
 
   private val dynamo = new DynamoChannelTests(stage, client)

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -1,7 +1,7 @@
 package services
 
 import models.{Channel, EpicTest, Status}
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, Bill
 
 import java.net.URI
 
-class DynamoChannelTestsSpec extends AnyFlatSpec with Matchers {
+class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers {
   private val stage = "TEST"
   private val runtime = zio.Runtime.default
 
@@ -60,18 +60,18 @@ class DynamoChannelTestsSpec extends AnyFlatSpec with Matchers {
   )
 
   it should "create and then fetch epic tests" in {
-    val result = runtime.unsafeRunSync {
+    val result = runtime.unsafeRunToFuture {
       for {
         _ <- dynamo.replaceChannelTests(epicTests, Channel.Epic)
         tests <- dynamo.getAllTests(Channel.Epic)
       } yield tests
 
     }
-    result.toEither should be(Right(epicTests))
+    result.map(tests => tests should be(epicTests))
   }
 
   it should "create and then delete epic tests" in {
-    val result = runtime.unsafeRunSync {
+    val result = runtime.unsafeRunToFuture {
       for {
         _ <- dynamo.replaceChannelTests(epicTests, Channel.Epic)
         _ <- dynamo.deleteTests(epicTests.map(_.name), Channel.Epic)
@@ -79,6 +79,6 @@ class DynamoChannelTestsSpec extends AnyFlatSpec with Matchers {
       } yield tests
 
     }
-    result.toEither should be(Right(Nil))
+    result.map(tests => tests should be(Nil))
   }
 }

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -1,0 +1,84 @@
+package services
+
+import models.{Channel, EpicTest, Status}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import models.EpicTest._
+import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, BillingMode, CreateTableRequest, KeySchemaElement, KeyType}
+
+import java.net.URI
+
+class DynamoChannelTestsSpec extends AnyFlatSpec with Matchers {
+  private val stage = "TEST"
+  private val runtime = zio.Runtime.default
+
+  // Use a local instance of dynamodb, available via the sbt-dynamodb plugin
+  private val client = DynamoDbClient
+    .builder
+    .region(Aws.region)
+    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("id", "secret")))
+    .endpointOverride(new URI("http://localhost:8000"))
+    .build
+
+  private val dynamo = new DynamoChannelTests(stage, client)
+
+  // Create a channel-tests table
+  client.createTable(
+    CreateTableRequest
+      .builder
+      .tableName(s"support-admin-console-channel-tests-$stage")
+      .attributeDefinitions(
+        AttributeDefinition.builder.attributeName("channel").attributeType("S").build,
+        AttributeDefinition.builder.attributeName("name").attributeType("S").build
+      )
+      .keySchema(
+        KeySchemaElement.builder.attributeName("channel").keyType(KeyType.HASH).build,
+        KeySchemaElement.builder.attributeName("name").keyType(KeyType.RANGE).build
+      )
+      .billingMode(BillingMode.PAY_PER_REQUEST)
+      .build
+  )
+
+  def buildEpic(name: String, priority: Int): EpicTest =
+    EpicTest(
+      name = name,
+      nickname = Some(name),
+      isOn = true,
+      status = Some(Status.Live),
+      channel = Some(Channel.Epic),
+      lockStatus = None,
+      priority = Some(priority),
+      maxViews = None,
+      variants = Nil
+    )
+
+  val epicTests = List(
+    buildEpic("test1", 0),
+    buildEpic("test2", 1)
+  )
+
+  it should "create and then fetch epic tests" in {
+    val result = runtime.unsafeRunSync {
+      for {
+        _ <- dynamo.replaceChannelTests(epicTests, Channel.Epic)
+        tests <- dynamo.getAllTests(Channel.Epic)
+      } yield tests
+
+    }
+    result.toEither should be(Right(epicTests))
+  }
+
+  it should "create and then delete epic tests" in {
+    val result = runtime.unsafeRunSync {
+      for {
+        _ <- dynamo.replaceChannelTests(epicTests, Channel.Epic)
+        _ <- dynamo.deleteTests(epicTests.map(_.name), Channel.Epic)
+        tests <- dynamo.getAllTests(Channel.Epic)
+      } yield tests
+
+    }
+    result.toEither should be(Right(Nil))
+  }
+}


### PR DESCRIPTION
we recently introduced dynamodb for storing channel tests.
This PR adds some basic tests, run against a local instance of dynamodb.

Note - we already have a DEV version of the dynamodb table for use when _running_ the app locally.
For running unit tests against a local dynamodb instance I've gone with the `sbt-dynamodb` plugin, which is fairly common at the Guardian. The alternative would probably be using docker, but I think it's simpler to stick with sbt for unit tests.