### PR TITLE
Add switch addition/removal functionality to the RRCP

### DIFF
--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -106,10 +106,6 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     display: 'flex',
     justifyContent: 'space-evenly',
   },
-  inputSpacing: {
-    // padding: '10px 12px',
-    // float: 'left',
-  },
   switchLayout: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -137,8 +133,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     return (
       pendingChanges.length > 0 && (
         <Alert severity="warning">
-          Switch settings have been changed. Changes need to be saved before they take
-          effect! Refresh the page to undo the changes.
+          Switch settings have been changed. Changes need to be saved before they take effect! Refresh the page to undo the changes.
           <List>
             {pendingChanges.map((change, index) => (
               <ListItem key={index}>

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -365,22 +365,6 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
       <SaveButton />
 
       <Divider variant="fullWidth" className={classes.divider} />
-
-      <Typography className={classes.newSwitchesHeader} variant="h6">
-        Create new switches
-      </Typography>
-      <Typography className={classes.textParagraph} variant="body1">
-        Currently, to create a new switch, update the JSON file in AWS S3 to include details of the
-        switch, then refresh this page so that the switch status can be viewed and updated. Also,
-        you need to add the new switch to{' '}
-        <a href="https://github.com/guardian/support-frontend/blob/main/support-frontend/app/admin/settings/Switches.scala">
-          support-frontend.
-        </a>
-      </Typography>
-      <Typography className={classes.textParagraph} variant="body1">
-        If there is a demand for it, we can add functionality to create new switches (and new switch
-        groups) to this page in due course.
-      </Typography>
     </form>
   );
 };

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -8,7 +8,7 @@ import {
   Button,
   FormLabel,
   FormControl,
-  FormControlLabel,
+  FormControlLabel, TextField, IconButton,
 } from '@material-ui/core';
 import SwitchUI from '@material-ui/core/Switch';
 import SaveIcon from '@material-ui/icons/Save';
@@ -23,6 +23,13 @@ import {
 } from '../utils/requests';
 
 import withS3Data, { InnerProps, DataFromServer } from '../hocs/withS3Data';
+import AddIcon from "@material-ui/icons/Add";
+import DeleteIcon from "@material-ui/icons/Delete";
+import {
+  createDuplicateValidator,
+  EMPTY_ERROR_HELPER_TEXT,
+} from "./channelManagement/helpers/validation";
+import CloseIcon from "@material-ui/icons/Close";
 
 enum SwitchState {
   On = 'On',
@@ -58,6 +65,10 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   button: {
     marginRight: spacing(2),
   },
+  addButton: {
+    padding: "0.2em",
+    margin: "0.1em 0.2em",
+  },
   buttons: {
     marginTop: spacing(2),
     marginBottom: spacing(2),
@@ -81,6 +92,17 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   },
   textParagraph: {
     marginBottom: spacing(2),
+  },
+  input: {
+    display: "inline-block",
+    width:"33%",
+    float: "left",
+    padding: "0.2em",
+    margin: "0.1em 0.2em",
+  },
+  inputSpacing: {
+    padding: '10px 12px',
+    float: "left",
   },
 }));
 
@@ -130,6 +152,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const isChecked = switchData.state === 'On';
 
     return (
+      <div>
       <FormControlLabel
         label={switchData.description}
         checked={switchData.state === 'On'}
@@ -138,6 +161,10 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
         value={switchId}
         key={switchId}
       />
+    <IconButton onClick={close} aria-label="close">
+      <DeleteIcon />
+    </IconButton>
+  </div>
     );
   };
 
