### PR TITLE
AWS asyncCredentialUpdateEnabled

### DIFF
--- a/app/services/Aws.scala
+++ b/app/services/Aws.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.regions.Region
 object Aws {
   val credentialsProvider = AwsCredentialsProviderChain.builder().credentialsProviders(
     ProfileCredentialsProvider.builder.profileName("membership").build,
-    InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build
+    InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(true).build
   )
 
   val region = Region.EU_WEST_1


### PR DESCRIPTION
The credentials sometimes expire while fetching data from S3.
AWS have asked us to make this change:
`Try setting asyncCredentialUpdateEnabled to true, it will fetch credentials asynchronously in the background.`