### PR TITLE
Remove _2022 from ticker names

### DIFF
--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -23,8 +23,8 @@ object TickerCountType {
 
 sealed trait TickerName
 object TickerName {
-  case object US_2022 extends TickerName
-  case object AU_2022 extends TickerName
+  case object US extends TickerName
+  case object AU extends TickerName
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val encoder = deriveEnumerationEncoder[TickerName]

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -257,8 +257,8 @@ export enum TickerCountType {
   money = 'money',
 }
 export enum TickerName {
-  US_2022 = 'US_2022',
-  AU_2022 = 'AU_2022',
+  US = 'US',
+  AU = 'AU',
 }
 
 interface TickerCopy {

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -43,7 +43,7 @@ const DEFAULT_TICKER_SETTINGS: TickerSettings = {
     goalReachedSecondary: 'but you can still support us',
   },
   currencySymbol: '$',
-  name: TickerName.US_2022,
+  name: TickerName.US,
 };
 
 interface TickerEditorProps {
@@ -147,15 +147,15 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
                 name="ticker-name"
               >
                 <FormControlLabel
-                  value={TickerName.US_2022}
+                  value={TickerName.US}
                   control={<Radio />}
-                  label="US_2022"
+                  label="US"
                   disabled={isDisabled}
                 />
                 <FormControlLabel
-                  value={TickerName.AU_2022}
+                  value={TickerName.AU}
                   control={<Radio />}
-                  label="AU_2022"
+                  label="AU"
                   disabled={isDisabled}
                 />
               </RadioGroup>


### PR DESCRIPTION
Rather than add a new ticker each year, it seems more sensible to reuse the existing ticker names. Therefore, removing the year from the name makes sense. This will need to be co-ordinated with the similar PRs on support-dotcom-components and contributions-ticker-calculator.