### PR TITLE
Revert "AWS asyncCredentialUpdateEnabled"

### DIFF
--- a/app/services/Aws.scala
+++ b/app/services/Aws.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.regions.Region
 object Aws {
   val credentialsProvider = AwsCredentialsProviderChain.builder().credentialsProviders(
     ProfileCredentialsProvider.builder.profileName("membership").build,
-    InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(true).build
+    InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build
   )
 
   val region = Region.EU_WEST_1


### PR DESCRIPTION
Reverts guardian/support-admin-console#377

`java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@7d80f2b2 rejected from java.util.concurrent.ScheduledThreadPoolExecutor@456256ca[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 2]`