### PR TITLE
Archived tests migration 

### DIFF
--- a/app/controllers/ArchivedTestsMigration.scala
+++ b/app/controllers/ArchivedTestsMigration.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import com.typesafe.scalalogging.LazyLogging
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import zio.{IO, ZEnv}
+import io.circe.parser.decode
+import models.Channel
+import play.api.mvc.Results.{BadRequest, Ok}
+import software.amazon.awssdk.services.dynamodb.model.{PutRequest, WriteRequest}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+class ArchivedTestsMigration(
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  stage: String,
+  runtime: zio.Runtime[ZEnv],
+  dynamoChannelTests: DynamoChannelTests,
+  dynamoArchivedChannelTests: DynamoArchivedChannelTests
+)(implicit ec: ExecutionContext) extends AbstractController(components) with LazyLogging {
+
+  private def run(channel: Channel) = runtime.unsafeRunToFuture {
+    dynamoChannelTests
+      .getAllArchived(channel)
+      .flatMap(tests => {
+        val writeRequests = tests.asScala.toList.map(test => WriteRequest.builder.putRequest(
+          PutRequest
+            .builder
+            .item(test)
+            .build()
+        ).build())
+
+        dynamoArchivedChannelTests
+          .putAllBatched(writeRequests)
+          .map(_ => writeRequests.length)
+      })
+      .map(count => Ok(s"Migrated $count items for channel $channel"))
+      .catchAll(error => {
+        logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
+        IO.succeed(InternalServerError(error.getMessage))
+      })
+  }
+
+  def migrate(channel: String): Action[AnyContent] = authAction.async { request =>
+    decode[Channel](channel) match {
+      case Right(channel) =>
+        run(channel)
+          .map(count => Ok(s"Migrated $count items for channel $channel"))
+      case Left(error) =>
+        Future.successful(BadRequest(error.getMessage))
+    }
+  }
+}

--- a/app/controllers/ArchivedTestsMigrationController.scala
+++ b/app/controllers/ArchivedTestsMigrationController.scala
@@ -6,7 +6,6 @@ import io.circe.Json
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests}
 import zio.{IO, ZEnv}
-import io.circe.generic.auto._
 import models.Channel
 import models.Channel._
 import software.amazon.awssdk.services.dynamodb.model.{PutRequest, WriteRequest}

--- a/app/controllers/ArchivedTestsMigrationController.scala
+++ b/app/controllers/ArchivedTestsMigrationController.scala
@@ -7,6 +7,7 @@ import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponent
 import services.{DynamoArchivedChannelTests, DynamoChannelTests}
 import zio.{IO, ZEnv}
 import models.Channel
+import models.Channel._
 import software.amazon.awssdk.services.dynamodb.model.{PutRequest, WriteRequest}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/controllers/ArchivedTestsMigrationController.scala
+++ b/app/controllers/ArchivedTestsMigrationController.scala
@@ -6,6 +6,7 @@ import io.circe.Json
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests}
 import zio.{IO, ZEnv}
+import io.circe.generic.auto._
 import models.Channel
 import models.Channel._
 import software.amazon.awssdk.services.dynamodb.model.{PutRequest, WriteRequest}

