### PR TITLE
Include null values in dynamodb

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -58,7 +58,7 @@ case class BannerTest(
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = None
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN")
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest = this.copy(channel = Some(channel))

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -87,7 +87,7 @@ case class EpicTest(
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = None
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN")
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -31,7 +31,7 @@ case class HeaderTest(
   variants: List[HeaderVariant],
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = None
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN")
 ) extends ChannelTest[HeaderTest] {
 
   override def withChannel(channel: Channel): HeaderTest = this.copy(channel = Some(channel))

--- a/app/utils/Circe.scala
+++ b/app/utils/Circe.scala
@@ -18,7 +18,7 @@ object Circe {
 
   // Converts Circe Json to Dynamodb Attributes
   def jsonToDynamo(json: Json): AttributeValue =
-    json.deepDropNullValues.fold(
+    json.fold(
       jsonNull = AttributeValue.builder().nul(true).build,
       jsonBoolean = bool => AttributeValue.builder.bool(bool).build,
       jsonNumber = n => AttributeValue.builder.n(n.toString).build,


### PR DESCRIPTION
Bug: if a test has an optional field (e.g. `articlesViewedSettings`) set, and a user removes that field in the UI, then the backend does not remove it from dynamodb because null values are dropped during serialization.

The solution is to include null values.
There is the special case of `campaignName`, which is optional, but is defined in an index as a `string` and so cannot be written with `null`. I have changed the backend to write `NOT_IN_CAMPAIGN` for this field if it is not set.