### PR TITLE
Basic Design UI: Part 1

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,7 +3,10 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc._
 
-class Application(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String) extends AbstractController(components) {
+class Application(authAction: AuthAction[AnyContent],
+                  components: ControllerComponents,
+                  stage: String)
+    extends AbstractController(components) {
   def healthcheck = Action {
     Ok("healthy")
   }
@@ -12,6 +15,6 @@ class Application(authAction: AuthAction[AnyContent], components: ControllerComp
     Ok(views.html.index(stage)).withHeaders(CACHE_CONTROL -> "no-cache")
   }
 
-  // Handler for endpoints with a test name in the path. The client takes care of using the testName
-  def indexWithName(testName: String) = index
+  // Handler for endpoints with a resource name in the path. The client takes care of using the name
+  def indexWithName(name: String) = index
 }

--- a/conf/routes
+++ b/conf/routes
@@ -8,35 +8,35 @@ GET /contribution-types                             controllers.Application.inde
 GET /amounts                                        controllers.Application.index
 
 GET /header-tests                                   controllers.Application.index
-GET /header-tests/:testName                         controllers.Application.indexWithName(testName: String)
+GET /header-tests/:name                             controllers.Application.indexWithName(name: String)
 
 GET /epic-tests                                     controllers.Application.index
-GET /epic-tests/:testName                           controllers.Application.indexWithName(testName: String)
+GET /epic-tests/:name                               controllers.Application.indexWithName(name: String)
 
 GET /liveblog-epic-tests                            controllers.Application.index
-GET /liveblog-epic-tests/:testName                  controllers.Application.indexWithName(testName: String)
+GET /liveblog-epic-tests/:name                      controllers.Application.indexWithName(name: String)
 
 GET /apple-news-epic-tests                          controllers.Application.index
-GET /apple-news-epic-tests/:testName                controllers.Application.indexWithName(testName: String)
+GET /apple-news-epic-tests/:name                    controllers.Application.indexWithName(name: String)
 
 GET /amp-epic-tests                                 controllers.Application.index
-GET /amp-epic-tests/:testName                       controllers.Application.indexWithName(testName: String)
+GET /amp-epic-tests/:name                           controllers.Application.indexWithName(name: String)
 
 GET /banner-tests                                   controllers.Application.index
-GET /banner-tests/:testName                         controllers.Application.indexWithName(testName: String)
+GET /banner-tests/:name                             controllers.Application.indexWithName(name: String)
 
 GET /banner-tests2                                  controllers.Application.index
-GET /banner-tests2/:testName                        controllers.Application.indexWithName(testName: String)
+GET /banner-tests2/:name                            controllers.Application.indexWithName(name: String)
 
 GET /banner-deploy                                  controllers.Application.index
 GET /channel-switches                               controllers.Application.index
 
 GET /campaigns                                      controllers.Application.index
-GET /campaigns/:testName                            controllers.Application.indexWithName(testName: String)
+GET /campaigns/:name                                controllers.Application.indexWithName(name: String)
 
 GET /qr-code                                        controllers.Application.index
 
-GET /apps-metering-switches                        controllers.Application.index
+GET /apps-metering-switches                         controllers.Application.index
 
 GET /default-promos                                 controllers.Application.index
 

--- a/conf/routes
+++ b/conf/routes
@@ -42,6 +42,9 @@ GET /default-promos                                 controllers.Application.inde
 
 GET /super-mode                                     controllers.Application.index
 
+GET /banner-designs                                 controllers.Application.index
+GET /banner-designs/:name                           controllers.Application.indexWithName(name: String)
+
 # ----- Authentication ----- #
 GET  /login                                         controllers.Login.login
 GET  /loginAction                                   controllers.Login.loginAction

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -5,4 +5,8 @@ type Props = {
   bannerDesign: BannerDesign;
 };
 
-export default ({ bannerDesign }: Props) => <div>{bannerDesign.name}</div>;
+const BannerDesignEditor: React.FC<Props> = ({ bannerDesign }: Props) => (
+  <div>{bannerDesign.name}</div>
+);
+
+export default BannerDesignEditor;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -4,4 +4,5 @@ import { BannerDesign } from '../../../models/BannerDesign';
 type Props = {
   bannerDesign: BannerDesign;
 };
+
 export default ({ bannerDesign }: Props) => <div>{bannerDesign.name}</div>;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+type Props = {
+  bannerDesign: BannerDesign;
+};
+export default ({ bannerDesign }: Props) => <div>{bannerDesign.name}</div>;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { List, ListItem, Theme, makeStyles, Button, Typography } from '@material-ui/core';
+import { red } from '@material-ui/core/colors';
+import BannerDesignsSidebar from './BannerDesignsSidebar';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    marginTop: '16px',
+  },
+  list: {
+    padding: 0,
+    width: '100%',
+  },
+  listItem: {
+    margin: 0,
+    padding: 0,
+    gutter: 0,
+    width: '100%',
+  },
+  button: {
+    position: 'relative',
+    height: '50px',
+    width: '290px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    background: 'white',
+    borderRadius: '4px',
+    padding: '0 12px',
+    marginBottom: '4px',
+  },
+  text: {
+    fontSize: '12px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+  },
+  live: {
+    border: `1px solid ${red[500]}`,
+
+    '&:hover': {
+      background: `${red[500]}`,
+      color: 'white',
+    },
+  },
+  liveInverted: {
+    background: `${red[500]}`,
+    color: 'white',
+
+    '&:hover': {
+      background: `${red[500]}`,
+      color: 'white',
+    },
+  },
+  draft: {
+    border: `1px solid ${palette.grey[700]}`,
+
+    '&:hover': {
+      background: `${palette.grey[700]}`,
+      color: 'white',
+    },
+  },
+  draftInverted: {
+    background: `${palette.grey[700]}`,
+    color: 'white',
+
+    '&:hover': {
+      background: `${palette.grey[700]}`,
+      color: 'white',
+    },
+  },
+}));
+
+interface Props {
+  designs: BannerDesign[];
+  selectedDesign?: BannerDesign;
+  onDesignSelected: (designName: string) => void;
+}
+
+const BannerDesignsList = ({
+  designs,
+  selectedDesign,
+  onDesignSelected,
+}: Props): React.ReactElement => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <List className={classes.list}>
+        {designs.map(design => (
+          <ListItem className={classes.button} key={design.name}>
+            <Button
+              key={`${design.name}-button`}
+              className={classes.button}
+              variant="outlined"
+              onClick={(): void => onDesignSelected(design.name)}
+            >
+              <Typography className={classes.text}>{design.name}</Typography>
+            </Button>
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  );
+};
+
+export default BannerDesignsList;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { List, ListItem, Theme, makeStyles, Button, Typography } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
-import BannerDesignsSidebar from './BannerDesignsSidebar';
 import { BannerDesign } from '../../../models/BannerDesign';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
@@ -36,32 +34,7 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
     textTransform: 'uppercase',
     letterSpacing: '1px',
   },
