### PR TITLE
World Press Freedom Day Banner

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -27,6 +27,7 @@ object BannerTemplate {
   case object PostElectionAuMomentHungBanner extends BannerTemplate
   case object PostElectionAuMomentMorrisonBanner extends BannerTemplate
   case object UkraineMomentBanner extends BannerTemplate
+  case object WorldPressFreedomDayBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val bannerTemplateEncoder = deriveEnumerationEncoder[BannerTemplate]

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@types/jest": "24.0.18",
         "@types/material-ui": "^0.21.7",
-        "@types/react": "^17.0.58",
+        "@types/react": "~17.0.58",
         "@types/react-dom": "^16.9.0",
         "@types/react-router-dom": "^5.0.1",
         "@typescript-eslint/eslint-plugin": "^4.1.1",

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -38,7 +38,9 @@ const templatesWithLabels = [
     label: 'Choice cards banner - yellow',
   },
   {
-    template: BannerTemplate.WorldPressFreedomDayBanner, label: 'World Press Freedom Day' },
+    template: BannerTemplate.WorldPressFreedomDayBanner,
+    label: 'World Press Freedom Day',
+  },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -37,6 +37,8 @@ const templatesWithLabels = [
     template: BannerTemplate.ChoiceCardsBannerYellow,
     label: 'Choice cards banner - yellow',
   },
+  {
+    template: BannerTemplate.WorldPressFreedomDayBanner, label: 'World Press Freedom Day' },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -291,7 +291,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.GlobalNewYearBanner ||
-            template === BannerTemplate.UkraineMomentBanner) && (
+            template === BannerTemplate.UkraineMomentBanner ||
+            template === BannerTemplate.WorldPressFreedomDayBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -145,7 +145,7 @@ const bannerModules = {
     name: 'ChoiceCardsBannerYellow',
   },
   [BannerTemplate.WorldPressFreedomDayBanner]: {
-    path: 'worldPressFreedomDayBanner/WorldPressFreedomDayBanner.js',
+    path: 'worldPressFreedomDay/WorldPressFreedomDayBanner.js',
     name: 'WorldPressFreedomDayBanner',
   },
 };

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -144,6 +144,10 @@ const bannerModules = {
     path: 'choiceCardsBanner/ChoiceCardsBannerYellow.js',
     name: 'ChoiceCardsBannerYellow',
   },
+  [BannerTemplate.WorldPressFreedomDayBanner]: {
+    path: 'worldPressFreedomDayBanner/WorldPressFreedomDayBanner.js',
+    name: 'WorldPressFreedomDayBanner',
+  }
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -147,7 +147,7 @@ const bannerModules = {
   [BannerTemplate.WorldPressFreedomDayBanner]: {
     path: 'worldPressFreedomDayBanner/WorldPressFreedomDayBanner.js',
     name: 'WorldPressFreedomDayBanner',
-  }
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -25,6 +25,7 @@ export enum BannerTemplate {
   GlobalNewYearBanner = 'GlobalNewYearBanner',
   CharityAppealBanner = 'CharityAppealBanner',
   UkraineMomentBanner = 'UkraineMomentBanner',
+  WorldPressFreedomDayBanner = 'WorldPressFreedomDayBanner',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
## What does this change?

This PR is the corresponding PR to https://github.com/guardian/support-dotcom-components/pull/889 in `support-dotcom-components` and set up the necessary configuration so the World Press Freedom Day Banner can be selected in the RRCP.