### PR TITLE
Remove 'supporter ticker' option

### DIFF
--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -21,7 +21,6 @@ object TickerCountType extends Enum[TickerCountType] with CirceEnum[TickerCountT
   override val values: IndexedSeq[TickerCountType] = findValues
 
   case object money extends TickerCountType
-  case object people extends TickerCountType
 }
 
 case class TickerCopy(

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -50,14 +50,14 @@ interface BannerProps {
 const anchor = 'bottom';
 
 const tickerSettings = {
-  countType: TickerCountType.people,
   endType: TickerEndType.unlimited,
-  currencySymbol: '$',
+  countType: TickerCountType.money,
   copy: {
-    countLabel: 'supporters in Australia',
+    countLabel: 'contributions',
     goalReachedPrimary: "We've hit our goal!",
     goalReachedSecondary: 'but you can still support us',
   },
+  currencySymbol: '$',
   tickerData: {
     total: 120_000,
     goal: 150_000,

--- a/public/src/components/channelManagement/epicTests/epicTestTickerEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestTickerEditor.tsx
@@ -96,11 +96,6 @@ const EpicTestTickerEditor: React.FC<EpicTestTickerEditorProps> = ({
     updateTickerSettings(isChecked ? DEFAULT_TICKER_SETTINGS : undefined);
   };
 
-  const onCountTypeChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const selectedType = event.target.value as TickerCountType;
-    tickerSettings && updateTickerSettings({ ...tickerSettings, countType: selectedType });
-  };
-
   const onEndTypeChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const selectedType = event.target.value as TickerEndType;
     tickerSettings && updateTickerSettings({ ...tickerSettings, endType: selectedType });
@@ -189,31 +184,6 @@ const EpicTestTickerEditor: React.FC<EpicTestTickerEditorProps> = ({
               fullWidth
             />
           )}
-
-          <div>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">Ticker count type</FormLabel>
-              <RadioGroup
-                value={tickerSettings.countType}
-                onChange={onCountTypeChanged}
-                aria-label="ticker-count-type"
-                name="ticker-count-type"
-              >
-                <FormControlLabel
-                  value={TickerCountType.money}
-                  control={<Radio />}
-                  label="Money"
-                  disabled={isDisabled}
-                />
-                <FormControlLabel
-                  value={TickerCountType.people}
-                  control={<Radio />}
-                  label="Supporters"
-                  disabled={isDisabled}
-                />
-              </RadioGroup>
-            </FormControl>
-          </div>
 
           <div>
             <FormControl component="fieldset">

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -248,7 +248,6 @@ export enum TickerEndType {
 }
 export enum TickerCountType {
   money = 'money',
-  people = 'people',
 }
 interface TickerCopy {
   countLabel: string;

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -7,20 +7,14 @@ import {
   SecondaryCta,
   Status,
   Test,
+  TickerCountType,
+  TickerEndType,
   UserCohort,
   Variant,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
 
-export enum TickerEndType {
-  unlimited = 'unlimited',
-  hardstop = 'hardstop',
-}
-export enum TickerCountType {
-  money = 'money',
-  people = 'people',
-}
 interface TickerCopy {
   countLabel: string;
   goalReachedPrimary: string;


### PR DESCRIPTION
This type of ticker hasn't been used in a long time, and the system that calculated it would need to be migrated to use BigQuery if we ever need it again.
We can simplify the SDC ticker logic if we remove support for this.

[SDC PR](https://github.com/guardian/support-dotcom-components/pull/792)


Before:
![Screenshot 2022-11-14 at 13 55 53](https://user-images.githubusercontent.com/1513454/201681892-3641daae-45d6-4688-87c0-bab546d36d2b.png)

After:
![Screenshot 2022-11-14 at 13 55 29](https://user-images.githubusercontent.com/1513454/201681908-62f7a398-772a-463a-9720-f744d38a3e9a.png)