@@ -145,13 +172,41 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const [groupId, groupData] = group;
 
     return (
+
       <FormControl className={classes.formControl} key={groupId}>
-        <FormLabel>{groupData.description}</FormLabel>
+        <FormLabel  >{groupData.description}</FormLabel>
         {Object.entries(groupData.switches)
           .sort(sortByDescription)
           .map(([switchId, switchData]) =>
             createSwitchesFromGroupData(switchId, switchData, groupId),
           )}
+        <div>
+        <TextField
+          className={classes.input}
+          // error={errors.nickname !== undefined}
+          // helperText={errors.nickname ? errors.nickname.message : DESCRIPTION_DEFAULT_HELPER_TEXT}
+          name="switchName"
+          label="Switch name"
+          margin="normal"
+          variant="outlined"
+          autoFocus
+          fullWidth
+        />
+          <span  className={classes.inputSpacing}/>
+        <TextField
+          className={classes.input}
+          // error={errors.name !== undefined}
+          // helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
+          name="description"
+          label="Description"
+          margin="normal"
+          variant="outlined"
+          autoFocus
+          fullWidth
+        />
+          <span className={classes.inputSpacing}/>
+         <AddButton/>
+        </div>
       </FormControl>
     );
   };
@@ -168,6 +223,31 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     saveData();
     setNeedToSaveDataWarning(false);
   };
