### PR TITLE
list campaign channel tests - initial work

### DIFF
--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -111,13 +111,15 @@ function CampaignsEditor({ campaign }: CampaignsEditorProps): React.ReactElement
 
   useEffect(() => {
     fetchCampaignTests(name).then(tests => {
-      // sort by channel
-      // const sortedTests = tests.sort((a: CombinedTest, b: CombinedTest) => {
-      //   return testChannelOrder.indexOf(a.channel) - testChannelOrder.indexOf(b.channel);
-      // });
-      setTestData(tests);
+      // sort by priority
+      const sortedTests = tests.sort((a: CombinedTest, b: CombinedTest) => {
+        return a.priority - b.priority;
+      });
+      setTestData(sortedTests);
     });
   }, [campaign]);
+
+  console.log(testData);
 
   return (
     <div className={classes.testEditorContainer}>

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
 import StickyTopBar from './StickyCampaignBar';
 import { Campaign } from './CampaignsForm';
-import { CombinedTest } from './CampaignsForm';
+import { Test } from '../helpers/shared';
 import ChannelCard from './ChannelCard';
 import { fetchCampaignTests } from '../../../utils/requests';
 
@@ -105,21 +105,22 @@ const testChannelData: TestChannelData = {
 function CampaignsEditor({ campaign }: CampaignsEditorProps): React.ReactElement {
   const classes = useStyles();
 
-  const [testData, setTestData] = useState<CombinedTest[]>([]);
+  const [testData, setTestData] = useState<Test[]>([]);
 
   const { name, nickname, description } = campaign;
 
   useEffect(() => {
     fetchCampaignTests(name).then(tests => {
       // sort by priority
-      const sortedTests = tests.sort((a: CombinedTest, b: CombinedTest) => {
-        return a.priority - b.priority;
+      const sortedTests = tests.sort((a: Test, b: Test) => {
+        if (a.priority != null && b.priority != null) {
+          return a.priority - b.priority;
+        }
+        return 0;
       });
       setTestData(sortedTests);
     });
   }, [campaign]);
-
-  console.log(testData);
 
   return (
     <div className={classes.testEditorContainer}>

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { makeStyles, Theme, Typography } from '@material-ui/core';
 import StickyTopBar from './StickyCampaignBar';
 import { Campaign } from './CampaignsForm';
+import { fetchCampaignTests } from '../../../utils/requests';
+import { Link } from 'react-router-dom';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   testEditorContainer: {
@@ -24,11 +26,90 @@ interface CampaignsEditorProps {
   campaign: Campaign;
 }
 
-function CampaignsEditor({ campaign }: CampaignsEditorProps): React.ReactElement {
+/*
+  The closest we seem to come to a single source of truth for channel names 
+  appears to be in the /app/models/ChannelTest.scala file
+
+  case object Epic extends Channel
+  case object EpicAMP extends Channel
+  case object EpicAppleNews extends Channel
+  case object EpicLiveblog extends Channel
+  case object EpicHoldback extends Channel
+  case object Banner1 extends Channel
+  case object Banner2 extends Channel
+  case object Header extends Channel
+
+  For UX, best if we present tests in the same order as the list of channels 
+  shown in the hamburger menu and defined in the 
+  /public/src/components/drawer.tsx file
+
+  [...]
+  <ListItemText primary="Header" />
+  <ListItemText primary="Epic" />
+  <ListItemText primary="Epic Holdback" />
+  <ListItemText primary="Liveblog Epic" />
+  <ListItemText primary="Apple News Epic" />
+  <ListItemText primary="AMP Epic" />
+  <ListItemText primary="Banner 1" />
+  <ListItemText primary="Banner 2" />
+  [...]
+*/ 
+const testChannelOrder = ['Header', 'Epic', 'EpicHoldback', 'EpicLiveblog', 'EpicAppleNews', 'EpicAMP', 'Banner1', 'Banner2'];
+
+const testChannelLinks = {
+  'Header': '/header-tests', 
+  'Epic': '/epic-tests', 
+  'EpicHoldback': '/epic-holdback-tests', 
+  'EpicLiveblog': '/liveblog-epic-tests', 
+  'EpicAppleNews': '/apple-news-epic-tests', 
+  'EpicAMP': '/amp-epic-tests', 
+  'Banner1': '/banner-tests', 
+  'Banner2': '/banner-tests2'
+};
+
+function CampaignsEditor({ 
+  campaign 
+}: CampaignsEditorProps): React.ReactElement {
   const classes = useStyles();
+
+  const [testData, setTestData] = useState<any[]>([]);
 
   const { name, nickname, description } = campaign;
 
+  useEffect(() => {
+    fetchCampaignTests(name).then(tests => {
+
+      // sort by channel
+      const sortedTests = tests.sort((a: any, b: any) => {
+        return testChannelOrder.indexOf(a.channel) - testChannelOrder.indexOf(b.channel)
+      });
+
+      console.log(sortedTests);
+
+      setTestData(sortedTests);
+    });
+  }, [campaign]);
+
+  const testCard = (test: any) => {
+
+    const getVariantNames = (variants: any) => {
+      const vNames = variants.map(v => v.name);
+      return vNames.join(', ');
+    }
+
+    return (
+      <div>
+        <ul>
+          <li><Link key={`${test.channel}|${test.name}`} to={`${testChannelLinks[test.channel]}/${test.name}`}><b>Test:</b> {test.name}</Link></li>
+          <li><b>Channel:</b> {test.channel}</li>
+          <li><b>Cohort:</b> {test.userCohort}</li>
+          <li><b>Locations:</b> {test.locations.join(', ')}</li>
+          <li><b>Variants:</b> {getVariantNames(test.variants)}</li>
+          <li><b>Status:</b> {test.status}</li>
+        </ul>
+      </div>
+    )
+  }
   return (
     <div className={classes.testEditorContainer}>
       <StickyTopBar name={name} nickname={nickname} />
@@ -39,6 +120,8 @@ function CampaignsEditor({ campaign }: CampaignsEditorProps): React.ReactElement
         {nickname && <Typography>Nickname: {nickname}</Typography>}
 
         {description && <Typography>Description: {description}</Typography>}
+
+        {testData.map(t => testCard(t))}
       </div>
     </div>
   );

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
 import StickyTopBar from './StickyCampaignBar';
 import { Campaign } from './CampaignsForm';
+import { CombinedTest } from './CampaignsForm';
 import ChannelCard from './ChannelCard';
 import { fetchCampaignTests } from '../../../utils/requests';
 
@@ -46,7 +47,16 @@ interface CampaignsEditorProps {
   campaign: Campaign;
 }
 
-const testChannelOrder = ['Header', 'Epic', 'EpicHoldback', 'EpicLiveblog', 'EpicAppleNews', 'EpicAMP', 'Banner1', 'Banner2'];
+const testChannelOrder = [
+  'Header',
+  'Epic',
+  'EpicHoldback',
+  'EpicLiveblog',
+  'EpicAppleNews',
+  'EpicAMP',
+  'Banner1',
+  'Banner2',
+];
 
 export interface TestChannelItem {
   name: string;
@@ -58,57 +68,54 @@ export interface TestChannelData {
 }
 
 const testChannelData: TestChannelData = {
-  'Header': {
+  Header: {
     name: 'Header',
     link: '/header-tests',
-  }, 
-  'Epic': {
+  },
+  Epic: {
     name: 'Epic',
     link: '/epic-tests',
-  }, 
-  'EpicHoldback': {
+  },
+  EpicHoldback: {
     name: 'Epic Holdback',
     link: '/epic-holdback-tests',
-  }, 
-  'EpicLiveblog': {
+  },
+  EpicLiveblog: {
     name: 'Liveblog Epic',
     link: '/liveblog-epic-tests',
-  }, 
-  'EpicAppleNews': {
+  },
+  EpicAppleNews: {
     name: 'Apple News Epic',
     link: '/apple-news-epic-tests',
-  }, 
-  'EpicAMP': {
+  },
+  EpicAMP: {
     name: 'AMP Epic',
     link: '/amp-epic-tests',
-  }, 
-  'Banner1': {
+  },
+  Banner1: {
     name: 'Banner 1',
     link: '/banner-tests',
-  }, 
-  'Banner2': {
+  },
+  Banner2: {
     name: 'Banner 2',
     link: '/banner-tests2',
-  }, 
+  },
 };
 
-function CampaignsEditor({ 
-  campaign 
-}: CampaignsEditorProps): React.ReactElement {
+function CampaignsEditor({ campaign }: CampaignsEditorProps): React.ReactElement {
   const classes = useStyles();
 
-  const [testData, setTestData] = useState<any[]>([]);
+  const [testData, setTestData] = useState<CombinedTest[]>([]);
 
   const { name, nickname, description } = campaign;
 
   useEffect(() => {
     fetchCampaignTests(name).then(tests => {
-
       // sort by channel
-      const sortedTests = tests.sort((a: any, b: any) => {
-        return testChannelOrder.indexOf(a.channel) - testChannelOrder.indexOf(b.channel)
-      });
-      setTestData(sortedTests);
+      // const sortedTests = tests.sort((a: CombinedTest, b: CombinedTest) => {
+      //   return testChannelOrder.indexOf(a.channel) - testChannelOrder.indexOf(b.channel);
+      // });
+      setTestData(tests);
     });
   }, [campaign]);
 
@@ -121,10 +128,13 @@ function CampaignsEditor({
           <Button
             className={classes.launchLink}
             variant="outlined"
-            onClick={() => {}}
+            onClick={(): void => {
+              console.log('TODO: tests status modal');
+            }}
             disabled={true}
           >
-            Button to open the tests status manager modal - needs to move into sticky bar (top right corner)
+            Button to open the tests status manager modal - needs to move into sticky bar (top right
+            corner)
           </Button>
           <div className={classes.notesContainer}>
             <div className={classes.notesHeader}>Notes (will be an editable RTE field):</div>

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
 import StickyTopBar from './StickyCampaignBar';
 import { Campaign } from './CampaignsForm';
+import ChannelCard from './ChannelCard';
 import { fetchCampaignTests } from '../../../utils/requests';
-import { Link } from 'react-router-dom';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   testEditorContainer: {
@@ -20,51 +20,76 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     paddingRight: spacing(1),
     paddingTop: spacing(2),
   },
+  formContainer: {
+    marginBottom: spacing(4),
+    borderBottom: '1px solid black',
+  },
+  notesContainer: {
+    marginBottom: spacing(4),
+  },
+  notesHeader: {
+    marginBottom: spacing(2),
+    fontSize: '18px',
+    fontWeight: 500,
+  },
+  launchLink: {
+    padding: '0 8px',
+    fontSize: '14px',
+    fontWeight: 'normal',
+    color: palette.grey[700],
+    lineHeight: 1.5,
+    marginBottom: spacing(2),
+  },
 }));
 
 interface CampaignsEditorProps {
   campaign: Campaign;
 }
 
-/*
-  The closest we seem to come to a single source of truth for channel names 
-  appears to be in the /app/models/ChannelTest.scala file
-
-  case object Epic extends Channel
-  case object EpicAMP extends Channel
-  case object EpicAppleNews extends Channel
-  case object EpicLiveblog extends Channel
-  case object EpicHoldback extends Channel
-  case object Banner1 extends Channel
-  case object Banner2 extends Channel
-  case object Header extends Channel
-
-  For UX, best if we present tests in the same order as the list of channels 
-  shown in the hamburger menu and defined in the 
-  /public/src/components/drawer.tsx file
-
-  [...]
-  <ListItemText primary="Header" />
-  <ListItemText primary="Epic" />
-  <ListItemText primary="Epic Holdback" />
-  <ListItemText primary="Liveblog Epic" />
-  <ListItemText primary="Apple News Epic" />
-  <ListItemText primary="AMP Epic" />
-  <ListItemText primary="Banner 1" />
-  <ListItemText primary="Banner 2" />
-  [...]
-*/ 
 const testChannelOrder = ['Header', 'Epic', 'EpicHoldback', 'EpicLiveblog', 'EpicAppleNews', 'EpicAMP', 'Banner1', 'Banner2'];
 
-const testChannelLinks = {
-  'Header': '/header-tests', 
-  'Epic': '/epic-tests', 
-  'EpicHoldback': '/epic-holdback-tests', 
-  'EpicLiveblog': '/liveblog-epic-tests', 
-  'EpicAppleNews': '/apple-news-epic-tests', 
-  'EpicAMP': '/amp-epic-tests', 
-  'Banner1': '/banner-tests', 
-  'Banner2': '/banner-tests2'
+export interface TestChannelItem {
+  name: string;
+  link: string;
+}
+
+export interface TestChannelData {
+  [index: string]: TestChannelItem;
+}
+
+const testChannelData: TestChannelData = {
+  'Header': {
+    name: 'Header',
+    link: '/header-tests',
+  }, 
+  'Epic': {
+    name: 'Epic',
+    link: '/epic-tests',
+  }, 
+  'EpicHoldback': {
+    name: 'Epic Holdback',
+    link: '/epic-holdback-tests',
+  }, 
+  'EpicLiveblog': {
+    name: 'Liveblog Epic',
+    link: '/liveblog-epic-tests',
+  }, 
+  'EpicAppleNews': {
+    name: 'Apple News Epic',
+    link: '/apple-news-epic-tests',
+  }, 
+  'EpicAMP': {
+    name: 'AMP Epic',
+    link: '/amp-epic-tests',
+  }, 
+  'Banner1': {
+    name: 'Banner 1',
+    link: '/banner-tests',
+  }, 
+  'Banner2': {
+    name: 'Banner 2',
+    link: '/banner-tests2',
+  }, 
 };
 
 function CampaignsEditor({ 
@@ -83,45 +108,36 @@ function CampaignsEditor({
       const sortedTests = tests.sort((a: any, b: any) => {
         return testChannelOrder.indexOf(a.channel) - testChannelOrder.indexOf(b.channel)
       });
-
-      console.log(sortedTests);
-
       setTestData(sortedTests);
     });
   }, [campaign]);
 
-  const testCard = (test: any) => {
-
-    const getVariantNames = (variants: any) => {
-      const vNames = variants.map(v => v.name);
-      return vNames.join(', ');
-    }
-
-    return (
-      <div>
-        <ul>
-          <li><Link key={`${test.channel}|${test.name}`} to={`${testChannelLinks[test.channel]}/${test.name}`}><b>Test:</b> {test.name}</Link></li>
-          <li><b>Channel:</b> {test.channel}</li>
-          <li><b>Cohort:</b> {test.userCohort}</li>
-          <li><b>Locations:</b> {test.locations.join(', ')}</li>
-          <li><b>Variants:</b> {getVariantNames(test.variants)}</li>
-          <li><b>Status:</b> {test.status}</li>
-        </ul>
-      </div>
-    )
-  }
   return (
     <div className={classes.testEditorContainer}>
       <StickyTopBar name={name} nickname={nickname} />
 
       <div className={classes.scrollableContainer}>
-        <Typography>Name: {name}</Typography>
-
-        {nickname && <Typography>Nickname: {nickname}</Typography>}
-
-        {description && <Typography>Description: {description}</Typography>}
-
-        {testData.map(t => testCard(t))}
+        <div className={classes.formContainer}>
+          <Button
+            className={classes.launchLink}
+            variant="outlined"
+            onClick={() => {}}
+            disabled={true}
+          >
+            Button to open the tests status manager modal - needs to move into sticky bar (top right corner)
+          </Button>
+          <div className={classes.notesContainer}>
+            <div className={classes.notesHeader}>Notes (will be an editable RTE field):</div>
+            {description && <Typography>{description}</Typography>}
+          </div>
+        </div>
+        {testChannelOrder.map(channel => (
+          <ChannelCard
+            channelData={testChannelData[channel]}
+            tests={testData.filter(test => test.channel === channel)}
+            key={channel}
+          />
+        ))}
       </div>
     </div>
   );

--- a/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
@@ -49,8 +49,18 @@ const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
   },
 }));
 
-export type CombinedTest = BannerTest | EpicTest | HeaderTest;
 export type CombinedVariant = BannerVariant | EpicVariant | HeaderVariant;
+
+interface TestEnhancements {
+  priority: number;
+  channel: string;
+};
+
+interface EnhancedBannerTest extends BannerTest, TestEnhancements {};
+interface EnhancedEpicTest extends EpicTest, TestEnhancements {};
+interface EnhancedHeaderTest extends HeaderTest, TestEnhancements {};
+
+export type CombinedTest = EnhancedBannerTest | EnhancedEpicTest | EnhancedHeaderTest;
 
 export interface Campaign {
   name: string;

--- a/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
@@ -54,11 +54,11 @@ export type CombinedVariant = BannerVariant | EpicVariant | HeaderVariant;
 interface TestEnhancements {
   priority: number;
   channel: string;
-};
+}
 
-interface EnhancedBannerTest extends BannerTest, TestEnhancements {};
-interface EnhancedEpicTest extends EpicTest, TestEnhancements {};
-interface EnhancedHeaderTest extends HeaderTest, TestEnhancements {};
+interface EnhancedBannerTest extends BannerTest, TestEnhancements {}
+interface EnhancedEpicTest extends EpicTest, TestEnhancements {}
+interface EnhancedHeaderTest extends HeaderTest, TestEnhancements {}
 
 export type CombinedTest = EnhancedBannerTest | EnhancedEpicTest | EnhancedHeaderTest;
 

--- a/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { BannerTest, BannerVariant } from '../../../models/banner';
+import { EpicTest, EpicVariant } from '../../../models/epic';
+import { HeaderTest, HeaderVariant } from '../../../models/header';
 import CampaignsSidebar from './CampaignsSidebar';
 import CampaignsEditor from './CampaignsEditor';
 import { useParams } from 'react-router-dom';
@@ -45,6 +48,9 @@ const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
     justifyContent: 'center',
   },
 }));
+
+export type CombinedTest = BannerTest | EpicTest | HeaderTest;
+export type CombinedVariant = BannerVariant | EpicVariant | HeaderVariant;
 
 export interface Campaign {
   name: string;

--- a/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
 import { makeStyles, Theme, Typography } from '@material-ui/core';
-import { BannerTest, BannerVariant } from '../../../models/banner';
-import { EpicTest, EpicVariant } from '../../../models/epic';
-import { HeaderTest, HeaderVariant } from '../../../models/header';
 import CampaignsSidebar from './CampaignsSidebar';
 import CampaignsEditor from './CampaignsEditor';
 import { useParams } from 'react-router-dom';
@@ -48,19 +45,6 @@ const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
     justifyContent: 'center',
   },
 }));
-
-export type CombinedVariant = BannerVariant | EpicVariant | HeaderVariant;
-
-interface TestEnhancements {
-  priority: number;
-  channel: string;
-}
-
-interface EnhancedBannerTest extends BannerTest, TestEnhancements {}
-interface EnhancedEpicTest extends EpicTest, TestEnhancements {}
-interface EnhancedHeaderTest extends HeaderTest, TestEnhancements {}
-
-export type CombinedTest = EnhancedBannerTest | EnhancedEpicTest | EnhancedHeaderTest;
 
 export interface Campaign {
   name: string;

--- a/public/src/components/channelManagement/campaigns/ChannelCard.tsx
+++ b/public/src/components/channelManagement/campaigns/ChannelCard.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 import TestCard from './TestCard';
 import { TestChannelItem } from './CampaignsEditor';
 import { CombinedTest } from './CampaignsForm';
 
-const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+const useStyles = makeStyles(({ spacing }: Theme) => ({
   channelContainer: {
     marginBottom: spacing(4),
     paddingTop: spacing(2),
+  },
+  noTestsWarning: {
+    marginLeft: spacing(4),
   },
   channelTitle: {
     marginBottom: spacing(2),
@@ -21,35 +24,31 @@ interface ChannelCardProps {
   tests: CombinedTest[];
 }
 
-function ChannelCard({ 
-  channelData,
-  tests,
-}: ChannelCardProps): React.ReactElement {
+function ChannelCard({ channelData, tests }: ChannelCardProps): React.ReactElement {
   const classes = useStyles();
 
   const getKey = (test: CombinedTest) => {
     return `${channelData.name}|${test.name}`;
-  }
+  };
 
   return (
     <div className={classes.channelContainer}>
       <div className={classes.channelTitle}>{channelData.name} channel</div>
-        {tests.length > 0 ? (
-          tests.map(test => (
-            <TestCard
-              test={test}
-              keyId={`${getKey(test)}_LINK`}
-              linkPath={channelData.link}
-              key={`${getKey(test)}_CARD`}
-            />
-          ))
-        ) : (
-          <Typography>No tests have been set up for this channel</Typography>
-        )
-      }
+      {tests.length > 0 ? (
+        tests.map(test => (
+          <TestCard
+            test={test}
+            keyId={`${getKey(test)}_LINK`}
+            linkPath={channelData.link}
+            key={`${getKey(test)}_CARD`}
+          />
+        ))
+      ) : (
+        <div className={classes.noTestsWarning}>No tests have been set up for this channel</div>
+      )}
       {}
     </div>
-  )
+  );
 }
 
 export default ChannelCard;

--- a/public/src/components/channelManagement/campaigns/ChannelCard.tsx
+++ b/public/src/components/channelManagement/campaigns/ChannelCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { makeStyles, Theme, Typography } from '@material-ui/core';
+import TestCard from './TestCard';
+import { TestChannelItem } from './CampaignsEditor';
+import { CombinedTest } from './CampaignsForm';
+
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  channelContainer: {
+    marginBottom: spacing(4),
+    paddingTop: spacing(2),
+  },
+  channelTitle: {
+    marginBottom: spacing(2),
+    fontSize: '18px',
+    fontWeight: 500,
+  },
+}));
+
+interface ChannelCardProps {
+  channelData: TestChannelItem;
+  tests: CombinedTest[];
+}
+
+function ChannelCard({ 
+  channelData,
+  tests,
+}: ChannelCardProps): React.ReactElement {
+  const classes = useStyles();
+
+  const getKey = (test: CombinedTest) => {
+    return `${channelData.name}|${test.name}`;
+  }
+
+  return (
+    <div className={classes.channelContainer}>
+      <div className={classes.channelTitle}>{channelData.name} channel</div>
+        {tests.length > 0 ? (
+          tests.map(test => (
+            <TestCard
+              test={test}
+              keyId={`${getKey(test)}_LINK`}
+              linkPath={channelData.link}
+              key={`${getKey(test)}_CARD`}
+            />
+          ))
+        ) : (
+          <Typography>No tests have been set up for this channel</Typography>
+        )
+      }
+      {}
+    </div>
+  )
+}
+
+export default ChannelCard;

--- a/public/src/components/channelManagement/campaigns/ChannelCard.tsx
+++ b/public/src/components/channelManagement/campaigns/ChannelCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { makeStyles, Theme } from '@material-ui/core';
 import TestCard from './TestCard';
 import { TestChannelItem } from './CampaignsEditor';
-import { CombinedTest } from './CampaignsForm';
+import { Test } from '../helpers/shared';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   channelContainer: {
@@ -21,13 +21,13 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 
 interface ChannelCardProps {
   channelData: TestChannelItem;
-  tests: CombinedTest[];
+  tests: Test[];
 }
 
 function ChannelCard({ channelData, tests }: ChannelCardProps): React.ReactElement {
   const classes = useStyles();
 
-  const getKey = (test: CombinedTest) => {
+  const getKey = (test: Test) => {
     return `${channelData.name}|${test.name}`;
   };
 
@@ -44,7 +44,7 @@ function ChannelCard({ channelData, tests }: ChannelCardProps): React.ReactEleme
           />
         ))
       ) : (
-        <div className={classes.noTestsWarning}>No tests have been set up for this channel</div>
+        <div className={classes.noTestsWarning}>No Tests have been set up for this Channel.</div>
       )}
       {}
     </div>

--- a/public/src/components/channelManagement/campaigns/TestCard.tsx
+++ b/public/src/components/channelManagement/campaigns/TestCard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   makeStyles,
   Theme,
-  Typography,
   Card,
   CardContent,
   CardActions,
@@ -12,6 +11,9 @@ import { Link } from 'react-router-dom';
 import { CombinedTest, CombinedVariant } from './CampaignsForm';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
+  cardContainer: {
+    marginBottom: '4px',
+  },
   cardContent: {
     fontSize: '16px',
   },
@@ -28,13 +30,63 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   variantsData: {
     fontSize: '14px',
   },
-  variantsDataWarning: {
+  dataWarning: {
     fontSize: '14px',
     color: '#f00',
     fontStyle: 'italic',
   },
-  statusData: {
+  priorityAndStatusLine: {
     marginTop: spacing(2),
+  },
+  prioritySpan: {
+    padding: '4px 8px',
+    border: '1px solid black',
+    marginRight: '8px',
+  },
+  statusDraftSpan: {
+    padding: '4px 8px',
+    border: '1px solid black',
+    backgroundColor: '#ddd',
+    color: '#000',
+  },
+  statusLiveSpan: {
+    padding: '4px 8px',
+    border: '1px solid black',
+    backgroundColor: '#f00',
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  cohortLine: {
+    marginBottom: spacing(2),
+  },
+  cohortSelectedSpan: {
+    fontSize: '13px',
+    marginLeft: '4px',
+    padding: '4px 8px',
+    border: '1px solid black',
+    backgroundColor: '#00a',
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  locationsLine: {
+    marginBottom: spacing(2),
+  },
+  locationSelectedSpan: {
+    fontSize: '13px',
+    marginLeft: '4px',
+    padding: '4px 8px',
+    border: '1px solid black',
+    backgroundColor: '#0a0',
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  notSelectedSpan: {
+    fontSize: '13px',
+    marginLeft: '4px',
+    padding: '4px 8px',
+    border: '1px solid black',
+    backgroundColor: '#eee',
+    color: '#555',
   },
 }));
 
@@ -54,14 +106,78 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
       );
     }
     return (
-      <div className={classes.variantsDataWarning}>
+      <div className={classes.dataWarning}>
         No variants have been created for this test!
       </div>
     );
   };
 
