### PR TITLE
Endpoint to list tests in a campaign

### DIFF
--- a/app/controllers/CampaignsController.scala
+++ b/app/controllers/CampaignsController.scala
@@ -3,10 +3,27 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.Campaigns._
 import play.api.mvc.{AnyContent, ControllerComponents}
+import services.DynamoChannelTests
+import utils.Circe.noNulls
 import zio.ZEnv
+import io.circe.syntax._
+import models.ChannelTest.channelTestEncoder
 
 import scala.concurrent.ExecutionContext
 
-class CampaignsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class CampaignsController(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  stage: String,
+  runtime: zio.Runtime[ZEnv],
+  dynamo: DynamoChannelTests
+)(implicit ec: ExecutionContext)
   extends S3ObjectController[Campaigns](authAction, components, stage, filename = "campaigns.json", runtime) {
+
+  def getTests(campaignName: String) = authAction.async { request =>
+    run {
+      dynamo.getAllTestsInCampaign(campaignName)
+        .map(tests => Ok(noNulls(tests.asJson)))
+    }
+  }
 }

--- a/app/controllers/S3ObjectController.scala
+++ b/app/controllers/S3ObjectController.scala
@@ -34,9 +34,10 @@ abstract class S3ObjectController[T : Decoder : Encoder](
   )
   private val s3Client = services.S3
 
-  private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
+  protected def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
     runtime.unsafeRunToFuture {
       f.catchAll { error =>
+        logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
         IO.succeed(InternalServerError(error.getMessage))
       }
     }

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -1,17 +1,14 @@
 package models
 