+  const actionAddNewSwitch = (): void => {
+
+    const updatedState = cloneDeep(data);
+
+    // updatedState[groupId].switches[switchId].state = SwitchState.Off;
+
+    setData(updatedState);
+    setNeedToSaveDataWarning(true);
+
+  };
+
+
+  const AddButton = (): JSX.Element => (
+    <div className={classes.buttons}>
+      <Button
+        variant="contained"
+        onClick={actionAddNewSwitch}
+        className={classes.addButton}
+        disabled={saving}
+      >
+        <AddIcon/>
+      </Button>
+    </div>
+  );
+
 
   const SaveButton = (): JSX.Element => (
     <div className={classes.buttons}>

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -179,7 +179,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     updatedState[groupId].switches[switchId].state = isChecked ? SwitchState.On : SwitchState.Off;
     const currentSwitchState = updatedState[groupId].switches[switchId].state;
     setData(updatedState);
-
+    setNewUnsavedData(true);
     setPendingChange(
       'Turned ' + currentSwitchState + ':',
       switchData.description,
@@ -310,6 +310,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     saveData();
     setNeedToSaveDataWarning(false);
     setNewUnsavedData(false);
+    setPendingChanges([]);
   };
 
   const SaveButton = (): JSX.Element => (
@@ -346,6 +347,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const updatedState = cloneDeep(data);
     delete updatedState[groupId].switches[switchId];
     setData(updatedState);
+    setNewUnsavedData(true);
     setPendingChange('Removed', description, groupData.description);
     setNeedToSaveDataWarning(true);
   };
@@ -363,7 +365,6 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
 
       {displayNeedToSaveDataWarning()}
       <SaveButton />
-
       <Divider variant="fullWidth" className={classes.divider} />
     </form>
   );

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -133,7 +133,8 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     return (
       pendingChanges.length > 0 && (
         <Alert severity="warning">
-          Switch settings have been changed. Changes need to be saved before they take effect! Refresh the page to undo the changes.
+          Switch settings have been changed. Changes need to be saved before they take effect!
+          Refresh the page to undo the changes.
           <List>
             {pendingChanges.map((change, index) => (
               <ListItem key={index}>

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -27,9 +27,8 @@ import AddIcon from "@material-ui/icons/Add";
 import DeleteIcon from "@material-ui/icons/Delete";
 import {
   createDuplicateValidator,
-  EMPTY_ERROR_HELPER_TEXT, INVALID_CHARACTERS_ERROR_HELPER_TEXT, VALID_CHARACTERS_REGEX,
+  EMPTY_ERROR_HELPER_TEXT,
 } from "./channelManagement/helpers/validation";
-import CloseIcon from "@material-ui/icons/Close";
 import {useForm} from "react-hook-form";
 
 enum SwitchState {
@@ -120,7 +119,6 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
   const classes = useStyles();
 
   const [needToSaveDataWarning, setNeedToSaveDataWarning] = useState(false);
-
   type FormData = {
     switchId: string;
     description: string;
@@ -168,9 +166,10 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
         value={switchId}
         key={switchId}
       />
-    <IconButton onClick={close} aria-label="close">
-      <DeleteIcon />
-    </IconButton>
+        <IconButton onClick={(): void => actionRemoveSwitchData(groupId,switchId,switchData.description)} aria-label="removeSwitch">
+          <DeleteIcon />
+        </IconButton>
+
   </div>
     );
   };
@@ -186,7 +185,6 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
       setData(updatedState);
       setNeedToSaveDataWarning(true);
     };
-
 
     return (
 
@@ -278,6 +276,28 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
       </Button>
     </div>
   );
+
+  const actionRemoveSwitchData = ( groupId: string,
+                                   switchId: string,
+                                   description: string,
+  ): void => {
+    const userConfirmation=confirm("You are going to delete the switch.Make sure you have already removed the switch  from support-frontend code. Are you sure you want to proceed?")
+    console.log("UserConfirm",userConfirmation)
+    userConfirmation ? confirmRemoveData(groupId,switchId,description) :   ""
+  };
+
+  const confirmRemoveData = (groupId: string,switchId:string,description:string): void  => {
+    console.log("Here")
+    console.log("OldData",cloneDeep(data))
+    const updatedState = cloneDeep(data);
+    console.log("updatedState[groupId].switches[switchId]",updatedState[groupId].switches[switchId])
+    delete updatedState[groupId].switches[switchId]
+    setData(updatedState);
+    console.log("After data",updatedState)
+    console.log("NewData",cloneDeep(data))
+    setNeedToSaveDataWarning(true);
+
+  };
 
   return (
     <form className={classes.form}>

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
 import {
-  Divider,
   Typography,
   Button,
   FormLabel,
@@ -136,9 +135,10 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
 
   const displayNeedToSaveDataWarning = (): JSX.Element | false => {
     return (
-      (pendingChanges.length > 0)  && (
+      pendingChanges.length > 0 && (
         <Alert severity="warning">
-          Switch settings have been changed. Changes need to be saved before they take effect!Refresh the page to undo the changes.
+          Switch settings have been changed. Changes need to be saved before they take
+          effect!Refresh the page to undo the changes.
           <List>
             {pendingChanges.map((change, index) => (
               <ListItem key={index}>
@@ -251,7 +251,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
             autoFocus
             fullWidth
           />
-          <span/>
+          <span />
           <TextField
             className={classes.input}
             id={groupId + '-add-switch-switch-description'}
@@ -272,7 +272,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
             autoFocus
             fullWidth
           />
-          <span/>
+          <span />
           <div className={classes.buttons}>
             <Button
               aria-label="Add switch"

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -8,12 +8,15 @@ import {
   Button,
   FormLabel,
   FormControl,
-  FormControlLabel, TextField, IconButton, Checkbox, List, ListItem,
+  FormControlLabel,
+  TextField,
+  IconButton,
+  List,
+  ListItem,
 } from '@material-ui/core';
 import SwitchUI from '@material-ui/core/Switch';
 import SaveIcon from '@material-ui/icons/Save';
 import Alert from '@material-ui/lab/Alert';
-import {Dialog, DialogTitle, DialogContent, DialogActions} from '@mui/material';
 
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -24,15 +27,14 @@ import {
 } from '../utils/requests';
 
 import withS3Data, { InnerProps, DataFromServer } from '../hocs/withS3Data';
-import AddIcon from "@material-ui/icons/Add";
-import DeleteIcon from "@material-ui/icons/Delete";
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
 import {
   createDuplicateValidator,
   EMPTY_ERROR_HELPER_TEXT,
-} from "./channelManagement/helpers/validation";
-import {useForm} from "react-hook-form";
-import CloseIcon from "@material-ui/icons/Close";
-import ListItemText from "@material-ui/core/ListItemText";
+} from './channelManagement/helpers/validation';
+import { useForm } from 'react-hook-form';
+import ListItemText from '@material-ui/core/ListItemText';
 
 enum SwitchState {
   On = 'On',
@@ -64,14 +66,14 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     paddingLeft: spacing(2),
     paddingRight: spacing(2),
     border: `1px solid ${palette.grey['300']}`,
-    width:"45%",
+    width: '45%',
   },
   button: {
     marginRight: spacing(2),
   },
   addButton: {
-    padding: "0.2em",
-    margin: "0.1em 0.2em",
+    padding: '0.2em',
+    margin: '0.1em 0.2em',
   },
   buttons: {
     marginTop: spacing(2),
@@ -98,26 +100,26 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     marginBottom: spacing(2),
   },
   input: {
-    display: "inline-block",
-    width:"33%",
-    padding: "0.2em",
-    margin: "0.1em 0.2em",
+    display: 'inline-block',
+    width: '33%',
+    padding: '0.2em',
+    margin: '0.1em 0.2em',
   },
   inputGroup: {
     marginTop: spacing(2),
-    display: "flex",
-    justifyContent: "space-evenly",
+    display: 'flex',
+    justifyContent: 'space-evenly',
   },
   inputSpacing: {
     padding: '10px 12px',
-    float: "left",
+    float: 'left',
   },
   switchLayout: {
-    display: "flex",
-    justifyContent: "space-between",
-    "&:nth-child(even)": {
-      backgroundColor: "#e7e7e7",
-    }
+    display: 'flex',
+    justifyContent: 'space-between',
+    '&:nth-child(even)': {
+      backgroundColor: '#e7e7e7',
+    },
   },
 }));
 
@@ -142,10 +144,10 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     description: string;
   };
 
-
   const displayNeedToSaveDataWarning = (): JSX.Element | false => {
     return (
-      needToSaveDataWarning && (
+      needToSaveDataWarning &&
+      newUnsavedData && (
         <Alert severity="warning">
           Switch settings have been changed. Changes need to be saved before they take effect!
           <List>
@@ -160,51 +162,56 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     );
   };
 
-  const setPendingChange =(changeName:string,description:string,groupId:string): void =>{
-    const unsavedChange=changeName +" "+ description +" in "+groupId
-   // Add the changeName to the list of pendingChanges
-    setPendingChanges((prevChanges) => [...prevChanges, unsavedChange]);
-
-  }
+  const setPendingChange = (changeName: string, description: string, groupId: string): void => {
+    const unsavedChange = changeName + ' ' + description + ' in ' + groupId;
+    // Add the changeName to the list of pendingChanges
+    setPendingChanges(prevChanges => [...prevChanges, unsavedChange]);
+  };
 
   const updateSwitchSetting = (
     switchId: string,
     switchData: Switch,
-    groupId: string,
+    group: [string, SwitchGroup],
     isChecked: boolean,
   ): void => {
     const updatedState = cloneDeep(data);
-
+    const [groupId, groupData] = group;
     updatedState[groupId].switches[switchId].state = isChecked ? SwitchState.On : SwitchState.Off;
-    let currentSwitchState= updatedState[groupId].switches[switchId].state
+    const currentSwitchState = updatedState[groupId].switches[switchId].state;
     setData(updatedState);
 
-    setPendingChange("Turned "+ currentSwitchState +":",switchData.description,groupId)
+    setPendingChange(
+      'Turned ' + currentSwitchState + ':',
+      switchData.description,
+      groupData.description,
+    );
     setNeedToSaveDataWarning(true);
   };
 
   const createSwitchesFromGroupData = (
     switchId: string,
     switchData: Switch,
-    groupId: string,
+    group: [string, SwitchGroup],
   ): JSX.Element => {
     const isChecked = switchData.state === 'On';
 
     return (
       <div className={classes.switchLayout}>
-      <FormControlLabel
-        label={switchData.description}
-        checked={switchData.state === 'On'}
-        control={<SwitchUI />}
-        onChange={(): void => updateSwitchSetting(switchId, switchData, groupId, !isChecked)}
-        value={switchId}
-        key={switchId}
-      />
-        <IconButton onClick={(): void => actionRemoveSwitchData(groupId,switchId,switchData.description)} aria-label="removeSwitch">
+        <FormControlLabel
+          label={switchData.description}
+          checked={switchData.state === 'On'}
+          control={<SwitchUI />}
+          onChange={(): void => updateSwitchSetting(switchId, switchData, group, !isChecked)}
+          value={switchId}
+          key={switchId}
+        />
+        <IconButton
+          onClick={(): void => actionRemoveSwitchData(group, switchId, switchData.description)}
+          aria-label="removeSwitch"
+        >
           <DeleteIcon />
         </IconButton>
-
-  </div>
+      </div>
     );
   };
 
@@ -212,64 +219,70 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const [groupId, groupData] = group;
     const { register, handleSubmit, errors } = useForm<FormData>();
 
-    const onSubmit = ({ switchId,description }: FormData): void => {
+    const onSubmit = ({ switchId, description }: FormData): void => {
       const updatedState = cloneDeep(data);
 
-      updatedState[groupId].switches[switchId] = { description: description, state: SwitchState.Off };
+      updatedState[groupId].switches[switchId] = {
+        description: description,
+        state: SwitchState.Off,
+      };
       setData(updatedState);
       setNewUnsavedData(true);
-      setPendingChange("Added", description,groupId);
+      setPendingChange('Added', description, groupData.description);
       setNeedToSaveDataWarning(true);
     };
 
     return (
-
       <FormControl className={classes.formControl} key={groupId}>
-        <FormLabel  > <strong>{groupData.description} </strong></FormLabel><br/>
+        <FormLabel>
+          {' '}
+          <strong>{groupData.description} </strong>
+        </FormLabel>
+        <br />
         {Object.entries(groupData.switches)
           .sort(sortByDescription)
           .map(([switchId, switchData]) =>
-            createSwitchesFromGroupData(switchId, switchData, groupId),
+            createSwitchesFromGroupData(switchId, switchData, group),
           )}
         <div className={classes.inputGroup}>
-        <TextField
-          className={classes.input}
-          inputRef={register({
-            required: EMPTY_ERROR_HELPER_TEXT,
-            validate: switchId => {
-              return (
-                createDuplicateValidator(Object.entries(groupData.switches).map(([switchId, switchData])=>switchId))(switchId)
-              );
-            },
-          })}
-          error={errors.switchId !== undefined}
-          helperText={errors.switchId ? errors.switchId.message : ""}
-          name="switchId"
-          label="Switch name"
-          margin="normal"
-          variant="outlined"
-          autoFocus
-          fullWidth
-        />
-          <span  className={classes.inputSpacing}/>
-        <TextField
-          className={classes.input}
-          inputRef={register({
-            required: EMPTY_ERROR_HELPER_TEXT,
-            validate: description => {
-              return undefined
-            },
-          })}
-          error={errors.description !== undefined}
-          helperText={errors.description ? errors.description.message : ""}
-          name="description"
-          label="Description"
-          margin="normal"
-          variant="outlined"
-          autoFocus
-          fullWidth
-        />
-          <span className={classes.inputSpacing}/>
+          <TextField
+            className={classes.input}
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              validate: switchId => {
+                return createDuplicateValidator(Object.keys(groupData.switches))(switchId);
+              },
+            })}
+            error={errors.switchId !== undefined}
+            helperText={errors.switchId ? errors.switchId.message : ''}
+            name="switchId"
+            label="Switch name"
+            margin="normal"
+            variant="outlined"
+            autoFocus
+            fullWidth
+          />
+          <span className={classes.inputSpacing} />
+          <TextField
+            className={classes.input}
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              validate: description => {
+                return createDuplicateValidator(
+                  Object.values(groupData.switches).map(switchData => switchData.description),
+                )(description);
+              },
+            })}
+            error={errors.description !== undefined}
+            helperText={errors.description ? errors.description.message : ''}
+            name="description"
+            label="Description"
+            margin="normal"
+            variant="outlined"
+            autoFocus
+            fullWidth
+          />
+          <span className={classes.inputSpacing} />
           <div className={classes.buttons}>
             <Button
               variant="contained"
@@ -277,7 +290,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
               className={classes.addButton}
               disabled={saving}
             >
-              <AddIcon/>
+              <AddIcon />
             </Button>
           </div>
         </div>
@@ -292,7 +305,6 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
         .map(group => createGroupsFromData(group))}
     </>
   );
-
 
   const actionSaveData = (): void => {
     saveData();
@@ -314,20 +326,27 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     </div>
   );
 
-  const actionRemoveSwitchData = ( groupId: string,
-                                   switchId: string,
-                                   description: string,
+  const actionRemoveSwitchData = (
+    group: [string, SwitchGroup],
+    switchId: string,
+    description: string,
   ): void => {
-    const userConfirmation=confirm(`Deleting switch "${description}". If this switch hasn’t been removed from support-frontend yet, this will cause errors! Make sure you delete it there first. Are you sure you want to proceed?`)
-    console.log("UserConfirm",userConfirmation)
-    userConfirmation ? confirmRemoveData(groupId,switchId,description) :   ""
+    const userConfirmation = confirm(
+      `Deleting switch "${description}". If this switch hasn’t been removed from support-frontend yet, this will cause errors! Make sure you delete it there first. Are you sure you want to proceed?`,
+    );
+    userConfirmation ? confirmRemoveData(group, switchId, description) : '';
   };
 
-  const confirmRemoveData = (groupId: string,switchId:string,description:string): void  => {
+  const confirmRemoveData = (
+    group: [string, SwitchGroup],
+    switchId: string,
+    description: string,
+  ): void => {
+    const [groupId, groupData] = group;
     const updatedState = cloneDeep(data);
-    delete updatedState[groupId].switches[switchId]
+    delete updatedState[groupId].switches[switchId];
     setData(updatedState);
-    setPendingChange("Removed",description,groupId)
+    setPendingChange('Removed', description, groupData.description);
     setNeedToSaveDataWarning(true);
   };
 

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -281,22 +281,16 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
                                    switchId: string,
                                    description: string,
   ): void => {
-    const userConfirmation=confirm("You are going to delete the switch.Make sure you have already removed the switch  from support-frontend code. Are you sure you want to proceed?")
+    const userConfirmation=confirm(`Deleting switch "${description}". If this switch hasn’t been removed from support-frontend yet, this will cause errors! Make sure you delete it there first. Are you sure you want to proceed?`)
     console.log("UserConfirm",userConfirmation)
     userConfirmation ? confirmRemoveData(groupId,switchId,description) :   ""
   };
 
   const confirmRemoveData = (groupId: string,switchId:string,description:string): void  => {
-    console.log("Here")
-    console.log("OldData",cloneDeep(data))
     const updatedState = cloneDeep(data);
-    console.log("updatedState[groupId].switches[switchId]",updatedState[groupId].switches[switchId])
     delete updatedState[groupId].switches[switchId]
     setData(updatedState);
-    console.log("After data",updatedState)
-    console.log("NewData",cloneDeep(data))
     setNeedToSaveDataWarning(true);
-
   };
 
   return (

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     paddingLeft: spacing(2),
     paddingRight: spacing(2),
     border: `1px solid ${palette.grey['300']}`,
+    width:"45%",
   },
   button: {
     marginRight: spacing(2),
@@ -96,13 +97,24 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   input: {
     display: "inline-block",
     width:"33%",
-    float: "left",
     padding: "0.2em",
     margin: "0.1em 0.2em",
+  },
+  inputGroup: {
+    marginTop: spacing(2),
+    display: "flex",
+    justifyContent: "space-evenly",
   },
   inputSpacing: {
     padding: '10px 12px',
     float: "left",
+  },
+  switchLayout: {
+    display: "flex",
+    justifyContent: "space-between",
+    "&:nth-child(even)": {
+      backgroundColor: "#e7e7e7",
+    }
   },
 }));
 
@@ -157,7 +169,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const isChecked = switchData.state === 'On';
 
     return (
-      <div>
+      <div className={classes.switchLayout}>
       <FormControlLabel
         label={switchData.description}
         checked={switchData.state === 'On'}
@@ -195,7 +207,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
           .map(([switchId, switchData]) =>
             createSwitchesFromGroupData(switchId, switchData, groupId),
           )}
-        <div>
+        <div className={classes.inputGroup}>
         <TextField
           className={classes.input}
           inputRef={register({

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -138,7 +138,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
       pendingChanges.length > 0 && (
         <Alert severity="warning">
           Switch settings have been changed. Changes need to be saved before they take
-          effect!Refresh the page to undo the changes.
+          effect! Refresh the page to undo the changes.
           <List>
             {pendingChanges.map((change, index) => (
               <ListItem key={index}>


### PR DESCRIPTION
## What does this change?

Currently, to add a switch to or remove a switch from the [RRCP](https://support.gutools.co.uk/), one must edit the underlying JSON file [switches_v2.json](https://s3.console.aws.amazon.com/s3/object/support-admin-console?prefix=PROD%2Fswitches_v2.json&region=eu-west-1#). This task is to enable switch addition/removal directly in the RRCP.

Since support-frontend explicitly models the switches in [Switches.scala](https://github.com/guardian/support-frontend/blob/main/support-frontend/app/admin/settings/Switches.scala), it would probably be worthwhile asking the user for confirmation that they’ve removed a switch from that file before allowing them to delete it from the RRCP (otherwise support-frontend will break).

Also there is a small change in the Switches page layout in RRCP.

## Images

### Before Change

<img width="1728" alt="image" src="https://github.com/guardian/support-admin-console/assets/73653255/bce86311-caa1-4914-871d-c13ced61a53a">


### After Change

<img width="1728" alt="image" src="https://github.com/guardian/support-admin-console/assets/73653255/c5c0577b-a14a-454a-9494-df780da5cb80">

### Changes 
### Add New Switch

Steps
1.Enter new switch details into Switch name and Description textbooks
2.The unsaved changes would be shown as an alert-"Added Testing New Switch in Feature switches"
3.Click on save to confirm the changes

<img width="1728" alt="Screenshot 2023-06-21 at 09 59 51" src="https://github.com/guardian/support-admin-console/assets/73653255/f1800a18-68e6-4985-b394-661281b0d2d5">


### Toggle Switch State 
1.Toggle the switch state 
2.The unsaved changes would be shown as an alert-"Turned On: Testing New Switch in Feature switches / Turned Off: Testing New Switch in Feature switches"
3.Click on save to confirm the changes

<img width="1728" alt="Screenshot 2023-06-21 at 10 00 16" src="https://github.com/guardian/support-admin-console/assets/73653255/46fab591-aafa-4fcf-8308-4bef922a1ea3">

### Remove Switch

Steps
1.Click the delete button next to the Switch to be removed 
2.User confirmation dialog opens up to check the remove action 
3.The unsaved changes would be shown as an alert-"Removed Testing New Switch in Feature switches" 
4.Click on save to confirm the changes,Otherwise refresh the page to undo the changes.

<img width="1728" alt="Screenshot 2023-06-21 at 10 12 58" src="https://github.com/guardian/support-admin-console/assets/73653255/385f5edf-11b8-4dc9-a64c-e7ce1ca89def">

<img width="1728" alt="Screenshot 2023-06-21 at 10 13 04" src="https://github.com/guardian/support-admin-console/assets/73653255/264f1511-b107-4ab1-9f06-607c2726331a">

Removed the below part from the Switches Page
<img width="1728" alt="image" src="https://github.com/guardian/support-admin-console/assets/73653255/25e06094-9aa0-4b93-996d-9c5bdd33b462">

