### PR TITLE
Use channel-status-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Refresh automatically:
 npm run watch
 ```
 
+### Running scala tests
+The scala backend tests use dynamodb-local. This doesn't support Apple Silicon (M1).
+
+If while running `sbt test` you get the error `cannot load library: java.lang.UnsatisfiedLinkError: no sqlite4java-osx-aarch64`, use this work around:
+1. download the correct `.dylib` from e.g. https://repo1.maven.org/maven2/io/github/ganadist/sqlite4java/libsqlite4java-osx-arm64/1.0.392/libsqlite4java-osx-arm64-1.0.392.dylib
+2. copy it into the `dynamodb-local/DynamoDBLocal_lib/` directory in this project
+
 ### SSH
 You can ssh using [ssm-scala](https://github.com/guardian/ssm-scala):
 

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -318,6 +318,10 @@ Object {
             "AttributeName": "campaignName",
             "AttributeType": "S",
           },
+          Object {
+            "AttributeName": "status",
+            "AttributeType": "S",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
         "GlobalSecondaryIndexes": Array [
@@ -330,6 +334,22 @@ Object {
               },
               Object {
                 "AttributeName": "name",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": Object {
+              "ProjectionType": "ALL",
+            },
+          },
+          Object {
+            "IndexName": "channel-status-index",
+            "KeySchema": Array [
+              Object {
+                "AttributeName": "channel",
+                "KeyType": "HASH",
+              },
+              Object {
+                "AttributeName": "status",
                 "KeyType": "RANGE",
               },
             ],

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -56,6 +56,19 @@ export class AdminConsole extends GuStack {
       },
     });
 
+    table.addGlobalSecondaryIndex({
+      indexName: 'channel-status-index',
+      projectionType: ProjectionType.ALL,
+      partitionKey: {
+        name: 'channel',
+        type: AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'status',
+        type: AttributeType.STRING,
+      },
+    });
+
     // Give it a better name
     const defaultChild = table.node.defaultChild as unknown as CfnElement;
     defaultChild.overrideLogicalId(id);

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import models.EpicTest._
 import org.scalatest.{Assertion, Assertions, BeforeAndAfterEach}
 import models.DynamoErrors.{DynamoError, DynamoNoLockError}
-import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, BillingMode, CreateTableRequest, DeleteTableRequest, GlobalSecondaryIndex, KeySchemaElement, KeyType}
+import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, BillingMode, CreateTableRequest, DeleteTableRequest, GlobalSecondaryIndex, KeySchemaElement, KeyType, Projection, ProjectionType}
 import zio.{ZEnv, ZIO}
 
 import java.net.URI
@@ -66,7 +66,8 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
         .tableName(tableName)
         .attributeDefinitions(
           AttributeDefinition.builder.attributeName("channel").attributeType("S").build,
-          AttributeDefinition.builder.attributeName("name").attributeType("S").build
+          AttributeDefinition.builder.attributeName("name").attributeType("S").build,
+          AttributeDefinition.builder.attributeName("status").attributeType("S").build
         )
         .keySchema(
           KeySchemaElement.builder.attributeName("channel").keyType(KeyType.HASH).build,
@@ -80,6 +81,7 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
               KeySchemaElement.builder.attributeName("channel").keyType(KeyType.HASH).build,
               KeySchemaElement.builder.attributeName("status").keyType(KeyType.RANGE).build
             )
+            .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
             .build()
         )
         .billingMode(BillingMode.PAY_PER_REQUEST)

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import models.EpicTest._
 import org.scalatest.{Assertion, Assertions, BeforeAndAfterEach}
 import models.DynamoErrors.{DynamoError, DynamoNoLockError}
-import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, BillingMode, CreateTableRequest, DeleteTableRequest, KeySchemaElement, KeyType}
+import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, BillingMode, CreateTableRequest, DeleteTableRequest, GlobalSecondaryIndex, KeySchemaElement, KeyType}
 import zio.{ZEnv, ZIO}
 
 import java.net.URI
@@ -71,6 +71,16 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
         .keySchema(
           KeySchemaElement.builder.attributeName("channel").keyType(KeyType.HASH).build,
           KeySchemaElement.builder.attributeName("name").keyType(KeyType.RANGE).build
+        )
+        .globalSecondaryIndexes(
+          GlobalSecondaryIndex
+            .builder()
+            .indexName("channel-status-index")
+            .keySchema(
+              KeySchemaElement.builder.attributeName("channel").keyType(KeyType.HASH).build,
+              KeySchemaElement.builder.attributeName("status").keyType(KeyType.RANGE).build
+            )
+            .build()
         )
         .billingMode(BillingMode.PAY_PER_REQUEST)
         .build


### PR DESCRIPTION
We've started to see an issue in the epic tool where some tests are not being returned by Dynamodb.
tl;dr - this is because we now have so many archived epic tests that the sdk wants to paginate.

### Existing behaviour:
When we query for all Live + Draft tests for a channel, the query looks like this:
```
.keyConditionExpression("channel = :channel")
...
.filterExpression("#status <> :archived")
```
Here we're using the primary index, which is on `(channel, name)`. So the result of the query is _all_ epic tests, and the filter expression is then applied by Dynamodb to filter out tests with `status` of `Archived`. So while the query on `channel` is efficient, Dynamodb has to then scan all epic tests to do the `status` filter.
Once the size of the data to be scanned exceeds a limit, the Dynamodb sdk [requires us to paginate](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination), which is why we're not getting all results.

### New behaviour:
This PR adds a new secondary index on `(channel, status)`, which we can now query. This means Dynamodb doesn't have to perform a scan on the query results.


### Result:
While testing this locally I logged:
- count - the number of items returned by Dynamodb
- scannedCount - the number of items that had to be scanned by Dynamodb after querying
- lastEvaluatedKey - a value returned by Dynamodb if it's having to paginate

Before:
```
count: 20
scannedCount: 267
lastEvaluatedKey: {name=AttributeValue(S=PP_V3__ABORTION_US), channel=AttributeValue(S=Epic)}
```

After:
```
count: 20
scannedCount: 20
lastEvaluatedKey: {}
```


TODO - change SDC and apple-news to use the new secondary index when fetching channel tests from Dynamodb