+  const getPriorityAndStatus = (test: CombinedTest) => {
+    return (
+      <div className={classes.priorityAndStatusLine}>
+        Priority: <span className={classes.prioritySpan}>{test.priority}</span>
+        Status: <span className={test.status === 'Live' ? classes.statusLiveSpan : classes.statusDraftSpan}>{test.status}</span>
+      </div>
+    );
+  };
+
+  const getCohort = (test: CombinedTest) => {
+    const userCohort = test.userCohort;
+
+    const checkCohort = (wanted: string) => {
+      if (userCohort === 'Everyone') {
+        return classes.cohortSelectedSpan;
+      }
+      if (userCohort === wanted) {
+        return classes.cohortSelectedSpan;
+      }
+      return classes.notSelectedSpan;
+    };
+
+    return (
+      <div className={classes.cohortLine}>
+        Cohort: 
+          <span className={checkCohort('AllExistingSupporters')}>Existing Supporters</span>
+          <span className={checkCohort('AllNonSupporters')}>Non-Supporters</span>
+      </div>
+    );
+  };
+
+  const getLocations = (test: CombinedTest) => {
+    const locations: string[] = test.locations || [];
+
+    const checkLocation = (wanted: string) => {
+      if (locations.indexOf(wanted) < 0) {
+        return classes.notSelectedSpan;
+      }
+      return classes.locationSelectedSpan;
+    };
+
+    if (!locations.length) {
+      return (
+        <div className={classes.locationsLine}>
+          Locations: <span className={classes.dataWarning}>No locations have been selected for this Test</span>
+        </div>
+      )
+    }
+
+    return (
+      <div className={classes.locationsLine}>
+        Locations: 
+          <span className={checkLocation('AUDCountries')}>AU</span>
+          <span className={checkLocation('Canada')}>CA</span>
+          <span className={checkLocation('EURCountries')}>EU</span>
+          <span className={checkLocation('NZDCountries')}>NZ</span>
+          <span className={checkLocation('GBPCountries')}>UK</span>
+          <span className={checkLocation('UnitedStates')}>US</span>
+          <span className={checkLocation('International')}>ROW</span>
+      </div>
+    );
+  };
+
+
   return (
-    <Card>
+    <Card className={classes.cardContainer}>
       <CardContent className={classes.cardContent}>
         <CardActions>
           <div>
@@ -73,32 +189,16 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
         <div className={classes.dataContainer}>
           <div>
             {getVariantNames(test.variants)}
-            <div className={classes.statusData}>Status: {test.status}</div>
+            {getPriorityAndStatus(test)}
           </div>
           <div>
-            <div>
-              <Typography>Cohort: {test.userCohort}</Typography>
-            </div>
-            <div>
-              <Typography>Locations: {test.locations.join(', ')}</Typography>
-            </div>
+            {getCohort(test)}
+            {getLocations(test)}
           </div>
         </div>
       </CardContent>
     </Card>
   );
