### PR TITLE
Fix conditional statement to allow ticker editor for Aus banner

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -362,8 +362,8 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
 
   const allowVariantTicker =
     variant.template === BannerTemplate.UsEoyMomentBanner ||
-    variant.template === BannerTemplate.UsEoyGivingTuesMomentBanner;
-  variant.template === BannerTemplate.AusEoyMomentBanner;
+    variant.template === BannerTemplate.UsEoyGivingTuesMomentBanner ||
+    variant.template === BannerTemplate.AusEoyMomentBanner;
 
   const onMobileContentRadioChange = (): void => {
     if (variant.mobileBannerContent === undefined) {


### PR DESCRIPTION
## What does this change?
This fixes the `allowVariantTicker` condition which dictates whether we show the ticker editor for the Aus EOY banner
