### PR TITLE
Little banner design fixes

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignListItem.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignListItem.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { ListItem, Theme, makeStyles, Typography } from '@material-ui/core';
+import { BannerDesign } from '../../../models/BannerDesign';
+import EditIcon from '@material-ui/icons/Edit';
+import useHover from '../../../hooks/useHover';
+
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  listItem: {
+    position: 'relative',
+    height: '50px',
+    width: '290px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    background: 'white',
+    borderRadius: '4px',
+    padding: '0 12px',
+    border: `1px solid ${palette.grey[700]}`,
+
+    '&:hover': {
+      background: `${palette.grey[700]}`,
+    },
+  },
+  text: {
+    maxWidth: '190px',
+    fontSize: '12px',
+    fontWeight: 500,
+    lineHeight: '24px',
+    textTransform: 'uppercase',
+  },
+  textInverted: {
+    color: '#FFFFFF',
+  },
+  inverted: {
+    background: `${palette.grey[700]}`,
+  },
+  whitePencil: {
+    color: 'white',
+  },
+  labelAndNameContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > * + *': {
+      marginLeft: '4px',
+    },
+  },
+}));
+
+interface Props {
+  design: BannerDesign;
+  isSelected: boolean;
+  onDesignSelected: (designName: string) => void;
+  isLockedForEditing: boolean;
+}
+
+const BannerDesignListItem = ({
+  design,
+  isSelected,
+  onDesignSelected,
+  isLockedForEditing,
+}: Props): React.ReactElement => {
+  const classes = useStyles();
+
+  const [ref, isHovered] = useHover<HTMLDivElement>();
+
+  const itemContainerClasses = [classes.listItem];
+  const shouldInvertColor = isHovered || isSelected;
+  if (shouldInvertColor) {
+    itemContainerClasses.push(classes.inverted);
+  }
+
+  const textClasses = [classes.text];
+  if (isSelected) {
+    textClasses.push(classes.textInverted);
+  }
+
+  return (
+    <ListItem
+      button={true}
+      className={itemContainerClasses.join(' ')}
+      key={design.name}
+      onClick={(): void => onDesignSelected(design.name)}
+      ref={ref}
+    >
+      <div className={classes.labelAndNameContainer}>
+        {isLockedForEditing &&
+          (isSelected ? <EditIcon className={classes.whitePencil} /> : <EditIcon />)}
+
+        <Typography className={textClasses.join(' ')}>{design.name}</Typography>
+      </div>
+    </ListItem>
+  );
+};
+
+export default BannerDesignListItem;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -1,46 +1,17 @@
 import React from 'react';
-import { List, ListItem, Theme, makeStyles, Button, Typography } from '@material-ui/core';
+import { List, makeStyles } from '@material-ui/core';
 import { BannerDesign } from '../../../models/BannerDesign';
+import BannerDesignListItem from './BannerDesignListItem';
 
-const useStyles = makeStyles(({ palette }: Theme) => ({
+const useStyles = makeStyles(() => ({
   container: {
     marginTop: '16px',
   },
   list: {
     padding: 0,
-    width: '100%',
-  },
-  listItem: {
-    margin: 0,
-    padding: 0,
-    gutter: 0,
-    width: '100%',
-  },
-  button: {
-    position: 'relative',
-    height: '50px',
-    width: '290px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    background: 'white',
-    borderRadius: '4px',
-    padding: '0 12px',
-    marginBottom: '4px',
-  },
-  text: {
-    fontSize: '12px',
-    fontWeight: 500,
-    textTransform: 'uppercase',
-    letterSpacing: '1px',
-  },
-  selected: {
-    background: `${palette.grey[700]}`,
-    color: 'white',
-
-    '&:hover': {
-      background: `${palette.grey[700]}`,
-      color: 'white',
+    marginTop: 0,
+    '& > * + *': {
+      marginTop: '8px',
     },
   },
 }));
@@ -62,19 +33,16 @@ const BannerDesignsList = ({
     <div className={classes.container}>
       <List className={classes.list}>
         {designs.map(design => {
-          const isSelected = selectedDesign && selectedDesign.name === design.name;
+          const isSelected = Boolean(selectedDesign && selectedDesign.name === design.name);
 
           return (
-            <ListItem className={classes.listItem} key={design.name}>
-              <Button
-                key={`${design.name}-button`}
-                className={[classes.button, isSelected && classes.selected].join(' ')}
-                variant="outlined"
-                onClick={(): void => onDesignSelected(design.name)}
-              >
-                <Typography className={classes.text}>{design.name}</Typography>
-              </Button>
-            </ListItem>
+            <BannerDesignListItem
+              key={design.name}
+              design={design}
+              isSelected={isSelected}
+              isLockedForEditing={Boolean(design.lockStatus?.locked)}
+              onDesignSelected={(): void => onDesignSelected(design.name)}
+            />
           );
         })}
       </List>

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -59,7 +59,7 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
 
   const onSubmit = (design: BannerDesign): void => {
     createDesign({
-      name: design.name,
+      name: design.name.toUpperCase(),
       // Hardcode this until the form is working
       imageUrl:
         'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',


### PR DESCRIPTION
## What does this change?

This PR makes a couple of small fixes to the banner design tool:

* Show in the left nav when a banner is locked for editing
* Uppercase names before saving (to be consistent with channel tests)

### Before

<img width="1032" alt="Screenshot 2023-08-04 at 16 12 25" src="https://github.com/guardian/support-admin-console/assets/379839/cbb992e6-174d-4d7c-82fb-5e276e45508b">

### After

<img width="989" alt="Screenshot 2023-08-04 at 16 13 54" src="https://github.com/guardian/support-admin-console/assets/379839/3904ae78-893a-46d9-9389-f3dcc6e433d3">

(Note that the data is different as one screenshot is from my local env and one is from code).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
