### PR TITLE
Add `enableScheduledBannerDeploys` switch

### DIFF
--- a/app/models/ChannelSwitches.scala
+++ b/app/models/ChannelSwitches.scala
@@ -11,6 +11,7 @@ case class ChannelSwitches(
   enableSuperMode: Boolean,
   enableHardcodedEpicTests: Boolean,
   enableHardcodedBannerTests: Boolean,
+  enableScheduledBannerDeploys: Boolean = true,
 )
 
 object ChannelSwitches {

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -28,7 +28,8 @@ type SwitchName =
   | 'enableHeaders'
   | 'enableSuperMode'
   | 'enableHardcodedEpicTests'
-  | 'enableHardcodedBannerTests';
+  | 'enableHardcodedBannerTests'
+  | 'enableScheduledBannerDeploys';
 
 type ChannelSwitches = {
   [key in SwitchName]: boolean;
@@ -113,6 +114,12 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
         name="enableHardcodedBannerTests"
         label="Enable hardcoded banner tests"
         enabled={switches.enableHardcodedBannerTests}
+        setSwitch={onSwitchChange}
+      />
+      <ChannelSwitch
+        name="enableScheduledBannerDeploys"
+        label="Enable scheduled banner deploys"
+        enabled={switches.enableScheduledBannerDeploys}
         setSwitch={onSwitchChange}
       />
 


### PR DESCRIPTION
## What does this change?

Adds `enableScheduledBannerDeploys` switch to `ChannelSwitches.scala` and `ChannelSwitches.tsx`.

## Images

### Before
<img width="541" alt="Screenshot 2022-10-17 at 16 30 36" src="https://user-images.githubusercontent.com/55602675/196219660-0223fca3-f9de-4f40-b9cc-0d9a94c5d82f.png">


### After
<img width="559" alt="Screenshot 2022-10-17 at 16 30 03" src="https://user-images.githubusercontent.com/55602675/196219694-3429c032-4612-48a6-88a7-3f956f5476cc.png">