-
-  // return (
-  //   <div>
-  //     <ul>
-  //       <li><Link key={`${test.channel}|${test.name}`} to={`${linkPath}/${test.name}`}><b>Test:</b> {test.name}</Link></li>
-  //       <li><b>Cohort:</b> {test.userCohort}</li>
-  //       <li><b>Locations:</b> {test.locations.join(', ')}</li>
-  //       <li><b>Variants:</b> {getVariantNames(test.variants)}</li>
-  //       <li><b>Status:</b> {test.status}</li>
-  //     </ul>
-  //   </div>
-  // )
 }
 
 export default TestCard;

--- a/public/src/components/channelManagement/campaigns/TestCard.tsx
+++ b/public/src/components/channelManagement/campaigns/TestCard.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  makeStyles,
-  Theme,
-  Card,
-  CardContent,
-  CardActions,
-  Button,
-} from '@material-ui/core';
+import { makeStyles, Theme, Card, CardContent, CardActions, Button } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { CombinedTest, CombinedVariant } from './CampaignsForm';
 
@@ -105,18 +98,17 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
         <div className={classes.variantsData}>Variants: {variants.map(v => v.name).join(', ')}</div>
       );
     }
-    return (
-      <div className={classes.dataWarning}>
-        No variants have been created for this test!
-      </div>
-    );
+    return <div className={classes.dataWarning}>No variants have been created for this test!</div>;
   };
 
   const getPriorityAndStatus = (test: CombinedTest) => {
     return (
       <div className={classes.priorityAndStatusLine}>
         Priority: <span className={classes.prioritySpan}>{test.priority}</span>
-        Status: <span className={test.status === 'Live' ? classes.statusLiveSpan : classes.statusDraftSpan}>{test.status}</span>
+        Status:{' '}
+        <span className={test.status === 'Live' ? classes.statusLiveSpan : classes.statusDraftSpan}>
+          {test.status}
+        </span>
       </div>
     );
   };
