### PR TITLE
Show campaign name on tests

### DIFF
--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -70,6 +70,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
 interface StickyTopBarProps {
   name: string;
   nickname?: string;
+  campaignName?: string;
   isNew: boolean;
   lockStatus: LockStatus;
   userHasTestLocked: boolean;
@@ -88,6 +89,7 @@ interface StickyTopBarProps {
 const StickyTopBar: React.FC<StickyTopBarProps> = ({
   name,
   nickname,
+  campaignName,
   isNew,
   lockStatus,
   userHasTestLocked,
@@ -104,13 +106,15 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
 }: StickyTopBarProps) => {
   const classes = useStyles();
   const mainHeader = nickname ? nickname : name;
+  const campaignHeader =
+    campaignName && campaignName !== 'NOT_IN_CAMPAIGN' ? `[${campaignName}]` : '';
   const secondaryHeader = nickname ? name : null;
 
   return (
     <header className={classes.container}>
       <div className={classes.namesContainer}>
         <Typography variant="h2" className={classes.mainHeader}>
-          {mainHeader}
+          {campaignHeader} {mainHeader}
         </Typography>
         <div className={classes.secondaryHeaderContainer}>
           <Typography className={classes.secondaryHeader}>{secondaryHeader}</Typography>

--- a/public/src/components/channelManagement/validatedTestEditor.tsx
+++ b/public/src/components/channelManagement/validatedTestEditor.tsx
@@ -69,6 +69,7 @@ export const ValidatedTestEditor = <T extends Test>(
         <StickyTopBar
           name={test.name}
           nickname={test.nickname}
+          campaignName={test.campaignName}
           isNew={!!test.isNew}
           lockStatus={test.lockStatus || { locked: false }}
           userHasTestLocked={userHasTestLocked}


### PR DESCRIPTION
## What does this change?

This adds the campaign name to the top bar of the test editor (if the test is in a campaign).

## Images

Test in a campaign
![Screenshot test in a campaign](https://user-images.githubusercontent.com/99180049/175558782-892c2591-bb99-4836-b16b-d755ee984fe4.png)

Test not in a campaign
![Screenshot test not in a campaign](https://user-images.githubusercontent.com/99180049/175558828-9ae6e406-9477-45e6-83fd-096a1dcf6a3a.png)
