### PR TITLE
Ticker name field

### DIFF
--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -21,6 +21,16 @@ object TickerCountType {
   implicit val decoder = deriveEnumerationDecoder[TickerCountType]
 }
 
+sealed trait TickerName
+object TickerName {
+  case object US_2022 extends TickerName
+  case object AU_2022 extends TickerName
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val encoder = deriveEnumerationEncoder[TickerName]
+  implicit val decoder = deriveEnumerationDecoder[TickerName]
+}
+
 case class TickerCopy(
   countLabel: String,
   goalReachedPrimary: String,
@@ -31,5 +41,6 @@ case class TickerSettings(
   endType: TickerEndType,
   countType: TickerCountType,
   currencySymbol: String,
-  copy: TickerCopy
+  copy: TickerCopy,
+  name: TickerName
 )

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -3,7 +3,7 @@ import { Theme, makeStyles, Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
 import { BannerTemplate, BannerVariant, BannerContent } from '../../../models/banner';
-import { TickerCountType, TickerEndType, TickerSettings } from '../helpers/shared';
+import { TickerCountType, TickerEndType, TickerName, TickerSettings } from '../helpers/shared';
 import Typography from '@material-ui/core/Typography';
 import { useModule } from '../../../hooks/useModule';
 
@@ -58,6 +58,7 @@ const tickerSettings = {
     goalReachedSecondary: 'but you can still support us',
   },
   currencySymbol: '$',
+  name: TickerName.US_2022,
   tickerData: {
     total: 120_000,
     goal: 150_000,

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Theme, makeStyles } from '@material-ui/core';
 
-import { EpicModuleName, TickerSettings } from '../helpers/shared';
+import { EpicModuleName, TickerName, TickerSettings } from '../helpers/shared';
 import { useModule } from '../../../hooks/useModule';
 import { EpicVariant } from '../../../models/epic';
 
@@ -159,6 +159,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
           endType: variant.tickerSettings.endType,
           currencySymbol: variant.tickerSettings.currencySymbol,
           copy: variant.tickerSettings.copy,
+          name: TickerName.US_2022,
           tickerData: {
             total: 50000,
             goal: 100000,

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -249,6 +249,11 @@ export enum TickerEndType {
 export enum TickerCountType {
   money = 'money',
 }
+export enum TickerName {
+  US_2022 = 'US_2022',
+  AU_2022 = 'AU_2022',
+}
+
 interface TickerCopy {
   countLabel: string;
   goalReachedPrimary: string;
@@ -259,6 +264,7 @@ export interface TickerSettings {
   countType: TickerCountType;
   currencySymbol: string;
   copy: TickerCopy;
+  name: TickerName;
 }
 
 export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -2,16 +2,16 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import {
   Checkbox,
-  makeStyles,
-  TextField,
   FormControl,
   FormLabel,
+  makeStyles,
   Radio,
   RadioGroup,
+  TextField,
   Theme,
 } from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { TickerCountType, TickerEndType, TickerSettings } from './helpers/shared';
+import { TickerCountType, TickerEndType, TickerName, TickerSettings } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
@@ -43,6 +43,7 @@ const DEFAULT_TICKER_SETTINGS: TickerSettings = {
     goalReachedSecondary: 'but you can still support us',
   },
   currencySymbol: '$',
+  name: TickerName.US_2022,
 };
 
 interface TickerEditorProps {
@@ -101,6 +102,11 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
     tickerSettings && updateTickerSettings({ ...tickerSettings, endType: selectedType });
   };
 
+  const onNameChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const selectedName = event.target.value as TickerName;
+    tickerSettings && updateTickerSettings({ ...tickerSettings, name: selectedName });
+  };
+
   const onSubmit = ({
     countLabel,
     goalReachedPrimary,
@@ -131,6 +137,31 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
 
       {!!tickerSettings && (
         <div className={classes.fieldsContainer}>
+          <div>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">Ticker campaign name</FormLabel>
+              <RadioGroup
+                value={tickerSettings.name}
+                onChange={onNameChanged}
+                aria-label="ticker-name"
+                name="ticker-name"
+              >
+                <FormControlLabel
+                  value={TickerName.US_2022}
+                  control={<Radio />}
+                  label="US_2022"
+                  disabled={isDisabled}
+                />
+                <FormControlLabel
+                  value={TickerName.AU_2022}
+                  control={<Radio />}
+                  label="AU_2022"
+                  disabled={isDisabled}
+                />
+              </RadioGroup>
+            </FormControl>
+          </div>
+
           <TextField
             inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
             error={!!errors.countLabel}


### PR DESCRIPTION
A recent [SDC PR added](https://github.com/guardian/support-dotcom-components/pull/794/files#diff-f6d008991ff4c942fd35b6f10f9d66bea4d5206c66e28b836b6fdf91a003bc83R95) the `name` field to the `TickerSettings` type.
This will enable Marketing to select which ticker campaign to use.

This PR adds it to the model SAC, with radio buttons in the TickerSettings component:
![Screenshot 2022-11-17 at 13 56 01](https://user-images.githubusercontent.com/1513454/202465225-dd570ac4-267e-434d-9269-b7b4f281cb57.png)

Note - one day we may want to tie this to the campaigns feature.