### PR TITLE
Basic Design UI: Part 2 (Creating and locking designs)

### DIFF
--- a/app/controllers/banner/BannerDesignsController.scala
+++ b/app/controllers/banner/BannerDesignsController.scala
@@ -33,6 +33,7 @@ class BannerDesignsController(
 
   case class BannerDesignsResponse(
       bannerDesigns: List[BannerDesign],
+      userEmail: String,
   )
 
   val lockFileName = "banner-designs"
@@ -63,6 +64,7 @@ class BannerDesignsController(
         .map { bannerDesigns =>
           val response = BannerDesignsResponse(
             bannerDesigns,
+            request.user.email
           )
           Ok(noNulls(response.asJson))
         }

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -1,5 +1,8 @@
 package models
 
-case class BannerDesign(name: String)
+case class BannerDesign(
+    name: String,
+    imageUrl: String,
+)
 
 object BannerDesign {}

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -3,6 +3,7 @@ package models
 case class BannerDesign(
     name: String,
     imageUrl: String,
+    lockStatus: LockStatus,
 )
 
 object BannerDesign {}

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -3,7 +3,7 @@ package models
 case class BannerDesign(
     name: String,
     imageUrl: String,
-    lockStatus: LockStatus,
+    lockStatus: Option[LockStatus],
 )
 
 object BannerDesign {}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BannerDesign } from '../../../models/BannerDesign';
 import StickyTopBar from './StickyTopBar';
 import { makeStyles, Theme } from '@material-ui/core';
+import { LockStatus } from '../helpers/shared';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   container: {
@@ -19,14 +20,30 @@ type Props = {
   onLock: (designName: string, force: boolean) => void;
   onUnlock: (designName: string) => void;
   onSave: (designName: string) => void;
+  userHasLock: boolean;
+  lockStatus: LockStatus;
 };
 
-const BannerDesignEditor: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props) => {
+const BannerDesignEditor: React.FC<Props> = ({
+  name,
+  onLock,
+  onUnlock,
+  onSave,
+  userHasLock,
+  lockStatus,
+}: Props) => {
   const classes = useStyles();
 
   return (
     <div className={classes.container}>
-      <StickyTopBar name={name} onLock={onLock} onUnlock={onUnlock} onSave={onSave} />
+      <StickyTopBar
+        name={name}
+        onLock={onLock}
+        onUnlock={onUnlock}
+        onSave={onSave}
+        userHasLock={userHasLock}
+        lockStatus={lockStatus}
+      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -1,12 +1,31 @@
 import React from 'react';
 import { BannerDesign } from '../../../models/BannerDesign';
+import StickyTopBar from './StickyTopBar';
+import { makeStyles, Theme } from '@material-ui/core';
+
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+    background: palette.background.paper, // #FFFFFF
+    borderLeft: `1px solid ${palette.grey[500]}`,
+  },
+}));
 
 type Props = {
   bannerDesign: BannerDesign;
 };
 
-const BannerDesignEditor: React.FC<Props> = ({ bannerDesign }: Props) => (
-  <div>{bannerDesign.name}</div>
-);
+const BannerDesignEditor: React.FC<Props> = ({ bannerDesign }: Props) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <StickyTopBar bannerDesign={bannerDesign} />
+    </div>
+  );
+};
 
 export default BannerDesignEditor;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BannerDesign } from '../../../models/BannerDesign';
 import StickyTopBar from './StickyTopBar';
 import { makeStyles, Theme } from '@material-ui/core';
 import { LockStatus } from '../helpers/shared';

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -15,15 +15,18 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
 }));
 
 type Props = {
-  bannerDesign: BannerDesign;
+  name: string;
+  onLock: (designName: string, force: boolean) => void;
+  onUnlock: (designName: string) => void;
+  onSave: (designName: string) => void;
 };
 
