### PR TITLE
Use real ticker data in preview

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -6,6 +6,7 @@ import { BannerTemplate, BannerVariant, BannerContent } from '../../../models/ba
 import { TickerCountType, TickerEndType, TickerName, TickerSettings } from '../helpers/shared';
 import Typography from '@material-ui/core/Typography';
 import { useModule } from '../../../hooks/useModule';
+import useTickerData from "../hooks/useTickerData";
 
 interface ProductPriceData {
   Monthly: {
@@ -195,6 +196,12 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   const classes = useStyles();
 
   const [drawerOpen, setDrawerOpen] = useState<boolean>();
+  const tickerSettingsWithData = useTickerData(variant.tickerSettings);
+
+  if (variant.tickerSettings && !tickerSettingsWithData) {
+    // ticker data is required but not ready yet
+    return null;
+  }
 
   const Banner = useModule<BannerProps>(
     `banners/${bannerModules[variant.template].path}`,

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -3,10 +3,9 @@ import { Theme, makeStyles, Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
 import { BannerTemplate, BannerVariant, BannerContent } from '../../../models/banner';
-import { TickerCountType, TickerEndType, TickerName, TickerSettings } from '../helpers/shared';
 import Typography from '@material-ui/core/Typography';
 import { useModule } from '../../../hooks/useModule';
-import useTickerData from "../hooks/useTickerData";
+import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 
 interface ProductPriceData {
   Monthly: {
@@ -44,29 +43,16 @@ interface BannerProps {
   numArticles: number;
   content: BannerContent;
   mobileContent?: BannerContent;
-  tickerSettings?: TickerSettings;
+  tickerSettings?: TickerSettingsWithData;
   separateArticleCount?: boolean;
 }
 
 const anchor = 'bottom';
 
-const tickerSettings = {
-  endType: TickerEndType.unlimited,
-  countType: TickerCountType.money,
-  copy: {
-    countLabel: 'contributions',
-    goalReachedPrimary: "We've hit our goal!",
-    goalReachedSecondary: 'but you can still support us',
-  },
-  currencySymbol: '$',
-  name: TickerName.US_2022,
-  tickerData: {
-    total: 120_000,
-    goal: 150_000,
-  },
-};
-
-const buildProps = (variant: BannerVariant): BannerProps => ({
+const buildProps = (
+  variant: BannerVariant,
+  tickerSettingsWithData?: TickerSettingsWithData,
+): BannerProps => ({
   tracking: {
     ophanPageId: 'ophanPageId',
     platformId: 'GUARDIAN_WEB',
@@ -105,7 +91,7 @@ const buildProps = (variant: BannerVariant): BannerProps => ({
     },
   },
   numArticles: 13,
-  tickerSettings,
+  tickerSettings: tickerSettingsWithData,
   separateArticleCount: variant.separateArticleCount,
 });
 
@@ -198,11 +184,6 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   const [drawerOpen, setDrawerOpen] = useState<boolean>();
   const tickerSettingsWithData = useTickerData(variant.tickerSettings);
 
-  if (variant.tickerSettings && !tickerSettingsWithData) {
-    // ticker data is required but not ready yet
-    return null;
-  }
-
   const Banner = useModule<BannerProps>(
     `banners/${bannerModules[variant.template].path}`,
     bannerModules[variant.template].name,
@@ -213,7 +194,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
     setDrawerOpen(open);
   };
 
-  const props = buildProps(variant);
+  const props = buildProps(variant, tickerSettingsWithData);
 
   return (
     <div>

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Theme, makeStyles } from '@material-ui/core';
 
-import { EpicModuleName, TickerName, TickerSettings } from '../helpers/shared';
+import { EpicModuleName } from '../helpers/shared';
 import { useModule } from '../../../hooks/useModule';
 import { EpicVariant } from '../../../models/epic';
+import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 
 // Article count TS defs
 export interface ArticleCounts {
@@ -77,16 +78,6 @@ const generateRegionalChoiceCard = (name: string): ConfiguredRegionAmounts => {
   };
 };
 
-// Ticker additional TS defs
-interface TickerData {
-  total: number;
-  goal: number;
-}
-
-interface TickerSettingsWithData extends TickerSettings {
-  tickerData?: TickerData;
-}
-
 // Secondary CTA TS defs
 interface ShowReminderFields {
   reminderCta: string;
@@ -120,7 +111,10 @@ interface EpicProps {
   hasConsentForArticleCount?: boolean;
 }
 
-const buildProps = (variant: EpicVariant): EpicProps => ({
+const buildProps = (
+  variant: EpicVariant,
+  tickerSettingsWithData?: TickerSettingsWithData,
+): EpicProps => ({
   variant: {
     name: variant.name,
     heading: variant.heading,
@@ -154,19 +148,7 @@ const buildProps = (variant: EpicVariant): EpicProps => ({
     },
 
     showTicker: variant.showTicker,
-    tickerSettings: variant.tickerSettings
-      ? {
-          countType: variant.tickerSettings.countType,
-          endType: variant.tickerSettings.endType,
-          currencySymbol: variant.tickerSettings.currencySymbol,
-          copy: variant.tickerSettings.copy,
-          name: TickerName.US_2022,
-          tickerData: {
-            total: 50000,
-            goal: 100000,
-          },
-        }
-      : undefined,
+    tickerSettings: tickerSettingsWithData,
   },
   tracking: {
     ophanPageId: 'ophanPageId',
@@ -205,9 +187,11 @@ const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
 }: EpicVariantPreviewProps) => {
   const classes = useStyles();
 
+  const tickerSettingsWithData = useTickerData(variant.tickerSettings);
+
   const Epic = useModule<EpicProps>(`epics/${moduleName}.js`, moduleName);
 
-  const props = buildProps(variant);
+  const props = buildProps(variant, tickerSettingsWithData);
 
   return <div className={classes.container}>{Epic && <Epic {...props} />}</div>;
 };

--- a/public/src/components/channelManagement/hooks/useTickerData.ts
+++ b/public/src/components/channelManagement/hooks/useTickerData.ts
@@ -1,0 +1,37 @@
+import { TickerSettings } from '../helpers/shared';
+import { useEffect, useState } from 'react';
+
+interface TickerData {
+  total: number;
+  goal: number;
+}
+
+interface TickerSettingsWithData extends TickerSettings {
+  tickerData: TickerData;
+}
+
+const useTickerData = (
+  tickerSettings: TickerSettings | undefined,
+): TickerSettingsWithData | undefined => {
+  const [tickerData, setTickerData] = useState<TickerData | undefined>(undefined);
+
+  useEffect(() => {
+    if (tickerSettings) {
+      fetch(`https://support.theguardian.com/ticker/${tickerSettings.name}.json`)
+        .then(resp => resp.json())
+        .then(setTickerData)
+        .catch(err => alert(`Error fetching ticker data: ${err}`));
+    }
+  }, [tickerSettings]);
+
+  if (tickerSettings && tickerData) {
+    return {
+      ...tickerSettings,
+      tickerData,
+    };
+  } else {
+    return undefined;
+  }
+};
+
+export default useTickerData;

--- a/public/src/components/channelManagement/hooks/useTickerData.ts
+++ b/public/src/components/channelManagement/hooks/useTickerData.ts
@@ -6,7 +6,7 @@ interface TickerData {
   goal: number;
 }
 
-interface TickerSettingsWithData extends TickerSettings {
+export interface TickerSettingsWithData extends TickerSettings {
   tickerData: TickerData;
 }
 
@@ -19,7 +19,12 @@ const useTickerData = (
     if (tickerSettings) {
       fetch(`https://support.theguardian.com/ticker/${tickerSettings.name}.json`)
         .then(resp => resp.json())
-        .then(setTickerData)
+        .then(json => {
+          setTickerData({
+            total: parseInt(json.total),
+            goal: parseInt(json.goal),
+          });
+        })
         .catch(err => alert(`Error fetching ticker data: ${err}`));
     }
   }, [tickerSettings]);


### PR DESCRIPTION
instead of some hardcoded amounts, it fetches the real data based on the configured campaign.
A new custom hook is shared by epic/banner previews