--- a/app/models/Channel.scala
+++ b/app/models/Channel.scala
@@ -1,0 +1,20 @@
+package models
+
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+
+sealed trait Channel
+
+object Channel {
+  case object Epic extends Channel
+  case object EpicAMP extends Channel
+  case object EpicAppleNews extends Channel
+  case object EpicLiveblog extends Channel
+  case object Banner1 extends Channel
+  case object Banner2 extends Channel
+  case object Header extends Channel
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val statusEncoder = deriveEnumerationEncoder[Channel]
+  implicit val statusDecoder = deriveEnumerationDecoder[Channel]
+}

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -9,28 +9,14 @@ sealed trait Status
 
 object Status {
   case object Live extends Status
+
   case object Draft extends Status
+
   case object Archived extends Status
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val statusEncoder = deriveEnumerationEncoder[Status]
   implicit val statusDecoder = deriveEnumerationDecoder[Status]
-}
-
-sealed trait Channel
-
-object Channel {
-  case object Epic extends Channel
-  case object EpicAMP extends Channel
-  case object EpicAppleNews extends Channel
-  case object EpicLiveblog extends Channel
-  case object Banner1 extends Channel
-  case object Banner2 extends Channel
-  case object Header extends Channel
-
-  implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val statusEncoder = deriveEnumerationEncoder[Channel]
-  implicit val statusDecoder = deriveEnumerationDecoder[Channel]
 }
 
 trait ChannelTest[T] {

--- a/app/services/DynamoArchivedChannelTests.scala
+++ b/app/services/DynamoArchivedChannelTests.scala
@@ -1,0 +1,64 @@
+package services
+
+import com.typesafe.scalalogging.StrictLogging
+import models.DynamoErrors._
+import models._
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
+import zio.blocking.effectBlocking
+import zio.duration.durationInt
+import zio.stream.ZStream
+import zio.{ZEnv, ZIO}
+
+import scala.jdk.CollectionConverters._
+
+
+class DynamoArchivedChannelTests(stage: String, client: DynamoDbClient) extends StrictLogging {
+
+  private val tableName = s"support-admin-console-archived-channel-tests-$stage"
+
+  // Sends a batch of write requests, and returns any unprocessed items
+  private def putAll(writeRequests: List[WriteRequest]): ZIO[ZEnv, DynamoPutError, List[WriteRequest]] =
+    effectBlocking {
+      val batchWriteRequest =
+        BatchWriteItemRequest
+          .builder
+          .requestItems(Map(tableName -> writeRequests.asJava).asJava)
+          .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+          .build()
+
+      val result = client.batchWriteItem(batchWriteRequest)
+      logger.info(s"BatchWriteItemResponse: $result")
+
+      result.unprocessedItems().asScala
+        .get(tableName)
+        .map(items => items.asScala.toList)
+        .getOrElse(Nil)
+
+    }.mapError(DynamoPutError)
+
+  /**
+   * Dynamodb limits us to batches of 25 items, and may return unprocessed items in the response.
+   * This function groups items into batches of 25, and also checks the `unprocessedItems` in case we need to send
+   * any again.
+   * It uses an infinite zio stream to do this, pausing between batches to avoid any throttling. It stops processing
+   * the stream when the list of batches is empty.
+   */
+  private val BATCH_SIZE = 25
+  def putAllBatched(writeRequests: List[WriteRequest]): ZIO[ZEnv, DynamoPutError, Unit] = {
+    val batches = writeRequests.grouped(BATCH_SIZE).toList
+    ZStream(())
+      .forever
+      .fixed(2.seconds) // wait 2 seconds between batches
+      .timeoutError(DynamoPutError(new Throwable("Timed out writing batches to dynamodb")))(1.minute)
+      .foldWhileM(batches)(_.nonEmpty) {
+        case (nextBatch :: remainingBatches, _) =>
+          putAll(nextBatch).map {
+            case Nil => remainingBatches
+            case unprocessed => unprocessed :: remainingBatches
+          }
+        case (Nil, _) => ZIO.succeed(Nil)
+      }
+      .unit // on success, the result value isn't meaningful
+  }
+}

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -77,6 +77,25 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends StrictLo
       ).items
     }.mapError(DynamoGetError)
 
+  def getAllArchived(channel: Channel): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
+    effectBlocking {
+      client.query(
+        QueryRequest
+          .builder
+          .tableName(tableName)
+          .keyConditionExpression("channel = :channel")
+          .expressionAttributeValues(Map(
+            ":channel" -> AttributeValue.builder.s(channel.toString).build,
+            ":archived" -> AttributeValue.builder.s("Archived").build
+          ).asJava)
+          .expressionAttributeNames(Map(
+            "#status" -> "status"
+          ).asJava)
+          .filterExpression("#status = :archived")
+          .build()
+      ).items
+    }.mapError(DynamoGetError)
+
   private def getAllInCampaign(campaignName: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
     effectBlocking {
       client.query(

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -11,7 +11,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.{Athena, Aws, CapiService, DynamoCampaigns, DynamoChannelTests, DynamoSuperMode, S3}
+import services.{Athena, Aws, CapiService, DynamoArchivedChannelTests, DynamoCampaigns, DynamoChannelTests, DynamoSuperMode, S3}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
@@ -63,6 +63,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     .build
 
   val dynamoTestsService = new DynamoChannelTests(stage, dynamoClient)
+  val dynamoArchivedChannelTests = new DynamoArchivedChannelTests(stage, dynamoClient)
 
   val dynamoCampaignsService = new DynamoCampaigns(stage, dynamoClient)
 
@@ -91,6 +92,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new AppsMeteringSwitchesController(authAction, controllerComponents, stage, runtime),
     new DefaultPromosController(authAction,controllerComponents, stage, runtime),
     new SuperModeController(authAction, controllerComponents, stage, runtime, dynamoSuperModeService, athena),
+    new ArchivedTestsMigrationController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -214,5 +214,9 @@ POST  /support-frontend/default-promos/update              controllers.DefaultPr
 GET   /frontend/super-mode                             controllers.SuperModeController.getSuperModeRows()
 GET   /frontend/epic-article-data                      controllers.SuperModeController.getArticleData()
 
+
+# ----- archived test migration ----- #
+POST  /migrate-archived-tests/:channel                 controllers.ArchivedTestsMigration.migrate(channel: String)
+
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/conf/routes
+++ b/conf/routes
@@ -216,7 +216,7 @@ GET   /frontend/epic-article-data                      controllers.SuperModeCont
 
 
 # ----- archived test migration ----- #
-POST  /migrate-archived-tests/:channel                 controllers.ArchivedTestsMigration.migrate(channel: String)
+GET  /migrate-archived-tests/:channel                 controllers.ArchivedTestsMigrationController.migrate(channel: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
Following on from [the creation of an archived tests table](https://github.com/guardian/support-admin-console/pull/457), this PR adds a temporary endpoint for migrating archived tests over.

I've added it as an endpoint because it's reusing logic on the server, and so this is simpler than building a standalone program.

The endpoint is e.g. `/migrate-archived-tests/Epic`, and it:
1. gets all archived tests for that channel from the old table
2. copies them to the new archived tests table
3. does not delete them from the old table. This can be done manually from the dynamodb console once we're happy