### PR TITLE
Banner Design UI: Part 4 (Support for 3 different image sizes)

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -1,8 +1,15 @@
 package models
 
+case class BannerDesignImage(
+    mobileUrl: String,
+    tabletDesktopUrl: String,
+    wideUrl: String,
+    altText: String
+)
+
 case class BannerDesign(
     name: String,
-    imageUrl: String,
+    image: BannerDesignImage,
     lockStatus: Option[LockStatus],
 )
 

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -3,7 +3,10 @@ import { TextField, Typography } from '@material-ui/core';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
 import { BannerDesign } from '../../../models/BannerDesign';
-import { BannerDesignFormData as FormData, DEFAULT_BANNER_DESIGN } from './utils/defaults';
+import {
+  BannerDesignImageFormData as ImageFormData,
+  DEFAULT_BANNER_DESIGN,
+} from './utils/defaults';
 import { useStyles } from '../helpers/testEditorStyles';
 
 type Props = {
@@ -26,11 +29,14 @@ const BannerDesignForm: React.FC<Props> = ({
     setValidationStatus(validationScope, isValid);
   };
 
-  const defaultValues: FormData = {
-    imageUrl: design.imageUrl || DEFAULT_BANNER_DESIGN.imageUrl,
+  const defaultValues: ImageFormData = {
+    mobileUrl: design.image.mobileUrl || DEFAULT_BANNER_DESIGN.mobileUrl,
+    tabletDesktopUrl: design.image.tabletDesktopUrl || DEFAULT_BANNER_DESIGN.tabletDesktopUrl,
+    wideUrl: design.image.wideUrl || DEFAULT_BANNER_DESIGN.wideUrl,
+    altText: design.image.altText || DEFAULT_BANNER_DESIGN.altText,
   };
 
-  const { register, handleSubmit, errors, reset } = useForm<FormData>({
+  const { register, handleSubmit, errors, reset } = useForm<ImageFormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -39,14 +45,14 @@ const BannerDesignForm: React.FC<Props> = ({
     reset(defaultValues);
   }, [design]);
 
-  const onSubmit = ({ imageUrl }: FormData): void => {
-    onChange({ ...design, imageUrl });
+  const onSubmit = (formData: ImageFormData): void => {
+    onChange({ ...design, image: formData });
   };
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.imageUrl]);
+  }, [errors.mobileUrl, errors.tabletDesktopUrl, errors.wideUrl, errors.altText]);
 
   return (
     <div className={classes.container}>
@@ -59,11 +65,53 @@ const BannerDesignForm: React.FC<Props> = ({
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
             })}
-            error={errors.imageUrl !== undefined}
-            helperText={errors.imageUrl?.message}
+            error={errors.mobileUrl !== undefined}
+            helperText={errors.mobileUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="imageUrl"
-            label="Banner Image URL"
+            name="mobileUrl"
+            label="Banner Image URL (Mobile)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors.tabletDesktopUrl !== undefined}
+            helperText={errors.tabletDesktopUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="tabletDesktopUrl"
+            label="Banner Image URL (Tablet & Desktop)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors.wideUrl !== undefined}
+            helperText={errors.wideUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="wideUrl"
+            label="Banner Image URL (Wide)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors.altText !== undefined}
+            helperText={errors.altText?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="altText"
+            label="Banner Image Description (alt text)"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,15 +1,23 @@
 import { BannerDesign } from '../../../../models/BannerDesign';
 
-export type BannerDesignFormData = {
-  imageUrl: string;
+export type BannerDesignImageFormData = {
+  mobileUrl: string;
+  tabletDesktopUrl: string;
+  wideUrl: string;
+  altText: string;
 };
 
-export const DEFAULT_BANNER_DESIGN: BannerDesignFormData = {
-  imageUrl:
+export const DEFAULT_BANNER_DESIGN: BannerDesignImageFormData = {
+  mobileUrl:
     'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+  tabletDesktopUrl:
+    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+  wideUrl:
+    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+  altText: 'Image description',
 };
 
 export const createDefaultBannerDesign = (name: string): BannerDesign => ({
   name,
-  ...DEFAULT_BANNER_DESIGN,
+  image: DEFAULT_BANNER_DESIGN,
 });

--- a/public/src/models/BannerDesign.ts
+++ b/public/src/models/BannerDesign.ts
@@ -1,8 +1,15 @@
 import { LockStatus } from '../components/channelManagement/helpers/shared';
 
+interface BannerDesignImage {
+  mobileUrl: string;
+  tabletDesktopUrl: string;
+  wideUrl: string;
+  altText: string;
+}
+
 export interface BannerDesign {
   name: string;
-  imageUrl: string;
+  image: BannerDesignImage;
   isNew?: boolean;
   lockStatus?: LockStatus;
 }


### PR DESCRIPTION
## What does this change?

Adds support for multiple image URLs for different screen sizes: mobile, tablet/desktop and wide. From talking to Rik the convention is that 3 images are specified (although in the component 6 are supported, we specify 3 pairs).

I've slightly re-structured the BannerDesign type to have an complex "image" property which contains the 3 image URLs plus the alt text.

![Screenshot 2023-08-18 at 13 39 44](https://github.com/guardian/support-admin-console/assets/379839/8fcadff1-6ae0-42a0-9f1f-41f4d2d5c11e)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
