### PR TITLE
Add US Supreme Court Moment banner

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -31,6 +31,7 @@ object BannerTemplate {
   case object PostElectionAuMomentMorrisonBanner extends BannerTemplate
   case object UkraineMomentBanner extends BannerTemplate
   case object WorldPressFreedomDayBanner extends BannerTemplate
+  case object Scotus2023MomentBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val bannerTemplateEncoder = deriveEnumerationEncoder[BannerTemplate]

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -42,6 +42,10 @@ const templatesWithLabels = [
     template: BannerTemplate.WorldPressFreedomDayBanner,
     label: 'World Press Freedom Day',
   },
+  {
+    template: BannerTemplate.Scotus2023MomentBanner,
+    label: 'US Supreme Court 2023 Moment',
+  },
 ];
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -295,7 +295,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.GlobalNewYearBanner ||
             template === BannerTemplate.UkraineMomentBanner ||
-            template === BannerTemplate.WorldPressFreedomDayBanner) && (
+            template === BannerTemplate.WorldPressFreedomDayBanner ||
+            template === BannerTemplate.Scotus2023MomentBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -160,6 +160,10 @@ const bannerModules = {
     path: 'worldPressFreedomDay/WorldPressFreedomDayBanner.js',
     name: 'WorldPressFreedomDayBanner',
   },
+  [BannerTemplate.Scotus2023MomentBanner]: {
+    path: 'usSupremeCourt2023/Scotus2023MomentBanner.js',
+    name: 'Scotus2023MomentBanner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -29,6 +29,7 @@ export enum BannerTemplate {
   CharityAppealBanner = 'CharityAppealBanner',
   UkraineMomentBanner = 'UkraineMomentBanner',
   WorldPressFreedomDayBanner = 'WorldPressFreedomDayBanner',
+  Scotus2023MomentBanner = 'Scotus2023MomentBanner',
 }
 
 export interface BannerContent {


### PR DESCRIPTION
## What does this change?
We have an ask to create a new Template Banner for the upcoming US Supreme Court Moment. 

To complete the work, we will merge 2 PRs in the following repos:
+ https://github.com/guardian/support-dotcom-components/pull/907
+ https://github.com/guardian/support-admin-console/pull/455

## How to test
+ A Storybook story has been created for this template banner, which we can use to make sure it conforms with design (see Trello card for link to Figma file)
+ We will test the banner by deploying both PRs and creating a new banner test using the template and reviewing its presentation and functionality in both `live` and `web` views in RRCP

## How can we measure success?
Marketing have defined success criteria in their scoping document for this work

## Have we considered potential risks?
We judge the risk to be low for this work as we are building the template on top of moment template code. No changes to layout or design are required beyond color and image changes

## Screenshots
[TODO - add screenshots of the new banner template]
