### PR TITLE
Update RRCP to support Apple News UK targeted messages

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -328,6 +328,7 @@ export const getEpicTestEditor = (
               showDeviceTypeSelector={epicEditorConfig.allowDeviceTypeTargeting}
               selectedSignedInStatus={test.signedInStatus}
               onSignedInStatusChange={onSignedInStatusChange}
+              platform={epicEditorConfig.platform}
             />
           </div>
         )}

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -144,7 +144,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowCustomVariantSplit: false,
   allowContentTargeting: true,
   allowLocationTargeting: true,
-  supportedRegions: [Region.UnitedStates, Region.AUDCountries],
+  supportedRegions: [Region.UnitedStates, Region.AUDCountries, Region.GBPCountries],
   allowSupporterStatusTargeting: false,
   allowDeviceTypeTargeting: false,
   allowViewFrequencySettings: false,

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Theme, Typography, makeStyles } from '@material-ui/core';
 import { Region } from '../../utils/models';
-import { DeviceType, SignedInStatus, UserCohort } from './helpers/shared';
+import { DeviceType, SignedInStatus, UserCohort, TestPlatform } from './helpers/shared';
 
 import TestEditorTargetRegionsSelector from './testEditorTargetRegionsSelector';
 import TypedRadioGroup from './TypedRadioGroup';
@@ -40,6 +40,7 @@ interface TestEditorTargetAudienceSelectorProps {
   showDeviceTypeSelector: boolean;
   selectedSignedInStatus?: SignedInStatus;
   onSignedInStatusChange: (signedInStatus: SignedInStatus) => void;
+  platform?: TestPlatform;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
   selectedRegions,
@@ -54,6 +55,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   showDeviceTypeSelector,
   selectedSignedInStatus,
   onSignedInStatusChange,
+  platform,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
 
@@ -66,6 +68,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
           onRegionsUpdate={onRegionsUpdate}
           supportedRegions={supportedRegions}
           isDisabled={isDisabled}
+          platform={platform}
         />
       </div>
 

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -60,7 +60,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
       return 'the US + Canada';
     }
     return regionLabels[region];
-  }
+  };
 
   return (
     <FormGroup>

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Checkbox, FormControlLabel, FormGroup, Theme, makeStyles } from '@material-ui/core';
 import { Region } from '../../utils/models';
+import { TestPlatform } from './helpers/shared';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   indentedContainer: {
@@ -15,7 +16,7 @@ const regionLabels = {
   EURCountries: 'Europe',
   NZDCountries: 'New Zealand',
   GBPCountries: 'the UK',
-  UnitedStates: 'the US + Canada',
+  UnitedStates: 'the US',
   International: 'Rest-of-world',
 };
 
@@ -26,12 +27,14 @@ interface TestEditorTargetRegionsSelectorProps {
   onRegionsUpdate: (selectedRegions: Region[]) => void;
   supportedRegions?: Region[];
   isDisabled: boolean;
+  platform?: TestPlatform;
 }
 const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorProps> = ({
   selectedRegions,
   onRegionsUpdate,
   supportedRegions,
   isDisabled,
+  platform,
 }: TestEditorTargetRegionsSelectorProps) => {
   const classes = useStyles();
   const allRegions = supportedRegions || ALL_REGIONS;
@@ -51,6 +54,13 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
       onRegionsUpdate(selectedRegions.filter((_, index) => index !== regionIndex));
     }
   };
+
+  const checkLabelByChannel = (platform: TestPlatform | undefined, region: Region) => {
+    if (platform === 'APPLE_NEWS' && region === 'UnitedStates') {
+      return 'the US + Canada';
+    }
+    return regionLabels[region];
+  }
 
   return (
     <FormGroup>
@@ -77,7 +87,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
                 disabled={isDisabled}
               />
             }
-            label={regionLabels[region]}
+            label={checkLabelByChannel(platform, region)}
           />
         ))}
       </FormGroup>

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -15,7 +15,7 @@ const regionLabels = {
   EURCountries: 'Europe',
   NZDCountries: 'New Zealand',
   GBPCountries: 'the UK',
-  UnitedStates: 'the US',
+  UnitedStates: 'the US + Canada',
   International: 'Rest-of-world',
 };
 
@@ -63,7 +63,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
             disabled={isDisabled}
           />
         }
-        label={'All regions'}
+        label={'All supported regions'}
       />
       <FormGroup className={classes.indentedContainer}>
         {allRegions.map(region => (


### PR DESCRIPTION
## What does this change?
The business is in preparation to start posting articles to the Apple UK service. We already post to Apple US+Canada, and Apple Australia.

This PR adds `GBPCountries` to the `regions` array of regions supported by the Apple news Channel, and tidies up the labels associated with the regions selector component for the Apple News channel page.

### Related Trello cards
+ [Apple News UK: RRCP change](https://trello.com/c/GmubqW1i)
+ [RRCP: Apple News epic tool should specify US + Canada](https://trello.com/c/pW8Yzo0o)

## Screenshots

__Before changes__
![Screenshot 2023-02-13 at 10 27 56](https://user-images.githubusercontent.com/5357530/218435834-2e42fb02-7eda-463a-b44f-e68c48f8e372.png)

__After changes__
![Screenshot 2023-02-13 at 10 28 13](https://user-images.githubusercontent.com/5357530/218435919-78e541fd-a551-478d-a82c-4934a162797d.png)

__Check that changes do no affect other channel pages__
![Screenshot 2023-02-13 at 11 10 46](https://user-images.githubusercontent.com/5357530/218443014-4ad13aae-d897-4be3-a75a-e96895c820cd.png)