-  live: {
-    border: `1px solid ${red[500]}`,
-
-    '&:hover': {
-      background: `${red[500]}`,
-      color: 'white',
-    },
-  },
-  liveInverted: {
-    background: `${red[500]}`,
-    color: 'white',
-
-    '&:hover': {
-      background: `${red[500]}`,
-      color: 'white',
-    },
-  },
-  draft: {
-    border: `1px solid ${palette.grey[700]}`,
-
-    '&:hover': {
-      background: `${palette.grey[700]}`,
-      color: 'white',
-    },
-  },
-  draftInverted: {
+  selected: {
     background: `${palette.grey[700]}`,
     color: 'white',
 
@@ -88,18 +61,22 @@ const BannerDesignsList = ({
   return (
     <div className={classes.container}>
       <List className={classes.list}>
-        {designs.map(design => (
-          <ListItem className={classes.button} key={design.name}>
-            <Button
-              key={`${design.name}-button`}
-              className={classes.button}
-              variant="outlined"
-              onClick={(): void => onDesignSelected(design.name)}
-            >
-              <Typography className={classes.text}>{design.name}</Typography>
-            </Button>
-          </ListItem>
-        ))}
+        {designs.map(design => {
+          const isSelected = selectedDesign && selectedDesign.name === design.name;
+
+          return (
+            <ListItem className={classes.button} key={design.name}>
+              <Button
+                key={`${design.name}-button`}
+                className={[classes.button, isSelected && classes.selected].join(' ')}
+                variant="outlined"
+                onClick={(): void => onDesignSelected(design.name)}
+              >
+                <Typography className={classes.text}>{design.name}</Typography>
+              </Button>
+            </ListItem>
+          );
+        })}
       </List>
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
@@ -14,15 +14,6 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     marginTop: '8px',
   },
-  searchField: {
-    marginTop: '8px',
-  },
-  buttonsContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '8px',
-    marginBottom: '10px',
-  },
 }));
 
 interface Props {

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { makeStyles, TextField } from '@material-ui/core';
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
 import BannerDesignsList from './BannerDesignsList';
 import { BannerDesign } from '../../../models/BannerDesign';
 
@@ -28,13 +28,11 @@ const useStyles = makeStyles(() => ({
 interface Props {
   designs: BannerDesign[];
   selectedDesign?: BannerDesign;
-  createDesign: (design: BannerDesign) => void;
   onDesignSelected: (designName: string) => void;
 }
 
 const BannerDesignsSidebar = ({
   designs,
-  createDesign,
   selectedDesign,
   onDesignSelected,
 }: Props): React.ReactElement => {

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { makeStyles, TextField } from '@material-ui/core';
+import BannerDesignsList from './BannerDesignsList';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingLeft: '32px',
+  },
+  listsContainer: {
+    position: 'relative',
+    display: 'flex',
+    marginTop: '8px',
+  },
+  searchField: {
+    marginTop: '8px',
+  },
+  buttonsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '10px',
+  },
+}));
+
+interface Props {
+  designs: BannerDesign[];
+  selectedDesign?: BannerDesign;
+  createDesign: (design: BannerDesign) => void;
+  onDesignSelected: (designName: string) => void;
+}
+
+const BannerDesignsSidebar = ({
+  designs,
+  createDesign,
+  selectedDesign,
+  onDesignSelected,
+}: Props): React.ReactElement => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.listsContainer}>
+        <BannerDesignsList
+          designs={designs}
+          selectedDesign={selectedDesign}
+          onDesignSelected={onDesignSelected}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default BannerDesignsSidebar;

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const BannerDesigns = () => null;

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -4,8 +4,8 @@ import BannerDesignsSidebar from './BannerDesignsSidebar';
 import BannerDesignEditor from './BannerDesignEditor';
 import { useParams } from 'react-router-dom';
 
