### PR TITLE
Banner Design UI: Part 3 (First configurable field - imageUrl)

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -6,7 +6,7 @@ import useValidation from '../hooks/useValidation';
 import BannerDesignForm from './BannerDesignForm';
 import { BannerDesign } from '../../../models/BannerDesign';
 
-const useStyles = makeStyles(({ palette }: Theme) => ({
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
     display: 'flex',
     flexDirection: 'column',
@@ -14,6 +14,12 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
     width: '100%',
     background: palette.background.paper,
     borderLeft: `1px solid ${palette.grey[500]}`,
+  },
+  scrollableContainer: {
+    overflowY: 'auto',
+    paddingLeft: spacing(3),
+    paddingRight: spacing(1),
+    paddingTop: spacing(2),
   },
 }));
 
@@ -62,12 +68,14 @@ const BannerDesignEditor: React.FC<Props> = ({
         userHasLock={userHasLock}
         lockStatus={lockStatus}
       />
-      <BannerDesignForm
-        design={design}
-        setValidationStatus={setValidationStatus}
-        isDisabled={!userHasLock}
-        onChange={onChange}
-      />
+      <div className={classes.scrollableContainer}>
+        <BannerDesignForm
+          design={design}
+          setValidationStatus={setValidationStatus}
+          isDisabled={!userHasLock}
+          onChange={onChange}
+        />
+      </div>
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import StickyTopBar from './StickyTopBar';
 import { makeStyles, Theme } from '@material-ui/core';
 import { LockStatus } from '../helpers/shared';
+import useValidation from '../hooks/useValidation';
+import BannerDesignForm from './BannerDesignForm';
+import { BannerDesign } from '../../../models/BannerDesign';
+import BannerDesigns from './index';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   container: {
@@ -16,22 +20,38 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
 
 type Props = {
   name: string;
+  design: BannerDesign;
   onLock: (designName: string, force: boolean) => void;
   onUnlock: (designName: string) => void;
   onSave: (designName: string) => void;
   userHasLock: boolean;
   lockStatus: LockStatus;
+  onChange: (design: BannerDesign) => void;
 };
 
 const BannerDesignEditor: React.FC<Props> = ({
+  design,
   name,
   onLock,
   onUnlock,
   onSave,
   userHasLock,
   lockStatus,
+  onChange,
 }: Props) => {
   const classes = useStyles();
+
+  const [isValid, setIsValid] = useState<boolean>(true);
+
+  const setValidationStatusForField = useValidation(setIsValid);
+
+  const onSaveWithValidation = (designName: string): void => {
+    if (isValid) {
+      onSave(designName);
+    } else {
+      alert('Form contains errors. Please fix any errors before saving.');
+    }
+  };
 
   return (
     <div className={classes.container}>
@@ -39,9 +59,15 @@ const BannerDesignEditor: React.FC<Props> = ({
         name={name}
         onLock={onLock}
         onUnlock={onUnlock}
-        onSave={onSave}
+        onSave={onSaveWithValidation}
         userHasLock={userHasLock}
         lockStatus={lockStatus}
+      />
+      <BannerDesignForm
+        design={design}
+        setValidationStatusForField={setValidationStatusForField}
+        isDisabled={!userHasLock}
+        onChange={onChange}
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -5,7 +5,6 @@ import { LockStatus } from '../helpers/shared';
 import useValidation from '../hooks/useValidation';
 import BannerDesignForm from './BannerDesignForm';
 import { BannerDesign } from '../../../models/BannerDesign';
-import BannerDesigns from './index';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   container: {
@@ -13,7 +12,7 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
     flexDirection: 'column',
     height: '100%',
     width: '100%',
-    background: palette.background.paper, // #FFFFFF
+    background: palette.background.paper,
     borderLeft: `1px solid ${palette.grey[500]}`,
   },
 }));
@@ -43,7 +42,7 @@ const BannerDesignEditor: React.FC<Props> = ({
 
   const [isValid, setIsValid] = useState<boolean>(true);
 
-  const setValidationStatusForField = useValidation(setIsValid);
+  const setValidationStatus = useValidation(setIsValid);
 
   const onSaveWithValidation = (designName: string): void => {
     if (isValid) {
@@ -65,7 +64,7 @@ const BannerDesignEditor: React.FC<Props> = ({
       />
       <BannerDesignForm
         design={design}
-        setValidationStatusForField={setValidationStatusForField}
+        setValidationStatus={setValidationStatus}
         isDisabled={!userHasLock}
         onChange={onChange}
       />

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -1,29 +1,16 @@
 import React, { useEffect } from 'react';
-import { makeStyles, TextField, Theme } from '@material-ui/core';
+import { TextField, Typography } from '@material-ui/core';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
 import { BannerDesign } from '../../../models/BannerDesign';
-
-const useStyles = makeStyles(({ palette }: Theme) => ({
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-    width: '100%',
-    background: palette.background.paper, // #FFFFFF
-    borderLeft: `1px solid ${palette.grey[500]}`,
-  },
-}));
+import { BannerDesignFormData as FormData, DEFAULT_BANNER_DESIGN } from './utils/defaults';
+import { useStyles } from '../helpers/testEditorStyles';
 
 type Props = {
   design: BannerDesign;
   setValidationStatus: (scope: string, isValid: boolean) => void;
   isDisabled: boolean;
   onChange: (design: BannerDesign) => void;
-};
-
-type FormData = {
-  imageUrl: string;
 };
 
 const BannerDesignForm: React.FC<Props> = ({
@@ -40,7 +27,7 @@ const BannerDesignForm: React.FC<Props> = ({
   };
 
   const defaultValues: FormData = {
-    imageUrl: design.imageUrl,
+    imageUrl: design.imageUrl || DEFAULT_BANNER_DESIGN.imageUrl,
   };
 
   const { register, handleSubmit, errors, reset } = useForm<FormData>({
@@ -49,9 +36,7 @@ const BannerDesignForm: React.FC<Props> = ({
   });
 
   useEffect(() => {
-    reset({
-      imageUrl: design.imageUrl,
-    });
+    reset(defaultValues);
   }, [design]);
 
   const onSubmit = ({ imageUrl }: FormData): void => {
@@ -65,20 +50,27 @@ const BannerDesignForm: React.FC<Props> = ({
 
   return (
     <div className={classes.container}>
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
-        error={errors.imageUrl !== undefined}
-        helperText={errors.imageUrl?.message}
-        onBlur={handleSubmit(onSubmit)}
-        name="imageUrl"
-        label="Banner Image URL"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth
-      />
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Images
+        </Typography>
+        <div>
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors.imageUrl !== undefined}
+            helperText={errors.imageUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="imageUrl"
+            label="Banner Image URL"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { makeStyles, TextField, Theme } from '@material-ui/core';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
@@ -17,7 +17,7 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
 
 type Props = {
   design: BannerDesign;
-  setValidationStatusForField: (fieldName: string, isValid: boolean) => void;
+  setValidationStatus: (scope: string, isValid: boolean) => void;
   isDisabled: boolean;
   onChange: (design: BannerDesign) => void;
 };
@@ -28,21 +28,40 @@ type FormData = {
 
 const BannerDesignForm: React.FC<Props> = ({
   design,
-  setValidationStatusForField,
+  setValidationStatus,
   isDisabled,
   onChange,
 }: Props) => {
   const classes = useStyles();
 
+  const onValidationChange = (isValid: boolean): void => {
+    const validationScope = design.name;
+    setValidationStatus(validationScope, isValid);
+  };
+
   const defaultValues: FormData = {
     imageUrl: design.imageUrl,
   };
 
-  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+  const { register, handleSubmit, errors, reset } = useForm<FormData>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    reset({
+      imageUrl: design.imageUrl,
+    });
+  }, [design]);
 
   const onSubmit = ({ imageUrl }: FormData): void => {
     onChange({ ...design, imageUrl });
   };
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange(isValid);
+  }, [errors.imageUrl]);
 
   return (
     <div className={classes.container}>
@@ -52,13 +71,13 @@ const BannerDesignForm: React.FC<Props> = ({
         })}
         error={errors.imageUrl !== undefined}
         helperText={errors.imageUrl?.message}
-        onBlur={() => handleSubmit(onSubmit)}
+        onBlur={handleSubmit(onSubmit)}
         name="imageUrl"
         label="Banner Image URL"
         margin="normal"
         variant="outlined"
-        fullWidth
         disabled={isDisabled}
+        fullWidth
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { makeStyles, TextField, Theme } from '@material-ui/core';
+import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import { useForm } from 'react-hook-form';
+import { BannerDesign } from '../../../models/BannerDesign';
+
+const useStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+    background: palette.background.paper, // #FFFFFF
+    borderLeft: `1px solid ${palette.grey[500]}`,
+  },
+}));
+
+type Props = {
+  design: BannerDesign;
+  setValidationStatusForField: (fieldName: string, isValid: boolean) => void;
+  isDisabled: boolean;
+  onChange: (design: BannerDesign) => void;
+};
+
+type FormData = {
+  imageUrl: string;
+};
+
+const BannerDesignForm: React.FC<Props> = ({
+  design,
+  setValidationStatusForField,
+  isDisabled,
+  onChange,
+}: Props) => {
+  const classes = useStyles();
+
+  const defaultValues: FormData = {
+    imageUrl: design.imageUrl,
+  };
+
+  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+
+  const onSubmit = ({ imageUrl }: FormData): void => {
+    onChange({ ...design, imageUrl });
+  };
+
+  return (
+    <div className={classes.container}>
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        error={errors.imageUrl !== undefined}
+        helperText={errors.imageUrl?.message}
+        onBlur={() => handleSubmit(onSubmit)}
+        name="imageUrl"
+        label="Banner Image URL"
+        margin="normal"
+        variant="outlined"
+        fullWidth
+        disabled={isDisabled}
+      />
+    </div>
+  );
+};
+
+export default BannerDesignForm;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -41,10 +41,7 @@ const BannerDesignsList = ({
               design={design}
               isSelected={isSelected}
               isLockedForEditing={Boolean(design.lockStatus?.locked)}
-              onDesignSelected={(): void => {
-                console.log(design.name);
-                onDesignSelected(design.name);
-              }}
+              onDesignSelected={(): void => onDesignSelected(design.name)}
             />
           );
         })}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -41,7 +41,10 @@ const BannerDesignsList = ({
               design={design}
               isSelected={isSelected}
               isLockedForEditing={Boolean(design.lockStatus?.locked)}
-              onDesignSelected={(): void => onDesignSelected(design.name)}
+              onDesignSelected={(): void => {
+                console.log(design.name);
+                onDesignSelected(design.name);
+              }}
             />
           );
         })}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
@@ -27,7 +27,7 @@ interface Props {
   designs: BannerDesign[];
   selectedDesign?: BannerDesign;
   onDesignSelected: (designName: string) => void;
-  createDesign: (design: BannerDesign) => void;
+  createDesign: (name: string) => void;
 }
 
 const BannerDesignsSidebar = ({

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -37,8 +37,12 @@ interface CreateBannerDesignDialogProps {
   isOpen: boolean;
   close: () => void;
   existingNames: string[];
-  createDesign: (data: BannerDesign) => void;
+  createDesign: (name: string) => void;
 }
+
+type FormData = {
+  name: string;
+};
 
 const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
   isOpen,
@@ -48,20 +52,16 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
 }: CreateBannerDesignDialogProps) => {
   const classes = useStyles();
 
-  const defaultValues: BannerDesign = {
+  const defaultValues: FormData = {
     name: '',
-    imageUrl: '',
   };
 
-  const { register, handleSubmit, errors } = useForm<BannerDesign>({
+  const { register, handleSubmit, errors } = useForm<FormData>({
     defaultValues,
   });
 
-  const onSubmit = (design: BannerDesign): void => {
-    createDesign({
-      name: design.name.toUpperCase(),
-      imageUrl: design.imageUrl,
-    });
+  const onSubmit = ({ name }: FormData): void => {
+    createDesign(name.toUpperCase());
     close();
   };
 

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -17,7 +17,6 @@ import {
   VALID_CHARACTERS_REGEX,
 } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
-import { BannerDesign } from '../../../models/BannerDesign';
 
 const useStyles = makeStyles(() => ({
   dialogHeader: {

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -60,9 +60,7 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
   const onSubmit = (design: BannerDesign): void => {
     createDesign({
       name: design.name.toUpperCase(),
-      // Hardcode this until the form is working
-      imageUrl:
-        'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+      imageUrl: design.imageUrl,
     });
     close();
   };

--- a/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button, makeStyles, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import useOpenable from '../../../hooks/useOpenable';
-import { BannerDesign } from '../../../models/BannerDesign';
 import CreateBannerDesignDialog from './CreateBannerDesignDialog';
 
 const useStyles = makeStyles(() => ({

--- a/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
 
 interface Props {
   existingNames: string[];
-  createDesign: (campaign: BannerDesign) => void;
+  createDesign: (name: string) => void;
 }
 
 const NewCampaignButton: React.FC<Props> = ({ existingNames, createDesign }: Props) => {

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -160,11 +160,13 @@ const BannerDesigns: React.FC = () => {
         {selectedBannerDesign ? (
           <BannerDesignEditor
             name={selectedBannerDesign.name}
+            design={selectedBannerDesign}
             onLock={onLock}
             onUnlock={onUnlock}
             onSave={onSave}
             userHasLock={selectedBannerDesign.lockStatus?.email === userEmail}
             lockStatus={selectedBannerDesign.lockStatus || { locked: false }}
+            onChange={onDesignChange}
           />
         ) : (
           <div className={classes.viewTextContainer}>

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -48,6 +48,12 @@ const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
     display: 'flex',
     justifyContent: 'center',
   },
+  scrollableContainer: {
+    overflowY: 'auto',
+    paddingLeft: spacing(3),
+    paddingRight: spacing(1),
+    paddingTop: spacing(2),
+  },
 }));
 
 const BannerDesigns: React.FC = () => {

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -15,6 +15,7 @@ import {
   updateBannerDesign,
 } from '../../../utils/requests';
 import { BannerDesign } from '../../../models/BannerDesign';
+import { createDefaultBannerDesign } from './utils/defaults';
 
 const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
   viewTextContainer: {
@@ -79,9 +80,9 @@ const BannerDesigns: React.FC = () => {
     }
   }, [bannerDesignName, bannerDesigns]);
 
-  const createDesign = (newUnsavedDesign: BannerDesign): void => {
+  const createDesign = (name: string): void => {
     const design = {
-      ...newUnsavedDesign,
+      ...createDefaultBannerDesign(name),
       isNew: true,
       lockStatus: {
         locked: true,

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -73,8 +73,6 @@ const BannerDesigns: React.FC = () => {
     }
   }, [bannerDesignName, bannerDesigns]);
 
-  const selectedBannerDesign = bannerDesigns.find(b => b.name === selectedBannerDesignName);
-
   const createDesign = (newUnsavedDesign: BannerDesign): void => {
     const design = {
       ...newUnsavedDesign,
@@ -108,6 +106,7 @@ const BannerDesigns: React.FC = () => {
         refreshDesign(designName);
       });
   };
+
   const onUnlock = (designName: string): void => {
     const design = bannerDesigns.find(design => design.name === designName);
     if (design && design.isNew) {
@@ -134,7 +133,7 @@ const BannerDesigns: React.FC = () => {
         createBannerDesign(unlocked)
           .then(() => refreshDesign(designName))
           .catch(error => {
-            alert(`Error while creating new test: ${error}`);
+            alert(`Error while creating new design: ${error}`);
           });
       } else {
         updateBannerDesign(design)
@@ -145,6 +144,8 @@ const BannerDesigns: React.FC = () => {
       }
     }
   };
+
+  const selectedBannerDesign = bannerDesigns.find(b => b.name === selectedBannerDesignName);
 
   return (
     <div className={classes.body}>

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,0 +1,8 @@
+export type BannerDesignFormData = {
+  imageUrl: string;
+};
+
+export const DEFAULT_BANNER_DESIGN: BannerDesignFormData = {
+  imageUrl:
+    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+};

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,3 +1,5 @@
+import { BannerDesign } from '../../../../models/BannerDesign';
+
 export type BannerDesignFormData = {
   imageUrl: string;
 };
@@ -6,3 +8,8 @@ export const DEFAULT_BANNER_DESIGN: BannerDesignFormData = {
   imageUrl:
     'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
 };
+
+export const createDefaultBannerDesign = (name: string): BannerDesign => ({
+  name,
+  ...DEFAULT_BANNER_DESIGN,
+});


### PR DESCRIPTION
## What does this change?

This PR adds a first configurable field to a banner design (beyond the existing name field). It is a required field and we provide a default when creating a new design. It is editable for existing designs too. The UI will show an inline error message if the user clears the field, and will show an alert if the user attempts to save a design with an empty image URL field. In this PR validation is based on presence only (i.e. it isn't validated for being a URL, we could add this in future).

![Screen Recording 2023-08-15 at 16 06 56 mov](https://github.com/guardian/support-admin-console/assets/379839/a70d50d5-1510-4f82-89c5-e76722fbc6ac)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
