### PR TITLE
Add reminder CTA option to Liveblog Epic variants

### DIFF
--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -123,7 +123,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantImageUrl: false,
   allowVariantFooter: false,
   allowVariantCustomPrimaryCta: true,
-  allowVariantCustomSecondaryCta: false,
+  allowVariantCustomSecondaryCta: true,
   allowVariantSeparateArticleCount: false,
   allowVariantTicker: false,
   allowVariantChoiceCards: false,


### PR DESCRIPTION
## What does this change?
Marketing have requested the ability to add a Reminder CTA button to Liveblog Epics. This PR enables that functionality in RRCP. 

A second PR in the SDC repo does the work to make the reminder functionality work in Liveblog Epics - https://github.com/guardian/support-dotcom-components/pull/751

**Screenshots of RRCP**
![Screenshot 2022-09-21 at 14 34 37](https://user-images.githubusercontent.com/5357530/191725488-ed8a0e41-2535-4dd1-ae9f-ba7d0c0cff3d.png)
![Screenshot 2022-09-21 at 14 35 17](https://user-images.githubusercontent.com/5357530/191725514-cbfa0ca9-3982-46f0-9f3a-3cf5ba4855e2.png)
![Screenshot 2022-09-21 at 14 35 49](https://user-images.githubusercontent.com/5357530/191725551-80e98f36-dda9-44a6-bd2e-c30064e774ea.png)