@@ -136,9 +128,9 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
 
     return (
       <div className={classes.cohortLine}>
-        Cohort: 
-          <span className={checkCohort('AllExistingSupporters')}>Existing Supporters</span>
-          <span className={checkCohort('AllNonSupporters')}>Non-Supporters</span>
+        Cohort:
+        <span className={checkCohort('AllExistingSupporters')}>Existing Supporters</span>
+        <span className={checkCohort('AllNonSupporters')}>Non-Supporters</span>
       </div>
     );
   };
@@ -156,25 +148,25 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
     if (!locations.length) {
       return (
         <div className={classes.locationsLine}>
-          Locations: <span className={classes.dataWarning}>No locations have been selected for this Test</span>
+          Locations:{' '}
+          <span className={classes.dataWarning}>No locations have been selected for this Test</span>
         </div>
-      )
+      );
     }
 
     return (
       <div className={classes.locationsLine}>
-        Locations: 
-          <span className={checkLocation('AUDCountries')}>AU</span>
-          <span className={checkLocation('Canada')}>CA</span>
-          <span className={checkLocation('EURCountries')}>EU</span>
-          <span className={checkLocation('NZDCountries')}>NZ</span>
-          <span className={checkLocation('GBPCountries')}>UK</span>
-          <span className={checkLocation('UnitedStates')}>US</span>
-          <span className={checkLocation('International')}>ROW</span>
+        Locations:
+        <span className={checkLocation('AUDCountries')}>AU</span>
+        <span className={checkLocation('Canada')}>CA</span>
+        <span className={checkLocation('EURCountries')}>EU</span>
+        <span className={checkLocation('NZDCountries')}>NZ</span>
+        <span className={checkLocation('GBPCountries')}>UK</span>
+        <span className={checkLocation('UnitedStates')}>US</span>
+        <span className={checkLocation('International')}>ROW</span>
       </div>
     );
   };
