### PR TITLE
Banner Design UI: Part 5 (Banner variants have a template or a design)

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -3,82 +3,47 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import io.circe.generic.extras.semiauto._
-import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+import io.circe.{Decoder, Encoder, Json}
 
 sealed trait BannerUI
 object BannerUI {
-  case object AusEoyMomentBanner extends BannerUI
-  case object AusAnniversaryBanner extends BannerUI
-  case object AuBrandMomentBanner extends BannerUI
-  case object ChoiceCardsBannerBlue extends BannerUI
-  case object ChoiceCardsBannerYellow extends BannerUI
-  case object ChoiceCardsButtonsBannerBlue extends BannerUI
-  case object ChoiceCardsButtonsBannerYellow extends BannerUI
-  case object ClimateCrisisMomentBanner extends BannerUI
-  case object ContributionsBanner extends BannerUI
-  case object ContributionsBannerWithSignIn extends BannerUI
-  case object CharityAppealBanner extends BannerUI
-  case object DigitalSubscriptionsBanner extends BannerUI
-  case object ElectionAuMomentBanner extends BannerUI
-  case object EnvironmentMomentBanner extends BannerUI
-  case object GlobalNewYearBanner extends BannerUI
-  case object GuardianWeeklyBanner extends BannerUI
-  case object InvestigationsMomentBanner extends BannerUI
-  case object PostElectionAuMomentAlbaneseBanner extends BannerUI
-  case object PostElectionAuMomentHungBanner extends BannerUI
-  case object PostElectionAuMomentMorrisonBanner extends BannerUI
-  case object UkraineMomentBanner extends BannerUI
-  case object WorldPressFreedomDayBanner extends BannerUI
-  case object Scotus2023MomentBanner extends BannerUI
-  case class BannerDesignName(name: String) extends BannerUI
+  // For backwards compatibility BannerUI is either the name of a template, or has a nested designName field
+  case class BannerDesignName(designName: String) extends BannerUI
+  sealed trait BannerTemplate extends BannerUI
+
+  case object AusEoyMomentBanner extends BannerTemplate
+  case object AusAnniversaryBanner extends BannerTemplate
+  case object AuBrandMomentBanner extends BannerTemplate
+  case object ChoiceCardsBannerBlue extends BannerTemplate
+  case object ChoiceCardsBannerYellow extends BannerTemplate
+  case object ChoiceCardsButtonsBannerBlue extends BannerTemplate
+  case object ChoiceCardsButtonsBannerYellow extends BannerTemplate
+  case object ClimateCrisisMomentBanner extends BannerTemplate
+  case object ContributionsBanner extends BannerTemplate
+  case object ContributionsBannerWithSignIn extends BannerTemplate
+  case object CharityAppealBanner extends BannerTemplate
+  case object DigitalSubscriptionsBanner extends BannerTemplate
+  case object ElectionAuMomentBanner extends BannerTemplate
+  case object EnvironmentMomentBanner extends BannerTemplate
+  case object GlobalNewYearBanner extends BannerTemplate
+  case object GuardianWeeklyBanner extends BannerTemplate
+  case object InvestigationsMomentBanner extends BannerTemplate
+  case object PostElectionAuMomentAlbaneseBanner extends BannerTemplate
+  case object PostElectionAuMomentHungBanner extends BannerTemplate
+  case object PostElectionAuMomentMorrisonBanner extends BannerTemplate
+  case object UkraineMomentBanner extends BannerTemplate
+  case object WorldPressFreedomDayBanner extends BannerTemplate
+  case object Scotus2023MomentBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
+  import cats.syntax.functor._  // for the widen syntax
 
-  implicit val bannerDesignNameDecoder: Decoder[BannerDesignName] =
-    deriveDecoder[BannerDesignName]
-  implicit val bannerDesignNameEncoder: Encoder[BannerDesignName] =
-    deriveEncoder[BannerDesignName]
+  implicit val bannerUIDecoder: Decoder[BannerUI] = Decoder[BannerDesignName].widen or deriveEnumerationDecoder[BannerTemplate].widen
 
-  implicit val customDecoder: Decoder[BannerUI] = (c: HCursor) =>
-    c.as[String].flatMap {
-      case "AusEoyMomentBanner"      => Right(AusEoyMomentBanner)
-      case "AusAnniversaryBanner"    => Right(AusAnniversaryBanner)
-      case "AuBrandMomentBanner"     => Right(AuBrandMomentBanner)
-      case "ChoiceCardsBannerBlue"   => Right(ChoiceCardsBannerBlue)
-      case "ChoiceCardsBannerYellow" => Right(ChoiceCardsBannerYellow)
-      case "ChoiceCardsButtonsBannerBlue" =>
-        Right(ChoiceCardsButtonsBannerBlue)
-      case "ChoiceCardsButtonsBannerYellow" =>
-        Right(ChoiceCardsButtonsBannerYellow)
-      case "ClimateCrisisMomentBanner" => Right(ClimateCrisisMomentBanner)
-      case "ContributionsBanner"       => Right(ContributionsBanner)
-      case "ContributionsBannerWithSignIn" =>
-        Right(ContributionsBannerWithSignIn)
-      case "CharityAppealBanner"        => Right(CharityAppealBanner)
-      case "DigitalSubscriptionsBanner" => Right(DigitalSubscriptionsBanner)
-      case "ElectionAuMomentBanner"     => Right(ElectionAuMomentBanner)
-      case "EnvironmentMomentBanner"    => Right(EnvironmentMomentBanner)
-      case "GlobalNewYearBanner"        => Right(GlobalNewYearBanner)
-      case "GuardianWeeklyBanner"       => Right(GuardianWeeklyBanner)
-      case "InvestigationsMomentBanner" => Right(InvestigationsMomentBanner)
-      case "PostElectionAuMomentAlbaneseBanner" =>
-        Right(PostElectionAuMomentAlbaneseBanner)
-      case "PostElectionAuMomentHungBanner" =>
-        Right(PostElectionAuMomentHungBanner)
-      case "PostElectionAuMomentMorrisonBanner" =>
-        Right(PostElectionAuMomentMorrisonBanner)
-      case "UkraineMomentBanner"        => Right(UkraineMomentBanner)
-      case "WorldPressFreedomDayBanner" => Right(WorldPressFreedomDayBanner)
-      case "Scotus2023MomentBanner"     => Right(Scotus2023MomentBanner)
-      case stringValue =>
-        Left(
-          DecodingFailure(s"Unknown template value: $stringValue", c.history))
-    } orElse c.as[BannerDesignName]
-
-  implicit val customEncoder: Encoder[BannerUI] = Encoder.instance {
-    case designName: BannerDesignName =>
-      Json.obj("name" -> Json.fromString(designName.name))
-    case template => Json.fromString(s"$template")
+  implicit val bannerUIEncoder: Encoder[BannerUI] = Encoder.instance {
+    case BannerDesignName(designName) =>
+      Json.obj("designName" -> Json.fromString(designName))
+    case template: BannerTemplate => Json.fromString(s"$template")
   }
 }
 

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -3,83 +3,123 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import io.circe.generic.extras.semiauto._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 
-
-
-sealed trait BannerTemplate
-object BannerTemplate {
-  case object AusEoyMomentBanner extends BannerTemplate
-  case object AusAnniversaryBanner extends BannerTemplate
-  case object AuBrandMomentBanner extends BannerTemplate
-  case object ChoiceCardsBannerBlue extends BannerTemplate
-  case object ChoiceCardsBannerYellow extends BannerTemplate
-  case object ChoiceCardsButtonsBannerBlue extends BannerTemplate
-  case object ChoiceCardsButtonsBannerYellow extends BannerTemplate
-  case object ClimateCrisisMomentBanner extends BannerTemplate
-  case object ContributionsBanner extends BannerTemplate
-  case object ContributionsBannerWithSignIn extends BannerTemplate
-  case object CharityAppealBanner extends BannerTemplate
-  case object DigitalSubscriptionsBanner extends BannerTemplate
-  case object ElectionAuMomentBanner extends BannerTemplate
-  case object EnvironmentMomentBanner extends BannerTemplate
-  case object GlobalNewYearBanner extends BannerTemplate
-  case object GuardianWeeklyBanner extends BannerTemplate
-  case object InvestigationsMomentBanner extends BannerTemplate
-  case object PostElectionAuMomentAlbaneseBanner extends BannerTemplate
-  case object PostElectionAuMomentHungBanner extends BannerTemplate
-  case object PostElectionAuMomentMorrisonBanner extends BannerTemplate
-  case object UkraineMomentBanner extends BannerTemplate
-  case object WorldPressFreedomDayBanner extends BannerTemplate
-  case object Scotus2023MomentBanner extends BannerTemplate
+sealed trait BannerUI
+object BannerUI {
+  case object AusEoyMomentBanner extends BannerUI
+  case object AusAnniversaryBanner extends BannerUI
+  case object AuBrandMomentBanner extends BannerUI
+  case object ChoiceCardsBannerBlue extends BannerUI
+  case object ChoiceCardsBannerYellow extends BannerUI
+  case object ChoiceCardsButtonsBannerBlue extends BannerUI
+  case object ChoiceCardsButtonsBannerYellow extends BannerUI
+  case object ClimateCrisisMomentBanner extends BannerUI
+  case object ContributionsBanner extends BannerUI
+  case object ContributionsBannerWithSignIn extends BannerUI
+  case object CharityAppealBanner extends BannerUI
+  case object DigitalSubscriptionsBanner extends BannerUI
+  case object ElectionAuMomentBanner extends BannerUI
+  case object EnvironmentMomentBanner extends BannerUI
+  case object GlobalNewYearBanner extends BannerUI
+  case object GuardianWeeklyBanner extends BannerUI
+  case object InvestigationsMomentBanner extends BannerUI
+  case object PostElectionAuMomentAlbaneseBanner extends BannerUI
+  case object PostElectionAuMomentHungBanner extends BannerUI
+  case object PostElectionAuMomentMorrisonBanner extends BannerUI
+  case object UkraineMomentBanner extends BannerUI
+  case object WorldPressFreedomDayBanner extends BannerUI
+  case object Scotus2023MomentBanner extends BannerUI
+  case class BannerDesignName(name: String) extends BannerUI
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val bannerTemplateEncoder = deriveEnumerationEncoder[BannerTemplate]
-  implicit val bannerTemplateDecoder = deriveEnumerationDecoder[BannerTemplate]
+
+  implicit val bannerDesignNameDecoder: Decoder[BannerDesignName] =
+    deriveDecoder[BannerDesignName]
+
+  implicit val customDecoder: Decoder[BannerUI] = (c: HCursor) =>
+    c.as[String].flatMap {
+      case "AusEoyMomentBanner"      => Right(AusEoyMomentBanner)
+      case "AusAnniversaryBanner"    => Right(AusAnniversaryBanner)
+      case "AuBrandMomentBanner"     => Right(AuBrandMomentBanner)
+      case "ChoiceCardsBannerBlue"   => Right(ChoiceCardsBannerBlue)
+      case "ChoiceCardsBannerYellow" => Right(ChoiceCardsBannerYellow)
+      case "ChoiceCardsButtonsBannerBlue" =>
+        Right(ChoiceCardsButtonsBannerBlue)
+      case "ChoiceCardsButtonsBannerYellow" =>
+        Right(ChoiceCardsButtonsBannerYellow)
+      case "ClimateCrisisMomentBanner" => Right(ClimateCrisisMomentBanner)
+      case "ContributionsBanner"       => Right(ContributionsBanner)
+      case "ContributionsBannerWithSignIn" =>
+        Right(ContributionsBannerWithSignIn)
+      case "CharityAppealBanner"        => Right(CharityAppealBanner)
+      case "DigitalSubscriptionsBanner" => Right(DigitalSubscriptionsBanner)
+      case "ElectionAuMomentBanner"     => Right(ElectionAuMomentBanner)
+      case "EnvironmentMomentBanner"    => Right(EnvironmentMomentBanner)
+      case "GlobalNewYearBanner"        => Right(GlobalNewYearBanner)
+      case "GuardianWeeklyBanner"       => Right(GuardianWeeklyBanner)
+      case "InvestigationsMomentBanner" => Right(InvestigationsMomentBanner)
+      case "PostElectionAuMomentAlbaneseBanner" =>
+        Right(PostElectionAuMomentAlbaneseBanner)
+      case "PostElectionAuMomentHungBanner" =>
+        Right(PostElectionAuMomentHungBanner)
+      case "PostElectionAuMomentMorrisonBanner" =>
+        Right(PostElectionAuMomentMorrisonBanner)
+      case "UkraineMomentBanner"        => Right(UkraineMomentBanner)
+      case "WorldPressFreedomDayBanner" => Right(WorldPressFreedomDayBanner)
+      case "Scotus2023MomentBanner"     => Right(Scotus2023MomentBanner)
+      case stringValue =>
+        Left(
+          DecodingFailure(s"Unknown template value: $stringValue", c.history))
+    } orElse c.as[BannerDesignName]
 }
 
 case class BannerContent(
-  heading: Option[String],
-  paragraphs: Option[List[String]],
-  messageText: Option[String],
-  highlightedText: Option[String],
-  cta: Option[Cta],
-  secondaryCta: Option[SecondaryCta]
+    heading: Option[String],
+    paragraphs: Option[List[String]],
+    messageText: Option[String],
+    highlightedText: Option[String],
+    cta: Option[Cta],
+    secondaryCta: Option[SecondaryCta]
 )
 
 case class BannerVariant(
-  name: String,
-  template: BannerTemplate,
-  bannerContent: Option[BannerContent],
-  mobileBannerContent: Option[BannerContent],
-  separateArticleCount: Option[Boolean],
-  tickerSettings: Option[TickerSettings] = None,
+    name: String,
+    template: BannerUI,
+    bannerContent: Option[BannerContent],
+    mobileBannerContent: Option[BannerContent],
+    separateArticleCount: Option[Boolean],
+    tickerSettings: Option[TickerSettings] = None,
 )
 
 case class BannerTest(
-  name: String,
-  channel: Option[Channel],
-  status: Option[Status],
-  lockStatus: Option[LockStatus],
-  priority: Option[Int],
-  nickname: Option[String],
-  minArticlesBeforeShowingBanner: Int,
-  userCohort: UserCohort,
-  locations: List[Region] = Nil,
-  variants: List[BannerVariant],
-  articlesViewedSettings: Option[ArticlesViewedSettings] = None,
-  controlProportionSettings: Option[ControlProportionSettings] = None,
-  deviceType: Option[DeviceType] = None,
-  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-  signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
+    name: String,
+    channel: Option[Channel],
+    status: Option[Status],
+    lockStatus: Option[LockStatus],
+    priority: Option[Int],
+    nickname: Option[String],
+    minArticlesBeforeShowingBanner: Int,
+    userCohort: UserCohort,
+    locations: List[Region] = Nil,
+    variants: List[BannerVariant],
+    articlesViewedSettings: Option[ArticlesViewedSettings] = None,
+    controlProportionSettings: Option[ControlProportionSettings] = None,
+    deviceType: Option[DeviceType] = None,
+    campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
+    signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
 ) extends ChannelTest[BannerTest] {
 
-  override def withChannel(channel: Channel): BannerTest = this.copy(channel = Some(channel))
-  override def withPriority(priority: Int): BannerTest = this.copy(priority = Some(priority))
+  override def withChannel(channel: Channel): BannerTest =
+    this.copy(channel = Some(channel))
+  override def withPriority(priority: Int): BannerTest =
+    this.copy(priority = Some(priority))
 }
 
 object BannerTest {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val bannerTestDecoder: Decoder[BannerTest] = deriveConfiguredDecoder[BannerTest]
-  implicit val bannerTestEncoder: Encoder[BannerTest] = deriveConfiguredEncoder[BannerTest]
+  implicit val bannerTestDecoder: Decoder[BannerTest] =
+    deriveConfiguredDecoder[BannerTest]
+  implicit val bannerTestEncoder: Encoder[BannerTest] =
+    deriveConfiguredEncoder[BannerTest]
 }

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -36,6 +36,8 @@ object BannerUI {
 
   implicit val bannerDesignNameDecoder: Decoder[BannerDesignName] =
     deriveDecoder[BannerDesignName]
+  implicit val bannerDesignNameEncoder: Encoder[BannerDesignName] =
+    deriveEncoder[BannerDesignName]
 
   implicit val customDecoder: Decoder[BannerUI] = (c: HCursor) =>
     c.as[String].flatMap {
@@ -72,6 +74,12 @@ object BannerUI {
         Left(
           DecodingFailure(s"Unknown template value: $stringValue", c.history))
     } orElse c.as[BannerDesignName]
+
+  implicit val customEncoder: Encoder[BannerUI] = Encoder.instance {
+    case designName: BannerDesignName =>
+      Json.obj("name" -> Json.fromString(designName.name))
+    case template => Json.fromString(s"$template")
+  }
 }
 
 case class BannerContent(

--- a/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTemplateSelector.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import { MenuItem, Select } from '@material-ui/core';
-import { BannerTemplate } from '../../../models/banner';
-
-function isBannerTemplate(s: string): s is BannerTemplate {
-  return Object.values(BannerTemplate).includes(s as BannerTemplate);
-}
+import { BannerTemplate, BannerUI, isBannerTemplate } from '../../../models/banner';
 
 interface BannerTemplateSelectorProps {
-  template: BannerTemplate;
+  template: BannerUI;
   onTemplateChange: (updatedTemplate: BannerTemplate) => void;
   editMode: boolean;
 }

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Region } from '../../../utils/models';
 import { ArticlesViewedSettings, DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
@@ -19,6 +19,12 @@ import { ControlProportionSettings } from '../helpers/controlProportionSettings'
 import TestVariantsSplitEditor from '../testVariantsSplitEditor';
 import { useStyles } from '../helpers/testEditorStyles';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
+import { BannerDesign } from '../../../models/BannerDesign';
+import {
+  BannerDesignsResponse,
+  fetchFrontendSettings,
+  FrontendSettingsType,
+} from '../../../utils/requests';
 
 const copyHasTemplate = (content: BannerContent, template: string): boolean =>
   (content.heading && content.heading.includes(template)) ||
@@ -39,6 +45,20 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   setValidationStatusForField,
 }: ValidatedTestEditorProps<BannerTest>) => {
   const classes = useStyles();
+
+  const [designs, setDesigns] = useState<BannerDesign[]>([]);
+
+  const fetchBannerDesigns = (): void => {
+    fetchFrontendSettings(FrontendSettingsType.bannerDesigns).then(
+      (response: BannerDesignsResponse) => {
+        setDesigns(response.bannerDesigns);
+      },
+    );
+  };
+
+  useEffect(() => {
+    fetchBannerDesigns();
+  }, []);
 
   const getArticlesViewedSettings = (test: BannerTest): ArticlesViewedSettings | undefined => {
     if (!!test.articlesViewedSettings) {
@@ -133,6 +153,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
       onVariantChange={onVariantChange}
       onDelete={(): void => onVariantDelete(variant.name)}
       editMode={userHasTestLocked}
+      designs={designs}
       onValidationChange={(isValid: boolean): void =>
         setValidationStatusForField(variant.name, isValid)
       }

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -17,7 +17,7 @@ import {
 } from '../helpers/validation';
 import { Cta, SecondaryCta } from '../helpers/shared';
 import BannerTemplateSelector from './bannerTemplateSelector';
-import { BannerContent, BannerTemplate, BannerVariant } from '../../../models/banner';
+import { BannerContent, BannerTemplate, BannerUI, BannerVariant } from '../../../models/banner';
 import { getDefaultVariant } from './utils/defaults';
 import useValidation from '../hooks/useValidation';
 import {
@@ -97,7 +97,7 @@ const getLabelSuffix = (deviceType: DeviceType): string => {
 
 interface BannerTestVariantContentEditorProps {
   content: BannerContent;
-  template: BannerTemplate;
+  template: BannerUI;
   onChange: (updatedContent: BannerContent) => void;
   onValidationChange: (isValid: boolean) => void;
   editMode: boolean;

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -16,8 +16,8 @@ import {
   templateValidatorForPlatform,
 } from '../helpers/validation';
 import { Cta, SecondaryCta } from '../helpers/shared';
-import BannerTemplateSelector from './bannerTemplateSelector';
-import { BannerContent, BannerTemplate, BannerUI, BannerVariant } from '../../../models/banner';
+import BannerUiSelector from './bannerUiSelector';
+import { BannerContent, BannerTemplate, BannerUi, BannerVariant } from '../../../models/banner';
 import { getDefaultVariant } from './utils/defaults';
 import useValidation from '../hooks/useValidation';
 import {
@@ -97,7 +97,7 @@ const getLabelSuffix = (deviceType: DeviceType): string => {
 
 interface BannerTestVariantContentEditorProps {
   content: BannerContent;
-  template: BannerUI;
+  template: BannerUi;
   onChange: (updatedContent: BannerContent) => void;
   onValidationChange: (isValid: boolean) => void;
   editMode: boolean;
@@ -391,12 +391,12 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
         <Typography className={classes.sectionHeader} variant="h4">
           Banner template
         </Typography>
-        <BannerTemplateSelector
-          template={variant.template}
-          onTemplateChange={(template): void =>
+        <BannerUiSelector
+          ui={variant.template}
+          onUiChange={(ui: BannerUi): void =>
             onVariantChange({
               ...variant,
-              template,
+              template: ui,
             })
           }
           editMode={editMode}

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -26,6 +26,7 @@ import {
   RichTextEditorSingleLine,
 } from '../richTextEditor/richTextEditor';
 import TickerEditor from '../tickerEditor';
+import { BannerDesign } from '../../../models/BannerDesign';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -356,6 +357,7 @@ interface BannerTestVariantEditorProps {
   editMode: boolean;
   onDelete: () => void;
   onValidationChange: (isValid: boolean) => void;
+  designs: BannerDesign[];
 }
 
 const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
@@ -363,6 +365,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   editMode,
   onValidationChange,
   onVariantChange,
+  designs,
 }: BannerTestVariantEditorProps) => {
   const classes = useStyles();
   const setValidationStatusForField = useValidation(onValidationChange);
@@ -393,6 +396,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
         </Typography>
         <BannerUiSelector
           ui={variant.template}
+          designs={designs}
           onUiChange={(ui: BannerUi): void =>
             onVariantChange({
               ...variant,

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -16,6 +16,7 @@ import {
   uiIsDesign,
 } from '../../../models/banner';
 import { BannerDesign } from '../../../models/BannerDesign';
+import { shouldShowBannerDesignsFeature } from '../../../utils/features';
 
 interface BannerUiSelectorProps {
   ui: BannerUi;
@@ -147,27 +148,29 @@ const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
 
   return (
     <>
-      <div>
-        <FormControl>
-          <FormLabel>UI Type</FormLabel>
-          <RadioGroup
-            name="controlled-radio-buttons-group"
-            value={uiType}
-            onChange={onUiTypeChange}
-          >
-            <FormControlLabel
-              value="Template"
-              control={<Radio disabled={!editMode} />}
-              label="Template"
-            />
-            <FormControlLabel
-              value="Design"
-              control={<Radio disabled={!editMode} />}
-              label="Design"
-            />
-          </RadioGroup>
-        </FormControl>
-      </div>
+      {shouldShowBannerDesignsFeature() && (
+        <div>
+          <FormControl>
+            <FormLabel>UI Type</FormLabel>
+            <RadioGroup
+              name="controlled-radio-buttons-group"
+              value={uiType}
+              onChange={onUiTypeChange}
+            >
+              <FormControlLabel
+                value="Template"
+                control={<Radio disabled={!editMode} />}
+                label="Template"
+              />
+              <FormControlLabel
+                value="Design"
+                control={<Radio disabled={!editMode} />}
+                label="Design"
+              />
+            </RadioGroup>
+          </FormControl>
+        </div>
+      )}
 
       {uiIsDesign(ui) ? (
         <BannerDesignSelector

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -104,8 +104,10 @@ const BannerDesignSelector: React.FC<BannerDesignSelectorProps> = ({
 }: BannerDesignSelectorProps) => {
   const onChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     const designName = event.target.value as string;
-    // TODO: Verify that this is a valid design name
-    onUiChange({ designName });
+    const isValidBannerDesign = designs.map(d => d.name).includes(designName);
+    if (isValidBannerDesign) {
+      onUiChange({ designName });
+    }
   };
 
   return (

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { MenuItem, Select } from '@material-ui/core';
-import { BannerTemplate, BannerUI, isBannerTemplate } from '../../../models/banner';
+import { BannerTemplate, BannerUi, isBannerTemplate, uiIsDesign } from '../../../models/banner';
+
+interface BannerUiSelectorProps {
+  ui: BannerUi;
+  onUiChange: (updatedUi: BannerUi) => void;
+  editMode: boolean;
+}
 
 interface BannerTemplateSelectorProps {
-  template: BannerUI;
-  onTemplateChange: (updatedTemplate: BannerTemplate) => void;
+  template: BannerTemplate;
+  onUiChange: (updatedUi: BannerUi) => void;
   editMode: boolean;
 }
 
@@ -46,13 +52,13 @@ const templatesWithLabels = [
 
 const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({
   template,
-  onTemplateChange,
+  onUiChange,
   editMode,
 }: BannerTemplateSelectorProps) => {
   const onChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     const value = event.target.value as string;
     if (isBannerTemplate(value)) {
-      onTemplateChange(value);
+      onUiChange(value);
     }
   };
 
@@ -67,4 +73,16 @@ const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({
   );
 };
 
-export default BannerTemplateSelector;
+const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
+  ui,
+  onUiChange,
+  editMode,
+}: BannerUiSelectorProps) => {
+  if (uiIsDesign(ui)) {
+    return <div>Implement design picker!</div>;
+  } else {
+    return <BannerTemplateSelector template={ui} onUiChange={onUiChange} editMode={editMode} />;
+  }
+};
+
+export default BannerUiSelector;

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -136,9 +136,10 @@ const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
     const uiType = event.target.value as UiType;
     setUiType(uiType);
 
-    onUiChange(
-      uiType === 'Design' ? { designName: 'EXAMPLE' } : BannerTemplate.ContributionsBanner,
-    );
+    const defaultUI =
+      uiType === 'Design' ? { designName: designs[0]?.name } : BannerTemplate.ContributionsBanner;
+
+    onUiChange(defaultUI);
   };
 
   useEffect(() => {

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -15,11 +15,13 @@ import {
   isBannerTemplate,
   uiIsDesign,
 } from '../../../models/banner';
+import { BannerDesign } from '../../../models/BannerDesign';
 
 interface BannerUiSelectorProps {
   ui: BannerUi;
   onUiChange: (updatedUi: BannerUi) => void;
   editMode: boolean;
+  designs: BannerDesign[];
 }
 
 const templatesWithLabels = [
@@ -91,20 +93,14 @@ interface BannerDesignSelectorProps {
   design: BannerDesignName;
   onUiChange: (updatedUi: BannerUi) => void;
   editMode: boolean;
+  designs: BannerDesign[];
 }
-
-// TODO: Thread these through dynamically
-const bannerDesignNames: BannerDesignName[] = [
-  { designName: 'EXAMPLE' },
-  { designName: 'FOO' },
-  { designName: 'BAR' },
-  { designName: 'BAZ' },
-];
 
 const BannerDesignSelector: React.FC<BannerDesignSelectorProps> = ({
   design,
   onUiChange,
   editMode,
+  designs,
 }: BannerDesignSelectorProps) => {
   const onChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     const designName = event.target.value as string;
@@ -114,9 +110,9 @@ const BannerDesignSelector: React.FC<BannerDesignSelectorProps> = ({
 
   return (
     <Select value={design.designName} onChange={onChange} disabled={!editMode}>
-      {bannerDesignNames.map(design => (
-        <MenuItem value={design.designName} key={design.designName}>
-          {design.designName}
+      {designs.map(design => (
+        <MenuItem value={design.name} key={design.name}>
+          {design.name}
         </MenuItem>
       ))}
     </Select>
@@ -129,6 +125,7 @@ const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
   ui,
   onUiChange,
   editMode,
+  designs,
 }: BannerUiSelectorProps) => {
   const [uiType, setUiType] = useState<UiType>(uiIsDesign(ui) ? 'Design' : 'Template');
 
@@ -171,7 +168,12 @@ const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
       </div>
 
       {uiIsDesign(ui) ? (
-        <BannerDesignSelector design={ui} onUiChange={onUiChange} editMode={editMode} />
+        <BannerDesignSelector
+          design={ui}
+          onUiChange={onUiChange}
+          editMode={editMode}
+          designs={designs}
+        />
       ) : (
         <BannerTemplateSelector template={ui} onUiChange={onUiChange} editMode={editMode} />
       )}

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -142,7 +142,7 @@ const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
   };
 
   useEffect(() => {
-    // This isn't part of the design, so when changes are discarded we want to reflect the unedited configuration
+    // This state isn't part of the variant, so when changes are discarded we want to reflect the unedited variant
     setUiType(uiIsDesign(ui) ? 'Design' : 'Template');
   }, [editMode]);
 

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -2,7 +2,12 @@ import React, { useState } from 'react';
 import { Theme, makeStyles, Button } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
-import { BannerTemplate, BannerVariant, BannerContent } from '../../../models/banner';
+import {
+  BannerTemplate,
+  BannerVariant,
+  BannerContent,
+  isBannerTemplate,
+} from '../../../models/banner';
 import Typography from '@material-ui/core/Typography';
 import { useModule } from '../../../hooks/useModule';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
@@ -226,10 +231,18 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   const [drawerOpen, setDrawerOpen] = useState<boolean>();
   const tickerSettingsWithData = useTickerData(variant.tickerSettings);
 
-  const Banner = useModule<BannerProps>(
-    `banners/${bannerModules[variant.template].path}`,
-    bannerModules[variant.template].name,
-  );
+  const moduleConfig = isBannerTemplate(variant.template)
+    ? {
+        path: `banners/${bannerModules[variant.template].path}`,
+        name: bannerModules[variant.template].name,
+      }
+    : {
+        // TODO: fixme!
+        path: `banners/hardcoded/banner/design/path`,
+        name: `designable banner name`,
+      };
+
+  const Banner = useModule<BannerProps>(moduleConfig.path, moduleConfig.name);
 
   const toggleDrawer = (open: boolean) => (event: React.MouseEvent): void => {
     event.stopPropagation();

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -7,7 +7,7 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import RRControlPanelLogo from './rrControlPanelLogo';
-import { getStage } from '../utils/stage';
+import { shouldShowBannerDesignsFeature } from '../utils/features';
 
 const useStyles = makeStyles({
   list: {
@@ -124,11 +124,6 @@ export default function NavDrawer(): React.ReactElement {
     return now.getMonth() == 9 && now.getDate() == 31;
   };
 
-  const shouldShowBannerDesignNav = (): boolean => {
-    const stage = getStage();
-    return stage !== 'PROD' && stage !== 'CODE';
-  };
-
   const list = (anchor: string): React.ReactElement => (
     <div
       className={classes.list}
@@ -201,7 +196,7 @@ export default function NavDrawer(): React.ReactElement {
             <span className={classes.super}>🦸</span>
           </ListItem>
         </Link>
-        {shouldShowBannerDesignNav() && (
+        {shouldShowBannerDesignsFeature() && (
           <Link key="Banner Designs" to="/banner-designs" className={classes.link}>
             <ListItem className={classes.listItem} button key="Banner Designs">
               <ListItemText primary="Banner Designs" />

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -33,7 +33,7 @@ export enum BannerTemplate {
 }
 
 export interface BannerDesignName {
-  name: string;
+  designName: string;
 }
 
 export type BannerUI = BannerTemplate | BannerDesignName;
@@ -66,6 +66,10 @@ export interface BannerTest extends Test {
   controlProportionSettings?: ControlProportionSettings;
   deviceType?: DeviceType;
   campaignName?: string;
+}
+
+export function uiIsDesign(ui: BannerUI): ui is BannerDesignName {
+  return (ui as BannerDesignName).designName !== undefined;
 }
 
 export function isBannerTemplate(s: BannerUI | string): s is BannerTemplate {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -11,7 +11,6 @@ import {
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
-import BannerTemplateSelector from '../components/channelManagement/bannerTests/bannerTemplateSelector';
 
 export enum BannerTemplate {
   AusAnniversaryBanner = 'AusAnniversaryBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -36,7 +36,7 @@ export interface BannerDesignName {
   designName: string;
 }
 
-export type BannerUI = BannerTemplate | BannerDesignName;
+export type BannerUi = BannerTemplate | BannerDesignName;
 
 export interface BannerContent {
   heading?: string;
@@ -47,7 +47,7 @@ export interface BannerContent {
   secondaryCta?: SecondaryCta;
 }
 export interface BannerVariant extends Variant {
-  template: BannerUI;
+  template: BannerUi;
   bannerContent: BannerContent;
   mobileBannerContent?: BannerContent;
   separateArticleCount?: boolean;
@@ -68,10 +68,10 @@ export interface BannerTest extends Test {
   campaignName?: string;
 }
 
-export function uiIsDesign(ui: BannerUI): ui is BannerDesignName {
+export function uiIsDesign(ui: BannerUi): ui is BannerDesignName {
   return (ui as BannerDesignName).designName !== undefined;
 }
 
-export function isBannerTemplate(s: BannerUI | string): s is BannerTemplate {
+export function isBannerTemplate(s: BannerUi | string): s is BannerTemplate {
   return Object.values(BannerTemplate).includes(s as BannerTemplate);
 }

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -11,6 +11,7 @@ import {
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
+import BannerTemplateSelector from '../components/channelManagement/bannerTests/bannerTemplateSelector';
 
 export enum BannerTemplate {
   AusAnniversaryBanner = 'AusAnniversaryBanner',
@@ -32,6 +33,12 @@ export enum BannerTemplate {
   Scotus2023MomentBanner = 'Scotus2023MomentBanner',
 }
 
+export interface BannerDesignName {
+  name: string;
+}
+
+export type BannerUI = BannerTemplate | BannerDesignName;
+
 export interface BannerContent {
   heading?: string;
   messageText?: string;
@@ -41,7 +48,7 @@ export interface BannerContent {
   secondaryCta?: SecondaryCta;
 }
 export interface BannerVariant extends Variant {
-  template: BannerTemplate;
+  template: BannerUI;
   bannerContent: BannerContent;
   mobileBannerContent?: BannerContent;
   separateArticleCount?: boolean;
@@ -60,4 +67,8 @@ export interface BannerTest extends Test {
   controlProportionSettings?: ControlProportionSettings;
   deviceType?: DeviceType;
   campaignName?: string;
+}
+
+export function isBannerTemplate(s: BannerUI | string): s is BannerTemplate {
+  return Object.values(BannerTemplate).includes(s as BannerTemplate);
 }

--- a/public/src/utils/features.ts
+++ b/public/src/utils/features.ts
@@ -1,0 +1,6 @@
+import { getStage } from './stage';
+
+export const shouldShowBannerDesignsFeature = (): boolean => {
+  const stage = getStage();
+  return stage !== 'PROD' && stage !== 'CODE';
+};

--- a/test/models/BannerTestsSpec.scala
+++ b/test/models/BannerTestsSpec.scala
@@ -5,7 +5,12 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.parser._
-import models.BannerUI.{BannerDesignName, Scotus2023MomentBanner}
+import io.circe.syntax.EncoderOps
+import models.BannerUI.{
+  AusAnniversaryBanner,
+  BannerDesignName,
+  Scotus2023MomentBanner
+}
 
 import scala.language.postfixOps
 
@@ -56,5 +61,24 @@ class BannerTestsSpec extends AnyFlatSpec with Matchers with EitherValues {
     val result = decode[BannerUI](rawJson)
 
     result.left.value shouldBe a[DecodingFailure]
+  }
+
+  "encoding json" should "return an object for a BannerDesignName" in {
+    val bannerDesignName = BannerDesignName("TEST_DESIGN")
+
+    val json = bannerDesignName.asJson
+
+    val expectedJson = Json.obj(
+      "name" -> Json.fromString("TEST_DESIGN")
+    )
+    json should be(expectedJson)
+  }
+
+  it should "return a string for a named template" in {
+    val template: BannerUI = AusAnniversaryBanner
+
+    val json = template.asJson
+
+    json should be(Json.fromString("AusAnniversaryBanner"))
   }
 }

--- a/test/models/BannerTestsSpec.scala
+++ b/test/models/BannerTestsSpec.scala
@@ -1,0 +1,60 @@
+package models
+
+import io.circe.{DecodingFailure, Json}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.circe.parser._
+import models.BannerUI.{BannerDesignName, Scotus2023MomentBanner}
+
+import scala.language.postfixOps
+
+class BannerTestsSpec extends AnyFlatSpec with Matchers with EitherValues {
+  "decoding json" should "return a BannerDesignName when the json is an object with a name field" in {
+    val rawJson =
+      """
+        |{
+        |  "name": "TEST_DESIGN"
+        |}
+        |""".stripMargin
+
+    val result = decode[BannerUI](rawJson)
+
+    result.value should be(BannerDesignName("TEST_DESIGN"))
+  }
+
+  it should "return the correct case object when the json is a string with a matching case class" in {
+    val rawJson =
+      """
+        |"Scotus2023MomentBanner"
+        |""".stripMargin
+
+    val result = decode[BannerUI](rawJson)
+
+    result.value should be(Scotus2023MomentBanner)
+  }
+
+  it should "return an error when the json is a string with no matching case class" in {
+    val rawJson =
+      """
+        |"FooBarBaz"
+        |""".stripMargin
+
+    val result = decode[BannerUI](rawJson)
+
+    result.left.value shouldBe a[DecodingFailure]
+  }
+
+  it should "return an error when the json is an object of the wrong shape" in {
+    val rawJson =
+      """
+        |{
+        |  "foo": "bar"
+        |}
+        |""".stripMargin
+
+    val result = decode[BannerUI](rawJson)
+
+    result.left.value shouldBe a[DecodingFailure]
+  }
+}

--- a/test/models/BannerTestsSpec.scala
+++ b/test/models/BannerTestsSpec.scala
@@ -19,7 +19,7 @@ class BannerTestsSpec extends AnyFlatSpec with Matchers with EitherValues {
     val rawJson =
       """
         |{
-        |  "name": "TEST_DESIGN"
+        |  "designName": "TEST_DESIGN"
         |}
         |""".stripMargin
 
@@ -64,12 +64,12 @@ class BannerTestsSpec extends AnyFlatSpec with Matchers with EitherValues {
   }
 
   "encoding json" should "return an object for a BannerDesignName" in {
-    val bannerDesignName = BannerDesignName("TEST_DESIGN")
+    val bannerDesignName: BannerUI = BannerDesignName("TEST_DESIGN")
 
     val json = bannerDesignName.asJson
 
     val expectedJson = Json.obj(
-      "name" -> Json.fromString("TEST_DESIGN")
+      "designName" -> Json.fromString("TEST_DESIGN")
     )
     json should be(expectedJson)
   }


### PR DESCRIPTION
## What does this change?

This PR updates the banner variant model to have either a template (as it does now) or a banner design. When creating/editing a banner variant you will be able to choose between selecting a variant or selecting a design:

![Screen Recording 2023-08-25 at 15 31 55 mov](https://github.com/guardian/support-admin-console/assets/379839/61a50678-f703-4f30-b4f0-2480798c8901)

This toggling is hidden behind a feature flag in CODE and PROD, so it isn't actually possible to give a banner variant a design in these environments. This is a good thing because currently SDC wouldn't know what to do in the case where a banner variant has a design, so would break.

The banner variant model has been extended in a backwards compatible way which I think means this change is safe to deploy. The TS variant model has been updated to go from having this:

```ts
template: BannerTemplate
```

to having this:

```ts
template: BannerTemplate | BannerDesignName
```

where `BannerDesignName` looks like this:

```ts
export interface BannerDesignName {
  designName: string;
}
```

So for all existing cases, where a `BannerTemplate` is specified, things will continue to work as they are.

On the server when creating/updating variants there isn't any validation currently that the banner design specified actually exists. I'm intending to add this in a future PR.

Note: previewing doesn't currently work for variants with a design (and won't work until SDC has been updated).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
