### PR TITLE
Set aws region for athena

### DIFF
--- a/app/services/Athena.scala
+++ b/app/services/Athena.scala
@@ -55,6 +55,7 @@ class Athena() extends StrictLogging {
   private val client = AthenaClient
     .builder()
     .credentialsProvider(Aws.credentialsProvider.build())
+    .region(Aws.region)
     .build()
 
   private val queryExecutionContext = QueryExecutionContext


### PR DESCRIPTION
currently when running locally you get an error:
`Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain`