### PR TITLE
Default promos page RRCP

### DIFF
--- a/app/controllers/DefaultPromosController.scala
+++ b/app/controllers/DefaultPromosController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import models.{AppsMeteringSwitches, DefaultPromos}
+import models.AppsMeteringSwitches._
+import play.api.mvc.{AnyContent, ControllerComponents}
+import zio.ZEnv
+
+import scala.concurrent.ExecutionContext
+
+class DefaultPromosController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+  extends S3ObjectController[DefaultPromos](authAction, components, stage, filename = "default-promos.json", runtime) {
+}

--- a/app/models/DefaultPromos.scala
+++ b/app/models/DefaultPromos.scala
@@ -4,9 +4,9 @@ import io.circe.generic.auto._
 import io.circe.{Decoder, Encoder}
 
 case class DefaultPromos(
-                          guardianWeekly: Seq[String],
-                          paper: Seq[String]
-                               )
+  guardianWeekly: Seq[String],
+  paper: Seq[String]
+)
 
 object DefaultPromos {
   implicit val decoder = Decoder[DefaultPromos]

--- a/app/models/DefaultPromos.scala
+++ b/app/models/DefaultPromos.scala
@@ -1,0 +1,14 @@
+package models
+
+import io.circe.generic.auto._
+import io.circe.{Decoder, Encoder}
+
+case class DefaultPromos(
+                          guardianWeekly: Seq[String],
+                          paper: Seq[String]
+                               )
+
+object DefaultPromos {
+  implicit val decoder = Decoder[DefaultPromos]
+  implicit val encoder = Encoder[DefaultPromos]
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -87,6 +87,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new CampaignsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoCampaignsService),
     new CapiController(authAction, capiService),
     new AppsMeteringSwitchesController(authAction, controllerComponents, stage, runtime),
+    new DefaultPromosController(authAction,controllerComponents, stage, runtime),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -41,6 +41,8 @@ GET /qr-code                                        controllers.Application.inde
 
 GET /apps-metering-switches                        controllers.Application.index
 
+GET /default-promos                                 controllers.Application.index
+
 # ----- Authentication ----- #
 GET  /login                                         controllers.Login.login
 GET  /loginAction                                   controllers.Login.loginAction
@@ -219,6 +221,10 @@ GET   /capi/sections                                   controllers.CapiControlle
 # ----- apps metering switches ----- #
 GET   /apps/apps-metering-switches                     controllers.AppsMeteringSwitchesController.get
 POST  /apps/apps-metering-switches/update              controllers.AppsMeteringSwitchesController.set
+
+# ----- default promos ---------- #
+GET   /support-frontend/default-promos                     controllers.DefaultPromosController.get
+POST  /support-frontend/default-promos/update              controllers.DefaultPromosController.set
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Hello = () => <div>Hello</div>;
+
+export default Hello;

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,4 +1,10 @@
-import React from 'react';
+import {
+  Button,
+  FormControlLabel,
+  TextField,
+  makeStyles,
+} from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
 import withS3Data, { InnerProps } from '../hocs/withS3Data';
 import {
   fetchSupportFrontendSettings,
@@ -12,13 +18,71 @@ type DefaultPromos = {
   [key in ProductName]: string[];
 };
 
+const useStyles = makeStyles(() => ({
+  container: {
+    margin: '30px',
+    maxWidth: '500px',
+    display: 'flex',
+    flexDirection: 'column',
+    '& > * + *': {
+      marginTop: '5px',
+    },
+  },
+}));
+
 const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
   data,
   setData,
   saveData,
   saving,
 }: InnerProps<DefaultPromos>) => {
-  return <div>{JSON.stringify(data)}</div>;
+  const [gwPromosString, setGwPromosString] = useState<string>();
+
+  useEffect(() => {
+    setGwPromosString(data.guardianWeekly.join(', '));
+  }, []);
+
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <TextField
+        value={gwPromosString}
+        name="guardianWeeklyDefaultPromos"
+        fullWidth={true}
+        onChange={e => {
+          const inputValue = e.target.value;
+          setGwPromosString(inputValue);
+
+          const parsedInputValue = inputValue.split(',').map(promo => promo.trim());
+          setData({
+            ...data,
+            guardianWeekly: parsedInputValue,
+          });
+        }}
+        type="text"
+        label="Guardian Weekly"
+      />
+      {/* <TextField
+        value={data.paper.join(', ')}
+        name="paperDefaultPromos"
+        fullWidth={true}
+        onChange={e => console.log(e.target)}
+        type="text"
+        label="Paper"
+      /> */}
+      <Button
+        onClick={saveData}
+        color="primary"
+        variant="contained"
+        size="large"
+        fullWidth={false}
+        disabled={saving}
+      >
+        Submit
+      </Button>
+    </div>
+  );
 };
 
 export default withS3Data<DefaultPromos>(

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,5 +1,28 @@
 import React from 'react';
+import withS3Data, { InnerProps } from '../hocs/withS3Data';
+import {
+  fetchSupportFrontendSettings,
+  saveSupportFrontendSettings,
+  SupportFrontendSettingsType,
+} from '../utils/requests';
 
-const Hello = () => <div>Hello</div>;
+type ProductName = 'guardianWeekly' | 'paper';
 
-export default Hello;
+type DefaultPromos = {
+  [key in ProductName]: string[];
+};
+
+const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
+  data,
+  setData,
+  saveData,
+  saving,
+}: InnerProps<DefaultPromos>) => {
+  return <div>{JSON.stringify(data)}</div>;
+};
+
+export default withS3Data<DefaultPromos>(
+  DefaultPromos,
+  () => fetchSupportFrontendSettings(SupportFrontendSettingsType.defaultPromos),
+  data => saveSupportFrontendSettings(SupportFrontendSettingsType.defaultPromos, data),
+);

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -48,8 +48,8 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
 
           const parsedInputValue = inputValue
             .split(',')
