### PR TITLE
Add campaign name field to tests

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -56,7 +56,8 @@ case class BannerTest(
   variants: List[BannerVariant],
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
-  deviceType: Option[DeviceType] = None
+  deviceType: Option[DeviceType] = None,
+  campaignName: Option[String]
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest = this.copy(channel = Some(channel))

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -57,7 +57,7 @@ case class BannerTest(
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String]
+  campaignName: Option[String] = None
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest = this.copy(channel = Some(channel))

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -38,6 +38,7 @@ trait ChannelTest[T] {
   val status: Option[Status]
   val lockStatus: Option[LockStatus]
   val priority: Option[Int] // 0 is top priority
+  val campaignName: Option[String]
 
   def withChannel(channel: Channel): T
   def withPriority(priority: Int): T

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -86,7 +86,7 @@ case class EpicTest(
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String]
+  campaignName: Option[String] = None
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -85,7 +85,8 @@ case class EpicTest(
   useLocalViewLog: Boolean = false,
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
-  deviceType: Option[DeviceType] = None
+  deviceType: Option[DeviceType] = None,
+  campaignName: Option[String]
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -30,7 +30,7 @@ case class HeaderTest(
   variants: List[HeaderVariant],
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String]
+  campaignName: Option[String] = None
 ) extends ChannelTest[HeaderTest] {
 
   override def withChannel(channel: Channel): HeaderTest = this.copy(channel = Some(channel))

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -29,7 +29,8 @@ case class HeaderTest(
   userCohort: Option[UserCohort] = None,
   variants: List[HeaderVariant],
   controlProportionSettings: Option[ControlProportionSettings] = None,
-  deviceType: Option[DeviceType] = None
+  deviceType: Option[DeviceType] = None,
+  campaignName: Option[String]
 ) extends ChannelTest[HeaderTest] {
 
   override def withChannel(channel: Channel): HeaderTest = this.copy(channel = Some(channel))

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -25,6 +25,7 @@ export interface Test {
   variants: Variant[];
   locations: Region[];
   isNew?: boolean; // true if test has not yet been POSTed to backend
+  campaignName?: string;
 }
 
 export interface EpicEditorConfig {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -52,4 +52,5 @@ export interface BannerTest extends Test {
   articlesViewedSettings?: ArticlesViewedSettings;
   controlProportionSettings?: ControlProportionSettings;
   deviceType?: DeviceType;
+  campaignName?: string;
 }

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -79,4 +79,5 @@ export interface EpicTest extends Test {
   articlesViewedSettings?: ArticlesViewedSettings;
   controlProportionSettings?: ControlProportionSettings;
   deviceType?: DeviceType;
+  campaignName?: string;
 }

--- a/public/src/models/header.ts
+++ b/public/src/models/header.ts
@@ -32,4 +32,5 @@ export interface HeaderTest extends Test {
   variants: HeaderVariant[];
   controlProportionSettings?: ControlProportionSettings;
   deviceType?: DeviceType;
+  campaignName?: string;
 }


### PR DESCRIPTION
## What does this change?

This adds a `campaignName` optional string field to banner, epic and header tests.
