### PR TITLE
Optionally hide the Epic Contributions Amounts card 'Choose your Amount' button

### DIFF
--- a/app/models/Amounts.scala
+++ b/app/models/Amounts.scala
@@ -3,31 +3,33 @@ package models
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.auto._
 
-case class AmountsSelection(amounts: List[Int], defaultAmount: Int)
+case class AmountsSelection(
+    amounts: List[Int], 
+    defaultAmount: Int,
+    hideChooseYourAmount: Option[Boolean],
+)
 
 case class ContributionAmounts(
     ONE_OFF: AmountsSelection,
     MONTHLY: AmountsSelection,
-    ANNUAL: AmountsSelection
+    ANNUAL: AmountsSelection,
 )
 
 case class AmountsTestVariant(
     name: String,
     amounts: ContributionAmounts,
-    hideChooseYourAmount: Option[Boolean]
 )
 
 case class AmountsTest(
     name: String,
     isLive: Boolean,
     variants: List[AmountsTestVariant],
-    seed: Int
+    seed: Int,
 )
 
 case class ConfiguredRegionAmounts(
     control: ContributionAmounts,
     test: Option[AmountsTest],
-    hideChooseYourAmount: Option[Boolean]
 )
 
 case class ConfiguredAmounts(
@@ -37,7 +39,7 @@ case class ConfiguredAmounts(
     AUDCountries: ConfiguredRegionAmounts,
     International: ConfiguredRegionAmounts,
     NZDCountries: ConfiguredRegionAmounts,
-    Canada: ConfiguredRegionAmounts
+    Canada: ConfiguredRegionAmounts,
 )
 
 object ConfiguredAmounts {

--- a/app/models/Amounts.scala
+++ b/app/models/Amounts.scala
@@ -26,7 +26,8 @@ case class AmountsTest(
 
 case class ConfiguredRegionAmounts(
     control: ContributionAmounts,
-    test: Option[AmountsTest]
+    test: Option[AmountsTest],
+    hideChooseYourAmount: Option[Boolean]
 )
 
 case class ConfiguredAmounts(

--- a/app/models/Amounts.scala
+++ b/app/models/Amounts.scala
@@ -11,11 +11,23 @@ case class ContributionAmounts(
     ANNUAL: AmountsSelection
 )
 
-case class AmountsTestVariant(name: String, amounts: ContributionAmounts)
+case class AmountsTestVariant(
+    name: String,
+    amounts: ContributionAmounts,
+    hideChooseYourAmount: Option[Boolean]
+)
 
-case class AmountsTest(name: String, isLive: Boolean, variants: List[AmountsTestVariant], seed: Int)
+case class AmountsTest(
+    name: String,
+    isLive: Boolean,
+    variants: List[AmountsTestVariant],
+    seed: Int
+)
 
-case class ConfiguredRegionAmounts(control: ContributionAmounts, test: Option[AmountsTest])
+case class ConfiguredRegionAmounts(
+    control: ContributionAmounts,
+    test: Option[AmountsTest]
+)
 
 case class ConfiguredAmounts(
     GBPCountries: ConfiguredRegionAmounts,

--- a/public/src/components/amounts/amountsEditorRow.tsx
+++ b/public/src/components/amounts/amountsEditorRow.tsx
@@ -3,16 +3,25 @@ import { makeStyles, Theme } from '@material-ui/core';
 import { AmountSelection } from './configuredAmountsEditor';
 import AmountInput from './amountInput';
 import AmountsEditorRowAmount from './amountsEditorRowAmount';
+import LiveSwitch from '../shared/liveSwitch';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
     display: 'flex',
-    flexDirection: 'row',
+    flexDirection: 'column',
     alignItems: 'center',
-
-    '& > * + *': {
-      marginLeft: spacing(4),
-    },
+  },
+  amountsLabelContainer: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    marginBottom: spacing(1),
+  },
+  otherAmountSwitchContainer: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    marginTop: spacing(1),
   },
   amountsLabel: {
     width: 80,
@@ -24,6 +33,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     flexGrow: 1,
     display: 'flex',
     justifyContent: 'space-between',
+    width: '100%',
 
     '& > * + *': {
       marginLeft: spacing(4),
@@ -32,6 +42,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   amountsContainer: {
     display: 'flex',
     flexDirection: 'row',
+    margin: 0,
 
     '& > * + *': {
       marginLeft: spacing(2),
@@ -43,12 +54,16 @@ interface AmountsEditorRowProps {
   label: string;
   amountsSelection: AmountSelection;
   updateSelection: (AmountSelection: AmountSelection) => void;
+  hideChooseYourAmount: boolean;
+  updateChooseYourAmountButton: (value: boolean) => void;
 }
 
 const AmountsEditorRow: React.FC<AmountsEditorRowProps> = ({
   label,
   amountsSelection,
   updateSelection,
+  hideChooseYourAmount,
+  updateChooseYourAmountButton,
 }: AmountsEditorRowProps) => {
   const classes = useStyles();
 
@@ -78,7 +93,9 @@ const AmountsEditorRow: React.FC<AmountsEditorRowProps> = ({
 
   return (
     <div className={classes.container}>
-      <div className={classes.amountsLabel}>{label}</div>
+      <div className={classes.amountsLabelContainer}>
+        <div className={classes.amountsLabel}>{label}</div>
+      </div>
       <div className={classes.amountsAndInputContainer}>
         <div className={classes.amountsContainer}>
           {amountsSelection.amounts.map((amount, index) => (
@@ -92,6 +109,14 @@ const AmountsEditorRow: React.FC<AmountsEditorRowProps> = ({
           ))}
         </div>
         <AmountInput amounts={amountsSelection.amounts} addAmount={addAmount} />
+      </div>
+      <div className={classes.otherAmountSwitchContainer}>
+        <LiveSwitch
+          label="Include CHOOSE button"
+          isLive={!hideChooseYourAmount}
+          onChange={() => updateChooseYourAmountButton(!hideChooseYourAmount)}
+          isDisabled={false}
+        />
       </div>
     </div>
   );

--- a/public/src/components/amounts/amountsTestEditor.tsx
+++ b/public/src/components/amounts/amountsTestEditor.tsx
@@ -38,17 +38,19 @@ const variantWithDefaultAmounts = (name: string): AmountsTestVariant => ({
     ONE_OFF: {
       amounts: [],
       defaultAmount: 0,
+      hideChooseYourAmount: false,
     },
     MONTHLY: {
       amounts: [],
       defaultAmount: 0,
+      hideChooseYourAmount: false,
     },
     ANNUAL: {
       amounts: [],
       defaultAmount: 0,
+      hideChooseYourAmount: false,
     },
   },
-  hideChooseYourAmount: false,
 });
 
 interface AmountsTestEditorProps {
@@ -64,20 +66,6 @@ const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
 }: AmountsTestEditorProps) => {
   const updateIsLive = (isLive: boolean): void => {
     updateTest({ ...test, isLive: isLive });
-  };
-
-  const updateVariantChooseAmountButton = (variantIndex: number) => (
-    hideChooseYourAmount: boolean,
-  ): void => {
-    const updatedVariants = [
-      ...test.variants.slice(0, variantIndex),
-      { ...test.variants[variantIndex], hideChooseYourAmount },
-      ...test.variants.slice(variantIndex + 1),
-    ];
-    updateTest({
-      ...test,
-      variants: updatedVariants,
-    });
   };
 
   const updateVariantContributionAmounts = (variantIndex: number) => (
@@ -139,8 +127,6 @@ const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
               <AmountsEditor
                 label={variant.name}
                 contributionAmounts={variant.amounts}
-                hideChooseYourAmount={variant.hideChooseYourAmount ?? false}
-                updateChooseYourAmountButton={updateVariantChooseAmountButton(index)}
                 updateContributionAmounts={updateVariantContributionAmounts(index)}
                 deleteContributionAmounts={deleteVariant(index)}
               />

--- a/public/src/components/amounts/amountsTestEditor.tsx
+++ b/public/src/components/amounts/amountsTestEditor.tsx
@@ -48,6 +48,7 @@ const variantWithDefaultAmounts = (name: string): AmountsTestVariant => ({
       defaultAmount: 0,
     },
   },
+  hideChooseYourAmount: false,
 });
 
 interface AmountsTestEditorProps {
@@ -65,7 +66,21 @@ const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
     updateTest({ ...test, isLive: isLive });
   };
 
-  const updateVariant = (variantIndex: number) => (
+  const updateVariantChooseAmountButton = (variantIndex: number) => (
+    hideChooseYourAmount: boolean,
+  ): void => {
+    const updatedVariants = [
+      ...test.variants.slice(0, variantIndex),
+      { ...test.variants[variantIndex], hideChooseYourAmount },
+      ...test.variants.slice(variantIndex + 1),
+    ];
+    updateTest({
+      ...test,
+      variants: updatedVariants,
+    });
+  };
+
+  const updateVariantContributionAmounts = (variantIndex: number) => (
     contributionAmounts: ContributionAmounts,
   ): void => {
     const updatedVariants = [
@@ -123,9 +138,11 @@ const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
             <div className={classes.amountsEditorContainer} key={variant.name}>
               <AmountsEditor
                 label={variant.name}
-                updateContributionAmounts={updateVariant(index)}
-                deleteContributionAmounts={deleteVariant(index)}
                 contributionAmounts={variant.amounts}
+                hideChooseYourAmount={variant.hideChooseYourAmount ?? false}
+                updateChooseYourAmountButton={updateVariantChooseAmountButton(index)}
+                updateContributionAmounts={updateVariantContributionAmounts(index)}
+                deleteContributionAmounts={deleteVariant(index)}
               />
             </div>
           ))

--- a/public/src/components/amounts/configuredAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredAmountsEditor.tsx
@@ -38,6 +38,7 @@ export interface AmountsTest {
 export type ConfiguredRegionAmounts = {
   control: ContributionAmounts;
   test?: AmountsTest;
+  hideChooseYourAmount?: boolean;
 };
 
 export type ConfiguredAmounts = {
@@ -87,6 +88,11 @@ const ConfiguredAmountsEditor: React.FC<InnerProps<ConfiguredAmounts>> = ({
   const updateConfiguredRegionAmounts = (configuredRegionAmounts: ConfiguredRegionAmounts): void =>
     setConfiguredAmounts({ ...configuredAmounts, [selectedRegion]: configuredRegionAmounts });
 
+  const updateControlChooseAmountButton = (hideChooseYourAmount: boolean): void => {
+    const updatedAmounts = { ...selectedRegionAmounts, hideChooseYourAmount };
+    setConfiguredAmounts({ ...configuredAmounts, [selectedRegion]: updatedAmounts });
+  };
+
   const existingTestNames = Object.values(configuredAmounts)
     .map(regionAmounts => regionAmounts.test?.name || '')
     .filter(name => !!name);
@@ -105,6 +111,8 @@ const ConfiguredAmountsEditor: React.FC<InnerProps<ConfiguredAmounts>> = ({
           label={selectedRegionPrettifiedName}
           configuredRegionAmounts={selectedRegionAmounts}
           updateConfiguredRegionAmounts={updateConfiguredRegionAmounts}
+          hideChooseYourAmount={selectedRegionAmounts.hideChooseYourAmount ?? false}
+          updateChooseYourAmountButton={updateControlChooseAmountButton}
           existingTestNames={existingTestNames}
         />
       </div>

--- a/public/src/components/amounts/configuredAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredAmountsEditor.tsx
@@ -25,6 +25,7 @@ export type ContributionAmounts = {
 export interface AmountsTestVariant {
   name: string;
   amounts: ContributionAmounts;
+  hideChooseYourAmount: boolean;
 }
 
 export interface AmountsTest {

--- a/public/src/components/amounts/configuredAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredAmountsEditor.tsx
@@ -16,6 +16,7 @@ import withS3Data, { InnerProps, DataFromServer } from '../../hocs/withS3Data';
 export interface AmountSelection {
   amounts: number[];
   defaultAmount: number;
+  hideChooseYourAmount?: boolean;
 }
 
 export type ContributionAmounts = {
@@ -25,7 +26,6 @@ export type ContributionAmounts = {
 export interface AmountsTestVariant {
   name: string;
   amounts: ContributionAmounts;
-  hideChooseYourAmount: boolean;
 }
 
 export interface AmountsTest {
@@ -38,7 +38,6 @@ export interface AmountsTest {
 export type ConfiguredRegionAmounts = {
   control: ContributionAmounts;
   test?: AmountsTest;
-  hideChooseYourAmount?: boolean;
 };
 
 export type ConfiguredAmounts = {
@@ -88,11 +87,6 @@ const ConfiguredAmountsEditor: React.FC<InnerProps<ConfiguredAmounts>> = ({
   const updateConfiguredRegionAmounts = (configuredRegionAmounts: ConfiguredRegionAmounts): void =>
     setConfiguredAmounts({ ...configuredAmounts, [selectedRegion]: configuredRegionAmounts });
 
-  const updateControlChooseAmountButton = (hideChooseYourAmount: boolean): void => {
-    const updatedAmounts = { ...selectedRegionAmounts, hideChooseYourAmount };
-    setConfiguredAmounts({ ...configuredAmounts, [selectedRegion]: updatedAmounts });
-  };
-
   const existingTestNames = Object.values(configuredAmounts)
     .map(regionAmounts => regionAmounts.test?.name || '')
     .filter(name => !!name);
@@ -111,8 +105,6 @@ const ConfiguredAmountsEditor: React.FC<InnerProps<ConfiguredAmounts>> = ({
           label={selectedRegionPrettifiedName}
           configuredRegionAmounts={selectedRegionAmounts}
           updateConfiguredRegionAmounts={updateConfiguredRegionAmounts}
-          hideChooseYourAmount={selectedRegionAmounts.hideChooseYourAmount ?? false}
-          updateChooseYourAmountButton={updateControlChooseAmountButton}
           existingTestNames={existingTestNames}
         />
       </div>

--- a/public/src/components/amounts/configuredRegionAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredRegionAmountsEditor.tsx
@@ -53,6 +53,8 @@ const generateRandomSeed = (): number => {
 interface ConfiguredRegionAmountsEditorProps {
   label: string;
   configuredRegionAmounts: ConfiguredRegionAmounts;
+  hideChooseYourAmount: boolean;
+  updateChooseYourAmountButton: (hideChooseYourAmount: boolean) => void;
   updateConfiguredRegionAmounts: (configuredRegionAmounts: ConfiguredRegionAmounts) => void;
   existingTestNames: string[];
 }
@@ -60,16 +62,13 @@ interface ConfiguredRegionAmountsEditorProps {
 const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps> = ({
   label,
   configuredRegionAmounts,
+  hideChooseYourAmount,
+  updateChooseYourAmountButton,
   updateConfiguredRegionAmounts,
   existingTestNames,
 }: ConfiguredRegionAmountsEditorProps) => {
   const updateControlAmounts = (contributionAmounts: ContributionAmounts): void =>
     updateConfiguredRegionAmounts({ ...configuredRegionAmounts, control: contributionAmounts });
-
-  // This does nothing at the moment
-  // Need to figure out a way to record status of hideChooseYourAmount in the control variant
-  // The amounts model is not very helpful for us here ...
-  const updateControlChooseYourAmountButton = (val: boolean): void => {};
 
   const updateTest = (updatedTest: AmountsTest): void =>
     updateConfiguredRegionAmounts({ ...configuredRegionAmounts, test: updatedTest });
@@ -90,8 +89,8 @@ const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps
       <div className={classes.amountsEditorContainer}>
         <AmountsEditor
           label="Control"
-          hideChooseYourAmount={false}
-          updateChooseYourAmountButton={updateControlChooseYourAmountButton}
+          hideChooseYourAmount={hideChooseYourAmount}
+          updateChooseYourAmountButton={() => updateChooseYourAmountButton(!hideChooseYourAmount)}
           updateContributionAmounts={updateControlAmounts}
           contributionAmounts={configuredRegionAmounts.control}
         />

--- a/public/src/components/amounts/configuredRegionAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredRegionAmountsEditor.tsx
@@ -63,7 +63,7 @@ const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps
   updateConfiguredRegionAmounts,
   existingTestNames,
 }: ConfiguredRegionAmountsEditorProps) => {
-  const updateControlAmounts = (contributionAmounts: ContributionAmounts): void =>
+  const updateControl = (contributionAmounts: ContributionAmounts): void =>
     updateConfiguredRegionAmounts({ ...configuredRegionAmounts, control: contributionAmounts });
 
   const updateTest = (updatedTest: AmountsTest): void =>
@@ -85,7 +85,7 @@ const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps
       <div className={classes.amountsEditorContainer}>
         <AmountsEditor
           label="Control"
-          updateContributionAmounts={updateControlAmounts}
+          updateContributionAmounts={updateControl}
           contributionAmounts={configuredRegionAmounts.control}
         />
       </div>

--- a/public/src/components/amounts/configuredRegionAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredRegionAmountsEditor.tsx
@@ -30,21 +30,17 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
   amountsEditorContainer: {
     marginTop: spacing(2),
-    backgroundColor: '#aaa',
   },
   testContainer: {
     marginTop: spacing(4),
-    backgroundColor: '#999',
   },
   testHeader: {
     fontSize: 16,
     textTransform: 'uppercase',
     fontWeight: 'bold',
-    backgroundColor: '#888',
   },
   createVariantButtonContainer: {
     marginTop: spacing(3),
-    backgroundColor: '#777',
   },
 }));
 

--- a/public/src/components/amounts/configuredRegionAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredRegionAmountsEditor.tsx
@@ -63,8 +63,13 @@ const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps
   updateConfiguredRegionAmounts,
   existingTestNames,
 }: ConfiguredRegionAmountsEditorProps) => {
-  const updateControl = (contributionAmounts: ContributionAmounts): void =>
+  const updateControlAmounts = (contributionAmounts: ContributionAmounts): void =>
     updateConfiguredRegionAmounts({ ...configuredRegionAmounts, control: contributionAmounts });
+
+  // This does nothing at the moment
+  // Need to figure out a way to record status of hideChooseYourAmount in the control variant
+  // The amounts model is not very helpful for us here ...
+  const updateControlChooseYourAmountButton = (val: boolean): void => {};
 
   const updateTest = (updatedTest: AmountsTest): void =>
     updateConfiguredRegionAmounts({ ...configuredRegionAmounts, test: updatedTest });
@@ -85,7 +90,9 @@ const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps
       <div className={classes.amountsEditorContainer}>
         <AmountsEditor
           label="Control"
-          updateContributionAmounts={updateControl}
+          hideChooseYourAmount={false}
+          updateChooseYourAmountButton={updateControlChooseYourAmountButton}
+          updateContributionAmounts={updateControlAmounts}
           contributionAmounts={configuredRegionAmounts.control}
         />
       </div>

--- a/public/src/components/amounts/configuredRegionAmountsEditor.tsx
+++ b/public/src/components/amounts/configuredRegionAmountsEditor.tsx
@@ -30,17 +30,21 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
   amountsEditorContainer: {
     marginTop: spacing(2),
+    backgroundColor: '#aaa',
   },
   testContainer: {
     marginTop: spacing(4),
+    backgroundColor: '#999',
   },
   testHeader: {
     fontSize: 16,
     textTransform: 'uppercase',
     fontWeight: 'bold',
+    backgroundColor: '#888',
   },
   createVariantButtonContainer: {
     marginTop: spacing(3),
+    backgroundColor: '#777',
   },
 }));
 
@@ -53,8 +57,6 @@ const generateRandomSeed = (): number => {
 interface ConfiguredRegionAmountsEditorProps {
   label: string;
   configuredRegionAmounts: ConfiguredRegionAmounts;
-  hideChooseYourAmount: boolean;
-  updateChooseYourAmountButton: (hideChooseYourAmount: boolean) => void;
   updateConfiguredRegionAmounts: (configuredRegionAmounts: ConfiguredRegionAmounts) => void;
   existingTestNames: string[];
 }
@@ -62,8 +64,6 @@ interface ConfiguredRegionAmountsEditorProps {
 const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps> = ({
   label,
   configuredRegionAmounts,
-  hideChooseYourAmount,
-  updateChooseYourAmountButton,
   updateConfiguredRegionAmounts,
   existingTestNames,
 }: ConfiguredRegionAmountsEditorProps) => {
@@ -89,8 +89,6 @@ const ConfiguredRegionAmountsEditor: React.FC<ConfiguredRegionAmountsEditorProps
       <div className={classes.amountsEditorContainer}>
         <AmountsEditor
           label="Control"
-          hideChooseYourAmount={hideChooseYourAmount}
-          updateChooseYourAmountButton={() => updateChooseYourAmountButton(!hideChooseYourAmount)}
           updateContributionAmounts={updateControlAmounts}
           contributionAmounts={configuredRegionAmounts.control}
         />

--- a/public/src/components/amounts/contributionAmountsEditor.tsx
+++ b/public/src/components/amounts/contributionAmountsEditor.tsx
@@ -3,14 +3,14 @@ import { makeStyles, Theme } from '@material-ui/core';
 import { AmountSelection, ContributionAmounts } from './configuredAmountsEditor';
 import AmountEditorRow from './amountsEditorRow';
 import AmountEditorDeleteButton from './contributionAmountsEditorDeleteButton';
-import LiveSwitch from '../shared/liveSwitch';
+import { ContributionType } from '../../utils/models';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
     padding: `${spacing(3)}px ${spacing(4)}px`,
     border: `1px solid ${palette.grey[700]}`,
     borderRadius: 4,
-    background: 'white',
+    backgroundColor: 'white',
 
     '& > * + *': {
       marginTop: spacing(2),
@@ -34,8 +34,6 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
 interface AmountsEditorProps {
   label: string;
   contributionAmounts: ContributionAmounts;
-  hideChooseYourAmount: boolean;
-  updateChooseYourAmountButton: (val: boolean) => void;
   updateContributionAmounts: (contributionAmounts: ContributionAmounts) => void;
   deleteContributionAmounts?: () => void;
 }
@@ -43,12 +41,31 @@ interface AmountsEditorProps {
 const AmountsEditor: React.FC<AmountsEditorProps> = ({
   label,
   contributionAmounts,
-  hideChooseYourAmount,
-  updateChooseYourAmountButton,
   updateContributionAmounts,
   deleteContributionAmounts,
 }: AmountsEditorProps) => {
   const classes = useStyles();
+
+  const handleAmountSelection = (product: ContributionType, change: AmountSelection) => {
+    updateContributionAmounts({
+      ...contributionAmounts,
+      [product]: change,
+    });
+  };
+
+  const handleOtherButtonChange = (product: ContributionType, change: boolean) => {
+    updateContributionAmounts({
+      ...contributionAmounts,
+      [product]: {
+        ...contributionAmounts[product],
+        hideChooseYourAmount: change,
+      },
+    });
+  };
+
+  const getOtherButtonValue = (product: ContributionType) => {
+    return contributionAmounts[product].hideChooseYourAmount ?? false;
+  };
 
   return (
     <div className={classes.container}>
@@ -58,32 +75,32 @@ const AmountsEditor: React.FC<AmountsEditorProps> = ({
           <AmountEditorDeleteButton onDelete={deleteContributionAmounts} />
         )}
       </div>
-      <LiveSwitch
-        label="'Choose your Amount' button"
-        isLive={!hideChooseYourAmount}
-        onChange={() => updateChooseYourAmountButton(!hideChooseYourAmount)}
-        isDisabled={false}
-      />
       <div className={classes.rowsContainer}>
         <AmountEditorRow
           label="One off"
           amountsSelection={contributionAmounts.ONE_OFF}
-          updateSelection={(amountSelection: AmountSelection): void =>
-            updateContributionAmounts({ ...contributionAmounts, ONE_OFF: amountSelection })
+          updateSelection={amount => handleAmountSelection(ContributionType.ONE_OFF, amount)}
+          hideChooseYourAmount={getOtherButtonValue(ContributionType.ONE_OFF)}
+          updateChooseYourAmountButton={value =>
+            handleOtherButtonChange(ContributionType.ONE_OFF, value)
           }
         />
         <AmountEditorRow
           label="Monthly"
           amountsSelection={contributionAmounts.MONTHLY}
-          updateSelection={(amountSelection: AmountSelection): void =>
-            updateContributionAmounts({ ...contributionAmounts, MONTHLY: amountSelection })
+          updateSelection={amount => handleAmountSelection(ContributionType.MONTHLY, amount)}
+          hideChooseYourAmount={getOtherButtonValue(ContributionType.MONTHLY)}
+          updateChooseYourAmountButton={value =>
+            handleOtherButtonChange(ContributionType.MONTHLY, value)
           }
         />
         <AmountEditorRow
           label="Annual"
           amountsSelection={contributionAmounts.ANNUAL}
-          updateSelection={(amountSelection: AmountSelection): void =>
-            updateContributionAmounts({ ...contributionAmounts, ANNUAL: amountSelection })
+          updateSelection={amount => handleAmountSelection(ContributionType.ANNUAL, amount)}
+          hideChooseYourAmount={getOtherButtonValue(ContributionType.ANNUAL)}
+          updateChooseYourAmountButton={value =>
+            handleOtherButtonChange(ContributionType.ANNUAL, value)
           }
         />
       </div>

--- a/public/src/components/amounts/contributionAmountsEditor.tsx
+++ b/public/src/components/amounts/contributionAmountsEditor.tsx
@@ -3,6 +3,7 @@ import { makeStyles, Theme } from '@material-ui/core';
 import { AmountSelection, ContributionAmounts } from './configuredAmountsEditor';
 import AmountEditorRow from './amountsEditorRow';
 import AmountEditorDeleteButton from './contributionAmountsEditorDeleteButton';
+import LiveSwitch from '../shared/liveSwitch';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
@@ -33,6 +34,8 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
 interface AmountsEditorProps {
   label: string;
   contributionAmounts: ContributionAmounts;
+  hideChooseYourAmount: boolean;
+  updateChooseYourAmountButton: (val: boolean) => void;
   updateContributionAmounts: (contributionAmounts: ContributionAmounts) => void;
   deleteContributionAmounts?: () => void;
 }
@@ -40,6 +43,8 @@ interface AmountsEditorProps {
 const AmountsEditor: React.FC<AmountsEditorProps> = ({
   label,
   contributionAmounts,
+  hideChooseYourAmount,
+  updateChooseYourAmountButton,
   updateContributionAmounts,
   deleteContributionAmounts,
 }: AmountsEditorProps) => {
@@ -53,6 +58,24 @@ const AmountsEditor: React.FC<AmountsEditorProps> = ({
           <AmountEditorDeleteButton onDelete={deleteContributionAmounts} />
         )}
       </div>
+      {/*
+      {label.toUpperCase() !== 'CONTROL' ? (
+        <LiveSwitch
+          label="'Choose your Amount' button"
+          isLive={!hideChooseYourAmount}
+          onChange={() => {}}
+          isDisabled={false}
+        />
+      ) : (
+        <div>The 'Choose your Amount' button always displays for the control variant.<br />This is because the Amounts model is complex, with the control amounts<br />separated from the variant test amounts.</div>
+      )}
+      */}
+      <LiveSwitch
+        label="'Choose your Amount' button"
+        isLive={!hideChooseYourAmount}
+        onChange={() => updateChooseYourAmountButton(!hideChooseYourAmount)}
+        isDisabled={false}
+      />
       <div className={classes.rowsContainer}>
         <AmountEditorRow
           label="One off"

--- a/public/src/components/amounts/contributionAmountsEditor.tsx
+++ b/public/src/components/amounts/contributionAmountsEditor.tsx
@@ -58,18 +58,6 @@ const AmountsEditor: React.FC<AmountsEditorProps> = ({
           <AmountEditorDeleteButton onDelete={deleteContributionAmounts} />
         )}
       </div>
-      {/*
-      {label.toUpperCase() !== 'CONTROL' ? (
-        <LiveSwitch
-          label="'Choose your Amount' button"
-          isLive={!hideChooseYourAmount}
-          onChange={() => {}}
-          isDisabled={false}
-        />
-      ) : (
-        <div>The 'Choose your Amount' button always displays for the control variant.<br />This is because the Amounts model is complex, with the control amounts<br />separated from the variant test amounts.</div>
-      )}
-      */}
       <LiveSwitch
         label="'Choose your Amount' button"
         isLive={!hideChooseYourAmount}

--- a/public/src/components/contributionTypes.tsx
+++ b/public/src/components/contributionTypes.tsx
@@ -20,6 +20,7 @@ import {
 interface ContributionTypeSetting {
   contributionType: ContributionType;
   isDefault?: boolean;
+  hideChooseYourAmount?: boolean;
 }
 
 type ContributionTypes = {


### PR DESCRIPTION
## What does this change?
+ Adds a new attribute to the Amounts model which will indicate whether the "Choose your Amount" button should be displayed in the Epic ContributionAmounts component
+ Updates the RRCP Amounts page to display the value of the new attribute on each Amounts variant, and allow users to change it

NOTE: this PR **must not be merged** until Marketing colleagues have been informed and given us the go-ahead to do so!

This PR is one of three PRs across three repos, all of which need to be merged at the same time:
+ PR in `support-admin-control` - https://github.com/guardian/support-admin-console/pull/428
+ PR in `support-dotcom-components` - https://github.com/guardian/support-dotcom-components/pull/832
+ PR in `support-frontend` - https://github.com/guardian/support-frontend/pull/4672 

## Testing
Changes to the test data model should be recorded in the appropriate file in this S3 bucket: `support-admin-console`

## Screenshot
![Screenshot 2023-01-25 at 15 39 20](https://user-images.githubusercontent.com/5357530/214607201-24b8e18e-4a89-4856-b21f-39aae16acdda.png)