-import {fetchBannerDesigns, fetchFrontendSettings, FrontendSettingsType} from '../../../utils/requests';
-import type { BannerDesign } from '../../../models/BannerDesign';
+import { fetchBannerDesigns } from '../../../utils/requests';
+import { BannerDesign } from '../../../models/BannerDesign';
 
 const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
   viewTextContainer: {
@@ -66,9 +66,8 @@ const BannerDesigns: React.FC = () => {
       <div className={classes.leftCol}>
         <BannerDesignsSidebar
           designs={bannerDesigns}
-          createDesign={(bannerDesign: BannerDesign) => {}}
           selectedDesign={selectedBannerDesign}
-          onDesignSelected={() => {}}
+          onDesignSelected={name => setSelectedBannerDesignName(name)}
         />
       </div>
       <div className={classes.rightCol}>

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -1,3 +1,90 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { makeStyles, Theme, Typography } from '@material-ui/core';
+import BannerDesignsSidebar from './BannerDesignsSidebar';
+import BannerDesignEditor from './BannerDesignEditor';
+import { useParams } from 'react-router-dom';
 
-export const BannerDesigns = () => null;
+import {fetchBannerDesigns, fetchFrontendSettings, FrontendSettingsType} from '../../../utils/requests';
+import type { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
+  viewTextContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: '-50px',
+  },
+  viewText: {
+    fontSize: typography.pxToRem(16),
+  },
+  body: {
+    display: 'flex',
+    overflow: 'hidden',
+    flexGrow: 1,
+    width: '100%',
+    height: '100%',
+  },
+  leftCol: {
+    height: '100%',
+    flexShrink: 0,
+    overflowY: 'auto',
+    background: 'white',
+    paddingTop: spacing(6),
+    paddingLeft: spacing(6),
+    paddingRight: spacing(6),
+  },
+  rightCol: {
+    flexGrow: 1,
+    display: 'flex',
+    justifyContent: 'center',
+  },
+}));
+
+const BannerDesigns: React.FC = () => {
+  const [bannerDesigns, setBannerDesigns] = useState<BannerDesign[]>([]);
+  const { bannerDesignName } = useParams<{ bannerDesignName?: string }>(); // querystring parameter
+  const [selectedBannerDesignName, setSelectedBannerDesignName] = useState<string | undefined>();
+  const classes = useStyles();
+
+  useEffect(() => {
+    fetchBannerDesigns().then(bannerDesigns => {
+      setBannerDesigns(bannerDesigns);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (bannerDesignName != null) {
+      setSelectedBannerDesignName(bannerDesignName);
+    }
+  }, [bannerDesignName, bannerDesigns]);
+
+  const selectedBannerDesign = bannerDesigns.find(b => b.name === selectedBannerDesignName);
+
+  return (
+    <div className={classes.body}>
+      <div className={classes.leftCol}>
+        <BannerDesignsSidebar
+          designs={bannerDesigns}
+          createDesign={(bannerDesign: BannerDesign) => {}}
+          selectedDesign={selectedBannerDesign}
+          onDesignSelected={() => {}}
+        />
+      </div>
+      <div className={classes.rightCol}>
+        {selectedBannerDesign ? (
+          <BannerDesignEditor bannerDesign={selectedBannerDesign} />
+        ) : (
+          <div className={classes.viewTextContainer}>
+            <Typography className={classes.viewText}>
+              Select an existing banner design from the menu,
+            </Typography>
+            <Typography className={classes.viewText}>or create a new one</Typography>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BannerDesigns;

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -195,6 +195,12 @@ export default function NavDrawer(): React.ReactElement {
             <span className={classes.super}>🦸</span>
           </ListItem>
         </Link>
+        <Link key="Banner Designs" to="/banner-designs" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Banner Designs">
+            <ListItemText primary="Banner Designs" />
+            <span className={classes.super}>🎨</span>
+          </ListItem>
+        </Link>
       </div>
 
       <div>

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -7,6 +7,7 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import RRControlPanelLogo from './rrControlPanelLogo';
+import { getStage } from '../utils/stage';
 
 const useStyles = makeStyles({
   list: {
@@ -123,6 +124,11 @@ export default function NavDrawer(): React.ReactElement {
     return now.getMonth() == 9 && now.getDate() == 31;
   };
 
+  const shouldShowBannerDesignNav = (): boolean => {
+    const stage = getStage();
+    return stage !== 'PROD' && stage !== 'CODE';
+  };
+
   const list = (anchor: string): React.ReactElement => (
     <div
       className={classes.list}
@@ -195,12 +201,14 @@ export default function NavDrawer(): React.ReactElement {
             <span className={classes.super}>🦸</span>
           </ListItem>
         </Link>
-        <Link key="Banner Designs" to="/banner-designs" className={classes.link}>
-          <ListItem className={classes.listItem} button key="Banner Designs">
-            <ListItemText primary="Banner Designs" />
-            <span className={classes.super}>🎨</span>
-          </ListItem>
-        </Link>
+        {shouldShowBannerDesignNav() && (
+          <Link key="Banner Designs" to="/banner-designs" className={classes.link}>
+            <ListItem className={classes.listItem} button key="Banner Designs">
+              <ListItemText primary="Banner Designs" />
+              <span className={classes.super}>🎨</span>
+            </ListItem>
+          </Link>
+        )}
       </div>
 
       <div>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -36,6 +36,7 @@ import { makeStyles } from '@material-ui/core';
 import QrCodePage from './components/utilities/QrCodePage';
 import AppsMeteringSwitches from './components/appsMeteringSwitches';
 import { SuperModeDashboard } from './components/channelManagement/superMode/superModeDashboard';
+import { BannerDesigns } from './components/channelManagement/bannerDesigns/';
 import DefaultPromos from './components/defaultPromos';
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
@@ -242,6 +243,12 @@ const AppRouter = () => {
           <Route
             path="/default-promos"
             render={(): React.ReactElement => createComponent(<DefaultPromos />, 'Default Promos')}
+          />
+          <Route
+            path="/banner-designs/:name?"
+            render={(): React.ReactElement =>
+              createComponent(<BannerDesigns />, 'Banner Designs')
+            }
           />
         </div>
       </Router>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -36,7 +36,7 @@ import { makeStyles } from '@material-ui/core';
 import QrCodePage from './components/utilities/QrCodePage';
 import AppsMeteringSwitches from './components/appsMeteringSwitches';
 import { SuperModeDashboard } from './components/channelManagement/superMode/superModeDashboard';
-import { BannerDesigns } from './components/channelManagement/bannerDesigns/';
+import BannerDesigns from './components/channelManagement/bannerDesigns/';
 import DefaultPromos from './components/defaultPromos';
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
@@ -246,9 +246,7 @@ const AppRouter = () => {
           />
           <Route
             path="/banner-designs/:name?"
-            render={(): React.ReactElement =>
-              createComponent(<BannerDesigns />, 'Banner Designs')
-            }
+            render={(): React.ReactElement => createComponent(<BannerDesigns />, 'Banner Designs')}
           />
         </div>
       </Router>

--- a/public/src/models/BannerDesign.ts
+++ b/public/src/models/BannerDesign.ts
@@ -1,0 +1,3 @@
+export interface BannerDesign {
+  name: string;
+}

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -1,5 +1,6 @@
 import { Test, Status } from '../components/channelManagement/helpers/shared';
 import { Campaign } from '../components/channelManagement/campaigns/CampaignsForm';
+import { BannerDesign } from '../models/BannerDesign';
 
 export enum SupportFrontendSettingsType {
   switches = 'switches',
@@ -20,6 +21,7 @@ export enum FrontendSettingsType {
   bannerDeploy2 = 'banner-deploy2',
   channelSwitches = 'channel-switches',
   campaigns = 'campaigns',
+  bannerDesigns = 'banner-designs',
 }
 
 export enum AppsSettingsType {
@@ -140,6 +142,16 @@ export function saveSupportFrontendSettings(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fetchFrontendSettings(settingsType: FrontendSettingsType): Promise<any> {
   return fetchSettings(`/frontend/${settingsType}`);
+}
+
+interface BannerDesignsResponse {
+  bannerDesigns: BannerDesign[];
+}
+
+export function fetchBannerDesigns(): Promise<BannerDesign[]> {
+  return fetchFrontendSettings(FrontendSettingsType.bannerDesigns).then(
+    (response: BannerDesignsResponse) => response.bannerDesigns,
+  );
 }
 
 export function saveFrontendSettings(


### PR DESCRIPTION
## What does this change?

This change is part 1 of adding a very simple banner design UI. It adds client side routing etc and a simple list of the available designs by name (which requires making a request to the API).

Navigation to the UI will be hidden in code/production, but can be navigated to directly (for developers).

![Screenshot 2023-07-31 at 12 02 48](https://github.com/guardian/support-admin-console/assets/379839/f9751d51-41f5-4f98-9eab-ec14bd4aa7ae)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
