### PR TITLE
Switches for apps metering

### DIFF
--- a/app/controllers/AppsMeteringSwitchesController.scala
+++ b/app/controllers/AppsMeteringSwitchesController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.AppsMeteringSwitches
+import models.AppsMeteringSwitches._
+import play.api.mvc.{AnyContent, ControllerComponents}
+import zio.ZEnv
+
+import scala.concurrent.ExecutionContext
+
+class AppsMeteringSwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+  extends S3ObjectController[AppsMeteringSwitches](authAction, components, stage, filename = "apps-metering-switches.json", runtime) {
+}

--- a/app/models/AppsMeteringSwitches.scala
+++ b/app/models/AppsMeteringSwitches.scala
@@ -1,0 +1,14 @@
+package models
+
+import io.circe.generic.auto._
+import io.circe.{Decoder, Encoder}
+
+case class AppsMeteringSwitches(
+  enabled: Boolean,
+  excludeBreakingNews: Boolean
+)
+
+object AppsMeteringSwitches {
+  implicit val decoder = Decoder[AppsMeteringSwitches]
+  implicit val encoder = Encoder[AppsMeteringSwitches]
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -84,6 +84,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new ChannelSwitchesController(authAction, controllerComponents, stage, runtime),
     new CampaignsController(authAction, controllerComponents, stage, runtime, dynamoTestsService),
     new CapiController(authAction, capiService),
+    new AppsMeteringSwitchesController(authAction, controllerComponents, stage, runtime),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,8 @@ GET /campaigns/:testName                            controllers.Application.inde
 
 GET /qr-code                                        controllers.Application.index
 
+GET /apps-metering-switches                        controllers.Application.index
+
 # ----- Authentication ----- #
 GET  /login                                         controllers.Login.login
 GET  /loginAction                                   controllers.Login.loginAction
@@ -213,6 +215,10 @@ GET   /frontend/campaign/:campaignName/tests           controllers.CampaignsCont
 # ----- capi ----- #
 GET   /capi/tags                                       controllers.CapiController.getTags()
 GET   /capi/sections                                   controllers.CapiController.getSections()
+
+# ----- apps metering switches ----- #
+GET   /apps/apps-metering-switches                     controllers.AppsMeteringSwitchesController.get
+POST  /apps/apps-metering-switches/update              controllers.AppsMeteringSwitchesController.set
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/public/src/components/appsMeteringSwitches.tsx
+++ b/public/src/components/appsMeteringSwitches.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
+import { AppsSettingsType, fetchAppsSettings, saveAppsSettings } from '../utils/requests';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Button from '@material-ui/core/Button';
+import withS3Data, { InnerProps } from '../hocs/withS3Data';
+
+const useStyles = makeStyles(() => ({
+  container: {
+    margin: '30px',
+    maxWidth: '500px',
+    display: 'flex',
+    flexDirection: 'column',
+    '& > * + *': {
+      marginTop: '5px',
+    },
+  },
+}));
+
+type SwitchName = 'enabled' | 'excludeBreakingNews';
+
+type AppsMeteringSwitches = {
+  [key in SwitchName]: boolean;
+};
+
+interface AppsMeteringSwitchProps {
+  name: SwitchName;
+  label: string;
+  enabled: boolean;
+  setSwitch: (name: SwitchName, enabled: boolean) => void;
+}
+
+const AppsMeteringSwitch: React.FC<AppsMeteringSwitchProps> = ({
+  name,
+  label,
+  enabled,
+  setSwitch,
+}: AppsMeteringSwitchProps) => (
+  <FormControlLabel
+    key={name}
+    label={label}
+    control={
+      <Switch
+        checked={enabled}
+        onChange={(event): void => {
+          setSwitch(name, event.target.checked);
+        }}
+        value={name}
+      />
+    }
+  />
+);
+
+const AppsMeteringSwitches: React.FC<InnerProps<AppsMeteringSwitches>> = ({
+  data: switches,
+  setData: setSwitches,
+  saveData: saveSwitches,
+}: InnerProps<AppsMeteringSwitches>) => {
+  const classes = useStyles();
+
+  const onSwitchChange = (name: SwitchName, enabled: boolean): void => {
+    setSwitches({
+      ...switches,
+      [name]: enabled,
+    });
+  };
+
+  return (
+    <div className={classes.container}>
+      <AppsMeteringSwitch
+        name="enabled"
+        label="Enable apps metering"
+        enabled={switches.enabled}
+        setSwitch={onSwitchChange}
+      />
+      <AppsMeteringSwitch
+        name="excludeBreakingNews"
+        label="Exclude breaking news articles from metering"
+        enabled={switches.excludeBreakingNews}
+        setSwitch={onSwitchChange}
+      />
+
+      <Button
+        onClick={saveSwitches}
+        color="primary"
+        variant="contained"
+        size="large"
+        fullWidth={false}
+      >
+        Submit
+      </Button>
+    </div>
+  );
+};
+
+export default withS3Data<AppsMeteringSwitches>(
+  AppsMeteringSwitches,
+  () => fetchAppsSettings(AppsSettingsType.appsMeteringSwitches),
+  data => saveAppsSettings(AppsSettingsType.appsMeteringSwitches, data),
+);

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -206,6 +206,11 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="QR Code Generator" />
           </ListItem>
         </Link>
+        <Link key="Apps Metering Switches" to="/apps-metering-switches" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Apps Metering Switches">
+            <ListItemText primary="Apps Metering Switches" />
+          </ListItem>
+        </Link>
       </div>
 
       <div>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -35,6 +35,7 @@ import CampaignsForm from './components/channelManagement/campaigns/CampaignsFor
 import { FontWeightProperty } from 'csstype';
 import { makeStyles } from '@material-ui/core';
 import QrCodePage from './components/utilities/QrCodePage';
+import AppsMeteringSwitches from './components/appsMeteringSwitches';
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
@@ -230,6 +231,12 @@ const AppRouter = () => {
           <Route
             path="/qr-code"
             render={(): React.ReactElement => createComponent(<QrCodePage />, 'QR Code Generator')}
+          />
+          <Route
+            path="/apps-metering-switches"
+            render={(): React.ReactElement =>
+              createComponent(<AppsMeteringSwitches />, 'Apps Metering Switches')
+            }
           />
         </div>
       </Router>

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -21,6 +21,10 @@ export enum FrontendSettingsType {
   campaigns = 'campaigns',
 }
 
+export enum AppsSettingsType {
+  appsMeteringSwitches = 'apps-metering-switches',
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeFetch(path: string, options?: RequestInit): Promise<any> {
   return fetch(path, options).then(resp => {
@@ -134,4 +138,12 @@ export function saveFrontendSettings(
   data: any,
 ): Promise<Response> {
   return saveSettings(`/frontend/${settingsType}/update`, data);
+}
+
+export function fetchAppsSettings<T>(settingsType: AppsSettingsType): Promise<T> {
+  return fetchSettings(`/apps/${settingsType}`);
+}
+
+export function saveAppsSettings<T>(settingsType: AppsSettingsType, data: T): Promise<Response> {
+  return saveSettings(`/apps/${settingsType}/update`, data);
 }


### PR DESCRIPTION
A very simple switchboard. Uses existing logic to write json to an S3 file.
Based heavily on [ChannelSwitches.tsx](https://github.com/guardian/support-admin-console/blob/main/public/src/components/channelManagement/ChannelSwitches.tsx)

![Screen Shot 2022-08-04 at 11 46 53](https://user-images.githubusercontent.com/1513454/182828979-d6700004-4285-4e4a-bd24-a3a418ffd944.png)
