### PR TITLE
Update automated banner deploy times copy

### DIFF
--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -52,11 +52,11 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
       {isChannel1 ? (
         <ul>
           <li>9am every Sunday</li>
+          <li>9am every Thursday</li>
         </ul>
       ) : (
         <ul>
-          <li>8am every Monday</li>
-          <li>8am every Friday</li>
+          <li>9am every Tuesday</li>
         </ul>
       )}
     </div>


### PR DESCRIPTION
## What does this change?
Following a request from Marketing, we have updated the banner automated deployment times - see PR https://github.com/guardian/support-dotcom-components/pull/824

This PR updates the copy on the Banner Deploy page to match these changes

### Screenshots
![Screenshot 2022-12-12 at 16 49 50](https://user-images.githubusercontent.com/5357530/207105571-5ab63c67-f1e9-4e56-bfca-6350588c69ee.png)