-
 
   return (
     <Card className={classes.cardContainer}>

--- a/public/src/components/channelManagement/campaigns/TestCard.tsx
+++ b/public/src/components/channelManagement/campaigns/TestCard.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
-import { makeStyles, Theme, Typography, Card, CardContent, CardActions, Button } from '@material-ui/core';
+import {
+  makeStyles,
+  Theme,
+  Typography,
+  Card,
+  CardContent,
+  CardActions,
+  Button,
+} from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { CombinedTest, CombinedVariant } from './CampaignsForm';
 
-const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+const useStyles = makeStyles(({ spacing }: Theme) => ({
   cardContent: {
     fontSize: '16px',
   },
@@ -36,38 +44,28 @@ interface TestCardProps {
   linkPath: string;
 }
 
-function TestCard({ 
-  test,
-  keyId,
-  linkPath
-}: TestCardProps): React.ReactElement {
+function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement {
   const classes = useStyles();
 
   const getVariantNames = (variants: CombinedVariant[]) => {
     if (variants.length > 0) {
       return (
-        <div className={classes.variantsData}>
-          Variants: {variants.map(v => v.name).join(', ')}
-        </div>
-      )
+        <div className={classes.variantsData}>Variants: {variants.map(v => v.name).join(', ')}</div>
+      );
     }
     return (
       <div className={classes.variantsDataWarning}>
         No variants have been created for this test!
       </div>
-    )
-  }
+    );
+  };
 
   return (
     <Card>
       <CardContent className={classes.cardContent}>
         <CardActions>
           <div>
-            <Link 
-              className={classes.linkButton}
-              key={keyId} 
-              to={`${linkPath}/${test.name}`}
-            >
+            <Link className={classes.linkButton} key={keyId} to={`${linkPath}/${test.name}`}>
               <Button variant="outlined">{test.name}</Button>
             </Link>
           </div>
@@ -75,9 +73,7 @@ function TestCard({
         <div className={classes.dataContainer}>
           <div>
             {getVariantNames(test.variants)}
-            <div className={classes.statusData}>
-              Status: {test.status}
-            </div>
+            <div className={classes.statusData}>Status: {test.status}</div>
           </div>
           <div>
             <div>
@@ -90,7 +86,7 @@ function TestCard({
         </div>
       </CardContent>
     </Card>
-  )
+  );
 
   // return (
   //   <div>

--- a/public/src/components/channelManagement/campaigns/TestCard.tsx
+++ b/public/src/components/channelManagement/campaigns/TestCard.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { makeStyles, Theme, Typography, Card, CardContent, CardActions, Button } from '@material-ui/core';
+import { Link } from 'react-router-dom';
+import { CombinedTest, CombinedVariant } from './CampaignsForm';
+
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  cardContent: {
+    fontSize: '16px',
+  },
+  linkButton: {
+    textDecoration: 'none',
+  },
+  dataContainer: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 2fr',
+    columnGap: spacing(2),
+    justifyItems: 'start',
+    marginLeft: spacing(3),
+  },
+  variantsData: {
+    fontSize: '14px',
+  },
+  variantsDataWarning: {
+    fontSize: '14px',
+    color: '#f00',
+    fontStyle: 'italic',
+  },
+  statusData: {
+    marginTop: spacing(2),
+  },
+}));
+
+interface TestCardProps {
+  test: CombinedTest;
+  keyId: string;
+  linkPath: string;
+}
+
+function TestCard({ 
+  test,
+  keyId,
+  linkPath
+}: TestCardProps): React.ReactElement {
+  const classes = useStyles();
+
+  const getVariantNames = (variants: CombinedVariant[]) => {
+    if (variants.length > 0) {
+      return (
+        <div className={classes.variantsData}>
+          Variants: {variants.map(v => v.name).join(', ')}
+        </div>
+      )
+    }
+    return (
+      <div className={classes.variantsDataWarning}>
+        No variants have been created for this test!
+      </div>
+    )
+  }
+
+  return (
+    <Card>
+      <CardContent className={classes.cardContent}>
+        <CardActions>
+          <div>
+            <Link 
+              className={classes.linkButton}
+              key={keyId} 
+              to={`${linkPath}/${test.name}`}
+            >
+              <Button variant="outlined">{test.name}</Button>
+            </Link>
+          </div>
+        </CardActions>
+        <div className={classes.dataContainer}>
+          <div>
+            {getVariantNames(test.variants)}
+            <div className={classes.statusData}>
+              Status: {test.status}
+            </div>
+          </div>
+          <div>
+            <div>
+              <Typography>Cohort: {test.userCohort}</Typography>
+            </div>
+            <div>
+              <Typography>Locations: {test.locations.join(', ')}</Typography>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+
+  // return (
+  //   <div>
+  //     <ul>
+  //       <li><Link key={`${test.channel}|${test.name}`} to={`${linkPath}/${test.name}`}><b>Test:</b> {test.name}</Link></li>
+  //       <li><b>Cohort:</b> {test.userCohort}</li>
+  //       <li><b>Locations:</b> {test.locations.join(', ')}</li>
+  //       <li><b>Variants:</b> {getVariantNames(test.variants)}</li>
+  //       <li><b>Status:</b> {test.status}</li>
+  //     </ul>
+  //   </div>
+  // )
+}
+
+export default TestCard;

--- a/public/src/components/channelManagement/campaigns/TestCard.tsx
+++ b/public/src/components/channelManagement/campaigns/TestCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles, Theme, Card, CardContent, CardActions, Button } from '@material-ui/core';
 import { Link } from 'react-router-dom';
-import { CombinedTest, CombinedVariant } from './CampaignsForm';
+import { Test, Variant } from '../helpers/shared';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   cardContainer: {
@@ -84,7 +84,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 }));
 
 interface TestCardProps {
-  test: CombinedTest;
+  test: Test;
   keyId: string;
   linkPath: string;
 }
