### PR TITLE
add charity banner to rrcp

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -11,6 +11,8 @@ sealed trait BannerTemplate
 object BannerTemplate {
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate
+  case object CharityAppealBanner extends BannerTemplate
+  case object CharityAppealBannerWithSignIn extends BannerTemplate
   case object DigitalSubscriptionsBanner extends BannerTemplate
   case object GuardianWeeklyBanner extends BannerTemplate
   case object InvestigationsMomentBanner extends BannerTemplate

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -12,7 +12,6 @@ object BannerTemplate {
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate
   case object CharityAppealBanner extends BannerTemplate
-  case object CharityAppealBannerWithSignIn extends BannerTemplate
   case object DigitalSubscriptionsBanner extends BannerTemplate
   case object GuardianWeeklyBanner extends BannerTemplate
   case object InvestigationsMomentBanner extends BannerTemplate

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -19,10 +19,6 @@ const templatesWithLabels = [
     label: 'Contributions - with sign in link',
   },
   { template: BannerTemplate.CharityAppealBanner, label: 'Charity Appeal' },
-  {
-    template: BannerTemplate.CharityAppealBannerrWithSignIn,
-    label: 'Charity Appeal - with sign in link',
-  },
   { template: BannerTemplate.DigitalSubscriptionsBanner, label: 'Digital subscriptions' },
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
   { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -18,6 +18,11 @@ const templatesWithLabels = [
     template: BannerTemplate.ContributionsBannerWithSignIn,
     label: 'Contributions - with sign in link',
   },
+  { template: BannerTemplate.CharityAppealBanner, label: 'Charity Appeal' },
+  {
+    template: BannerTemplate.CharityAppealBannerrWithSignIn,
+    label: 'Charity Appeal - with sign in link',
+  },
   { template: BannerTemplate.DigitalSubscriptionsBanner, label: 'Digital subscriptions' },
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
   { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -285,6 +285,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
           />
 
           {(template === BannerTemplate.ContributionsBanner ||
+            template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.ClimateCrisisMomentBanner ||
             template === BannerTemplate.UsEoyMomentBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -125,6 +125,14 @@ const bannerModules = {
     path: 'contributions/ContributionsBannerWithSignIn.js',
     name: 'ContributionsBannerWithSignIn',
   },
+  [BannerTemplate.CharityAppealBanner]: {
+    path: 'charityAppeal/CharityAppealBanner.js',
+    name: 'CharityAppealBanner',
+  },
+  [BannerTemplate.CharityAppealBannerrWithSignIn]: {
+    path: 'charityAppeal/CharityAppealBannerrWithSignIn.js',
+    name: 'CharityAppealBannerrWithSignIn',
+  },
   [BannerTemplate.InvestigationsMomentBanner]: {
     path: 'investigationsMoment/InvestigationsMomentBanner.js',
     name: 'InvestigationsMomentBanner',

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -129,10 +129,6 @@ const bannerModules = {
     path: 'charityAppeal/CharityAppealBanner.js',
     name: 'CharityAppealBanner',
   },
-  [BannerTemplate.CharityAppealBannerrWithSignIn]: {
-    path: 'charityAppeal/CharityAppealBannerrWithSignIn.js',
-    name: 'CharityAppealBannerrWithSignIn',
-  },
   [BannerTemplate.InvestigationsMomentBanner]: {
     path: 'investigationsMoment/InvestigationsMomentBanner.js',
     name: 'InvestigationsMomentBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -26,6 +26,8 @@ export enum BannerTemplate {
   UsEoyGivingTuesMomentBanner = 'UsEoyGivingTuesMomentBanner',
   AusEoyMomentBanner = 'AusEoyMomentBanner',
   UsEoyMomentBannerV3 = 'UsEoyMomentBannerV3',
+  CharityAppealBanner = 'CharityAppealBanner',
+  CharityAppealBannerrWithSignIn = 'CharityAppealBannerrWithSignIn',
 }
 
 export interface BannerContent {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -27,7 +27,6 @@ export enum BannerTemplate {
   AusEoyMomentBanner = 'AusEoyMomentBanner',
   UsEoyMomentBannerV3 = 'UsEoyMomentBannerV3',
   CharityAppealBanner = 'CharityAppealBanner',
-  CharityAppealBannerrWithSignIn = 'CharityAppealBannerrWithSignIn',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
## What does this change?
This PR creates a variant of the existing Contributions banner for the Guardian Charity appeal with RRCP

[Trello]
https://trello.com/c/ywnaWAFK/909-charity-appeal-banner-colour-change-9th-dec-target-reached

## Images
Pre->
| mobile | tablet | desktop |
|----------|--------|---------|
|![Mobile](https://user-images.githubusercontent.com/76729591/207146854-4cf22fe6-af50-4715-84ec-dbb8a8a9db89.png)| ![Tablet](https://user-images.githubusercontent.com/76729591/207122012-80d4d6c7-9c35-4060-948c-1c2dfd7bf300.png) | ![Wide](https://user-images.githubusercontent.com/76729591/207122057-f472931d-1f4f-4693-bc79-2a2d368daaa9.png)

Post->
| mobile | tablet | desktop |
|----------|--------|---------|
|![MobileNew](https://user-images.githubusercontent.com/76729591/207146942-f3d7c9ab-c394-42d9-9973-28c7b6ec2bce.png)|![TabletNew](https://user-images.githubusercontent.com/76729591/207123860-c02cf17e-f7ee-4a01-8e83-156053042a6e.png)|![WideNew](https://user-images.githubusercontent.com/76729591/207123871-e96bc9c7-06a9-46de-b675-92b77678fb1c.png)