-const BannerDesignEditor: React.FC<Props> = ({ bannerDesign }: Props) => {
+const BannerDesignEditor: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props) => {
   const classes = useStyles();
 
   return (
     <div className={classes.container}>
-      <StickyTopBar bannerDesign={bannerDesign} />
+      <StickyTopBar name={name} onLock={onLock} onUnlock={onUnlock} onSave={onSave} />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -65,7 +65,7 @@ const BannerDesignsList = ({
           const isSelected = selectedDesign && selectedDesign.name === design.name;
 
           return (
-            <ListItem className={classes.button} key={design.name}>
+            <ListItem className={classes.listItem} key={design.name}>
               <Button
                 key={`${design.name}-button`}
                 className={[classes.button, isSelected && classes.selected].join(' ')}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import BannerDesignsList from './BannerDesignsList';
 import { BannerDesign } from '../../../models/BannerDesign';
+import NewBannerDesignButton from './NewBannerDesignButton';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -14,23 +15,37 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     marginTop: '8px',
   },
+  buttonsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '10px',
+  },
 }));
 
 interface Props {
   designs: BannerDesign[];
   selectedDesign?: BannerDesign;
   onDesignSelected: (designName: string) => void;
+  createDesign: (design: BannerDesign) => void;
 }
 
 const BannerDesignsSidebar = ({
   designs,
   selectedDesign,
   onDesignSelected,
+  createDesign,
 }: Props): React.ReactElement => {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
+      <div className={classes.buttonsContainer}>
+        <NewBannerDesignButton
+          existingNames={designs.map(c => c.name)}
+          createDesign={createDesign}
+        />
+      </div>
       <div className={classes.listsContainer}>
         <BannerDesignsList
           designs={designs}

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -50,6 +50,7 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
 
   const defaultValues: BannerDesign = {
     name: '',
+    imageUrl: '',
   };
 
   const { register, handleSubmit, errors } = useForm<BannerDesign>({
@@ -59,6 +60,9 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
   const onSubmit = (design: BannerDesign): void => {
     createDesign({
       name: design.name,
+      // Hardcode this until the form is working
+      imageUrl:
+        'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
     });
     close();
   };

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  TextField,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import {
+  createDuplicateValidator,
+  EMPTY_ERROR_HELPER_TEXT,
+  INVALID_CHARACTERS_ERROR_HELPER_TEXT,
+  VALID_CHARACTERS_REGEX,
+} from '../helpers/validation';
+import { useForm } from 'react-hook-form';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(() => ({
+  dialogHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '8px',
+  },
+  input: {
+    '& input': {
+      textTransform: 'uppercase !important',
+    },
+  },
+}));
+
+interface CreateBannerDesignDialogProps {
+  isOpen: boolean;
+  close: () => void;
+  existingNames: string[];
+  createDesign: (data: BannerDesign) => void;
+}
+
+const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
+  isOpen,
+  close,
+  existingNames,
+  createDesign,
+}: CreateBannerDesignDialogProps) => {
+  const classes = useStyles();
+
+  const defaultValues: BannerDesign = {
+    name: '',
+  };
+
+  const { register, handleSubmit, errors } = useForm<BannerDesign>({
+    defaultValues,
+  });
+
+  const onSubmit = (design: BannerDesign): void => {
+    createDesign({
+      name: design.name,
+    });
+    close();
+  };
+
+  return (
+    <Dialog open={isOpen} onClose={close} aria-labelledby="create-design-dialog-title">
+      <div className={classes.dialogHeader}>
+        <DialogTitle id="create-design-dialog-title">Create a new banner design</DialogTitle>
+        <IconButton onClick={close} aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </div>
+      <DialogContent dividers>
+        <TextField
+          className={classes.input}
+          inputRef={register({
+            required: EMPTY_ERROR_HELPER_TEXT,
+            pattern: {
+              value: VALID_CHARACTERS_REGEX,
+              message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
+            },
+            validate: createDuplicateValidator(existingNames),
+          })}
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : ''}
+          name="name"
+          label="Banner design name"
+          margin="normal"
+          variant="outlined"
+          autoFocus
+          fullWidth
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSubmit(onSubmit)} color="primary">
+          Create banner design
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CreateBannerDesignDialog;

--- a/public/src/components/channelManagement/bannerDesigns/LockDetails.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/LockDetails.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { formattedTimestamp } from '../helpers/utilities';
+import { makeStyles, Typography } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  lockDetailsText: {
+    alignSelf: 'flex-end',
+  },
+}));
+
+interface Props {
+  email?: string;
+  timestamp?: string;
+}
+export const LockDetails: React.FC<Props> = ({ email, timestamp }: Props) => {
+  const classes = useStyles();
+  if (email && timestamp) {
+    const text = `Locked by ${email}, since ${formattedTimestamp(timestamp)}`;
+
+    return <Typography className={classes.lockDetailsText}>{text}</Typography>;
+  }
+  return null;
+};

