### PR TITLE
Add editable campaign field to test forms

### DIFF
--- a/public/src/components/channelManagement/CampaignSelector.tsx
+++ b/public/src/components/channelManagement/CampaignSelector.tsx
@@ -39,6 +39,8 @@ interface CampaignSelectorProps {
   disabled: boolean;
 }
 
+const unassignedCampaignLabel = 'NOT_IN_CAMPAIGN';
+
 const CampaignSelector: React.FC<CampaignSelectorProps> = ({
   onCampaignChange,
   test,
@@ -63,9 +65,6 @@ const CampaignSelector: React.FC<CampaignSelectorProps> = ({
           value={test.campaignName}
           displayEmpty
           renderValue={(campaign): string => {
-            if (campaign === undefined) {
-              return ''; // triggers the displayEmpty behaviour
-            }
             return campaign as string;
           }}
           onChange={(event: React.ChangeEvent<{ value: unknown }>): void => {
@@ -73,8 +72,8 @@ const CampaignSelector: React.FC<CampaignSelectorProps> = ({
           }}
           disabled={disabled}
         >
-          <MenuItem value={undefined} key={'campaignName-none'}>
-            No campaign
+          <MenuItem value={unassignedCampaignLabel} key={'campaignName-none'}>
+            {unassignedCampaignLabel}
           </MenuItem>
           {campaigns.map(campaign => (
             <MenuItem value={campaign.name} key={`campaign-${campaign.name}`}>

--- a/public/src/components/channelManagement/CampaignSelector.tsx
+++ b/public/src/components/channelManagement/CampaignSelector.tsx
@@ -83,7 +83,8 @@ const CampaignSelector: React.FC<CampaignSelectorProps> = ({
           ))}
         </Select>
         <div className={classes.warning}>
-          If you want to use this Test in a new or different campaign, please consider copying the test rather than changing its campaign value.
+          If you want to use this Test in a new or different campaign, please consider copying the
+          test rather than changing its campaign value.
         </div>
       </FormControl>
     </>

--- a/public/src/components/channelManagement/CampaignSelector.tsx
+++ b/public/src/components/channelManagement/CampaignSelector.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { fetchFrontendSettings, FrontendSettingsType } from '../../utils/requests';
+import { DataFromServer } from '../../hocs/withS3Data';
+import { Campaign } from './campaigns/CampaignsForm';
+import { Test } from './helpers/shared';
+
+import { Select, MenuItem, FormControl, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  dialogHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '8px',
+  },
+  input: {
+    '& input': {
+      textTransform: 'uppercase !important',
+    },
+  },
+  campaignSelector: {
+    marginBottom: '20px',
+    marginRight: '12px',
+    minWidth: '200px',
+  },
+  campaignSelectorContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  warning: {
+    color: '#555',
+  },
+}));
+
+interface CampaignSelectorProps {
+  onCampaignChange: (campaign?: string) => void;
+  test: Test;
+  disabled: boolean;
+}
+
+const CampaignSelector: React.FC<CampaignSelectorProps> = ({
+  onCampaignChange,
+  test,
+  disabled,
+}: CampaignSelectorProps) => {
+  const classes = useStyles();
+
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+
+  useEffect(() => {
+    fetchFrontendSettings(FrontendSettingsType.campaigns).then((data: DataFromServer<Campaign[]>) =>
+      setCampaigns(data.value),
+    );
+  }, []);
+
+  const setCampaignName = (campaign?: string) => onCampaignChange(campaign);
+
+  return (
+    <>
+      <FormControl className={classes.campaignSelector}>
+        <Select
+          value={test.campaignName}
+          displayEmpty
+          renderValue={(campaign): string => {
+            if (campaign === undefined) {
+              return ''; // triggers the displayEmpty behaviour
+            }
+            return campaign as string;
+          }}
+          onChange={(event: React.ChangeEvent<{ value: unknown }>): void => {
+            setCampaignName(event.target.value as string | undefined);
+          }}
+          disabled={disabled}
+        >
+          <MenuItem value={undefined} key={'campaignName-none'}>
+            No campaign
+          </MenuItem>
+          {campaigns.map(campaign => (
+            <MenuItem value={campaign.name} key={`campaign-${campaign.name}`}>
+              {campaign.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <div className={classes.warning}>
+        If you want to use this Test in a new or different campaign, please consider copying it,
+        rather than changing the Test campaign value.
+      </div>
+    </>
+  );
+};
+
+export default CampaignSelector;

--- a/public/src/components/channelManagement/CampaignSelector.tsx
+++ b/public/src/components/channelManagement/CampaignSelector.tsx
@@ -19,16 +19,17 @@ const useStyles = makeStyles(() => ({
     },
   },
   campaignSelector: {
-    marginBottom: '20px',
+    marginBottom: '8px',
     marginRight: '12px',
     minWidth: '200px',
-  },
-  campaignSelectorContainer: {
     display: 'flex',
     flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'flex-start',
   },
   warning: {
     color: '#555',
+    marginLeft: '24px',
   },
 }));
 
@@ -57,7 +58,7 @@ const CampaignSelector: React.FC<CampaignSelectorProps> = ({
 
   return (
     <>
-      <FormControl className={classes.campaignSelector}>
+      <FormControl className={classes.campaignSelector} size="small">
         <Select
           value={test.campaignName}
           displayEmpty
@@ -81,11 +82,10 @@ const CampaignSelector: React.FC<CampaignSelectorProps> = ({
             </MenuItem>
           ))}
         </Select>
+        <div className={classes.warning}>
+          If you want to use this Test in a new or different campaign, please consider copying the test rather than changing its campaign value.
+        </div>
       </FormControl>
-      <div className={classes.warning}>
-        If you want to use this Test in a new or different campaign, please consider copying it,
-        rather than changing the Test campaign value.
-      </div>
     </>
   );
 };

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -167,19 +167,6 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
       <div className={classes.container}>
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
-            Campaign
-          </Typography>
-          <div>
-            <CampaignSelector
-              test={test}
-              onCampaignChange={onCampaignChange}
-              disabled={!userHasTestLocked}
-            />
-          </div>
-        </div>
-
-        <div className={classes.sectionContainer}>
-          <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants
           </Typography>
           <div>
@@ -212,6 +199,19 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             </div>
           </div>
         )}
+
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Campaign
+          </Typography>
+          <div>
+            <CampaignSelector
+              test={test}
+              onCampaignChange={onCampaignChange}
+              disabled={!userHasTestLocked}
+            />
+          </div>
+        </div>
 
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -4,6 +4,7 @@ import { ArticlesViewedSettings, DeviceType, UserCohort } from '../helpers/share
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@material-ui/core';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
+import CampaignSelector from '../CampaignSelector';
 import TestVariantsEditor from '../testVariantsEditor';
 import TestEditorMinArticlesViewedInput from '../testEditorMinArticlesViewedInput';
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
@@ -54,6 +55,13 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
       ...updatedTest,
       // To save dotcom from having to work this out
       articlesViewedSettings: getArticlesViewedSettings(updatedTest),
+    });
+  };
+
+  const onCampaignChange = (campaign?: string): void => {
+    updateTest({
+      ...test,
+      campaignName: campaign,
     });
   };
 
@@ -157,6 +165,19 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   if (test) {
     return (
       <div className={classes.container}>
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Campaign
+          </Typography>
+          <div>
+            <CampaignSelector
+              test={test}
+              onCampaignChange={onCampaignChange}
+              disabled={!userHasTestLocked}
+            />
+          </div>
+        </div>
+
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
             Variants

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -209,19 +209,6 @@ export const getEpicTestEditor = (
 
     return (
       <div className={classes.container}>
-        <div className={classes.sectionContainer}>
-          <Typography variant={'h3'} className={classes.sectionHeader}>
-            Campaign
-          </Typography>
-          <div>
-            <CampaignSelector
-              test={test}
-              onCampaignChange={onCampaignChange}
-              disabled={!userHasTestLocked}
-            />
-          </div>
-        </div>
-
         {epicEditorConfig.allowMultipleVariants && (
           <div className={classes.sectionContainer}>
             <div className={classes.variantsHeaderContainer}>
@@ -283,6 +270,19 @@ export const getEpicTestEditor = (
             </div>
           </div>
         )}
+
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Campaign
+          </Typography>
+          <div>
+            <CampaignSelector
+              test={test}
+              onCampaignChange={onCampaignChange}
+              disabled={!userHasTestLocked}
+            />
+          </div>
+        </div>
 
         {epicEditorConfig.allowContentTargeting && (
           <div className={classes.sectionContainer}>

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -8,6 +8,7 @@ import {
   DeviceType,
 } from '../helpers/shared';
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
+import CampaignSelector from '../CampaignSelector';
 import TestVariantsEditor from '../testVariantsEditor';
 import TestEditorVariantSummary from '../testEditorVariantSummary';
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
@@ -74,6 +75,13 @@ export const getEpicTestEditor = (
         // To save dotcom from having to work this out
         hasCountryName: copyHasTemplate(updatedTest, COUNTRY_NAME_TEMPLATE),
         articlesViewedSettings: getArticlesViewedSettings(updatedTest),
+      });
+    };
+
+    const onCampaignChange = (campaign?: string): void => {
+      updateTest({
+        ...test,
+        campaignName: campaign,
       });
     };
 
@@ -201,6 +209,19 @@ export const getEpicTestEditor = (
 
     return (
       <div className={classes.container}>
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Campaign
+          </Typography>
+          <div>
+            <CampaignSelector
+              test={test}
+              onCampaignChange={onCampaignChange}
+              disabled={!userHasTestLocked}
+            />
+          </div>
+        </div>
+
         {epicEditorConfig.allowMultipleVariants && (
           <div className={classes.sectionContainer}>
             <div className={classes.variantsHeaderContainer}>

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -6,6 +6,7 @@ import { DeviceType, UserCohort } from '../helpers/shared';
 import { Typography } from '@material-ui/core';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
 import TestVariantsEditor from '../testVariantsEditor';
+import CampaignSelector from '../CampaignSelector';
 
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
 
@@ -28,6 +29,13 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
 
   const onVariantsSplitSettingsValidationChanged = (isValid: boolean): void =>
     setValidationStatusForField('variantsSplitSettings', isValid);
+
+  const onCampaignChange = (campaign?: string): void => {
+    onTestChange({
+      ...test,
+      campaignName: campaign,
+    });
+  };
 
   const onControlProportionSettingsChange = (
     controlProportionSettings?: ControlProportionSettings,
@@ -103,6 +111,19 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
 
   return (
     <div className={classes.container}>
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Campaign
+        </Typography>
+        <div>
+          <CampaignSelector
+            test={test}
+            onCampaignChange={onCampaignChange}
+            disabled={!userHasTestLocked}
+          />
+        </div>
+      </div>
+
       <div className={classes.sectionContainer}>
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Variants

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -113,19 +113,6 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
         <Typography variant={'h3'} className={classes.sectionHeader}>
-          Campaign
-        </Typography>
-        <div>
-          <CampaignSelector
-            test={test}
-            onCampaignChange={onCampaignChange}
-            disabled={!userHasTestLocked}
-          />
-        </div>
-      </div>
-
-      <div className={classes.sectionContainer}>
-        <Typography variant={'h3'} className={classes.sectionHeader}>
           Variants
         </Typography>
         <div>
@@ -158,6 +145,19 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
           </div>
         </div>
       )}
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Campaign
+        </Typography>
+        <div>
+          <CampaignSelector
+            test={test}
+            onCampaignChange={onCampaignChange}
+            disabled={!userHasTestLocked}
+          />
+        </div>
+      </div>
 
       <div className={classes.sectionContainer}>
         <Typography variant={'h3'} className={classes.sectionHeader}>

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -103,7 +103,6 @@ interface StickyTopBarProps {
 const StickyTopBar: React.FC<StickyTopBarProps> = ({
   name,
   nickname,
-  campaignName,
   isNew,
   status,
   lockStatus,
@@ -122,8 +121,6 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
 }: StickyTopBarProps) => {
   const classes = useStyles();
   const mainHeader = nickname ? nickname : name;
-  const campaignHeader =
-    campaignName && campaignName !== 'NOT_IN_CAMPAIGN' ? `[${campaignName}]` : '';
   const secondaryHeader = nickname ? name : null;
 
   return (

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -130,7 +130,7 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
     <header className={classes.container}>
       <div className={classes.namesContainer}>
         <Typography variant="h2" className={classes.mainHeader}>
-          {campaignHeader} {mainHeader}
+          {mainHeader}
         </Typography>
         <div className={classes.secondaryHeaderContainer}>
           <Typography className={classes.secondaryHeader}>{secondaryHeader}</Typography>


### PR DESCRIPTION
## What does this change?
The current functionality is for users to be able to assign a test to an existing campaign when that test is created. After creation there is no way for a user to assign the test to a different campaign, or remove it from the campaign.

This makes using the new campaigns functionality difficult for users as there may be times when they create some tests before thinking to group them together in a new campaign. It also means existing, long running tests that should be grouped together (for instance, the "evergreen" default tests, or the tests dedicated to the Ukraine war) cannot be assigned to a campaign.

This PR addresses these issues by adding an editable `campaign` selector to test forms. The selector will list all existing campaigns, and the update saved in the normal way.

### Screenshots

![Screenshot 2022-07-05 at 13 03 20](https://user-images.githubusercontent.com/5357530/177325156-a626b439-cc51-4992-8806-352d575bca51.png)

![Screenshot 2022-07-05 at 13 04 22](https://user-images.githubusercontent.com/5357530/177325190-05eca081-681b-4836-b654-aa1169c64990.png)



