### PR TITLE
Add navigation buttons to campaign channel cards

### DIFF
--- a/public/src/components/channelManagement/campaigns/ChannelCard.tsx
+++ b/public/src/components/channelManagement/campaigns/ChannelCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { makeStyles, Theme, Button } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 import TestCard from './TestCard';
 import { TestChannelItem } from './CampaignsEditor';
 import { Test } from '../helpers/shared';
@@ -12,10 +13,18 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   noTestsWarning: {
     marginLeft: spacing(4),
   },
+  channelHeading: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+  },
   channelTitle: {
     marginBottom: spacing(2),
     fontSize: '18px',
     fontWeight: 500,
+  },
+  linkButton: {
+    textDecoration: 'none',
   },
 }));
 
@@ -33,7 +42,12 @@ function ChannelCard({ channelData, tests }: ChannelCardProps): React.ReactEleme
 
   return (
     <div className={classes.channelContainer}>
-      <div className={classes.channelTitle}>{channelData.name} channel</div>
+      <div className={classes.channelHeading}>
+        <div className={classes.channelTitle}>{channelData.name} channel</div>
+        <Link className={classes.linkButton} key={channelData.name} to={`/${channelData.link}`}>
+          <Button variant="outlined">Go to {channelData.name} page</Button>
+        </Link>
+      </div>
       {tests.length > 0 ? (
         tests.map(test => {
           const key = getKey(test);


### PR DESCRIPTION
## What does this change?
This is a small UX fix to help users navigate from the campaigns page a little quicker. It adds navigation buttons to each channel card to take the user to that channel's main page.

### Before:
![Screenshot 2022-07-13 at 17 04 13](https://user-images.githubusercontent.com/5357530/178780867-d4ee7b16-1bde-4c1a-885b-5b473c08d5fb.png)

### After:
![Screenshot 2022-07-13 at 17 04 56](https://user-images.githubusercontent.com/5357530/178780912-c2e30e19-3e1d-4202-915d-324c687c668d.png)

