### PR TITLE
Europe local language moment banner, add to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -34,6 +34,7 @@ object BannerUI {
   case object UkraineMomentBanner extends BannerTemplate
   case object WorldPressFreedomDayBanner extends BannerTemplate
   case object Scotus2023MomentBanner extends BannerTemplate
+  case object EuropeMomentLocalLanguageBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   import cats.syntax.functor._  // for the widen syntax

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -297,7 +297,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.GlobalNewYearBanner ||
             template === BannerTemplate.UkraineMomentBanner ||
             template === BannerTemplate.WorldPressFreedomDayBanner ||
-            template === BannerTemplate.Scotus2023MomentBanner) && (
+            template === BannerTemplate.Scotus2023MomentBanner ||
+            template === BannerTemplate.EuropeMomentLocalLanguageBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -59,6 +59,10 @@ const templatesWithLabels = [
     template: BannerTemplate.Scotus2023MomentBanner,
     label: 'US Supreme Court 2023 Moment',
   },
+  {
+    template: BannerTemplate.EuropeMomentLocalLanguageBanner,
+    label: 'Europe Moment Local Language 2023',
+  },
 ];
 
 interface BannerTemplateSelectorProps {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -174,6 +174,10 @@ const bannerModules = {
     path: 'usSupremeCourt2023/Scotus2023MomentBanner.js',
     name: 'Scotus2023MomentBanner',
   },
+  [BannerTemplate.EuropeMomentLocalLanguageBanner]: {
+    path: 'europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.js',
+    name: 'EuropeMomentLocalLanguageBanner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -31,6 +31,7 @@ export enum BannerTemplate {
   UkraineMomentBanner = 'UkraineMomentBanner',
   WorldPressFreedomDayBanner = 'WorldPressFreedomDayBanner',
   Scotus2023MomentBanner = 'Scotus2023MomentBanner',
+  EuropeMomentLocalLanguageBanner = 'EuropeMomentLocalLanguageBanner',
 }
 
 export interface BannerDesignName {


### PR DESCRIPTION
## What does this change?

Creates a 'Local Language Moment 2023' banner using the moments template banner setup within a dropdown in the RRCP

[Trello] https://trello.com/c/OUXtdFcx/1497-europe-moment-banner-headline-in-local-language

[SupportDotcom Local Language Banner PR] https://github.com/guardian/support-dotcom-components/pull/943 

## Images
![image](https://github.com/guardian/support-admin-console/assets/76729591/e100bc65-51b8-4d91-abe2-ef2ba07bb1b6)


