### PR TITLE
add Ukraine moment banner to rrcp

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -28,6 +28,7 @@ object BannerTemplate {
   case object UsEoyGivingTuesMomentBanner extends BannerTemplate
   case object AusEoyMomentBanner extends BannerTemplate
   case object UsEoyMomentBannerV3 extends BannerTemplate
+  case object UkraineMomentBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val bannerTemplateEncoder = deriveEnumerationEncoder[BannerTemplate]

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -49,6 +49,10 @@ const templatesWithLabels = [
     template: BannerTemplate.UsEoyMomentBannerV3,
     label: 'US EOY moment banner v3 2022',
   },
+  {
+    template: BannerTemplate.UkraineMomentBanner,
+    label: 'Ukraine Moment Banner 2023',
+  },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -293,7 +293,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.UsEoyMomentBanner ||
             template === BannerTemplate.UsEoyGivingTuesMomentBanner ||
             template === BannerTemplate.AusEoyMomentBanner ||
-            template === BannerTemplate.UsEoyMomentBannerV3) && (
+            template === BannerTemplate.UsEoyMomentBannerV3 ||
+            template === BannerTemplate.UkraineMomentBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -156,6 +156,10 @@ const bannerModules = {
     path: 'usEoyMomentV3/UsEoyMomentBannerV3.js',
     name: 'UsEoyMomentBannerV3',
   },
+  [BannerTemplate.UkraineMomentBanner]: {
+    path: 'ukraineMoment/UkraineMomentBanner.js',
+    name: 'UkraineMomentBanner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -28,6 +28,7 @@ export enum BannerTemplate {
   AusEoyMomentBanner = 'AusEoyMomentBanner',
   UsEoyMomentBannerV3 = 'UsEoyMomentBannerV3',
   CharityAppealBanner = 'CharityAppealBanner',
+  UkraineMomentBanner = 'UkraineMomentBanner',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
## What does this change?
This PR creates a 'Ukraine One Year On Banner Moment' now using the moments template banner setup within the RRCP

[Trello]
https://trello.com/c/5Z1LPDKV/1042-ukraine-war-1-year-anniversary-campaign-build

## Images
Post->
| 375px | 740px | 980px | 1300+px 
|--------|---------|---------|---------|
| ![Screenshot 2023-02-13 at 10 13 01](https://user-images.githubusercontent.com/76729591/218431367-7bcb199b-ba01-4994-b9aa-3a85013f4430.jpg) | ![Screenshot 2023-02-13 at 10 18 13](https://user-images.githubusercontent.com/76729591/218432885-f3c12901-a574-449f-a7a4-85cfc6a2c88c.jpg) | ![Screenshot 2023-02-13 at 10 19 25](https://user-images.githubusercontent.com/76729591/218432029-b776ccd7-892f-4d1e-a9b3-3d42788351be.jpg) | ![Screenshot 2023-02-13 at 10 20 52](https://user-images.githubusercontent.com/76729591/218432289-0596ee3d-586d-460a-b6a2-d89ae304e96e.jpg)
 |