@@ -92,16 +92,16 @@ interface TestCardProps {
 function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement {
   const classes = useStyles();
 
-  const getVariantNames = (variants: CombinedVariant[]) => {
+  const getVariantNames = (variants: Variant[]) => {
     if (variants.length > 0) {
       return (
         <div className={classes.variantsData}>Variants: {variants.map(v => v.name).join(', ')}</div>
       );
     }
-    return <div className={classes.dataWarning}>No variants have been created for this test!</div>;
+    return <div className={classes.dataWarning}>No Variants have been created for this Test.</div>;
   };
 
-  const getPriorityAndStatus = (test: CombinedTest) => {
+  const getPriorityAndStatus = (test: Test) => {
     return (
       <div className={classes.priorityAndStatusLine}>
         Priority: <span className={classes.prioritySpan}>{test.priority}</span>
@@ -113,7 +113,7 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
     );
   };
 
-  const getCohort = (test: CombinedTest) => {
+  const getCohort = (test: Test) => {
     const userCohort = test.userCohort;
 
     const checkCohort = (wanted: string) => {
@@ -135,7 +135,7 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
     );
   };
 
-  const getLocations = (test: CombinedTest) => {
+  const getLocations = (test: Test) => {
     const locations: string[] = test.locations || [];
 
     const checkLocation = (wanted: string) => {
@@ -149,7 +149,9 @@ function TestCard({ test, keyId, linkPath }: TestCardProps): React.ReactElement 
       return (
         <div className={classes.locationsLine}>
           Locations:{' '}
-          <span className={classes.dataWarning}>No locations have been selected for this Test</span>
+          <span className={classes.dataWarning}>
+            No locations have been selected for this Test.
+          </span>
         </div>
       );
     }

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -26,6 +26,9 @@ export interface Test {
   locations: Region[];
   isNew?: boolean; // true if test has not yet been POSTed to backend
   campaignName?: string;
+  priority?: number;
+  userCohort?: string;
+  channel?: string;
 }
 
 export interface EpicEditorConfig {

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -108,6 +108,13 @@ export function fetchSupportFrontendSettings(
   return fetchSettings(`/support-frontend/${settingsType}`);
 }
 
+export function fetchCampaignTests(
+  campaign: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  return fetchSettings(`/frontend/campaign/${campaign}/tests`);
+}
+
 export function saveSupportFrontendSettings(
   settingsType: SupportFrontendSettingsType,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -1,3 +1,5 @@
+import { Test } from '../components/channelManagement/helpers/shared';
+
 export enum SupportFrontendSettingsType {
   switches = 'switches',
   contributionTypes = 'contribution-types',
@@ -108,10 +110,7 @@ export function fetchSupportFrontendSettings(
   return fetchSettings(`/support-frontend/${settingsType}`);
 }
 
-export function fetchCampaignTests(
-  campaign: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+export function fetchCampaignTests(campaign: string): Promise<Test[]> {
   return fetchSettings(`/frontend/campaign/${campaign}/tests`);
 }
 


### PR DESCRIPTION
## What does this change?
List all the tests associated with a campaign. Each test listed includes a link to that test in RRCP

This PR covers the basic functionality of listing all tests associated with a campaign, presented by channels. 

Each test displays in a card with basic information (status, priority, variant names, targeted cohorts and regions) visualised in a way that should allow users a quick way to keep check on their work while creating or managing a campaign.

Each card also includes functionality to show errors such as no variants being created for a test, or no regions selected. The test name is also a link to take the user directly to the test page where it can be edited and managed.

### Screenshots

![Screenshot 2022-06-28 at 14 09 50](https://user-images.githubusercontent.com/5357530/176206670-f21fedd2-a115-472a-82ce-1230bbe4143b.png)

![Screenshot 2022-06-28 at 14 10 16](https://user-images.githubusercontent.com/5357530/176206753-5e4824d5-9c7a-4d03-9e72-d2364925c2bb.png)

