### PR TITLE
pd - global new year banner moment

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -288,6 +288,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.ClimateCrisisMomentBanner ||
+            template === BannerTemplate.GlobalNewYearBanner ||
             template === BannerTemplate.UsEoyMomentBanner ||
             template === BannerTemplate.UsEoyGivingTuesMomentBanner ||
             template === BannerTemplate.AusEoyMomentBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -125,7 +125,7 @@ const bannerModules = {
     name: 'EnvironmentMomentBanner',
   },
   [BannerTemplate.GlobalNewYearBanner]: {
-    path: 'globalNewYear/GlobalNewYearBanner.js',
+    path: 'globalNYMoment/GlobalNYMomentBanner.js',
     name: 'GlobalNewYearBanner',
   },
   [BannerTemplate.AuBrandMomentBanner]: {


### PR DESCRIPTION
## What does this change?
This PR creates a 'Global New Year Banner Moment' now using the moments template banner setup within the RRCP

[Trello]
https://trello.com/c/Hih193K3/892-new-year-banner-moment-development-deadline-dec-23rd-live-date-jan-1st

## Images
Pre->
| 320px | 375px | 740px | 980px | 1300+px 
|----------|--------|---------|---------|---------|
| ![Screenshot 2022-12-19 at 14 12 01](https://user-images.githubusercontent.com/76729591/208445896-7d674d27-76c9-4c75-9bc3-224217337a1f.png) | ![Screenshot 2022-12-19 at 14 12 12](https://user-images.githubusercontent.com/76729591/208445875-0e0892a2-8d9d-4292-85f0-f6f825afe825.png) | ![Screenshot 2022-12-19 at 14 12 28](https://user-images.githubusercontent.com/76729591/208445853-5fea2a24-3f2a-4989-91c4-fb00006a6b69.png) | ![Screenshot 2022-12-19 at 14 12 49](https://user-images.githubusercontent.com/76729591/208445815-a4f311e1-f1ed-4120-9203-defe05fbd7fb.png) | ![Screenshot 2022-12-19 at 14 13 24](https://user-images.githubusercontent.com/76729591/208445785-5a24efed-8266-444a-ad3e-4d08329e5ab7.png) |

Post->
| 320px | 375px | 740px | 980px | 1300+px 
|----------|--------|---------|---------|---------|
| ![Screenshot 2022-12-19 at 14 20 24](https://user-images.githubusercontent.com/76729591/208447072-c9ac76b0-4288-4a3e-8ac5-0ff77313f0a5.png) | ![Screenshot 2022-12-19 at 14 20 46](https://user-images.githubusercontent.com/76729591/208446999-44919e77-fb8f-4168-8cff-803368c49f8c.png) |![Screenshot 2022-12-19 at 14 21 04](https://user-images.githubusercontent.com/76729591/208446940-8fa5262a-d1d4-4043-83fb-35e55cbd9dec.png) | ![Screenshot 2022-12-19 at 14 21 26](https://user-images.githubusercontent.com/76729591/208446894-950277ef-9d2c-4787-aadf-bd5ef3fc8d2a.png) | ![Screenshot 2022-12-19 at 14 21 47](https://user-images.githubusercontent.com/76729591/208446849-38d1dac9-557c-4821-be5b-879a2efcc34f.png) |
