### PR TITLE
`Signed In Status` checkbox in RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -60,7 +60,8 @@ case class BannerTest(
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN")
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
+  signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest = this.copy(channel = Some(channel))

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -57,7 +57,8 @@ case class EpicTest(
   articlesViewedSettings: Option[ArticlesViewedSettings] = None,
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN")
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
+  signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -30,7 +30,8 @@ case class HeaderTest(
   variants: List[HeaderVariant],
   controlProportionSettings: Option[ControlProportionSettings] = None,
   deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN")
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
+  signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
 ) extends ChannelTest[HeaderTest] {
 
   override def withChannel(channel: Channel): HeaderTest = this.copy(channel = Some(channel))

--- a/app/models/SignedInStatus.scala
+++ b/app/models/SignedInStatus.scala
@@ -1,0 +1,16 @@
+package models
+
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{ deriveEnumerationDecoder, deriveEnumerationEncoder }
+import io.circe.{Decoder, Encoder}
+
+sealed trait SignedInStatus
+
+object SignedInStatus {
+  case object All extends SignedInStatus
+  case object SignedIn extends SignedInStatus
+  case object SignedOut extends SignedInStatus
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val decoder: Decoder[SignedInStatus] = deriveEnumerationDecoder[SignedInStatus]
+  implicit val encoder: Encoder[SignedInStatus] = deriveEnumerationEncoder[SignedInStatus]
+}

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
-import { ArticlesViewedSettings, DeviceType, UserCohort } from '../helpers/shared';
+import { ArticlesViewedSettings, DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@material-ui/core';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
@@ -111,6 +111,10 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
 
   const onDeviceTypeChange = (updatedDeviceType: DeviceType): void => {
     updateTest({ ...test, deviceType: updatedDeviceType });
+  };
+
+  const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
+    onTestChange({ ...test, signedInStatus });
   };
 
   const onArticlesViewedSettingsChange = (
@@ -242,6 +246,8 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             isDisabled={!userHasTestLocked}
             showSupporterStatusSelector={true}
             showDeviceTypeSelector={true}
+            selectedSignedInStatus={test.signedInStatus}
+            onSignedInStatusChange={onSignedInStatusChange}
           />
         </div>
 

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -6,6 +6,7 @@ import {
   UserCohort,
   EpicEditorConfig,
   DeviceType,
+  SignedInStatus,
 } from '../helpers/shared';
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
 import CampaignSelector from '../CampaignSelector';
@@ -149,6 +150,10 @@ export const getEpicTestEditor = (
 
     const onDeviceTypeChange = (updatedDeviceType: DeviceType): void => {
       updateTest({ ...test, deviceType: updatedDeviceType });
+    };
+
+    const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
+      onTestChange({ ...test, signedInStatus });
     };
 
     const onArticlesViewedSettingsChange = (
@@ -321,6 +326,8 @@ export const getEpicTestEditor = (
               isDisabled={!userHasTestLocked}
               showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargeting}
               showDeviceTypeSelector={epicEditorConfig.allowDeviceTypeTargeting}
+              selectedSignedInStatus={test.signedInStatus}
+              onSignedInStatusChange={onSignedInStatusChange}
             />
           </div>
         )}

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 
-import { DeviceType, UserCohort } from '../helpers/shared';
+import { DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
 
 import { Typography } from '@material-ui/core';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
@@ -67,6 +67,10 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
 
   const onDeviceTypeChange = (updatedDeviceType: DeviceType): void => {
     onTestChange({ ...test, deviceType: updatedDeviceType });
+  };
+
+  const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
+    onTestChange({ ...test, signedInStatus });
   };
 
   const renderVariantEditor = (variant: HeaderVariant): React.ReactElement => (
@@ -175,6 +179,8 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
           isDisabled={!userHasTestLocked}
           showSupporterStatusSelector={true}
           showDeviceTypeSelector={true}
+          selectedSignedInStatus={test.signedInStatus}
+          onSignedInStatusChange={onSignedInStatusChange}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -26,6 +26,7 @@ export interface Test {
   priority?: number;
   userCohort?: string;
   channel?: string;
+  signedInStatus?: SignedInStatus;
 }
 
 export interface EpicEditorConfig {
@@ -275,3 +276,5 @@ export interface Image {
   mainUrl: string;
   altText: string;
 }
+
+export type SignedInStatus = 'SignedIn' | 'SignedOut' | 'All';

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Theme, Typography, makeStyles } from '@material-ui/core';
 import { Region } from '../../utils/models';
-import { DeviceType, UserCohort } from './helpers/shared';
+import { DeviceType, SignedInStatus, UserCohort } from './helpers/shared';
 
 import TestEditorTargetRegionsSelector from './testEditorTargetRegionsSelector';
 import TypedRadioGroup from './TypedRadioGroup';
@@ -38,6 +38,8 @@ interface TestEditorTargetAudienceSelectorProps {
   isDisabled: boolean;
   showSupporterStatusSelector: boolean;
   showDeviceTypeSelector: boolean;
+  selectedSignedInStatus?: SignedInStatus;
+  onSignedInStatusChange: (signedInStatus: SignedInStatus) => void;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
   selectedRegions,
@@ -50,6 +52,8 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   isDisabled,
   showSupporterStatusSelector,
   showDeviceTypeSelector,
+  selectedSignedInStatus,
+  onSignedInStatusChange,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
 
@@ -96,6 +100,20 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
           />
         </div>
       )}
+
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.heading}>Signed In Status</Typography>
+        <TypedRadioGroup
+          selectedValue={selectedSignedInStatus ?? 'All'}
+          onChange={onSignedInStatusChange}
+          isDisabled={isDisabled}
+          labels={{
+            All: 'All',
+            SignedIn: 'Signed in',
+            SignedOut: 'Signed out',
+          }}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## What does this change?

### Backend changes

- Creates trait `SignedInStatus` and adds signedInStatus to `BannerTests.scala`, `HeaderTests.scala` and `EpicTest.scala`

-  Creates `onSignedInStatusChange` function in `bannerTestEditor.tsx`, `headerTestEditor.tsx` and `epicTestEditor.tsx`

### UI changes

- Adds a `Singed in status` checkbox to `testEditorTargetAudienceSelector.tsx`


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Images

### Before
<img width="673" alt="Screenshot 2022-11-18 at 11 38 29" src="https://user-images.githubusercontent.com/55602675/202697205-b9a3c72e-7328-43e5-b937-41e2f79d22bd.png">



### After
<img width="898" alt="Screenshot 2022-11-18 at 11 39 42" src="https://user-images.githubusercontent.com/55602675/202697226-083be8eb-076a-4697-b301-df16a8d75abf.png">

