### PR TITLE
java 11

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
         PROD: AdminConsole-PROD.template.json
       amiParameter: AMIAdminconsole
       amiTags:
-        Recipe: bionic-membership-ARM
+        Recipe: bionic-membership-java11
         AmigoStage: PROD
       amiEncrypted: true
   admin-console:


### PR DESCRIPTION
The department is migrating scala apps to java 11.

Steps I have taken:
1. Created a new AMI recipe in Amigo, called `bionic-membership-java11`. I did this by cloning the existing `bionic-membership-ARM` recipe and changing the java version.
2. Updated (in this PR) the riff-raff.yaml to use the new recipe.
3. Updated the teamcity build to use java 11 for the JAVA_HOME env var

It builds/deploys to CODE successfully.