### PR TITLE
Add new apps-metering API switch: requireApiKey

### DIFF
--- a/app/models/AppsMeteringSwitches.scala
+++ b/app/models/AppsMeteringSwitches.scala
@@ -5,7 +5,8 @@ import io.circe.{Decoder, Encoder}
 
 case class AppsMeteringSwitches(
   enabled: Boolean,
-  excludeBreakingNews: Boolean
+  excludeBreakingNews: Boolean,
+  requireApiKey: Boolean
 )
 
 object AppsMeteringSwitches {

--- a/public/src/components/appsMeteringSwitches.tsx
+++ b/public/src/components/appsMeteringSwitches.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-type SwitchName = 'enabled' | 'excludeBreakingNews';
+type SwitchName = 'enabled' | 'excludeBreakingNews' | 'requireApiKey';
 
 type AppsMeteringSwitches = {
   [key in SwitchName]: boolean;
@@ -78,6 +78,12 @@ const AppsMeteringSwitches: React.FC<InnerProps<AppsMeteringSwitches>> = ({
         name="excludeBreakingNews"
         label="Exclude breaking news articles from metering"
         enabled={switches.excludeBreakingNews}
+        setSwitch={onSwitchChange}
+      />
+      <AppsMeteringSwitch
+        name="requireApiKey"
+        label="Require clients to provide an API key"
+        enabled={switches.requireApiKey}
         setSwitch={onSwitchChange}
       />
 


### PR DESCRIPTION
## What does this change?

Add new apps-metering API switch: `requireApiKey`. This controls whether the apps-metering API requires an API key from clients.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="540" alt="Screenshot 2022-08-12 at 15 28 19" src="https://user-images.githubusercontent.com/379839/184375317-6ebfef14-5850-465f-a56b-6fb654b39346.png">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
