### PR TITLE
Remove isOn field on backend

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -50,7 +50,6 @@ case class BannerTest(
   lockStatus: Option[LockStatus],
   priority: Option[Int],
   nickname: Option[String],
-  isOn: Boolean,
   minArticlesBeforeShowingBanner: Int,
   userCohort: UserCohort,
   locations: List[Region] = Nil,

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -71,7 +71,6 @@ case class EpicTest(
   lockStatus: Option[LockStatus],
   priority: Option[Int],
   nickname: Option[String],
-  isOn: Boolean,
   locations: List[Region] = Nil,
   tagIds: List[String] = Nil,
   sections: List[String] = Nil,

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -25,7 +25,6 @@ case class HeaderTest(
   lockStatus: Option[LockStatus],
   priority: Option[Int],
   nickname: Option[String],
-  isOn: Boolean,  // TODO - deprecate in favour of status
   locations: List[Region] = Nil,
   userCohort: Option[UserCohort] = None,
   variants: List[HeaderVariant],

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -33,7 +33,6 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
     EpicTest(
       name = name,
       nickname = Some(name),
-      isOn = true,
       status = Some(Status.Live),
       channel = Some(Channel.Epic),
       lockStatus = None,


### PR DESCRIPTION
this field is deprecated and has already been removed on the client, and SDC uses `status` instead