-            .filter(promo => promo !== '')
-            .map(promo => promo.trim());
+            .map(promo => promo.trim())
+            .filter(promo => promo !== '');
 
           setData({
             ...data,
@@ -69,8 +69,8 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
 
           const parsedInputValue = inputValue
             .split(',')
-            .filter(promo => promo !== '')
-            .map(promo => promo.trim());
+            .map(promo => promo.trim())
+            .filter(promo => promo !== '');
 
           setData({
             ...data,

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,5 +1,5 @@
 import { Button, TextField, makeStyles } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import withS3Data, { InnerProps } from '../hocs/withS3Data';
 import {
   fetchSupportFrontendSettings,
@@ -31,13 +31,8 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
   saveData,
   saving,
 }: InnerProps<DefaultPromos>) => {
-  const [gwPromosString, setGwPromosString] = useState<string>();
-  const [paperPromosString, setpaperPromosString] = useState<string>();
-
-  useEffect(() => {
-    setGwPromosString(data.guardianWeekly.join(', '));
-    setpaperPromosString(data.paper.join(', '));
-  }, []);
+  const [gwPromosString, setGwPromosString] = useState<string>(data.guardianWeekly.join(', '));
+  const [paperPromosString, setpaperPromosString] = useState<string>(data.paper.join(', '));
 
   const classes = useStyles();
 

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,9 +1,4 @@
-import {
-  Button,
-  FormControlLabel,
-  TextField,
-  makeStyles,
-} from '@material-ui/core';
+import { Button, TextField, makeStyles } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import withS3Data, { InnerProps } from '../hocs/withS3Data';
 import {
@@ -37,9 +32,11 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
   saving,
 }: InnerProps<DefaultPromos>) => {
   const [gwPromosString, setGwPromosString] = useState<string>();
+  const [paperPromosString, setpaperPromosString] = useState<string>();
 
   useEffect(() => {
     setGwPromosString(data.guardianWeekly.join(', '));
+    setpaperPromosString(data.paper.join(', '));
   }, []);
 
   const classes = useStyles();
@@ -54,7 +51,11 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
           const inputValue = e.target.value;
           setGwPromosString(inputValue);
 
-          const parsedInputValue = inputValue.split(',').map(promo => promo.trim());
+          const parsedInputValue = inputValue
+            .split(',')
+            .filter(promo => promo !== '')
+            .map(promo => promo.trim());
+
           setData({
             ...data,
             guardianWeekly: parsedInputValue,
@@ -63,14 +64,27 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
         type="text"
         label="Guardian Weekly"
       />
-      {/* <TextField
-        value={data.paper.join(', ')}
+      <TextField
+        value={paperPromosString}
         name="paperDefaultPromos"
         fullWidth={true}
-        onChange={e => console.log(e.target)}
+        onChange={e => {
+          const inputValue = e.target.value;
+          setpaperPromosString(inputValue);
+
+          const parsedInputValue = inputValue
+            .split(',')
+            .filter(promo => promo !== '')
+            .map(promo => promo.trim());
+
+          setData({
+            ...data,
+            paper: parsedInputValue,
+          });
+        }}
         type="text"
         label="Paper"
-      /> */}
+      />
       <Button
         onClick={saveData}
         color="primary"

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,6 +1,7 @@
 import { Button, TextField, makeStyles } from '@material-ui/core';
 import React, { useState } from 'react';
 import withS3Data, { InnerProps } from '../hocs/withS3Data';
+import { parsePromoInput } from '../utils/parsePromoInput';
 import {
   fetchSupportFrontendSettings,
   saveSupportFrontendSettings,
@@ -46,11 +47,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
           const inputValue = e.target.value;
           setGwPromosString(inputValue);
 
-          const parsedInputValue = inputValue
-            .split(',')
-            .map(promo => promo.trim())
-            .filter(promo => promo !== '');
-
+          const parsedInputValue = parsePromoInput(inputValue);
           setData({
             ...data,
             guardianWeekly: parsedInputValue,
@@ -67,11 +64,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
           const inputValue = e.target.value;
           setpaperPromosString(inputValue);
 
-          const parsedInputValue = inputValue
-            .split(',')
-            .map(promo => promo.trim())
-            .filter(promo => promo !== '');
-
+          const parsedInputValue = parsePromoInput(inputValue);
           setData({
             ...data,
             paper: parsedInputValue,

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -220,6 +220,11 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Apps Metering Switches" />
           </ListItem>
         </Link>
+        <Link key="Default Promos" to="/default-promos" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Default Promos">
+            <ListItemText primary="Default Promos" />
+          </ListItem>
+        </Link>
       </div>
 
       <div>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -36,6 +36,7 @@ import { FontWeightProperty } from 'csstype';
 import { makeStyles } from '@material-ui/core';
 import QrCodePage from './components/utilities/QrCodePage';
 import AppsMeteringSwitches from './components/appsMeteringSwitches';
+import DefaultPromos from './components/defaultPromos';
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
@@ -237,6 +238,10 @@ const AppRouter = () => {
             render={(): React.ReactElement =>
               createComponent(<AppsMeteringSwitches />, 'Apps Metering Switches')
             }
+          />
+          <Route
+            path="/default-promos"
+            render={(): React.ReactElement => createComponent(<DefaultPromos />, 'Default Promos')}
           />
         </div>
       </Router>

--- a/public/src/utils/parsePromoInput.test.ts
+++ b/public/src/utils/parsePromoInput.test.ts
@@ -1,0 +1,43 @@
+import { parsePromoInput } from './parsePromoInput';
+
+describe('parsePromoInput', () => {
+  it('returns a list of promo codes', () => {
+    const promosText = 'Promo1, promo2, promo3';
+
+    const promosList = parsePromoInput(promosText);
+
+    expect(promosList).toEqual(['Promo1', 'promo2', 'promo3']);
+  });
+
+  it('discards an empty final item', () => {
+    const promosText = 'Promo1, promo2, promo3,';
+
+    const promosList = parsePromoInput(promosText);
+
+    expect(promosList).toEqual(['Promo1', 'promo2', 'promo3']);
+  });
+
+  it('discards an empty item in the middle', () => {
+    const promosText = 'Promo1, promo2, , promo3';
+
+    const promosList = parsePromoInput(promosText);
+
+    expect(promosList).toEqual(['Promo1', 'promo2', 'promo3']);
+  });
+
+  it('discards an empty item in the beginning', () => {
+    const promosText = ', Promo1, promo2, promo3';
+
+    const promosList = parsePromoInput(promosText);
+
+    expect(promosList).toEqual(['Promo1', 'promo2', 'promo3']);
+  });
+
+  it('discards extra spaces', () => {
+    const promosText = 'Promo1,   promo2,  promo3';
+
+    const promosList = parsePromoInput(promosText);
+
+    expect(promosList).toEqual(['Promo1', 'promo2', 'promo3']);
+  });
+});

--- a/public/src/utils/parsePromoInput.ts
+++ b/public/src/utils/parsePromoInput.ts
@@ -1,0 +1,5 @@
+export const parsePromoInput = (inputValue: string): string[] =>
+  inputValue
+    .split(',')
+    .map(promo => promo.trim())
+    .filter(promo => promo !== '');

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -5,6 +5,7 @@ export enum SupportFrontendSettingsType {
   switches = 'switches',
   contributionTypes = 'contribution-types',
   amounts = 'amounts',
+  defaultPromos = 'default-promos',
 }
 
 export enum FrontendSettingsType {


### PR DESCRIPTION
## What does this change?
Makes necessary backend and UI changes in order to enable the marketing team to update default promos file.

#### Backend
- Adds `DefaultPromosController.scala` and `DefaultPromos.scala`

#### UI
- Creates a new page in the RRCP for managing default promos.

## Screenshots

| Admin Console Before     | Admin Console After      |  New Default Promos Page   |
|-------------|-------------|------------|
![image](https://user-images.githubusercontent.com/55602675/204254846-7b69b4a2-a42e-4e49-9739-f9488b4cc399.png) | ![image](https://user-images.githubusercontent.com/55602675/204254990-ba86ae57-60e6-4315-9117-a7b2edc65364.png) | ![image](https://user-images.githubusercontent.com/55602675/204256516-d77110bb-363c-47e1-a569-55de7bf2aea6.png)|




