### PR TITLE
Set campaign field

### DIFF
--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -114,7 +114,7 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
     return '';
   };
 
-  const addPrefix = (name: string): string => `${name}${buildPrefix()}`;
+  const addPrefix = (name: string): string => `${buildPrefix()}${name}`;
 
   const doubleUnderscoresValidator = (s: string): string | undefined => {
     const count = (s.match(/__/g) || []).length;

--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -116,6 +116,7 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
 
   const addPrefix = (name: string): string => `${buildPrefix()}${name}`;
 
+  // There should only be one instance of a double-underscore, as this is used by the AB tests dashboard to group together tests with a common prefix
   const doubleUnderscoresValidator = (s: string): string | undefined => {
     const count = (s.match(/__/g) || []).length;
     if (count < 2) {

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -28,11 +28,10 @@ export const DUPLICATE_ERROR_HELPER_TEXT = 'Name already exists - please try ano
 
 export const createDuplicateValidator = (
   existing: string[],
-  testNamePrefix?: string,
 ): ((text: string) => string | undefined) => {
   const existingLowerCased = existing.map(value => value.toLowerCase());
   return (text: string): string | undefined => {
-    if (existingLowerCased.includes(`${testNamePrefix || ''}${text}`.toLowerCase())) {
+    if (existingLowerCased.includes(text.toLowerCase())) {
       return DUPLICATE_ERROR_HELPER_TEXT;
     }
     return undefined;

--- a/public/src/components/channelManagement/newTestButton.tsx
+++ b/public/src/components/channelManagement/newTestButton.tsx
@@ -22,7 +22,7 @@ interface NewTestButtonProps {
   existingNames: string[];
   existingNicknames: string[];
   testNamePrefix?: string;
-  createTest: (name: string, nickname: string) => void;
+  createTest: (name: string, nickname: string, campaignName?: string) => void;
   disabled: boolean;
 }
 

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -54,7 +54,7 @@ interface SidebarProps<T extends Test> {
   onTestPriorityChange: (newPriority: number, oldPriority: number) => void;
   onTestSelected: (testName: string) => void;
   testNamePrefix?: string;
-  createTest: (name: string, nickname: string) => void;
+  createTest: (name: string, nickname: string, campaignName?: string) => void;
   onBatchTestArchive: (batchTestNames: string[]) => void;
   onTestListOrderSave: () => void;
   onTestListLock: (force: boolean) => void;

--- a/public/src/components/channelManagement/stickyTopBar/testCopyButton.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/testCopyButton.tsx
@@ -21,7 +21,12 @@ interface TestCopyButtonProps {
   sourceName: string;
   sourceNickname?: string;
   testNamePrefix?: string;
-  onTestCopy: (oldName: string, newName: string, newNickname: string) => void;
+  onTestCopy: (
+    oldName: string,
+    newName: string,
+    newNickname: string,
+    campaignName?: string,
+  ) => void;
   disabled: boolean;
 }
 
@@ -57,7 +62,9 @@ export const TestCopyButton: React.FC<TestCopyButtonProps> = ({
         sourceNickname={sourceNickname}
         testNamePrefix={testNamePrefix}
         mode="COPY"
-        createTest={(newName, newNickname) => onTestCopy(sourceName, newName, newNickname)}
+        createTest={(newName, newNickname, campaignName) =>
+          onTestCopy(sourceName, newName, newNickname, campaignName)
+        }
       />
     </>
   );

--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -171,7 +171,7 @@ export const TestsForm = <T extends Test>(
         });
     };
 
-    const onTestCreate = (name: string, nickname: string): void => {
+    const onTestCreate = (name: string, nickname: string, campaignName?: string): void => {
       const newTest: T = {
         ...createDefaultTest(name, nickname),
         isNew: true,
@@ -181,12 +181,18 @@ export const TestsForm = <T extends Test>(
           email: email,
           timestamp: new Date().toISOString(),
         },
+        campaignName,
       };
       setTests([...tests, newTest]);
       setSelectedTestName(name);
     };
 
-    const onTestCopy = (oldName: string, newName: string, newNickname: string): void => {
+    const onTestCopy = (
+      oldName: string,
+      newName: string,
+      newNickname: string,
+      campaignName?: string,
+    ): void => {
       const oldTest = tests.find(test => test.name === oldName);
       if (oldTest) {
         const newTest: T = {
@@ -202,6 +208,7 @@ export const TestsForm = <T extends Test>(
             timestamp: new Date().toISOString(),
           },
           isNew: true,
+          campaignName,
         };
         setTests([...tests, newTest]);
         setSelectedTestName(newName);


### PR DESCRIPTION
When creating/copying a test, the selected `campaignName` is now passed up to the `TestsForm.tsx` and sent to the server.

I've also added some additional validation to prevent users from accidentally adding multiple instances of `__` to a test name. There should only be one, as this is used by the AB tests dashboard to group together tests with a common prefix.