### PR TITLE
Disable save button while saving

### DIFF
--- a/public/src/components/amounts/configuredAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredAmountsEditor.tsx
@@ -75,6 +75,7 @@ const ConfiguredAmountsEditor: React.FC<InnerProps<ConfiguredAmounts>> = ({
   data: configuredAmounts,
   setData: setConfiguredAmounts,
   saveData: saveConfiguredAmounts,
+  saving,
 }: InnerProps<ConfiguredAmounts>) => {
   const classes = useStyles();
   const [selectedRegion, setSelectedRegion] = useState<Region>(Region.GBPCountries);
@@ -92,7 +93,11 @@ const ConfiguredAmountsEditor: React.FC<InnerProps<ConfiguredAmounts>> = ({
   return (
     <div className={classes.body}>
       <div className={classes.leftCol}>
-        <Sidebar onRegionSelected={setSelectedRegion} save={saveConfiguredAmounts} />
+        <Sidebar
+          onRegionSelected={setSelectedRegion}
+          save={saveConfiguredAmounts}
+          saving={saving}
+        />
       </div>
       <div className={classes.rightCol}>
         <ConfiguredRegionAmountsEditor

--- a/public/src/components/amounts/sidebar.tsx
+++ b/public/src/components/amounts/sidebar.tsx
@@ -58,9 +58,10 @@ interface SidebarItemProps {
 interface SidebarProps {
   onRegionSelected: (region: Region) => void;
   save: () => void;
+  saving: boolean;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ onRegionSelected, save }: SidebarProps) => {
+const Sidebar: React.FC<SidebarProps> = ({ onRegionSelected, save, saving }: SidebarProps) => {
   const classes = useStyles();
 
   const SidebarSaveButton: React.FC = () => (
@@ -70,8 +71,9 @@ const Sidebar: React.FC<SidebarProps> = ({ onRegionSelected, save }: SidebarProp
       className={classes.button}
       startIcon={<SaveIcon />}
       onClick={save}
+      disabled={saving}
     >
-      <Typography className={classes.buttonText}>Save</Typography>
+      <Typography className={classes.buttonText}>{saving ? 'Saving' : 'Save'}</Typography>
     </Button>
   );
 

--- a/public/src/components/appsMeteringSwitches.tsx
+++ b/public/src/components/appsMeteringSwitches.tsx
@@ -56,6 +56,7 @@ const AppsMeteringSwitches: React.FC<InnerProps<AppsMeteringSwitches>> = ({
   data: switches,
   setData: setSwitches,
   saveData: saveSwitches,
+  saving,
 }: InnerProps<AppsMeteringSwitches>) => {
   const classes = useStyles();
 
@@ -93,6 +94,7 @@ const AppsMeteringSwitches: React.FC<InnerProps<AppsMeteringSwitches>> = ({
         variant="contained"
         size="large"
         fullWidth={false}
+        disabled={saving}
       >
         Submit
       </Button>

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -66,6 +66,7 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
   data: switches,
   setData: setSwitches,
   saveData: saveSwitches,
+  saving,
 }: InnerProps<ChannelSwitches>) => {
   const classes = useStyles();
 
@@ -121,6 +122,7 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
         variant="contained"
         size="large"
         fullWidth={false}
+        disabled={saving}
       >
         Submit
       </Button>

--- a/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
@@ -64,6 +64,7 @@ const CampaignsForm: React.FC<InnerProps<Campaigns>> = ({
   data: campaigns,
   setData: setCampaigns,
   saveData: saveCampaigns,
+  saving,
 }: InnerProps<Campaigns>) => {
   const classes = useStyles();
   const { testName } = useParams<{ testName?: string }>();
@@ -116,6 +117,7 @@ const CampaignsForm: React.FC<InnerProps<Campaigns>> = ({
           selectedCampaign={currentCampaign}
           onCampaignSelected={onCampaignSelected}
           saveAllCampaigns={saveAllCampaigns}
+          saving={saving}
         />
       </div>
       <div className={classes.rightCol}>

--- a/public/src/components/channelManagement/campaigns/CampaignsSidebar.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsSidebar.tsx
@@ -46,6 +46,7 @@ interface CampaignsSidebarProps {
   createCampaign: (campaign: Campaign) => void;
   onCampaignSelected: (campaignName: string) => void;
   saveAllCampaigns: () => void;
+  saving: boolean;
 }
 
 function CampaignsSidebar({
@@ -55,6 +56,7 @@ function CampaignsSidebar({
   newCampaignCreated,
   onCampaignSelected,
   saveAllCampaigns,
+  saving,
 }: CampaignsSidebarProps): React.ReactElement {
   const classes = useStyles();
 
@@ -70,6 +72,7 @@ function CampaignsSidebar({
           className={newCampaignCreated ? classes.saveAllButtonAlert : classes.saveAllButton}
           variant="outlined"
           onClick={saveAllCampaigns}
+          disabled={saving}
         >
           <Typography className={classes.saveAllButtonText}>Save all campaigns</Typography>
         </Button>

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -92,6 +92,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
   data,
   setData,
   saveData,
+  saving,
 }: InnerProps<SupportFrontendSwitches>) => {
   const classes = useStyles();
 
@@ -170,7 +171,12 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
 
   const SaveButton = (): JSX.Element => (
     <div className={classes.buttons}>
-      <Button variant="contained" onClick={actionSaveData} className={classes.button}>
+      <Button
+        variant="contained"
+        onClick={actionSaveData}
+        className={classes.button}
+        disabled={saving}
+      >
         <SaveIcon />
         Save
       </Button>

--- a/public/src/hocs/withS3Data.tsx
+++ b/public/src/hocs/withS3Data.tsx
@@ -10,6 +10,7 @@ export interface InnerProps<T> {
   data: T;
   setData: (data: T) => void;
   saveData: () => void;
+  saving: boolean;
 }
 
 type FetchSettings<T> = () => Promise<DataFromServer<T>>;
@@ -22,12 +23,12 @@ function withS3Data<T>(
 ): React.FC {
   const Wrapped: React.FC = () => {
     const [dataFromServer, setDataFromServer] = useState<DataFromServer<T> | null>(null);
+    const [saving, setIsSaving] = useState<boolean>(false);
 
-    const fetchData = (): void => {
+    const fetchData = (): Promise<void> =>
       fetchSettings()
         .then(data => setDataFromServer(data))
         .catch(err => alert(err));
-    };
 
     useEffect(() => {
       fetchData();
@@ -44,12 +45,15 @@ function withS3Data<T>(
       if (!dataFromServer) {
         return;
       }
+      setIsSaving(true);
 
-      saveSettings(dataFromServer).then(fetchData);
+      saveSettings(dataFromServer)
+        .then(fetchData)
+        .then(() => setIsSaving(false));
     };
 
     return dataFromServer ? (
-      <Inner data={dataFromServer.value} setData={setData} saveData={saveData} />
+      <Inner data={dataFromServer.value} setData={setData} saveData={saveData} saving={saving} />
     ) : null; // TODO: add spinner?
   };
 


### PR DESCRIPTION
The amounts tool UI gives no feedback after clicking save, and sometimes users spam the save button as a result.

This PR updates the `withS3Data` HOC to pass a `saving` boolean into the wrapped component.
The amounts tool can then disable the save button while `saving === true`.
![Screen Shot 2022-08-24 at 08 29 26](https://user-images.githubusercontent.com/1513454/186358282-a8ec58f2-d272-46bd-8ef6-5de5c9ac69ef.png)

In the 2nd commit I updated all other components which use `withS3Data` to also disable the save button. 