### PR TITLE
Fix amounts in preview

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -6,6 +6,7 @@ import { BannerTemplate, BannerVariant, BannerContent } from '../../../models/ba
 import Typography from '@material-ui/core/Typography';
 import { useModule } from '../../../hooks/useModule';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
+import { ContributionAmounts } from '../../amounts/configuredAmountsEditor';
 
 interface ProductPriceData {
   Monthly: {
@@ -21,6 +22,12 @@ interface CountryGroupPriceData {
 }
 export type Prices = {
   [index: string]: CountryGroupPriceData;
+};
+
+export type SelectedAmountsVariant = {
+  testName: string;
+  variantName?: string;
+  amounts?: ContributionAmounts;
 };
 
 interface BannerProps {
@@ -45,6 +52,7 @@ interface BannerProps {
   mobileContent?: BannerContent;
   tickerSettings?: TickerSettingsWithData;
   separateArticleCount?: boolean;
+  choiceCardAmounts?: SelectedAmountsVariant;
 }
 
 const anchor = 'bottom';
@@ -93,6 +101,24 @@ const buildProps = (
   numArticles: 13,
   tickerSettings: tickerSettingsWithData,
   separateArticleCount: variant.separateArticleCount,
+  choiceCardAmounts: {
+    testName: 'amounts_test',
+    variantName: 'control',
+    amounts: {
+      ONE_OFF: {
+        amounts: [5, 10, 15, 20],
+        defaultAmount: 5,
+      },
+      MONTHLY: {
+        amounts: [3, 6, 10],
+        defaultAmount: 10,
+      },
+      ANNUAL: {
+        amounts: [100],
+        defaultAmount: 100,
+      },
+    },
+  },
 });
 
 const bannerModules = {

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -5,6 +5,7 @@ import { EpicModuleName } from '../helpers/shared';
 import { useModule } from '../../../hooks/useModule';
 import { EpicVariant } from '../../../models/epic';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
+import { ContributionAmounts } from '../../amounts/configuredAmountsEditor';
 
 // Article count TS defs
 export interface ArticleCounts {
@@ -14,70 +15,6 @@ export interface ArticleCounts {
   forTargetedWeeks: number;
 }
 
-// Choice card TS defs and object generation
-// - Matches the TS set out in SDC file `/packages/shared/src/types/abTests/epic.ts`
-interface AmountSelection {
-  amounts: number[];
-  defaultAmount: number;
-}
-
-type ContributionAmounts = {
-  [index: string]: AmountSelection;
-};
-
-interface AmountsTestVariant {
-  name: string;
-  amounts: ContributionAmounts;
-}
-
-interface AmountsTest {
-  name: string;
-  isLive: boolean;
-  variants: AmountsTestVariant[];
-  seed: number;
-}
-
-type ConfiguredRegionAmounts = {
-  control: ContributionAmounts;
-  test?: AmountsTest;
-};
-
-type ChoiceCardAmounts = {
-  [index: string]: ConfiguredRegionAmounts;
-};
-
-const generateChoiceCardObject = (): AmountSelection => {
-  return {
-    amounts: [30, 60, 120, 240],
-    defaultAmount: 60,
-  };
-};
-
-const generateChoiceCardAmounts = () => {
-  return {
-    ONE_OFF: generateChoiceCardObject(),
-    MONTHLY: generateChoiceCardObject(),
-    ANNUAL: generateChoiceCardObject(),
-  };
-};
-
-const generateRegionalChoiceCard = (name: string): ConfiguredRegionAmounts => {
-  return {
-    control: generateChoiceCardAmounts(),
-    test: {
-      name,
-      isLive: false,
-      variants: [
-        {
-          name: 'V2_LOWER',
-          amounts: generateChoiceCardAmounts(),
-        },
-      ],
-      seed: 917618,
-    },
-  };
-};
-
 // Secondary CTA TS defs
 interface ShowReminderFields {
   reminderCta: string;
@@ -85,9 +22,15 @@ interface ShowReminderFields {
   reminderLabel: string;
 }
 
+export type SelectedAmountsVariant = {
+  testName: string;
+  variantName?: string;
+  amounts?: ContributionAmounts;
+};
+
 // Extend EpicVariant to include choice cards and tickers
 interface EpicVariantWithAdditionalData extends EpicVariant {
-  choiceCardAmounts: ChoiceCardAmounts;
+  choiceCardAmounts: SelectedAmountsVariant;
   tickerSettings?: TickerSettingsWithData;
   showReminderFields?: ShowReminderFields;
 }
@@ -138,13 +81,22 @@ const buildProps = (
 
     showChoiceCards: variant.showChoiceCards,
     choiceCardAmounts: {
-      GBPCountries: generateRegionalChoiceCard('2021-09-02_AMOUNTS_R5__UK'),
-      UnitedStates: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__US'),
-      EURCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__EU'),
-      AUDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__AU'),
-      International: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__INT'),
-      NZDCountries: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__NZ'),
-      Canada: generateRegionalChoiceCard('2021-03-11_AMOUNTS_R2__CA'),
+      testName: 'amounts_test',
+      variantName: 'control',
+      amounts: {
+        ONE_OFF: {
+          amounts: [5, 10, 15, 20],
+          defaultAmount: 5,
+        },
+        MONTHLY: {
+          amounts: [3, 6, 10],
+          defaultAmount: 10,
+        },
+        ANNUAL: {
+          amounts: [100],
+          defaultAmount: 100,
+        },
+      },
     },
 
     showTicker: variant.showTicker,


### PR DESCRIPTION
It was broken in the epic preview because the model in SDC has changed, and we've never had it in the banner.
Uses hardcoded amounts.

![Screenshot 2023-07-06 at 08 20 23](https://github.com/guardian/support-admin-console/assets/1513454/f832c519-2369-4e42-8c57-8337c6d3bd0a)
![Screenshot 2023-07-06 at 08 34 17](https://github.com/guardian/support-admin-console/assets/1513454/861486ba-1f41-4422-ab23-ce69e060f55a)
