### PR TITLE
Re-add choice cards banner buttons variant to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -14,6 +14,8 @@ object BannerTemplate {
   case object AuBrandMomentBanner extends BannerTemplate
   case object ChoiceCardsBannerBlue extends BannerTemplate
   case object ChoiceCardsBannerYellow extends BannerTemplate
+  case object ChoiceCardsButtonsBannerBlue extends BannerTemplate
+  case object ChoiceCardsButtonsBannerYellow extends BannerTemplate
   case object ClimateCrisisMomentBanner extends BannerTemplate
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -39,6 +39,14 @@ const templatesWithLabels = [
     label: 'Choice cards banner - yellow',
   },
   {
+    template: BannerTemplate.ChoiceCardsButtonsBannerBlue,
+    label: 'Choice cards buttons banner - blue',
+  },
+  {
+    template: BannerTemplate.ChoiceCardsButtonsBannerYellow,
+    label: 'Choice cards buttons banner - yellow',
+  },
+  {
     template: BannerTemplate.WorldPressFreedomDayBanner,
     label: 'World Press Freedom Day',
   },

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -32,11 +32,11 @@ const templatesWithLabels = [
   },
   {
     template: BannerTemplate.ChoiceCardsBannerBlue,
-    label: 'Choice cards banner - blue',
+    label: 'Choice cards banner - TABS',
   },
   {
     template: BannerTemplate.ChoiceCardsButtonsBannerBlue,
-    label: 'Choice cards buttons banner - blue',
+    label: 'Choice cards banner - BUTTONS',
   },
   {
     template: BannerTemplate.WorldPressFreedomDayBanner,

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -35,16 +35,8 @@ const templatesWithLabels = [
     label: 'Choice cards banner - blue',
   },
   {
-    template: BannerTemplate.ChoiceCardsBannerYellow,
-    label: 'Choice cards banner - yellow',
-  },
-  {
     template: BannerTemplate.ChoiceCardsButtonsBannerBlue,
     label: 'Choice cards buttons banner - blue',
-  },
-  {
-    template: BannerTemplate.ChoiceCardsButtonsBannerYellow,
-    label: 'Choice cards buttons banner - yellow',
   },
   {
     template: BannerTemplate.WorldPressFreedomDayBanner,

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -288,6 +288,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.ContributionsBanner ||
             template === BannerTemplate.ChoiceCardsBannerBlue ||
             template === BannerTemplate.ChoiceCardsBannerYellow ||
+            template === BannerTemplate.ChoiceCardsButtonsBannerBlue ||
+            template === BannerTemplate.ChoiceCardsButtonsBannerYellow ||
             template === BannerTemplate.GuardianWeeklyBanner ||
             template === BannerTemplate.CharityAppealBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -148,6 +148,14 @@ const bannerModules = {
     path: 'choiceCardsBanner/ChoiceCardsBannerYellow.js',
     name: 'ChoiceCardsBannerYellow',
   },
+  [BannerTemplate.ChoiceCardsButtonsBannerBlue]: {
+    path: 'choiceCardsButtonsBanner/ChoiceCardsButtonsBannerBlue.js',
+    name: 'ChoiceCardsButtonsBannerBlue',
+  },
+  [BannerTemplate.ChoiceCardsButtonsBannerYellow]: {
+    path: 'choiceCardsButtonsBanner/ChoiceCardsButtonsBannerYellow.js',
+    name: 'ChoiceCardsButtonsBannerYellow',
+  },
   [BannerTemplate.WorldPressFreedomDayBanner]: {
     path: 'worldPressFreedomDay/WorldPressFreedomDayBanner.js',
     name: 'WorldPressFreedomDayBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -18,6 +18,8 @@ export enum BannerTemplate {
   ContributionsBannerWithSignIn = 'ContributionsBannerWithSignIn',
   ChoiceCardsBannerBlue = 'ChoiceCardsBannerBlue',
   ChoiceCardsBannerYellow = 'ChoiceCardsBannerYellow',
+  ChoiceCardsButtonsBannerBlue = 'ChoiceCardsButtonsBannerBlue',
+  ChoiceCardsButtonsBannerYellow = 'ChoiceCardsButtonsBannerYellow',
   DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
   PrintSubscriptionsBanner = 'PrintSubscriptionsBanner',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',


### PR DESCRIPTION
## What does this change?
This re-adds the choice cards banner buttons ab test variants to the RRCP. 
See here for the banner https://github.com/guardian/support-dotcom-components/pull/894