### PR TITLE
Revert "Add Choice Card Banner AB test variants to RRCP"

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -11,10 +11,8 @@ sealed trait BannerTemplate
 object BannerTemplate {
   case object AusEoyMomentBanner extends BannerTemplate
   case object AuBrandMomentBanner extends BannerTemplate
-  case object ChoiceCardsButtonsBannerBlue extends BannerTemplate
-  case object ChoiceCardsButtonsBannerYellow extends BannerTemplate
-  case object ChoiceCardsTabsBannerBlue extends BannerTemplate
-  case object ChoiceCardsTabsBannerYellow extends BannerTemplate
+  case object ChoiceCardsBannerBlue extends BannerTemplate
+  case object ChoiceCardsBannerYellow extends BannerTemplate
   case object ClimateCrisisMomentBanner extends BannerTemplate
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -30,20 +30,12 @@ const templatesWithLabels = [
     label: 'Ukraine Moment Banner 2023',
   },
   {
-    template: BannerTemplate.ChoiceCardsButtonsBannerBlue,
-    label: 'Choice cards buttons banner - blue',
+    template: BannerTemplate.ChoiceCardsBannerBlue,
+    label: 'Choice cards banner - blue',
   },
   {
-    template: BannerTemplate.ChoiceCardsButtonsBannerYellow,
-    label: 'Choice cards buttons banner - yellow',
-  },
-  {
-    template: BannerTemplate.ChoiceCardsTabsBannerBlue,
-    label: 'Choice cards tabs banner - blue',
-  },
-  {
-    template: BannerTemplate.ChoiceCardsTabsBannerYellow,
-    label: 'Choice cards tabs banner - yellow',
+    template: BannerTemplate.ChoiceCardsBannerYellow,
+    label: 'Choice cards banner - yellow',
   },
 ];
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -285,10 +285,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
           />
 
           {(template === BannerTemplate.ContributionsBanner ||
-            template === BannerTemplate.ChoiceCardsButtonsBannerBlue ||
-            template === BannerTemplate.ChoiceCardsButtonsBannerYellow ||
-            template === BannerTemplate.ChoiceCardsTabsBannerBlue ||
-            template === BannerTemplate.ChoiceCardsTabsBannerYellow ||
+            template === BannerTemplate.ChoiceCardsBannerBlue ||
+            template === BannerTemplate.ChoiceCardsBannerYellow ||
             template === BannerTemplate.GuardianWeeklyBanner ||
             template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -136,21 +136,13 @@ const bannerModules = {
     path: 'ukraineMoment/UkraineMomentBanner.js',
     name: 'UkraineMomentBanner',
   },
-  [BannerTemplate.ChoiceCardsButtonsBannerBlue]: {
-    path: 'choiceCardsButtonsBanner/ChoiceCardsButtonsBannerBlue.js',
-    name: 'ChoiceCardsButtonsBannerBlue',
+  [BannerTemplate.ChoiceCardsBannerBlue]: {
+    path: 'choiceCardsBanner/ChoiceCardsBannerBlue.js',
+    name: 'ChoiceCardsBannerBlue',
   },
-  [BannerTemplate.ChoiceCardsButtonsBannerYellow]: {
-    path: 'choiceCardsButtonsBanner/ChoiceCardsButtonsBannerYellow.js',
-    name: 'ChoiceCardsButtonsBannerYellow',
-  },
-  [BannerTemplate.ChoiceCardsTabsBannerBlue]: {
-    path: 'choiceCardsTabsBanner/ChoiceCardsTabsBannerBlue.js',
-    name: 'ChoiceCardsTabsBannerBlue',
-  },
-  [BannerTemplate.ChoiceCardsTabsBannerYellow]: {
-    path: 'choiceCardsTabsBanner/ChoiceCardsTabsBannerYellow.js',
-    name: 'ChoiceCardsTabsBannerYellow',
+  [BannerTemplate.ChoiceCardsBannerYellow]: {
+    path: 'choiceCardsBanner/ChoiceCardsBannerYellow.js',
+    name: 'ChoiceCardsBannerYellow',
   },
 };
 

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -15,10 +15,8 @@ import { ControlProportionSettings } from '../components/channelManagement/helpe
 export enum BannerTemplate {
   ContributionsBanner = 'ContributionsBanner',
   ContributionsBannerWithSignIn = 'ContributionsBannerWithSignIn',
-  ChoiceCardsButtonsBannerBlue = 'ChoiceCardsButtonsBannerBlue',
-  ChoiceCardsButtonsBannerYellow = 'ChoiceCardsButtonsBannerYellow',
-  ChoiceCardsTabsBannerBlue = 'ChoiceCardsTabsBannerBlue',
-  ChoiceCardsTabsBannerYellow = 'ChoiceCardsTabsBannerYellow',
+  ChoiceCardsBannerBlue = 'ChoiceCardsBannerBlue',
+  ChoiceCardsBannerYellow = 'ChoiceCardsBannerYellow',
   DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
   PrintSubscriptionsBanner = 'PrintSubscriptionsBanner',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',


### PR DESCRIPTION
Reverts guardian/support-admin-console#442

To keep inline with SDC banner revert guardian/support-dotcom-components#877