### PR TITLE
Enable primary cta for Apple News

### DIFF
--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -126,7 +126,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHighlightedText: true,
   allowVariantImageUrl: false,
   allowVariantFooter: false,
-  allowVariantCustomPrimaryCta: false,
+  allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: false,
   allowVariantSeparateArticleCount: false,
   allowVariantTicker: false,


### PR DESCRIPTION
Currently users cannot configure the primary cta.
However, it was quietly setting the primary cta with the default values ("Continue").

apple-news currently uses a hardcoded value, but will soon be using the configured value from RRCP