### PR TITLE
fix useEffect to rectify issue

### DIFF
--- a/public/src/hooks/useModule.ts
+++ b/public/src/hooks/useModule.ts
@@ -30,7 +30,7 @@ export const useModule = <T>(path: string, name: string): React.FC<T> | undefine
     window.remoteImport(`${baseUrl}/${path}`).then(bannerModule => {
       setModule(() => withPreviewStyles(bannerModule[name]));
     });
-  }, []);
+  }, [name]);
 
   return Module;
 };


### PR DESCRIPTION
## What does this change?
This PR fixes a live preview issue for Banner templates. Currently, user is able to change a test variant's template, but cannot view the banner copy in the live preview until after they have saved the changes, clicked on a different banner test, and then returned to the original test - at this point the live preview will display the newly selected banner template.

Once this PR is merged users will be able to change the banner template while editing the test and, when they click on the live preview button, the correct banner template will appear.