### PR TITLE
SSM parameter with ALB, for WAF

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -73,6 +73,25 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "AlbSsmParam485C1D52": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Description": "The arn of the ALB for amiable-PROD. N.B. this parameter is created via cdk",
+        "Name": "/infosec/waf/services/PROD/support-admin-console-alb-arn",
+        "Tags": Object {
+          "Stack": "support",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/support-admin-console",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "LoadBalancerAdminconsole69251694",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AthenaOutputBucket826361ED": Object {
       "Properties": Object {
         "PolicyDocument": Object {

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -16,6 +16,7 @@ import { AttributeType, BillingMode, ProjectionType, Table } from 'aws-cdk-lib/a
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import type { Policy } from 'aws-cdk-lib/aws-iam';
 import { AccountPrincipal, ManagedPolicy, Role } from 'aws-cdk-lib/aws-iam';
+import { ParameterDataType, ParameterTier, StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface AdminConsoleProps extends GuStackProps {
   domainName: string;
@@ -223,6 +224,16 @@ export class AdminConsole extends GuStack {
       inlinePolicies: {
         dynamoPolicyForCapi: dynamoPolicyForCapi.document,
       },
+    });
+
+    // This parameter is used by our WAF configuration
+    new StringParameter(this, 'AlbSsmParam', {
+      parameterName: `/infosec/waf/services/${this.stage}/support-admin-console-alb-arn`,
+      description: `The arn of the ALB for amiable-${this.stage}. N.B. this parameter is created via cdk`,
+      simpleName: false,
+      stringValue: ec2App.loadBalancer.loadBalancerArn,
+      tier: ParameterTier.STANDARD,
+      dataType: ParameterDataType.TEXT,
     });
   }
 }


### PR DESCRIPTION
We want to use [WAF](https://aws.amazon.com/waf/) to improve protection and monitoring of this app.
This PR makes the ARN of the ALB available to the Guardian's WAF configuration. It does this by adding it to an SSM parameter.