### PR TITLE
Add Choice Card banner variants to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -9,24 +9,26 @@ import io.circe.{Decoder, Encoder}
 
 sealed trait BannerTemplate
 object BannerTemplate {
+  case object AusEoyMomentBanner extends BannerTemplate
+  case object AuBrandMomentBanner extends BannerTemplate
+  case object ChoiceCardsBannerBlue extends BannerTemplate
+  case object ChoiceCardsBannerYellow extends BannerTemplate
+  case object ClimateCrisisMomentBanner extends BannerTemplate
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate
   case object CharityAppealBanner extends BannerTemplate
   case object DigitalSubscriptionsBanner extends BannerTemplate
-  case object PrintSubscriptionsBanner extends BannerTemplate
-  case object GuardianWeeklyBanner extends BannerTemplate
-  case object InvestigationsMomentBanner extends BannerTemplate
+  case object ElectionAuMomentBanner extends BannerTemplate
   case object EnvironmentMomentBanner extends BannerTemplate
   case object GlobalNewYearBanner extends BannerTemplate
-  case object ElectionAuMomentBanner extends BannerTemplate
+  case object GuardianWeeklyBanner extends BannerTemplate
+  case object InvestigationsMomentBanner extends BannerTemplate
   case object PostElectionAuMomentAlbaneseBanner extends BannerTemplate
   case object PostElectionAuMomentHungBanner extends BannerTemplate
   case object PostElectionAuMomentMorrisonBanner extends BannerTemplate
-  case object AuBrandMomentBanner extends BannerTemplate
-  case object ClimateCrisisMomentBanner extends BannerTemplate
-  case object UsEoyMomentBanner extends BannerTemplate
+  case object PrintSubscriptionsBanner extends BannerTemplate
   case object UsEoyGivingTuesMomentBanner extends BannerTemplate
-  case object AusEoyMomentBanner extends BannerTemplate
+  case object UsEoyMomentBanner extends BannerTemplate
   case object UsEoyMomentBannerV3 extends BannerTemplate
   case object UkraineMomentBanner extends BannerTemplate
 

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -53,6 +53,14 @@ const templatesWithLabels = [
     template: BannerTemplate.UkraineMomentBanner,
     label: 'Ukraine Moment Banner 2023',
   },
+  {
+    template: BannerTemplate.ChoiceCardsBannerBlue,
+    label: 'Choice cards banner - blue',
+  },
+  {
+    template: BannerTemplate.ChoiceCardsBannerYellow,
+    label: 'Choice cards banner - yellow',
+  },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -285,6 +285,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
           />
 
           {(template === BannerTemplate.ContributionsBanner ||
+            template === BannerTemplate.ChoiceCardsBannerBlue ||
+            template === BannerTemplate.ChoiceCardsBannerYellow ||
             template === BannerTemplate.GuardianWeeklyBanner ||
             template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -160,6 +160,14 @@ const bannerModules = {
     path: 'ukraineMoment/UkraineMomentBanner.js',
     name: 'UkraineMomentBanner',
   },
+  [BannerTemplate.ChoiceCardsBannerBlue]: {
+    path: 'choiceCardsBanner/ChoiceCardsBannerBlue.js',
+    name: 'ChoiceCardsBannerBlue',
+  },
+  [BannerTemplate.ChoiceCardsBannerYellow]: {
+    path: 'choiceCardsBanner/ChoiceCardsBannerYellow.js',
+    name: 'ChoiceCardsBannerYellow',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -15,6 +15,8 @@ import { ControlProportionSettings } from '../components/channelManagement/helpe
 export enum BannerTemplate {
   ContributionsBanner = 'ContributionsBanner',
   ContributionsBannerWithSignIn = 'ContributionsBannerWithSignIn',
+  ChoiceCardsBannerBlue = 'ChoiceCardsBannerBlue',
+  ChoiceCardsBannerYellow = 'ChoiceCardsBannerYellow',
   DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
   PrintSubscriptionsBanner = 'PrintSubscriptionsBanner',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',


### PR DESCRIPTION
## What does this change?
This adds the choice cards banner test variants to the RRCP. [See here for the banner.](https://github.com/guardian/support-dotcom-components/pull/859)