### PR TITLE
Enable highlightedText field for GW banner

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -1,14 +1,30 @@
-import React, {useEffect, useState} from 'react';
-import {Controller, useForm} from 'react-hook-form';
-import {FormControlLabel, makeStyles, Radio, RadioGroup, Switch, Theme, Typography,} from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  FormControlLabel,
+  makeStyles,
+  Radio,
+  RadioGroup,
+  Switch,
+  Theme,
+  Typography,
+} from '@material-ui/core';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
-import {EMPTY_ERROR_HELPER_TEXT, getEmptyParagraphsError, templateValidatorForPlatform,} from '../helpers/validation';
-import {Cta, SecondaryCta} from '../helpers/shared';
+import {
+  EMPTY_ERROR_HELPER_TEXT,
+  getEmptyParagraphsError,
+  templateValidatorForPlatform,
+} from '../helpers/validation';
+import { Cta, SecondaryCta } from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
-import {BannerContent, BannerTemplate, BannerVariant} from '../../../models/banner';
-import {getDefaultVariant} from './utils/defaults';
+import { BannerContent, BannerTemplate, BannerVariant } from '../../../models/banner';
+import { getDefaultVariant } from './utils/defaults';
 import useValidation from '../hooks/useValidation';
-import {getRteCopyLength, RichTextEditor, RichTextEditorSingleLine,} from '../richTextEditor/richTextEditor';
+import {
+  getRteCopyLength,
+  RichTextEditor,
+  RichTextEditorSingleLine,
+} from '../richTextEditor/richTextEditor';
 import TickerEditor from '../tickerEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -1,30 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { useForm, Controller } from 'react-hook-form';
-import {
-  FormControlLabel,
-  Radio,
-  RadioGroup,
-  Theme,
-  Typography,
-  makeStyles,
-  Switch,
-} from '@material-ui/core';
+import React, {useEffect, useState} from 'react';
+import {Controller, useForm} from 'react-hook-form';
+import {FormControlLabel, makeStyles, Radio, RadioGroup, Switch, Theme, Typography,} from '@material-ui/core';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
-import {
-  EMPTY_ERROR_HELPER_TEXT,
-  getEmptyParagraphsError,
-  templateValidatorForPlatform,
-} from '../helpers/validation';
-import { Cta, SecondaryCta } from '../helpers/shared';
+import {EMPTY_ERROR_HELPER_TEXT, getEmptyParagraphsError, templateValidatorForPlatform,} from '../helpers/validation';
+import {Cta, SecondaryCta} from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
-import { BannerContent, BannerTemplate, BannerVariant } from '../../../models/banner';
-import { getDefaultVariant } from './utils/defaults';
+import {BannerContent, BannerTemplate, BannerVariant} from '../../../models/banner';
+import {getDefaultVariant} from './utils/defaults';
 import useValidation from '../hooks/useValidation';
-import {
-  RichTextEditor,
-  RichTextEditorSingleLine,
-  getRteCopyLength,
-} from '../richTextEditor/richTextEditor';
+import {getRteCopyLength, RichTextEditor, RichTextEditorSingleLine,} from '../richTextEditor/richTextEditor';
 import TickerEditor from '../tickerEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -285,6 +269,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
           />
 
           {(template === BannerTemplate.ContributionsBanner ||
+            template === BannerTemplate.GuardianWeeklyBanner ||
             template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.ClimateCrisisMomentBanner ||


### PR DESCRIPTION
Currently RRCP hides the `highlightedText` field  if the GuardianWeekly banner template is selected.
But - the GW banner in SDC _does_ render the `highlightedText` field.
If a user does not clear the default `highlightedText` content before selecting the GuardianWeekly template then they cannot see or remove it in the tool.

Perhaps the GW banner is not supposed to support `highlightedText`, but that's a question for another day.
This PR makes RRCP consistent with the component.