### PR TITLE
Epic liveblog preview fixes

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -143,6 +143,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
       isInEditMode={userHasTestLocked}
       topButton={<BannerVariantPreview variant={variant} />}
       platform="DOTCOM" // hardcoded as banners are currently not supported in AMP or Apple News
+      articleType="Standard"
     />
   );
 

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -218,7 +218,7 @@ export const getEpicTestEditor = (
               <Typography variant={'h3'} className={classes.sectionHeader}>
                 Variants
               </Typography>
-              <EpicTestPreviewButton test={test} />
+              <EpicTestPreviewButton test={test} moduleName={epicEditorConfig.moduleName} />
             </div>
             <div>
               <TestVariantsEditor<EpicVariant>

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -204,6 +204,9 @@ export const getEpicTestEditor = (
         testType="EPIC"
         isInEditMode={userHasTestLocked}
         platform={epicEditorConfig.platform}
+        articleType={
+          epicEditorConfig.moduleName === 'ContributionsLiveblogEpic' ? 'Liveblog' : 'Standard'
+        }
       />
     );
 

--- a/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
@@ -3,6 +3,7 @@ import { Button, Dialog, makeStyles, Theme, Typography } from '@material-ui/core
 import useOpenable from '../../../hooks/useOpenable';
 import EpicVariantPreview from './epicVariantPreview';
 import { EpicTest } from '../../../models/epic';
+import { EpicModuleName } from '../helpers/shared';
 
 const useStyles = makeStyles(({}: Theme) => ({
   dialog: {
@@ -24,10 +25,12 @@ const useStyles = makeStyles(({}: Theme) => ({
 
 interface EpicTestPreviewProps {
   test: EpicTest;
+  moduleName: EpicModuleName;
 }
 
 export const EpicTestPreviewButton: React.FC<EpicTestPreviewProps> = ({
   test,
+  moduleName,
 }: EpicTestPreviewProps) => {
   const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
@@ -48,7 +51,7 @@ export const EpicTestPreviewButton: React.FC<EpicTestPreviewProps> = ({
               <Typography variant={'h3'} className={classes.variantName}>
                 {variant.name}
               </Typography>
-              <EpicVariantPreview variant={variant} moduleName="ContributionsEpic" />
+              <EpicVariantPreview variant={variant} moduleName={moduleName} />
             </div>
           ))}
         </div>

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -90,6 +90,7 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
       isInEditMode={userHasTestLocked}
       // hardcoded as heads are currently not supported in AMP or Apple News
       platform="DOTCOM"
+      articleType="Standard"
     />
   );
 

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Theme, Typography, AccordionSummary, makeStyles } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
-import TestEditorVariantSummaryWebPreviewButton from './testEditorVariantSummaryWebPreviewButton';
+import TestEditorVariantSummaryWebPreviewButton, {
+  ArticleType,
+} from './testEditorVariantSummaryWebPreviewButton';
 import { TestPlatform, TestType } from './helpers/shared';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
@@ -46,6 +48,7 @@ interface TestEditorVariantSummaryProps {
   isInEditMode: boolean;
   topButton?: React.ReactElement;
   platform: TestPlatform;
+  articleType: ArticleType;
 }
 
 const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
@@ -55,6 +58,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
   isInEditMode,
   topButton,
   platform,
+  articleType,
 }: TestEditorVariantSummaryProps) => {
   const classes = useStyles();
 
@@ -76,6 +80,7 @@ const TestEditorVariantSummary: React.FC<TestEditorVariantSummaryProps> = ({
             testType={testType}
             platform={platform}
             isDisabled={isInEditMode}
+            articleType={articleType}
           />
         </div>
       </div>

--- a/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
@@ -2,30 +2,22 @@ import React from 'react';
 import { Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import { TestPlatform, TestType } from './helpers/shared';
-import { getStage } from '../../utils/stage';
+import { getStage, Stage } from '../../utils/stage';
 
-const BASE_ARTICLE_URL = {
-  PROD: {
-    DOTCOM:
-      'https://theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
-    AMP:
-      'https://amp.theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
-    APPLE_NEWS: '',
-  },
-  CODE: {
-    DOTCOM:
-      'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
-    AMP:
-      'https://amp.code.dev-theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
-    APPLE_NEWS: '',
-  },
-  DEV: {
-    DOTCOM:
-      'https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
-    AMP:
-      'https://amp.code.dev-theguardian.com/politics/2020/may/15/may-and-johnson-hung-civil-servants-out-to-dry-report-finds',
-    APPLE_NEWS: '',
-  },
+export type ArticleType = 'Standard' | 'Liveblog';
+
+const ArticlePaths: Record<ArticleType, string> = {
+  Standard:
+    'world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder',
+  Liveblog: 'uk-news/live/2022/sep/19/queen-elizabeth-ii-state-funeral-westminster-abbey-updates',
+};
+
+const getHostName = (stage: Stage, platform: TestPlatform): string => {
+  if (stage === 'PROD') {
+    return platform === 'AMP' ? 'amp.theguardian.com' : 'theguardian.com';
+  } else {
+    return platform === 'AMP' ? 'amp.code.dev-theguardian.com' : 'm.code.dev-theguardian.com';
+  }
 };
 
 const getPreviewUrl = (
@@ -33,11 +25,12 @@ const getPreviewUrl = (
   variantName: string,
   testType: TestType,
   platform: TestPlatform,
+  articleType: ArticleType,
 ): string => {
   const stage = getStage();
   const queryString = `?dcr&force-${testType.toLowerCase()}=${testName}:${variantName}`;
 
-  return stage ? `${BASE_ARTICLE_URL[stage][platform]}${queryString}` : '/';
+  return `https://${getHostName(stage, platform)}/${ArticlePaths[articleType]}${queryString}`;
 };
 
 interface TestEditorVariantSummaryPreviewButtonProps {
@@ -46,6 +39,7 @@ interface TestEditorVariantSummaryPreviewButtonProps {
   testType: TestType;
   platform: TestPlatform;
   isDisabled: boolean;
+  articleType: ArticleType;
 }
 
 const TestEditorVariantSummaryWebPreviewButton: React.FC<TestEditorVariantSummaryPreviewButtonProps> = ({
@@ -54,6 +48,7 @@ const TestEditorVariantSummaryWebPreviewButton: React.FC<TestEditorVariantSummar
   testType,
   platform,
   isDisabled,
+  articleType,
 }: TestEditorVariantSummaryPreviewButtonProps) => {
   const isIncompatiblePlatform = ['APPLE_NEWS'].includes(platform);
 
@@ -77,7 +72,7 @@ const TestEditorVariantSummaryWebPreviewButton: React.FC<TestEditorVariantSummar
       size="small"
       onClick={(event): void => event.stopPropagation()}
       onFocus={(event): void => event.stopPropagation()}
-      href={getPreviewUrl(testName, name, testType, platform)}
+      href={getPreviewUrl(testName, name, testType, platform, articleType)}
       target="_blank"
       rel="noopener noreferrer"
       disabled={checkForDisabledButton()}

--- a/public/src/utils/stage.ts
+++ b/public/src/utils/stage.ts
@@ -1,4 +1,4 @@
-type Stage = 'DEV' | 'CODE' | 'PROD';
+export type Stage = 'DEV' | 'CODE' | 'PROD';
 
 export const getStage = (): Stage => {
   return window.guardian.stage;


### PR DESCRIPTION
Fixes 2 bugs:
1. For the web preview it currently links to a standard article instead of a liveblog (commit 1)
2. For the multi-variant live preview it currently renders the standard epic (commit 2)

![Screenshot 2022-09-19 at 15 34 00](https://user-images.githubusercontent.com/1513454/191043340-a83ecfb9-486d-44bb-ba1d-149cad6dbdd9.png)
