### PR TITLE
Force netty version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ libraryDependencies ++= Seq(
 
 dependencyOverrides ++= List(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  // The version of netty-handler currently used by athena has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-handler" % "4.1.94.Final"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.13.10"
 
 val circeVersion = "0.14.1"
-val awsVersion = "2.18.39"
+val awsVersion = "2.20.89"
 val zioVersion = "1.0.14"
 val jacksonVersion = "2.14.1"
 
@@ -36,7 +36,10 @@ libraryDependencies ++= Seq(
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )
 
-dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+dependencyOverrides ++= List(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "io.netty" % "netty-handler" % "4.1.94.Final"
+)
 
 dynamoDBLocalPort := 8083
 startDynamoDBLocal := {startDynamoDBLocal.dependsOn(Test / compile).value}


### PR DESCRIPTION
flagged by snyk
https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-5725787

I've had to force it because the aws library that pulls it in has not yet been updated

Tested in CODE