### PR TITLE
Use dependencyOverrides for jackson-databind

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,8 @@ libraryDependencies ++= Seq(
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )
 
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+
 dynamoDBLocalPort := 8083
 startDynamoDBLocal := {startDynamoDBLocal.dependsOn(Test / compile).value}
 Test / testQuick := {(Test / testQuick).dependsOn(startDynamoDBLocal).evaluated}


### PR DESCRIPTION
Play brings in an old version of jackson-databind with a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244

We do already set the jackson-databind version to the latest, and the old version is evicted (sbt dependencyTree proves this). But snyk is still flagging it.
The `dependencyOverrides` setting should solve this. We do this elsewhere, [e.g payment-api](https://github.com/guardian/support-frontend/blob/bf114d34b916ad2a123989ba455be1962d260994/support-payment-api/build.sbt#L56)