### PR TITLE
Banner ticker settings

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -42,7 +42,8 @@ case class BannerVariant(
   template: BannerTemplate,
   bannerContent: Option[BannerContent],
   mobileBannerContent: Option[BannerContent],
-  separateArticleCount: Option[Boolean]
+  separateArticleCount: Option[Boolean],
+  tickerSettings: Option[TickerSettings] = None,
 )
 
 case class BannerTest(

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -8,34 +8,6 @@ import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable.IndexedSeq
 
-sealed trait TickerEndType extends EnumEntry
-object TickerEndType extends Enum[TickerEndType] with CirceEnum[TickerEndType] {
-  override val values: IndexedSeq[TickerEndType] = findValues
-
-  case object unlimited extends TickerEndType
-  case object hardstop extends TickerEndType
-}
-
-sealed trait TickerCountType extends EnumEntry
-object TickerCountType extends Enum[TickerCountType] with CirceEnum[TickerCountType] {
-  override val values: IndexedSeq[TickerCountType] = findValues
-
-  case object money extends TickerCountType
-}
-
-case class TickerCopy(
-  countLabel: String,
-  goalReachedPrimary: String,
-  goalReachedSecondary: String
-)
-
-case class TickerSettings(
-  endType: TickerEndType,
-  countType: TickerCountType,
-  currencySymbol: String,
-  copy: TickerCopy
-)
-
 sealed trait SeparateArticleCountType extends EnumEntry
 object SeparateArticleCountType extends Enum[SeparateArticleCountType] with CirceEnum[SeparateArticleCountType] {
   override val values: IndexedSeq[SeparateArticleCountType] = findValues

--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -1,0 +1,35 @@
+package models
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+
+sealed trait TickerEndType
+object TickerEndType {
+  case object unlimited extends TickerEndType
+  case object hardstop extends TickerEndType
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val encoder = deriveEnumerationEncoder[TickerEndType]
+  implicit val decoder = deriveEnumerationDecoder[TickerEndType]
+}
+
+sealed trait TickerCountType
+object TickerCountType {
+  case object money extends TickerCountType
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val encoder = deriveEnumerationEncoder[TickerCountType]
+  implicit val decoder = deriveEnumerationDecoder[TickerCountType]
+}
+
+case class TickerCopy(
+  countLabel: String,
+  goalReachedPrimary: String,
+  goalReachedSecondary: String
+)
+
+case class TickerSettings(
+  endType: TickerEndType,
+  countType: TickerCountType,
+  currencySymbol: String,
+  copy: TickerCopy
+)

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -25,6 +25,7 @@ import {
   RichTextEditorSingleLine,
   getRteCopyLength,
 } from '../richTextEditor/richTextEditor';
+import TickerEditor from '../tickerEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -356,6 +357,8 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   const classes = useStyles();
   const setValidationStatusForField = useValidation(onValidationChange);
 
+  const allowVariantTicker = true; // TODO - set based on template
+
   const onMobileContentRadioChange = (): void => {
     if (variant.mobileBannerContent === undefined) {
       onVariantChange({
@@ -455,6 +458,25 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           <Typography className={classes.switchLabel}>Enabled</Typography>
         </div>
       </div>
+      {allowVariantTicker && (
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.sectionHeader} variant="h4">
+            Ticker
+          </Typography>
+
+          <TickerEditor
+            tickerSettings={variant.tickerSettings}
+            updateTickerSettings={tickerSettings =>
+              onVariantChange({
+                ...variant,
+                tickerSettings,
+              })
+            }
+            isDisabled={!editMode}
+            onValidationChange={onValidationChange}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -357,7 +357,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   const classes = useStyles();
   const setValidationStatusForField = useValidation(onValidationChange);
 
-  const allowVariantTicker = true; // TODO - set based on template
+  const allowVariantTicker = false; // TODO - set based on template
 
   const onMobileContentRadioChange = (): void => {
     if (variant.mobileBannerContent === undefined) {

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -4,7 +4,7 @@ import { makeStyles, Theme, Typography } from '@material-ui/core';
 
 import EpicTestChoiceCardsEditor from './epicTestChoiceCardsEditor';
 import EpicTestSignInLinkEditor from './epicTestSignInLinkEditor';
-import EpicTestTickerEditor from './epicTestTickerEditor';
+import TickerEditor from '../tickerEditor';
 import EpicTestVariantEditorCtasEditor from './epicTestVariantEditorCtasEditor';
 
 import {
@@ -405,7 +405,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             Ticker
           </Typography>
 
-          <EpicTestTickerEditor
+          <TickerEditor
             tickerSettings={variant.tickerSettings}
             updateTickerSettings={updateTickerSettings}
             isDisabled={!editMode}

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -11,8 +11,8 @@ import {
   Theme,
 } from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { TickerCountType, TickerEndType, TickerSettings } from '../helpers/shared';
-import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import { TickerCountType, TickerEndType, TickerSettings } from './helpers/shared';
+import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -45,19 +45,19 @@ const DEFAULT_TICKER_SETTINGS: TickerSettings = {
   currencySymbol: '$',
 };
 
-interface EpicTestTickerEditorProps {
+interface TickerEditorProps {
   isDisabled: boolean;
   tickerSettings?: TickerSettings;
   updateTickerSettings: (updatedTickerSettings?: TickerSettings) => void;
   onValidationChange: (isValid: boolean) => void;
 }
 
-const EpicTestTickerEditor: React.FC<EpicTestTickerEditorProps> = ({
+const TickerEditor: React.FC<TickerEditorProps> = ({
   isDisabled,
   tickerSettings,
   updateTickerSettings,
   onValidationChange,
-}: EpicTestTickerEditorProps) => {
+}: TickerEditorProps) => {
   const classes = useStyles();
 
   const defaultValues: FormData = {
@@ -215,4 +215,4 @@ const EpicTestTickerEditor: React.FC<EpicTestTickerEditorProps> = ({
   );
 };
 
-export default EpicTestTickerEditor;
+export default TickerEditor;

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -7,6 +7,7 @@ import {
   SecondaryCta,
   DeviceType,
   Status,
+  TickerSettings,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
@@ -36,6 +37,7 @@ export interface BannerVariant extends Variant {
   bannerContent: BannerContent;
   mobileBannerContent?: BannerContent;
   separateArticleCount?: boolean;
+  tickerSettings?: TickerSettings;
 }
 
 export interface BannerTest extends Test {

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -7,25 +7,12 @@ import {
   SecondaryCta,
   Status,
   Test,
-  TickerCountType,
-  TickerEndType,
+  TickerSettings,
   UserCohort,
   Variant,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
-
-interface TickerCopy {
-  countLabel: string;
-  goalReachedPrimary: string;
-  goalReachedSecondary: string;
-}
-export interface TickerSettings {
-  endType: TickerEndType;
-  countType: TickerCountType;
-  currencySymbol: string;
-  copy: TickerCopy;
-}
 
 export interface SeparateArticleCount {
   type: 'above';


### PR DESCRIPTION
Sometimes banner templates can support tickers.
SDC already supports `tickerSettings` in the `BannerVariant` model - https://github.com/guardian/support-dotcom-components/blob/main/packages/shared/src/types/abTests/banner.ts#L33

This PR makes it possible to configure the epic from the banner tool. Currently no template supports tickers, but the upcoming US + AU banners will.

![Screenshot 2022-11-16 at 08 19 03](https://user-images.githubusercontent.com/1513454/202129034-eec40ad9-689c-4450-9f8f-959027157898.png)