--- a/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Button, makeStyles, Typography } from '@material-ui/core';
+import AddIcon from '@material-ui/icons/Add';
+import useOpenable from '../../../hooks/useOpenable';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(() => ({
+  button: {
+    justifyContent: 'start',
+    height: '48px',
+  },
+  text: {
+    fontSize: '12px',
+    fontWeight: 500,
+    letterSpacing: '1px',
+  },
+}));
+
+interface Props {
+  existingNames: string[];
+  createDesign: (campaign: BannerDesign) => void;
+}
+
+const NewCampaignButton: React.FC<Props> = ({ existingNames, createDesign }: Props) => {
+  const [isOpen, open, close] = useOpenable();
+  const classes = useStyles();
+
+  return (
+    <>
+      <Button className={classes.button} variant="outlined" startIcon={<AddIcon />} onClick={open}>
+        <Typography className={classes.text}>Create a new banner design</Typography>
+      </Button>
+      {/*<CreateCampaignDialog*/}
+      {/*  isOpen={isOpen}*/}
+      {/*  close={close}*/}
+      {/*  existingNames={existingNames}*/}
+      {/*  createCampaign={createCampaign}*/}
+      {/*/>*/}
+    </>
+  );
+};
+
+export default NewCampaignButton;

--- a/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
@@ -3,6 +3,7 @@ import { Button, makeStyles, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import useOpenable from '../../../hooks/useOpenable';
 import { BannerDesign } from '../../../models/BannerDesign';
+import CreateBannerDesignDialog from './CreateBannerDesignDialog';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -30,12 +31,12 @@ const NewCampaignButton: React.FC<Props> = ({ existingNames, createDesign }: Pro
       <Button className={classes.button} variant="outlined" startIcon={<AddIcon />} onClick={open}>
         <Typography className={classes.text}>Create a new banner design</Typography>
       </Button>
-      {/*<CreateCampaignDialog*/}
-      {/*  isOpen={isOpen}*/}
-      {/*  close={close}*/}
-      {/*  existingNames={existingNames}*/}
-      {/*  createCampaign={createCampaign}*/}
-      {/*/>*/}
+      <CreateBannerDesignDialog
+        isOpen={isOpen}
+        close={close}
+        existingNames={existingNames}
+        createDesign={createDesign}
+      />
     </>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -7,6 +7,7 @@ import LockIcon from '@material-ui/icons/Lock';
 import CloseIcon from '@material-ui/icons/Close';
 import SaveIcon from '@material-ui/icons/Save';
 import { grey } from '@material-ui/core/colors';
+import { LockStatus } from '../helpers/shared';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -61,13 +62,19 @@ interface Props {
   onLock: (name: string, force: boolean) => void;
   onUnlock: (name: string) => void;
   onSave: (name: string) => void;
+  lockStatus: LockStatus;
+  userHasLock: boolean;
 }
 
-const StickyTopBar: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props) => {
+const StickyTopBar: React.FC<Props> = ({
+  name,
+  onLock,
+  onUnlock,
+  onSave,
+  userHasLock,
+  lockStatus,
+}: Props) => {
   const classes = useStyles();
-
-  const userHasDesignLocked = true;
-  const lockStatus = { locked: true, email: undefined, timestamp: undefined };
 
   return (
     <header className={classes.container}>
@@ -78,7 +85,7 @@ const StickyTopBar: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props
       </div>
       <div className={classes.buttonsContainer}>
         <div className={classes.lockContainer}>
-          {!userHasDesignLocked && !lockStatus.locked && (
+          {!userHasLock && !lockStatus.locked && (
             <>
               <Button
                 variant="outlined"
@@ -90,7 +97,7 @@ const StickyTopBar: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props
               </Button>
             </>
           )}
-          {!userHasDesignLocked && lockStatus.locked && (
+          {!userHasLock && lockStatus.locked && (
             <>
               <LockDetails email={lockStatus.email} timestamp={lockStatus.timestamp} />
               <Button
@@ -103,7 +110,7 @@ const StickyTopBar: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props
               </Button>
             </>
           )}
-          {userHasDesignLocked && (
+          {userHasLock && (
             <>
               <Button
                 variant="outlined"

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Theme, Typography, makeStyles } from '@material-ui/core';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    paddingLeft: spacing(3),
+    paddingRight: spacing(3),
+    paddingBottom: spacing(2),
+    paddingTop: spacing(1),
+    backgroundColor: palette.grey[200],
+    borderBottom: `1px solid ${palette.grey[500]}`,
+  },
+  namesContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'spaced',
+    height: '100%',
+  },
+  mainHeader: {
+    fontSize: '32px',
+    fontWeight: 'normal',
+  },
+}));
+
+interface Props {
+  bannerDesign: BannerDesign;
+}
+
+const StickyTopBar: React.FC<Props> = ({ bannerDesign }: Props) => {
+  const classes = useStyles();
+
+  return (
+    <header className={classes.container}>
+      <div className={classes.namesContainer}>
+        <Typography variant="h2" className={classes.mainHeader}>
+          {bannerDesign.name}
+        </Typography>
+      </div>
+    </header>
+  );
+};
+
+export default StickyTopBar;

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
-import { BannerDesign } from '../../../models/BannerDesign';
 import EditIcon from '@material-ui/icons/Edit';
 import { LockDetails } from './LockDetails';
 import LockIcon from '@material-ui/icons/Lock';

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import { Theme, Typography, makeStyles } from '@material-ui/core';
+import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
 import { BannerDesign } from '../../../models/BannerDesign';
+import EditIcon from '@material-ui/icons/Edit';
+import { LockDetails } from './LockDetails';
+import LockIcon from '@material-ui/icons/Lock';
+import CloseIcon from '@material-ui/icons/Close';
+import SaveIcon from '@material-ui/icons/Save';
+import { grey } from '@material-ui/core/colors';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -24,21 +30,100 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     fontSize: '32px',
     fontWeight: 'normal',
   },
+  buttonsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignSelf: 'flex-end',
+    paddingBottom: spacing(1),
+  },
+  lockContainer: {
+    alignSelf: 'flex-end',
+    display: 'flex',
+    '& > * + *': {
+      marginLeft: spacing(2),
+    },
+    marginLeft: spacing(1),
+  },
+  buttonText: {
+    fontSize: '14px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    color: palette.grey[800],
+  },
+  icon: {
+    color: grey[700],
+  },
 }));
 
 interface Props {
-  bannerDesign: BannerDesign;
+  name: string;
+  onLock: (name: string, force: boolean) => void;
+  onUnlock: (name: string) => void;
+  onSave: (name: string) => void;
 }
 
-const StickyTopBar: React.FC<Props> = ({ bannerDesign }: Props) => {
+const StickyTopBar: React.FC<Props> = ({ name, onLock, onUnlock, onSave }: Props) => {
   const classes = useStyles();
+
+  const userHasDesignLocked = true;
+  const lockStatus = { locked: true, email: undefined, timestamp: undefined };
 
   return (
     <header className={classes.container}>
       <div className={classes.namesContainer}>
         <Typography variant="h2" className={classes.mainHeader}>
-          {bannerDesign.name}
+          {name}
         </Typography>
+      </div>
+      <div className={classes.buttonsContainer}>
+        <div className={classes.lockContainer}>
+          {!userHasDesignLocked && !lockStatus.locked && (
+            <>
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<EditIcon className={classes.icon} />}
+                onClick={() => onLock(name, false)}
+              >
+                <Typography className={classes.buttonText}>Edit test</Typography>
+              </Button>
+            </>
+          )}
+          {!userHasDesignLocked && lockStatus.locked && (
+            <>
+              <LockDetails email={lockStatus.email} timestamp={lockStatus.timestamp} />
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<LockIcon className={classes.icon} />}
+                onClick={() => onLock(name, true)}
+              >
+                <Typography className={classes.buttonText}>Take control</Typography>
+              </Button>
+            </>
+          )}
+          {userHasDesignLocked && (
+            <>
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<CloseIcon className={classes.icon} />}
+                onClick={() => onUnlock(name)}
+              >
+                <Typography className={classes.buttonText}>Discard</Typography>
+              </Button>
+              <Button
+                variant="outlined"
+                size="medium"
+                startIcon={<SaveIcon className={classes.icon} />}
+                onClick={() => onSave(name)}
+              >
+                <Typography className={classes.buttonText}>Save</Typography>
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -61,6 +61,10 @@ const BannerDesigns: React.FC = () => {
 
   const selectedBannerDesign = bannerDesigns.find(b => b.name === selectedBannerDesignName);
 
+  const createDesign = (design: BannerDesign): void => {
+    console.log('Creating banner design!', design);
+  };
+
   return (
     <div className={classes.body}>
       <div className={classes.leftCol}>
@@ -68,6 +72,7 @@ const BannerDesigns: React.FC = () => {
           designs={bannerDesigns}
           selectedDesign={selectedBannerDesign}
           onDesignSelected={name => setSelectedBannerDesignName(name)}
+          createDesign={createDesign}
         />
       </div>
       <div className={classes.rightCol}>

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -61,8 +61,9 @@ const BannerDesigns: React.FC = () => {
 
   const selectedBannerDesign = bannerDesigns.find(b => b.name === selectedBannerDesignName);
 
-  const createDesign = (design: BannerDesign): void => {
-    console.log('Creating banner design!', design);
+  const createDesign = (newUnsavedDesign: BannerDesign): void => {
+    setSelectedBannerDesignName(newUnsavedDesign.name);
+    setBannerDesigns([...bannerDesigns, newUnsavedDesign]);
   };
 
   return (

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -137,7 +137,6 @@ const BannerDesigns: React.FC = () => {
             alert(`Error while creating new test: ${error}`);
           });
       } else {
-        console.log('Not new: ', design);
         updateBannerDesign(design)
           .then(() => refreshDesign(designName))
           .catch(error => {

--- a/public/src/models/BannerDesign.ts
+++ b/public/src/models/BannerDesign.ts
@@ -1,3 +1,8 @@
+import { LockStatus } from '../components/channelManagement/helpers/shared';
+
 export interface BannerDesign {
   name: string;
+  imageUrl: string;
+  isNew?: boolean;
+  lockState?: LockStatus;
 }

--- a/public/src/models/BannerDesign.ts
+++ b/public/src/models/BannerDesign.ts
@@ -4,5 +4,5 @@ export interface BannerDesign {
   name: string;
   imageUrl: string;
   isNew?: boolean;
-  lockState?: LockStatus;
+  lockStatus?: LockStatus;
 }

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -144,14 +144,9 @@ export function fetchFrontendSettings(settingsType: FrontendSettingsType): Promi
   return fetchSettings(`/frontend/${settingsType}`);
 }
 
-interface BannerDesignsResponse {
+export interface BannerDesignsResponse {
   bannerDesigns: BannerDesign[];
-}
-
-export function fetchBannerDesigns(): Promise<BannerDesign[]> {
-  return fetchFrontendSettings(FrontendSettingsType.bannerDesigns).then(
-    (response: BannerDesignsResponse) => response.bannerDesigns,
-  );
+  userEmail: string;
 }
 
 export function fetchBannerDesign(designName: string): Promise<BannerDesign> {

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -154,6 +154,32 @@ export function fetchBannerDesigns(): Promise<BannerDesign[]> {
   );
 }
 
+export function fetchBannerDesign(designName: string): Promise<BannerDesign> {
+  return fetchSettings(`/frontend/${FrontendSettingsType.bannerDesigns}/${designName}`);
+}
+
+export function lockBannerDesign(designName: string, force: boolean): Promise<Response> {
+  const path = force
+    ? `/frontend/${FrontendSettingsType.bannerDesigns}/takecontrol/${designName}`
+    : `/frontend/${FrontendSettingsType.bannerDesigns}/lock/${designName}`;
+  return makeFetch(path, {
+    method: 'POST',
+  });
+}
+export function unlockBannerDesign(designName: string): Promise<Response> {
+  return makeFetch(`/frontend/${FrontendSettingsType.bannerDesigns}/unlock/${designName}`, {
+    method: 'POST',
+  });
+}
+
+export function updateBannerDesign(design: BannerDesign): Promise<Response> {
+  return saveSettings(`/frontend/${FrontendSettingsType.bannerDesigns}/update`, design);
+}
+
+export function createBannerDesign(design: BannerDesign): Promise<Response> {
+  return saveSettings(`/frontend/${FrontendSettingsType.bannerDesigns}/create`, design);
+}
+
 export function saveFrontendSettings(
   settingsType: FrontendSettingsType,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
## What does this change?

More baby steps with the design UI.

This adds the ability to create a banner design. The only field specifiable in the UI currently is the name (which must be unique).

When a new banner design is created it's opened in an editable state and is not yet saved to the server. From here you can either save or discard. I've added an `imageUrl` field with a default value, it's not yet configurable in the UI. I had to do this as the update statement we create for dynamo assumes there will be at least one other field to set.

You can also click a banner design to edit it, though there are no editable fields yet, this puts it into a locked state until you click save or discard.

Lots of this code has been duplicated from the existing tests code. In future there may be refactoring to consolidate some of the shared logic.

![Screen Recording 2023-08-03 at 13 13 56 mov](https://github.com/guardian/support-admin-console/assets/379839/e0530af3-9264-4aae-978d-961830ee17f7)

## How to test

Run locally (or on CODE).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
