### PR TITLE
Remove bucket names from Riff Raff config

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -16,5 +16,3 @@ deployments:
   admin-console:
     type: autoscaling
     dependencies: [cfn]
-    parameters:
-      bucket: membership-dist


### PR DESCRIPTION
## What does this change?
Removes bucket names from Riff Raff config as recommended by DevX. By default the bucket will be discovered by looking it up in parameter store.

This should remove the warnings we're currently seeing in Riff Raff for SAC deployments.

## How to test
Deploy to CODE via Riff Raff.

### Screenshot
**Before**
![Screenshot 2023-01-03 at 14 15 04](https://user-images.githubusercontent.com/5357530/210375034-b8d9b7c0-91bb-44e4-a259-b3886bb40978.png)

**After: testing in code**
![Screenshot 2023-01-03 at 14 50 18](https://user-images.githubusercontent.com/5357530/210381140-a7361cf2-d766-43c5-9344-037adb17a2b8.png)

