### PR TITLE
Update banner paragraphs maxchar limit

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -13,7 +13,6 @@ import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEdit
 import {
   EMPTY_ERROR_HELPER_TEXT,
   getEmptyParagraphsError,
-  MAXLENGTH_ERROR_HELPER_TEXT,
   templateValidatorForPlatform,
 } from '../helpers/validation';
 import { Cta, SecondaryCta } from '../helpers/shared';
@@ -79,7 +78,7 @@ const HEADER_DEFAULT_HELPER_TEXT = 'Assitive text';
 const BODY_DEFAULT_HELPER_TEXT = 'Main banner message paragraph';
 const HIGHTLIGHTED_TEXT_HELPER_TEXT = 'Final sentence of body copy';
 
-const BODY_COPY_WITHOUT_SECONDARY_CTA_RECOMMENDED_LENGTH = 525;
+const BODY_COPY_WITHOUT_SECONDARY_CTA_RECOMMENDED_LENGTH = 500;
 const BODY_COPY_WITH_SECONDARY_CTA_RECOMMENDED_LENGTH = 390;
 
 type DeviceType = 'ALL' | 'MOBILE' | 'NOT_MOBILE';
@@ -199,14 +198,14 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
     ];
   };
 
-  const getParagraphsHelperText = () => {
-    const [copyLength, recommendedLength] = getBodyCopyLength();
+  const [copyLength, recommendedLength] = getBodyCopyLength();
 
+  const getParagraphsHelperText = () => {
     if (!copyLength) {
       return EMPTY_ERROR_HELPER_TEXT;
     }
     if (copyLength > recommendedLength) {
-      return MAXLENGTH_ERROR_HELPER_TEXT;
+      return `This copy is longer than the recommended length (${recommendedLength} chars). Please preview across breakpoints before publishing.`;
     }
     return `${BODY_DEFAULT_HELPER_TEXT} (${recommendedLength} chars)`;
   };
@@ -264,7 +263,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             render={data => {
               return (
                 <RichTextEditor
-                  error={errors.paragraphs !== undefined}
+                  error={errors.paragraphs !== undefined || copyLength > recommendedLength}
                   helperText={
                     errors.paragraphs
                       ? // @ts-ignore -- react-hook-form doesn't believe it has a message field


### PR DESCRIPTION
## What does this change?
This PR fixes two related issues:

1. Marketing have asked that the recommended maximum characters value for the variant paragraphs copy be reduced from 525 to 500
2. Error messages for the variant paragraphs field were not being highlighted, making it more difficult for users to notice them

### Screenshots

**Before:**
![Screenshot 2022-08-18 at 16 33 23](https://user-images.githubusercontent.com/5357530/185437669-68259175-9266-4385-9563-c718dc23d87d.png)

**After - including all possible error messages for the field**
![Screenshot 2022-08-18 at 16 34 35](https://user-images.githubusercontent.com/5357530/185437884-38f08b1a-7e82-4877-99e3-67c6ddc29134.png)

![Screenshot 2022-08-18 at 16 33 46](https://user-images.githubusercontent.com/5357530/185437947-5be53bf6-7a04-4927-8759-9eb9ce229be0.png)

![Screenshot 2022-08-18 at 16 34 07](https://user-images.githubusercontent.com/5357530/185437999-4866aa5c-b134-4f4f-a552-5d36e9939c26.png)

![Screenshot 2022-08-18 at 16 34 53](https://user-images.githubusercontent.com/5357530/185438053-002dc529-23b5-4fb0-8063-d04a749caa9b.png)