-import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
-import scala.collection.immutable.IndexedSeq
 
 
-sealed trait BannerTemplate extends EnumEntry
-object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate] {
-  override val values: IndexedSeq[BannerTemplate] = findValues
-
+sealed trait BannerTemplate
+object BannerTemplate {
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate
   case object DigitalSubscriptionsBanner extends BannerTemplate
@@ -23,6 +20,10 @@ object BannerTemplate extends Enum[BannerTemplate] with CirceEnum[BannerTemplate
   case object PostElectionAuMomentAlbaneseBanner extends BannerTemplate
   case object PostElectionAuMomentHungBanner extends BannerTemplate
   case object PostElectionAuMomentMorrisonBanner extends BannerTemplate
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val bannerTemplateEncoder = deriveEnumerationEncoder[BannerTemplate]
+  implicit val bannerTemplateDecoder = deriveEnumerationDecoder[BannerTemplate]
 }
 
 case class BannerContent(
@@ -66,6 +67,6 @@ case class BannerTest(
 
 object BannerTest {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val bannerTestDecoder = Decoder[BannerTest]
-  implicit val bannerTestEncoder = Encoder[BannerTest]
+  implicit val bannerTestDecoder: Decoder[BannerTest] = deriveConfiguredDecoder[BannerTest]
+  implicit val bannerTestEncoder: Encoder[BannerTest] = deriveConfiguredEncoder[BannerTest]
 }

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -1,7 +1,9 @@
 package models
 
+import io.circe.Decoder.Result
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+import io.circe.generic.extras.semiauto.{deriveDecoder, deriveEnumerationDecoder, deriveEnumerationEncoder}
 
 sealed trait Status
 
@@ -42,4 +44,26 @@ trait ChannelTest[T] {
 
   def withChannel(channel: Channel): T
   def withPriority(priority: Int): T
+}
+
+object ChannelTest {
+  import Channel._
+
+  implicit def channelTestDecoder = new Decoder[ChannelTest[_]] {
+    override def apply(c: HCursor): Result[ChannelTest[_]] = {
+      c.downField("channel").as[Channel].flatMap {
+        case Header => HeaderTest.headerTestDecoder(c)
+        case Banner1 | Banner2 => BannerTest.bannerTestDecoder(c)
+        case epic => EpicTest.epicTestDecoder(c)
+      }
+    }
+  }
+
+  implicit def channelTestEncoder = new Encoder[ChannelTest[_]] {
+    override def apply(test: ChannelTest[_]): Json = test match {
+      case header: HeaderTest => HeaderTest.headerTestEncoder(header)
+      case banner: BannerTest => BannerTest.bannerTestEncoder(banner)
+      case epic: EpicTest => EpicTest.epicTestEncoder(epic)
+    }
+  }
 }

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -3,6 +3,7 @@ package models
 import enumeratum.{CirceEnum, Enum, EnumEntry}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable.IndexedSeq
@@ -95,6 +96,6 @@ case class EpicTest(
 
 object EpicTest {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val epicTestDecoder = Decoder[EpicTest]
-  implicit val epicTestEncoder = Encoder[EpicTest]
+  implicit val epicTestDecoder: Decoder[EpicTest] = deriveConfiguredDecoder[EpicTest]
+  implicit val epicTestEncoder: Encoder[EpicTest] = deriveConfiguredEncoder[EpicTest]
 }

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -2,6 +2,7 @@ package models
 
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
 case class HeaderContent(
@@ -39,6 +40,6 @@ case class HeaderTest(
 
 object HeaderTest {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val headerTestDecoder = Decoder[HeaderTest]
-  implicit val headerTestEncoder = Encoder[HeaderTest]
+  implicit val headerTestDecoder: Decoder[HeaderTest] = deriveConfiguredDecoder[HeaderTest]
+  implicit val headerTestEncoder: Encoder[HeaderTest] = deriveConfiguredEncoder[HeaderTest]
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -82,7 +82,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new BannerDeployController(authAction, controllerComponents, stage, runtime),
     new BannerDeployController2(authAction, controllerComponents, stage, runtime),
     new ChannelSwitchesController(authAction, controllerComponents, stage, runtime),
-    new CampaignsController(authAction, controllerComponents, stage, runtime),
+    new CampaignsController(authAction, controllerComponents, stage, runtime, dynamoTestsService),
     new CapiController(authAction, capiService),
     assets
   )

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -201,8 +201,30 @@ Object {
             "AttributeName": "name",
             "AttributeType": "S",
           },
+          Object {
+            "AttributeName": "campaignName",
+            "AttributeType": "S",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": Array [
+          Object {
+            "IndexName": "campaign-test-index",
+            "KeySchema": Array [
+              Object {
+                "AttributeName": "campaignName",
+                "KeyType": "HASH",
+              },
+              Object {
+                "AttributeName": "name",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": Object {
+              "ProjectionType": "ALL",
+            },
+          },
+        ],
         "KeySchema": Array [
           Object {
             "AttributeName": "channel",

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -209,7 +209,7 @@ Object {
         "BillingMode": "PAY_PER_REQUEST",
         "GlobalSecondaryIndexes": Array [
           Object {
-            "IndexName": "campaign-test-index",
+            "IndexName": "campaignName-name-index",
             "KeySchema": Array [
               Object {
                 "AttributeName": "campaignName",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -41,7 +41,7 @@ export class AdminConsole extends GuStack {
     });
 
     table.addGlobalSecondaryIndex({
-      indexName: 'campaign-test-index',
+      indexName: 'campaignName-name-index',
       projectionType: ProjectionType.ALL,
       partitionKey: {
         name: 'campaignName',

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -12,7 +12,7 @@ import {
 } from '@guardian/cdk/lib/constructs/iam';
 import type { App, CfnElement } from 'aws-cdk-lib';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
-import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { AttributeType, BillingMode, ProjectionType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
 export interface AdminConsoleProps extends GuStackProps {
@@ -32,6 +32,19 @@ export class AdminConsole extends GuStack {
       billingMode: BillingMode.PAY_PER_REQUEST,
       partitionKey: {
         name: 'channel',
+        type: AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'name',
+        type: AttributeType.STRING,
+      },
+    });
+
+    table.addGlobalSecondaryIndex({
+      indexName: 'campaign-test-index',
+      projectionType: ProjectionType.ALL,
+      partitionKey: {
+        name: 'campaignName',
         type: AttributeType.STRING,
       },
       sortKey: {

--- a/conf/routes
+++ b/conf/routes
@@ -36,7 +36,6 @@ POST  /support-frontend/contribution-types/update   controllers.ContributionType
 GET   /support-frontend/amounts                     controllers.AmountsController.get
 POST  /support-frontend/amounts/update              controllers.AmountsController.set
 
-
 # ----- Epic tests ----- #
 GET   /frontend/epic-tests                          controllers.epic.EpicTestsController.get
 # epic list endpoints
@@ -188,6 +187,7 @@ POST  /frontend/channel-switches/update                controllers.ChannelSwitch
 # ----- campaigns ----- #
 GET   /frontend/campaigns                              controllers.CampaignsController.get
 POST  /frontend/campaigns/update                       controllers.CampaignsController.set
+GET   /frontend/campaign/:campaignName/tests           controllers.CampaignsController.getTests(campaignName: String)
 
 # ----- capi ----- #
 GET   /capi/tags                                       controllers.CapiController.getTags()


### PR DESCRIPTION
1. adds a new index on (`campaignName`, `name`)
2. adds a GET endpoint for listing all tests in a campaign, ordered by channel
3. adds Decoder/Encoder for the `ChannelTest` trait. This is to validate the tests we get back from dynamodb. Arguably this is a bit excessive - we should be able to trust the data in dynamodb.