### PR TITLE
Decouple test status from test editing

### DIFF
--- a/app/controllers/ChannelTestsController.scala
+++ b/app/controllers/ChannelTestsController.scala
@@ -210,14 +210,6 @@ abstract class ChannelTestsController[T <: ChannelTest[T] : Decoder : Encoder](
     }
   }
 
-  def archiveTests = authAction.async(circe.json[List[String]]) { request =>
-    run {
-      logger.info(s"${request.user.email} is archiving ${request.body}")
-      dynamo.updateStatuses(request.body, channel, models.Status.Archived)
-        .map(_ => Ok("archived"))
-    }
-  }
-
   private def parseStatus(rawStatus: String): Option[models.Status] = rawStatus.toLowerCase match {
     case "live" => Some(models.Status.Live)
     case "draft" => Some(models.Status.Draft)

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -269,7 +269,8 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends StrictLo
 
   def updateTest[T <: ChannelTest[T] : Encoder](test: T, channel: Channel, email: String): ZIO[ZEnv, DynamoError, Unit] = {
     val item = jsonToDynamo(test.asJson).m().asScala.toMap -
-      "priority" -    // Do not update priority
+      "status" -      // Do not update status - this is a separate action
+      "priority" -    // Do not update priority - this is a separate action
       "lockStatus" -  // Unlock by removing lockStatus
       "name" -        // key field
       "channel"       // key field

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -261,8 +261,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends StrictLo
     */
   private def buildUpdateTestExpression(item: Map[String, AttributeValue]): String = {
     val subExprs = item.foldLeft[List[String]](Nil) { case (acc, (key, value)) =>
-      val name = if (key == "status") "#status" else key // status is a reserved word, so we alias with #
-      s"$name = :$key" +: acc
+      s"$key = :$key" +: acc
     }
     s"set ${subExprs.mkString(", ")} remove lockStatus" // Unlock the test at the same time
   }
@@ -287,9 +286,6 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends StrictLo
       .key(buildKey(channel, test.name))
       .updateExpression(updateExpression)
       .expressionAttributeValues(attributeValuesWithEmail.asJava)
-      .expressionAttributeNames(Map(
-        "#status" -> "status"
-      ).asJava)
       .conditionExpression("lockStatus.email = :email")
       .build()
 

--- a/conf/routes
+++ b/conf/routes
@@ -67,7 +67,7 @@ POST  /frontend/epic-tests/test/create                controllers.epic.EpicTests
 POST  /frontend/epic-tests/test/lock/:testName        controllers.epic.EpicTestsController.lockTest(testName: String)
 POST  /frontend/epic-tests/test/unlock/:testName      controllers.epic.EpicTestsController.unlockTest(testName: String)
 POST  /frontend/epic-tests/test/takecontrol/:testName controllers.epic.EpicTestsController.forceLockTest(testName: String)
-POST  /frontend/epic-tests/test/archive               controllers.epic.EpicTestsController.archiveTests
+POST  /frontend/epic-tests/test/status/:rawStatus     controllers.epic.EpicTestsController.setStatus(rawStatus: String)
 
 
 # ----- Header tests ----- #
@@ -84,7 +84,6 @@ POST  /frontend/header-tests/test/create                controllers.HeaderTestsC
 POST  /frontend/header-tests/test/lock/:testName        controllers.HeaderTestsController.lockTest(testName: String)
 POST  /frontend/header-tests/test/unlock/:testName      controllers.HeaderTestsController.unlockTest(testName: String)
 POST  /frontend/header-tests/test/takecontrol/:testName controllers.HeaderTestsController.forceLockTest(testName: String)
-POST  /frontend/header-tests/test/archive               controllers.HeaderTestsController.archiveTests
 POST  /frontend/header-tests/test/status/:rawStatus     controllers.HeaderTestsController.setStatus(rawStatus: String)
 
 
@@ -102,7 +101,7 @@ POST  /frontend/epic-holdback-tests/test/create                controllers.epic.
 POST  /frontend/epic-holdback-tests/test/lock/:testName        controllers.epic.EpicHoldbackTestsController.lockTest(testName: String)
 POST  /frontend/epic-holdback-tests/test/unlock/:testName      controllers.epic.EpicHoldbackTestsController.unlockTest(testName: String)
 POST  /frontend/epic-holdback-tests/test/takecontrol/:testName controllers.epic.EpicHoldbackTestsController.forceLockTest(testName: String)
-POST  /frontend/epic-holdback-tests/test/archive               controllers.epic.EpicHoldbackTestsController.archiveTests
+POST  /frontend/epic-holdback-tests/test/status/:rawStatus     controllers.epic.EpicHoldbackTestsController.setStatus(rawStatus: String)
 
 
 # ----- Liveblog epic tests ----- #
@@ -119,7 +118,7 @@ POST  /frontend/liveblog-epic-tests/test/create                controllers.epic.
 POST  /frontend/liveblog-epic-tests/test/lock/:testName        controllers.epic.LiveblogEpicTestsController.lockTest(testName: String)
 POST  /frontend/liveblog-epic-tests/test/unlock/:testName      controllers.epic.LiveblogEpicTestsController.unlockTest(testName: String)
 POST  /frontend/liveblog-epic-tests/test/takecontrol/:testName controllers.epic.LiveblogEpicTestsController.forceLockTest(testName: String)
-POST  /frontend/liveblog-epic-tests/test/archive               controllers.epic.LiveblogEpicTestsController.archiveTests
+POST  /frontend/liveblog-epic-tests/test/status/:rawStatus     controllers.epic.LiveblogEpicTestsController.setStatus(rawStatus: String)
 
 
 # ----- Apple News epic 'tests' ----- #
@@ -136,7 +135,7 @@ POST  /frontend/apple-news-epic-tests/test/create                controllers.epi
 POST  /frontend/apple-news-epic-tests/test/lock/:testName        controllers.epic.AppleNewsEpicTestsController.lockTest(testName: String)
 POST  /frontend/apple-news-epic-tests/test/unlock/:testName      controllers.epic.AppleNewsEpicTestsController.unlockTest(testName: String)
 POST  /frontend/apple-news-epic-tests/test/takecontrol/:testName controllers.epic.AppleNewsEpicTestsController.forceLockTest(testName: String)
-POST  /frontend/apple-news-epic-tests/test/archive               controllers.epic.AppleNewsEpicTestsController.archiveTests
+POST  /frontend/apple-news-epic-tests/test/status/:rawStatus     controllers.epic.AppleNewsEpicTestsController.setStatus(rawStatus: String)
 
 
 # ----- AMP epic 'tests' ----- #
@@ -153,7 +152,7 @@ POST  /frontend/amp-epic-tests/test/create                controllers.epic.AMPEp
 POST  /frontend/amp-epic-tests/test/lock/:testName        controllers.epic.AMPEpicTestsController.lockTest(testName: String)
 POST  /frontend/amp-epic-tests/test/unlock/:testName      controllers.epic.AMPEpicTestsController.unlockTest(testName: String)
 POST  /frontend/amp-epic-tests/test/takecontrol/:testName controllers.epic.AMPEpicTestsController.forceLockTest(testName: String)
-POST  /frontend/amp-epic-tests/test/archive               controllers.epic.AMPEpicTestsController.archiveTests
+POST  /frontend/amp-epic-tests/test/status/:rawStatus     controllers.epic.AMPEpicTestsController.setStatus(rawStatus: String)
 
 
 # ----- Banner channel 1 tests ----- #
@@ -170,7 +169,7 @@ POST  /frontend/banner-tests/test/create                controllers.banner.Banne
 POST  /frontend/banner-tests/test/lock/:testName        controllers.banner.BannerTestsController.lockTest(testName: String)
 POST  /frontend/banner-tests/test/unlock/:testName      controllers.banner.BannerTestsController.unlockTest(testName: String)
 POST  /frontend/banner-tests/test/takecontrol/:testName controllers.banner.BannerTestsController.forceLockTest(testName: String)
-POST  /frontend/banner-tests/test/archive               controllers.banner.BannerTestsController.archiveTests
+POST  /frontend/banner-tests/test/status/:rawStatus     controllers.banner.BannerTestsController.setStatus(rawStatus: String)
 
 
 # ----- Banner channel 2 tests ----- #
@@ -187,7 +186,7 @@ POST  /frontend/banner-tests2/test/create                controllers.banner.Bann
 POST  /frontend/banner-tests2/test/lock/:testName        controllers.banner.BannerTestsController2.lockTest(testName: String)
 POST  /frontend/banner-tests2/test/unlock/:testName      controllers.banner.BannerTestsController2.unlockTest(testName: String)
 POST  /frontend/banner-tests2/test/takecontrol/:testName controllers.banner.BannerTestsController2.forceLockTest(testName: String)
-POST  /frontend/banner-tests2/test/archive               controllers.banner.BannerTestsController2.archiveTests
+POST  /frontend/banner-tests2/test/status/:rawStatus     controllers.banner.BannerTestsController2.setStatus(rawStatus: String)
 
 
 # ----- banner deploys ----- #

--- a/conf/routes
+++ b/conf/routes
@@ -85,6 +85,7 @@ POST  /frontend/header-tests/test/lock/:testName        controllers.HeaderTestsC
 POST  /frontend/header-tests/test/unlock/:testName      controllers.HeaderTestsController.unlockTest(testName: String)
 POST  /frontend/header-tests/test/takecontrol/:testName controllers.HeaderTestsController.forceLockTest(testName: String)
 POST  /frontend/header-tests/test/archive               controllers.HeaderTestsController.archiveTests
+POST  /frontend/header-tests/test/status/:rawStatus     controllers.HeaderTestsController.setStatus(rawStatus: String)
 
 
 # ----- Epic holdback tests ----- #

--- a/public/src/components/amounts/amountsTestEditor.tsx
+++ b/public/src/components/amounts/amountsTestEditor.tsx
@@ -114,6 +114,7 @@ const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
           label="Live on support.theguardian.com"
           isLive={test.isLive}
           onChange={updateIsLive}
+          isDisabled={false}
         />
       </div>
 

--- a/public/src/components/amounts/amountsTestEditor.tsx
+++ b/public/src/components/amounts/amountsTestEditor.tsx
@@ -114,7 +114,6 @@ const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
           label="Live on support.theguardian.com"
           isLive={test.isLive}
           onChange={updateIsLive}
-          isDisabled={false}
         />
       </div>
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
-import { ArticlesViewedSettings, DeviceType, setStatus, UserCohort } from '../helpers/shared';
+import { ArticlesViewedSettings, DeviceType, UserCohort } from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@material-ui/core';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
@@ -10,7 +10,6 @@ import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelecto
 import TestEditorArticleCountEditor, {
   DEFAULT_ARTICLES_VIEWED_SETTINGS,
 } from '../testEditorArticleCountEditor';
-import LiveSwitch from '../../shared/liveSwitch';
 import { BannerContent, BannerTest, BannerVariant } from '../../../models/banner';
 import { getDefaultVariant } from './utils/defaults';
 import TestEditorVariantSummary from '../testEditorVariantSummary';
@@ -70,10 +69,6 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   const onControlProportionSettingsChange = (
     controlProportionSettings?: ControlProportionSettings,
   ): void => updateTest({ ...test, controlProportionSettings });
-
-  const onLiveSwitchChange = (isOn: boolean): void => {
-    updateTest({ ...test, isOn, status: setStatus(isOn) });
-  };
 
   const onVariantsChange = (updatedVariantList: BannerVariant[]): void => {
     updateTest({ ...test, variants: updatedVariantList });
@@ -162,15 +157,6 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   if (test) {
     return (
       <div className={classes.container}>
-        <div className={classes.switchContainer}>
-          <LiveSwitch
-            label="Live on Guardian.com"
-            isLive={test.isOn}
-            isDisabled={!userHasTestLocked}
-            onChange={onLiveSwitchChange}
-          />
-        </div>
-
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -49,7 +49,6 @@ export const getDefaultVariant = (): BannerVariant => {
 const DEV_AND_CODE_DEFAULT_BANNER_TEST: BannerTest = {
   name: 'TEST',
   nickname: 'TEST',
-  isOn: false,
   status: 'Draft',
   minArticlesBeforeShowingBanner: 0,
   userCohort: UserCohort.AllNonSupporters,
@@ -61,7 +60,6 @@ const DEV_AND_CODE_DEFAULT_BANNER_TEST: BannerTest = {
 const PROD_DEFAULT_BANNER: BannerTest = {
   name: '',
   nickname: '',
-  isOn: false,
   status: 'Draft',
   minArticlesBeforeShowingBanner: 0,
   userCohort: UserCohort.AllNonSupporters,

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -6,7 +6,6 @@ import {
   UserCohort,
   EpicEditorConfig,
   DeviceType,
-  setStatus,
 } from '../helpers/shared';
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
 import TestVariantsEditor from '../testVariantsEditor';
@@ -23,7 +22,6 @@ import EpicTestMaxViewsEditor from './epicTestMaxViewsEditor';
 import { ARTICLE_COUNT_TEMPLATE, COUNTRY_NAME_TEMPLATE } from '../helpers/validation';
 import TestVariantsSplitEditor from '../testVariantsSplitEditor';
 import { getDefaultVariant } from './utils/defaults';
-import LiveSwitch from '../../shared/liveSwitch';
 import {
   canHaveCustomVariantSplit,
   ControlProportionSettings,
@@ -124,10 +122,6 @@ export const getEpicTestEditor = (
       updateTest({ ...test, [fieldName]: updatedBool });
     };
 
-    const onLiveSwitchChange = (isOn: boolean): void => {
-      updateTest({ ...test, isOn, status: setStatus(isOn) });
-    };
-
     const updateTargetSections = (
       tagIds: string[],
       sections: string[],
@@ -207,23 +201,14 @@ export const getEpicTestEditor = (
 
     return (
       <div className={classes.container}>
-        <div className={classes.switchContainer}>
-          <LiveSwitch
-            label="Live on Guardian.com"
-            isLive={test.isOn}
-            isDisabled={!userHasTestLocked}
-            onChange={onLiveSwitchChange}
-          />
-          <div>
-            <EpicTestPreviewButton test={test} />
-          </div>
-        </div>
-
         {epicEditorConfig.allowMultipleVariants && (
           <div className={classes.sectionContainer}>
-            <Typography variant={'h3'} className={classes.sectionHeader}>
-              Variants
-            </Typography>
+            <div className={classes.variantsHeaderContainer}>
+              <Typography variant={'h3'} className={classes.sectionHeader}>
+                Variants
+              </Typography>
+              <EpicTestPreviewButton test={test} />
+            </div>
             <div>
               <TestVariantsEditor<EpicVariant>
                 variants={test.variants}

--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -59,7 +59,6 @@ export const getDefaultVariant = (): EpicVariant => {
 const DEV_AND_CODE_DEFAULT_TEST: EpicTest = {
   name: 'TEST',
   nickname: 'TEST',
-  isOn: false,
   status: 'Draft',
   locations: [],
   tagIds: [],
@@ -78,7 +77,6 @@ const DEV_AND_CODE_DEFAULT_TEST: EpicTest = {
 const PROD_DEFAULT_TEST: EpicTest = {
   name: 'TEST',
   nickname: 'TEST',
-  isOn: false,
   status: 'Draft',
   locations: [],
   tagIds: [],

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 
-import { DeviceType, setStatus, UserCohort } from '../helpers/shared';
+import { DeviceType, UserCohort } from '../helpers/shared';
 
 import { Typography } from '@material-ui/core';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
@@ -9,7 +9,6 @@ import TestVariantsEditor from '../testVariantsEditor';
 
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
 
-import LiveSwitch from '../../shared/liveSwitch';
 import { HeaderTest, HeaderVariant } from '../../../models/header';
 import { getDefaultVariant } from './utils/defaults';
 import TestEditorVariantSummary from '../testEditorVariantSummary';
@@ -33,10 +32,6 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
   const onControlProportionSettingsChange = (
     controlProportionSettings?: ControlProportionSettings,
   ): void => onTestChange({ ...test, controlProportionSettings });
-
-  const onLiveSwitchChange = (isOn: boolean): void => {
-    onTestChange({ ...test, isOn, status: setStatus(isOn) });
-  };
 
   const onVariantsChange = (updatedVariantList: HeaderVariant[]): void => {
     onTestChange({ ...test, variants: updatedVariantList });
@@ -108,15 +103,6 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
 
   return (
     <div className={classes.container}>
-      <div className={classes.switchContainer}>
-        <LiveSwitch
-          label="Live on Guardian.com"
-          isLive={test.isOn}
-          isDisabled={!userHasTestLocked}
-          onChange={onLiveSwitchChange}
-        />
-      </div>
-
       <div className={classes.sectionContainer}>
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Variants

--- a/public/src/components/channelManagement/headerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/headerTests/utils/defaults.ts
@@ -42,7 +42,6 @@ export const getDefaultVariant = (): HeaderVariant => {
 const DEV_AND_CODE_DEFAULT_BANNER_TEST: HeaderTest = {
   name: '',
   nickname: '',
-  isOn: false,
   status: 'Draft',
   userCohort: UserCohort.AllNonSupporters,
   locations: [],
@@ -52,7 +51,6 @@ const DEV_AND_CODE_DEFAULT_BANNER_TEST: HeaderTest = {
 const PROD_DEFAULT_BANNER: HeaderTest = {
   name: '',
   nickname: '',
-  isOn: false,
   status: 'Draft',
   userCohort: UserCohort.AllNonSupporters,
   locations: [],

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -13,8 +13,6 @@ export type EpicModuleName = 'ContributionsEpic' | 'ContributionsLiveblogEpic';
 
 export type Status = 'Live' | 'Draft' | 'Archived';
 
-export const setStatus = (isOn: boolean): Status => (isOn ? 'Live' : 'Draft');
-
 export interface Test {
   name: string;
   nickname?: string;

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -16,7 +16,6 @@ export type Status = 'Live' | 'Draft' | 'Archived';
 export interface Test {
   name: string;
   nickname?: string;
-  isOn: boolean; // Deprecated and soon to be removed, use status instead
   status: Status;
   lockStatus?: LockStatus;
   articlesViewedSettings?: ArticlesViewedSettings;

--- a/public/src/components/channelManagement/helpers/testEditorStyles.ts
+++ b/public/src/components/channelManagement/helpers/testEditorStyles.ts
@@ -8,12 +8,6 @@ export const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     width: '100%',
     background: palette.background.paper, // #FFFFFF
   },
-  switchContainer: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    paddingBottom: spacing(2),
-    borderBottom: `1px solid ${palette.grey[500]}`,
-  },
   sectionContainer: {
     paddingTop: spacing(1),
     paddingBottom: spacing(6),
@@ -27,6 +21,11 @@ export const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     fontSize: 16,
     fontWeight: 500,
     color: palette.grey[700],
+  },
+  variantsHeaderContainer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
   },
   buttonsContainer: {
     paddingTop: spacing(4),

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -100,7 +100,7 @@ function Sidebar<T extends Test>({
 
         <BatchProcessTestButton
           // filter out live tests and any test currently being edited
-          draftTests={tests.filter(t => (!t.isOn && t.name !== selectedTestName ? true : false))}
+          draftTests={tests.filter(t => !(t.status === 'Live' && t.name !== selectedTestName))}
           onBatchTestArchive={onBatchTestArchive}
         />
 

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -141,18 +141,9 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
             Copy link
           </Button>
         </div>
-        {/*<div className={classes.switchContainer}>*/}
-        {/*  <LiveSwitch*/}
-        {/*    label="Live on theguardian.com"*/}
-        {/*    isLive={status === 'Live'}*/}
-        {/*    onChange={(isLive: boolean) => onStatusChange(isLive ? 'Live' : 'Draft')}*/}
-        {/*    disabled={userHasTestLocked && lockStatus.locked} // cannot change test status while still editing it*/}
-        {/*  />*/}
-        {/*</div>*/}
       </div>
 
       <div className={classes.buttonsContainer}>
-        {/*{!lockStatus.locked &&*/}
         <div className={classes.switchContainer}>
           <TestLiveSwitch
             isLive={status === 'Live'}
@@ -160,7 +151,6 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
             disabled={userHasTestLocked && lockStatus.locked} // cannot change test status while still editing it
           />
         </div>
-        {/*}*/}
         <div className={classes.lockContainer}>
           {!userHasTestLocked && !lockStatus.locked && (
             <>

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -11,7 +11,7 @@ import { TestCopyButton } from './testCopyButton';
 import { grey } from '@material-ui/core/colors';
 import { Link } from '@material-ui/icons';
 import { FrontendSettingsType } from '../../../utils/requests';
-import LiveSwitch from '../../shared/liveSwitch';
+import TestLiveSwitch from '../testLiveSwitch';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -20,7 +20,6 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     justifyContent: 'space-between',
     paddingLeft: spacing(3),
     paddingRight: spacing(3),
-    paddingBottom: spacing(1),
     paddingTop: spacing(1),
     backgroundColor: palette.grey[200],
     borderBottom: `1px solid ${palette.grey[500]}`,
@@ -28,6 +27,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   namesContainer: {
     display: 'flex',
     flexDirection: 'column',
+    paddingBottom: spacing(2),
   },
   mainHeader: {
     fontSize: '32px',
@@ -35,14 +35,20 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   },
   secondaryHeaderContainer: {
     display: 'flex',
-    borderBottom: `1px solid ${palette.grey[500]}`,
-    paddingBottom: spacing(1),
+    marginTop: '4px',
   },
   secondaryHeader: {
     fontSize: '14px',
     color: palette.grey[700],
   },
+  buttonsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignSelf: 'flex-end',
+    paddingBottom: spacing(1),
+  },
   switchContainer: {
+    alignSelf: 'flex-end',
     display: 'flex',
   },
   lockContainer: {
@@ -135,70 +141,83 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
             Copy link
           </Button>
         </div>
+        {/*<div className={classes.switchContainer}>*/}
+        {/*  <LiveSwitch*/}
+        {/*    label="Live on theguardian.com"*/}
+        {/*    isLive={status === 'Live'}*/}
+        {/*    onChange={(isLive: boolean) => onStatusChange(isLive ? 'Live' : 'Draft')}*/}
+        {/*    disabled={userHasTestLocked && lockStatus.locked} // cannot change test status while still editing it*/}
+        {/*  />*/}
+        {/*</div>*/}
+      </div>
+
+      <div className={classes.buttonsContainer}>
+        {/*{!lockStatus.locked &&*/}
         <div className={classes.switchContainer}>
-          <LiveSwitch
-            label="Live on theguardian.com"
+          <TestLiveSwitch
             isLive={status === 'Live'}
             onChange={(isLive: boolean) => onStatusChange(isLive ? 'Live' : 'Draft')}
+            disabled={userHasTestLocked && lockStatus.locked} // cannot change test status while still editing it
           />
         </div>
-      </div>
-      <div className={classes.lockContainer}>
-        {!userHasTestLocked && !lockStatus.locked && (
-          <>
-            <TestCopyButton
-              existingNames={existingNames}
-              existingNicknames={existingNicknames}
-              sourceName={name}
-              sourceNickname={nickname}
-              testNamePrefix={testNamePrefix}
-              onTestCopy={onTestCopy}
-              disabled={userHasTestListLocked}
-            />
-            <Button
-              variant="outlined"
-              size="medium"
-              startIcon={<EditIcon className={classes.icon} />}
-              onClick={() => onTestLock(name, false)}
-            >
-              <Typography className={classes.buttonText}>Edit test</Typography>
-            </Button>
-          </>
-        )}
-        {!userHasTestLocked && lockStatus.locked && (
-          <>
-            <TestLockDetails email={lockStatus.email} timestamp={lockStatus.timestamp} />
-            <Button
-              variant="outlined"
-              size="medium"
-              startIcon={<LockIcon className={classes.icon} />}
-              onClick={() => onTestLock(name, true)}
-            >
-              <Typography className={classes.buttonText}>Take control</Typography>
-            </Button>
-          </>
-        )}
-        {userHasTestLocked && (
-          <>
-            {!isNew && <TestArchiveButton onTestArchive={onTestArchive} />}
-            <Button
-              variant="outlined"
-              size="medium"
-              startIcon={<CloseIcon className={classes.icon} />}
-              onClick={() => onTestUnlock(name)}
-            >
-              <Typography className={classes.buttonText}>Discard</Typography>
-            </Button>
-            <Button
-              variant="outlined"
-              size="medium"
-              startIcon={<SaveIcon className={classes.icon} />}
-              onClick={() => onTestSave(name)}
-            >
-              <Typography className={classes.buttonText}>Save test</Typography>
-            </Button>
-          </>
-        )}
+        {/*}*/}
+        <div className={classes.lockContainer}>
+          {!userHasTestLocked && !lockStatus.locked && (
+            <>
+              <TestCopyButton
+                existingNames={existingNames}
+                existingNicknames={existingNicknames}
+                sourceName={name}
+                sourceNickname={nickname}
+                testNamePrefix={testNamePrefix}
+                onTestCopy={onTestCopy}
+                disabled={userHasTestListLocked}
+              />
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<EditIcon className={classes.icon} />}
+                onClick={() => onTestLock(name, false)}
+              >
+                <Typography className={classes.buttonText}>Edit test</Typography>
+              </Button>
+            </>
+          )}
+          {!userHasTestLocked && lockStatus.locked && (
+            <>
+              <TestLockDetails email={lockStatus.email} timestamp={lockStatus.timestamp} />
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<LockIcon className={classes.icon} />}
+                onClick={() => onTestLock(name, true)}
+              >
+                <Typography className={classes.buttonText}>Take control</Typography>
+              </Button>
+            </>
+          )}
+          {userHasTestLocked && (
+            <>
+              {!isNew && <TestArchiveButton onTestArchive={onTestArchive} />}
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<CloseIcon className={classes.icon} />}
+                onClick={() => onTestUnlock(name)}
+              >
+                <Typography className={classes.buttonText}>Discard</Typography>
+              </Button>
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<SaveIcon className={classes.icon} />}
+                onClick={() => onTestSave(name)}
+              >
+                <Typography className={classes.buttonText}>Save test</Typography>
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';
-import { LockStatus } from '../helpers/shared';
+import { LockStatus, Status } from '../helpers/shared';
 import CloseIcon from '@material-ui/icons/Close';
 import SaveIcon from '@material-ui/icons/Save';
 import LockIcon from '@material-ui/icons/Lock';
@@ -11,6 +11,7 @@ import { TestCopyButton } from './testCopyButton';
 import { grey } from '@material-ui/core/colors';
 import { Link } from '@material-ui/icons';
 import { FrontendSettingsType } from '../../../utils/requests';
+import LiveSwitch from '../../shared/liveSwitch';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -19,7 +20,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     justifyContent: 'space-between',
     paddingLeft: spacing(3),
     paddingRight: spacing(3),
-    paddingBottom: spacing(2),
+    paddingBottom: spacing(1),
     paddingTop: spacing(1),
     backgroundColor: palette.grey[200],
     borderBottom: `1px solid ${palette.grey[500]}`,
@@ -34,10 +35,15 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   },
   secondaryHeaderContainer: {
     display: 'flex',
+    borderBottom: `1px solid ${palette.grey[500]}`,
+    paddingBottom: spacing(1),
   },
   secondaryHeader: {
     fontSize: '14px',
     color: palette.grey[700],
+  },
+  switchContainer: {
+    display: 'flex',
   },
   lockContainer: {
     alignSelf: 'flex-end',
@@ -71,6 +77,7 @@ interface StickyTopBarProps {
   name: string;
   nickname?: string;
   isNew: boolean;
+  status: Status;
   lockStatus: LockStatus;
   userHasTestLocked: boolean;
   userHasTestListLocked: boolean;
@@ -82,6 +89,7 @@ interface StickyTopBarProps {
   onTestSave: (testName: string) => void;
   onTestArchive: () => void;
   onTestCopy: (oldName: string, newName: string, newNickname: string) => void;
+  onStatusChange: (status: Status) => void;
   settingsType: FrontendSettingsType;
 }
 
@@ -89,6 +97,7 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
   name,
   nickname,
   isNew,
+  status,
   lockStatus,
   userHasTestLocked,
   userHasTestListLocked,
@@ -100,6 +109,7 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
   onTestSave,
   onTestArchive,
   onTestCopy,
+  onStatusChange,
   settingsType,
 }: StickyTopBarProps) => {
   const classes = useStyles();
@@ -124,6 +134,13 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
           >
             Copy link
           </Button>
+        </div>
+        <div className={classes.switchContainer}>
+          <LiveSwitch
+            label="Live on theguardian.com"
+            isLive={status === 'Live'}
+            onChange={(isLive: boolean) => onStatusChange(isLive ? 'Live' : 'Draft')}
+          />
         </div>
       </div>
       <div className={classes.lockContainer}>

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -80,16 +80,19 @@ const TestListTest: React.FC<TestListTestProps> = ({
   const shouldInvertColor = isHovered || isSelected;
 
   const containerClasses = [classes.test];
-  containerClasses.push(test.isOn ? classes.live : classes.draft);
+  containerClasses.push(test.status === 'Live' ? classes.live : classes.draft);
   if (shouldInvertColor) {
-    containerClasses.push(test.isOn ? classes.liveInverted : classes.draftInverted);
+    containerClasses.push(test.status === 'Live' ? classes.liveInverted : classes.draftInverted);
   }
 
   return (
     <ListItem className={containerClasses.join(' ')} button={true} onClick={onClick} ref={ref}>
       <div className={classes.labelAndNameContainer}>
         {isEdited && (isSelected ? <EditIcon className={classes.whitePencil} /> : <EditIcon />)}
-        <TestListTestLiveLabel isLive={test.isOn} shouldInvertColor={shouldInvertColor} />
+        <TestListTestLiveLabel
+          isLive={test.status === 'Live'}
+          shouldInvertColor={shouldInvertColor}
+        />
         <TestListTestName
           name={test.name}
           nickname={test.nickname}

--- a/public/src/components/channelManagement/testLiveSwitch.tsx
+++ b/public/src/components/channelManagement/testLiveSwitch.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  Switch,
+  Theme,
+  Typography,
+} from '@material-ui/core';
+import useOpenable from '../../hooks/useOpenable';
+import CloseIcon from '@material-ui/icons/Close';
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+
+    '& > * + *': {
+      marginLeft: spacing(2),
+    },
+  },
+  switchContainer: {
+    display: 'flex',
+    alignItems: 'center',
+
+    '& > * + *': {
+      marginLeft: spacing(1),
+    },
+  },
+  onOffLabel: {
+    fontSize: '14px',
+    fontWeight: 500,
+  },
+  dialogHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '8px',
+  },
+}));
+
+interface LiveSwitchProps {
+  isLive: boolean;
+  onChange: (isLive: boolean) => void;
+  disabled: boolean;
+}
+
+const TestLiveSwitch: React.FC<LiveSwitchProps> = ({
+  isLive,
+  onChange,
+  disabled,
+}: LiveSwitchProps) => {
+  const classes = useStyles();
+  const [isOpen, open, close] = useOpenable();
+
+  const onSubmit = () => {
+    onChange(!isLive);
+    close();
+  };
+
+  return (
+    <div className={classes.container}>
+      <Typography>Status on theguardian.com:</Typography>
+
+      <div className={classes.switchContainer}>
+        <Typography className={classes.onOffLabel}>Draft</Typography>
+        <Switch checked={isLive} onChange={open} disabled={disabled} />
+        <Typography className={classes.onOffLabel}>Live</Typography>
+
+        <Dialog open={isOpen} onClose={close}>
+          <div className={classes.dialogHeader}>
+            <DialogTitle>Change test status</DialogTitle>
+            <IconButton onClick={close} aria-label="close">
+              <CloseIcon />
+            </IconButton>
+          </div>
+          <DialogContent dividers>
+            {`This will ${
+              isLive ? 'disable' : 'enable'
+            } this test on the site with immediate effect - are you sure?`}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={close} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={onSubmit} color="primary">
+              Yes
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    </div>
+  );
+};
+
+export default TestLiveSwitch;

--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { makeStyles, Theme, Typography } from '@material-ui/core';
 import Sidebar from './sidebar';
-import { LockStatus, Test } from './helpers/shared';
+import { LockStatus, Status, Test } from './helpers/shared';
 import {
   fetchFrontendSettings,
   fetchTest,
@@ -12,8 +12,8 @@ import {
   updateTest,
   saveTestListOrder,
   unlockTest,
-  archiveTests,
   createTest,
+  updateStatuses,
 } from '../../utils/requests';
 import { useParams } from 'react-router-dom';
 
@@ -67,6 +67,7 @@ export interface TestEditorProps<T extends Test> {
   onTestSave: (testName: string) => void;
   onTestArchive: (testName: string) => void;
   onTestCopy: (oldName: string, newName: string, newNickname: string) => void;
+  onStatusChange: (status: Status) => void;
   existingNames: string[];
   existingNicknames: string[];
   settingsType: FrontendSettingsType;
@@ -159,7 +160,7 @@ export const TestsForm = <T extends Test>(
     };
 
     const onTestsArchive = (testNames: string[]): void => {
-      archiveTests(settingsType, testNames)
+      updateStatuses(settingsType, testNames, 'Archived')
         .then(() => fetchTests())
         .catch(error => {
           alert(`Error while archiving test: ${error}`);
@@ -167,10 +168,18 @@ export const TestsForm = <T extends Test>(
     };
 
     const onTestArchive = (testName: string): void => {
-      archiveTests(settingsType, [testName])
+      updateStatuses(settingsType, [testName], 'Archived')
         .then(() => setTests(tests.filter(test => test.name !== testName)))
         .catch(error => {
           alert(`Error while archiving test: ${error}`);
+        });
+    };
+
+    const onStatusChange = (status: Status, testName: string): void => {
+      updateStatuses(settingsType, [testName], status)
+        .then(() => refreshTest(testName))
+        .catch(error => {
+          alert(`Error while setting test status to ${status}: ${error}`);
         });
     };
 
@@ -292,6 +301,7 @@ export const TestsForm = <T extends Test>(
               onTestSave={onTestSave}
               onTestArchive={onTestArchive}
               onTestCopy={onTestCopy}
+              onStatusChange={status => onStatusChange(status, selectedTest.name)}
               settingsType={settingsType}
             />
           ) : (

--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -211,7 +211,6 @@ export const TestsForm = <T extends Test>(
           ...oldTest,
           name: newName,
           nickname: newNickname,
-          isOn: false,
           status: 'Draft',
           // Set lockStatus client-side, so that the StickyTopBar knows what to render
           lockStatus: {

--- a/public/src/components/channelManagement/validatedTestEditor.tsx
+++ b/public/src/components/channelManagement/validatedTestEditor.tsx
@@ -50,6 +50,7 @@ export const ValidatedTestEditor = <T extends Test>(
     existingNames,
     existingNicknames,
     settingsType,
+    onStatusChange,
   }: TestEditorProps<T>) => {
     const classes = useStyles();
     const [isValid, setIsValid] = useState<boolean>(true);
@@ -70,6 +71,7 @@ export const ValidatedTestEditor = <T extends Test>(
           name={test.name}
           nickname={test.nickname}
           isNew={!!test.isNew}
+          status={test.status}
           lockStatus={test.lockStatus || { locked: false }}
           userHasTestLocked={userHasTestLocked}
           userHasTestListLocked={userHasTestListLocked}
@@ -81,6 +83,7 @@ export const ValidatedTestEditor = <T extends Test>(
           onTestSave={onSave}
           onTestArchive={() => onTestArchive(test.name)}
           onTestCopy={onTestCopy}
+          onStatusChange={onStatusChange}
           settingsType={settingsType}
         />
 

--- a/public/src/components/shared/liveSwitch.tsx
+++ b/public/src/components/shared/liveSwitch.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
     alignItems: 'center',
 
     '& > * + *': {
-      marginLeft: spacing(5),
+      marginLeft: spacing(2),
     },
   },
   switchContainer: {
@@ -27,28 +27,18 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 interface LiveSwitchProps {
   isLive: boolean;
   label: string;
-  isDisabled: boolean;
   onChange: (isLive: boolean) => void;
 }
 
-const LiveSwitch: React.FC<LiveSwitchProps> = ({
-  isLive,
-  label,
-  isDisabled,
-  onChange,
-}: LiveSwitchProps) => {
+const LiveSwitch: React.FC<LiveSwitchProps> = ({ isLive, label, onChange }: LiveSwitchProps) => {
   const classes = useStyles();
   return (
     <div className={classes.container}>
-      <Typography>{label}</Typography>
+      <Typography>{label}:</Typography>
 
       <div className={classes.switchContainer}>
         <Typography className={classes.onOffLabel}>Off</Typography>
-        <Switch
-          checked={isLive}
-          onChange={(e): void => onChange(e.target.checked)}
-          disabled={isDisabled}
-        />
+        <Switch checked={isLive} onChange={(e): void => onChange(e.target.checked)} />
         <Typography className={classes.onOffLabel}>On</Typography>
       </div>
     </div>

--- a/public/src/components/shared/liveSwitch.tsx
+++ b/public/src/components/shared/liveSwitch.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
     alignItems: 'center',
 
     '& > * + *': {
-      marginLeft: spacing(2),
+      marginLeft: spacing(5),
     },
   },
   switchContainer: {
@@ -27,18 +27,28 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 interface LiveSwitchProps {
   isLive: boolean;
   label: string;
+  isDisabled: boolean;
   onChange: (isLive: boolean) => void;
 }
 
-const LiveSwitch: React.FC<LiveSwitchProps> = ({ isLive, label, onChange }: LiveSwitchProps) => {
+const LiveSwitch: React.FC<LiveSwitchProps> = ({
+  isLive,
+  label,
+  isDisabled,
+  onChange,
+}: LiveSwitchProps) => {
   const classes = useStyles();
   return (
     <div className={classes.container}>
-      <Typography>{label}:</Typography>
+      <Typography>{label}</Typography>
 
       <div className={classes.switchContainer}>
         <Typography className={classes.onOffLabel}>Off</Typography>
-        <Switch checked={isLive} onChange={(e): void => onChange(e.target.checked)} />
+        <Switch
+          checked={isLive}
+          onChange={(e): void => onChange(e.target.checked)}
+          disabled={isDisabled}
+        />
         <Typography className={classes.onOffLabel}>On</Typography>
       </div>
     </div>

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -43,7 +43,6 @@ export interface BannerVariant extends Variant {
 export interface BannerTest extends Test {
   name: string;
   nickname?: string;
-  isOn: boolean;
   status: Status;
   minArticlesBeforeShowingBanner: number;
   userCohort: UserCohort;

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -62,7 +62,6 @@ export interface MaxEpicViews {
 export interface EpicTest extends Test {
   name: string;
   nickname?: string;
-  isOn: boolean;
   status: Status;
   locations: Region[];
   tagIds: string[];

--- a/public/src/models/header.ts
+++ b/public/src/models/header.ts
@@ -25,7 +25,6 @@ export interface HeaderVariant extends Variant {
 export interface HeaderTest extends Test {
   name: string;
   nickname?: string;
-  isOn: boolean;
   status: Status;
   userCohort: UserCohort;
   locations: Region[];

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -1,3 +1,5 @@
+import { Status } from '../components/channelManagement/helpers/shared';
+
 export enum SupportFrontendSettingsType {
   switches = 'switches',
   contributionTypes = 'contribution-types',
@@ -83,11 +85,12 @@ export function updateTest<T>(settingsType: FrontendSettingsType, test: T): Prom
 export function createTest<T>(settingsType: FrontendSettingsType, test: T): Promise<Response> {
   return saveSettings(`/frontend/${settingsType}/test/create`, test);
 }
-export function archiveTests(
+export function updateStatuses(
   settingsType: FrontendSettingsType,
   testNames: string[],
+  status: Status,
 ): Promise<Response> {
-  return saveSettings(`/frontend/${settingsType}/test/archive`, testNames);
+  return saveSettings(`/frontend/${settingsType}/test/status/${status}`, testNames);
 }
 export function requestTestListLock(settingsType: FrontendSettingsType): Promise<Response> {
   return makeFetch(`/frontend/${settingsType}/list/lock`, {


### PR DESCRIPTION
Currently a user has to lock/edit the whole test to toggle status between Draft/Live.
This will become problematic when we add status toggling to the campaigns page.

This PR:
1. moves the toggle into the StickTopBar
2. the toggle becomes disabled while the test is being edited, to avoid any unexpected behaviour
3. replaces the `/test/archive` endpoint in favour of more general `test/status/:rawStatus` endpoint, for changing the status of a list of tests
4. removes the deprecated `isOn` field, which is no longer used by SDC

### Not editing the test:
![Screen Shot 2022-06-27 at 15 57 01](https://user-images.githubusercontent.com/1513454/175974238-77192935-2066-4e97-9560-9d01ce09764c.png)

### Editing the test:
![Screen Shot 2022-06-27 at 16 02 26](https://user-images.githubusercontent.com/1513454/175974242-4a3e39d5-3ecd-4eab-a71e-ea6442195c67.png)

### Confirmation dialogs:
![Screen Shot 2022-06-27 at 16 02 35](https://user-images.githubusercontent.com/1513454/175974254-6bba248b-b733-477d-a591-ab9d12d5b24a.png)
![Screen Shot 2022-06-27 at 16 02 45](https://user-images.githubusercontent.com/1513454/175974257-bf0ee07c-7e6f-4e84-806d-9bf9aebfbdf0.png)
