### PR TITLE
Improve withS3Data

### DIFF
--- a/public/src/components/amounts/AmountsForm.tsx
+++ b/public/src/components/amounts/AmountsForm.tsx
@@ -43,9 +43,9 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 
 const AmountsForm: React.FC<InnerProps<AmountsTests>> = ({
   data: configuredAmounts,
-  setData: setConfiguredAmounts,
-  saveData: saveConfiguredAmounts,
-  replaceData: replaceConfiguredAmounts,
+  update,
+  sendToS3,
+  updateAndSendToS3,
 }: InnerProps<AmountsTests>) => {
   const classes = useStyles();
 
@@ -139,7 +139,7 @@ const AmountsForm: React.FC<InnerProps<AmountsTests>> = ({
       };
 
       const updatedTests = [...configuredAmounts, newTest];
-      setConfiguredAmounts(updatedTests);
+      update(updatedTests);
       setSelectedTest({ ...newTest });
     }
   };
@@ -147,19 +147,13 @@ const AmountsForm: React.FC<InnerProps<AmountsTests>> = ({
   const updateLocalTest = (updated: AmountsTest) => {
     const updatedTests = configuredAmounts.filter(t => t.testName !== updated.testName);
     updatedTests.push(updated);
-    setConfiguredAmounts(updatedTests);
+    update(updatedTests);
   };
 
   const deleteLocalTest = (name: string) => {
-    if (replaceConfiguredAmounts) {
-      const updatedTests = configuredAmounts.filter(t => t.testName !== name);
-      replaceConfiguredAmounts(updatedTests);
-      setSelectedTest(undefined);
-    }
-  };
-
-  const saveLocalTestToS3 = () => {
-    saveConfiguredAmounts();
+    const updatedTests = configuredAmounts.filter(t => t.testName !== name);
+    updateAndSendToS3(updatedTests);
+    setSelectedTest(undefined);
   };
 
   return (
@@ -178,7 +172,7 @@ const AmountsForm: React.FC<InnerProps<AmountsTests>> = ({
         <AmountsTestEditor
           test={selectedTest}
           checkLiveTestNameIsUnique={checkLiveTestNameIsUnique}
-          saveTest={saveLocalTestToS3}
+          saveTest={sendToS3}
           updateTest={updateLocalTest}
           deleteTest={deleteLocalTest}
         />
@@ -194,7 +188,4 @@ const fetchSettings = (): Promise<any> =>
 const saveSettings = (data: DataFromServer<AmountsTests>): Promise<Response> =>
   saveSupportFrontendSettings(SupportFrontendSettingsType.amounts, data);
 
-const replaceSettings = (data: DataFromServer<AmountsTests>): Promise<Response> =>
-  saveSupportFrontendSettings(SupportFrontendSettingsType.amounts, data);
-
-export default withS3Data<AmountsTests>(AmountsForm, fetchSettings, saveSettings, replaceSettings);
+export default withS3Data<AmountsTests>(AmountsForm, fetchSettings, saveSettings);

--- a/public/src/components/appsMeteringSwitches.tsx
+++ b/public/src/components/appsMeteringSwitches.tsx
@@ -54,14 +54,14 @@ const AppsMeteringSwitch: React.FC<AppsMeteringSwitchProps> = ({
 
 const AppsMeteringSwitches: React.FC<InnerProps<AppsMeteringSwitches>> = ({
   data: switches,
-  setData: setSwitches,
-  saveData: saveSwitches,
+  update,
+  sendToS3,
   saving,
 }: InnerProps<AppsMeteringSwitches>) => {
   const classes = useStyles();
 
   const onSwitchChange = (name: SwitchName, enabled: boolean): void => {
-    setSwitches({
+    update({
       ...switches,
       [name]: enabled,
     });
@@ -89,7 +89,7 @@ const AppsMeteringSwitches: React.FC<InnerProps<AppsMeteringSwitches>> = ({
       />
 
       <Button
-        onClick={saveSwitches}
+        onClick={sendToS3}
         color="primary"
         variant="contained"
         size="large"

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -65,14 +65,14 @@ const ChannelSwitch: React.FC<ChannelSwitchProps> = ({
 
 const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
   data: switches,
-  setData: setSwitches,
-  saveData: saveSwitches,
+  update,
+  sendToS3,
   saving,
 }: InnerProps<ChannelSwitches>) => {
   const classes = useStyles();
 
   const onSwitchChange = (name: SwitchName, enabled: boolean): void => {
-    setSwitches({
+    update({
       ...switches,
       [name]: enabled,
     });
@@ -124,7 +124,7 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
       />
 
       <Button
-        onClick={saveSwitches}
+        onClick={sendToS3}
         color="primary"
         variant="contained"
         size="large"

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -28,8 +28,8 @@ const useStyles = makeStyles(() => ({
 
 const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
   data,
-  setData,
-  saveData,
+  update,
+  sendToS3,
   saving,
 }: InnerProps<DefaultPromos>) => {
   const [gwPromosString, setGwPromosString] = useState<string>(data.guardianWeekly.join(', '));
@@ -48,7 +48,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
           setGwPromosString(inputValue);
 
           const parsedInputValue = parsePromoInput(inputValue);
-          setData({
+          update({
             ...data,
             guardianWeekly: parsedInputValue,
           });
@@ -65,7 +65,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
           setpaperPromosString(inputValue);
 
           const parsedInputValue = parsePromoInput(inputValue);
-          setData({
+          update({
             ...data,
             paper: parsedInputValue,
           });
@@ -74,7 +74,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
         label="Paper"
       />
       <Button
-        onClick={saveData}
+        onClick={sendToS3}
         color="primary"
         variant="contained"
         size="large"

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -121,15 +121,15 @@ function sortByDescription<T extends Switch | SwitchGroup>(a: [string, T], b: [s
 
 const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
   data,
-  setData,
-  saveData,
+  update,
+  sendToS3,
   saving,
 }: InnerProps<SupportFrontendSwitches>) => {
   const classes = useStyles();
 
   const [pendingChanges, setPendingChanges] = useState<string[]>([]);
 
-  const displayNeedToSaveDataWarning = (): JSX.Element | false => {
+  const displayNeedTosendToS3Warning = (): JSX.Element | false => {
     return (
       pendingChanges.length > 0 && (
         <Alert severity="warning">
@@ -163,7 +163,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const [groupId, groupData] = group;
     updatedState[groupId].switches[switchId].state = isChecked ? SwitchState.On : SwitchState.Off;
     const currentSwitchState = updatedState[groupId].switches[switchId].state;
-    setData(updatedState);
+    update(updatedState);
     setPendingChange(
       'Turned ' + currentSwitchState + ':',
       switchData.description,
@@ -213,7 +213,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
         description: description,
         state: SwitchState.Off,
       };
-      setData(updatedState);
+      update(updatedState);
       setPendingChange('Added', description, groupData.description);
     };
 
@@ -293,8 +293,8 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     </>
   );
 
-  const actionSaveData = (): void => {
-    saveData();
+  const actionsendToS3 = (): void => {
+    sendToS3();
     setPendingChanges([]);
   };
 
@@ -302,7 +302,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     <div className={classes.buttons}>
       <Button
         variant="contained"
-        onClick={actionSaveData}
+        onClick={actionsendToS3}
         className={classes.button}
         disabled={saving}
       >
@@ -331,7 +331,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     const [groupId, groupData] = group;
     const updatedState = cloneDeep(data);
     delete updatedState[groupId].switches[switchId];
-    setData(updatedState);
+    update(updatedState);
     setPendingChange('Removed', description, groupData.description);
   };
 
@@ -341,12 +341,12 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
         Manage existing switches
       </Typography>
 
-      {displayNeedToSaveDataWarning()}
+      {displayNeedTosendToS3Warning()}
       <SaveButton />
 
       {createSwitchFields()}
 
-      {displayNeedToSaveDataWarning()}
+      {displayNeedTosendToS3Warning()}
       <SaveButton />
     </form>
   );

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -129,7 +129,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
 
   const [pendingChanges, setPendingChanges] = useState<string[]>([]);
 
-  const displayNeedTosendToS3Warning = (): JSX.Element | false => {
+  const displayNeedToSaveDataWarning = (): JSX.Element | false => {
     return (
       pendingChanges.length > 0 && (
         <Alert severity="warning">
@@ -293,7 +293,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     </>
   );
 
-  const actionsendToS3 = (): void => {
+  const actionSaveData = (): void => {
     sendToS3();
     setPendingChanges([]);
   };
@@ -302,7 +302,7 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
     <div className={classes.buttons}>
       <Button
         variant="contained"
-        onClick={actionsendToS3}
+        onClick={actionSaveData}
         className={classes.button}
         disabled={saving}
       >
@@ -341,12 +341,12 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
         Manage existing switches
       </Typography>
 
-      {displayNeedTosendToS3Warning()}
+      {displayNeedToSaveDataWarning()}
       <SaveButton />
 
       {createSwitchFields()}
 
-      {displayNeedTosendToS3Warning()}
+      {displayNeedToSaveDataWarning()}
       <SaveButton />
     </form>
   );

--- a/public/src/hocs/withS3Data.tsx
+++ b/public/src/hocs/withS3Data.tsx
@@ -8,9 +8,9 @@ export interface DataFromServer<T> {
 
 export interface InnerProps<T> {
   data: T;
-  setData: (data: T) => void;
-  saveData: () => void;
-  replaceData?: (data: T) => void;
+  update: (data: T) => void;
+  sendToS3: () => void;
+  updateAndSendToS3: (data: T) => void;
   saving: boolean;
 }
 
@@ -21,7 +21,6 @@ function withS3Data<T>(
   Inner: React.FC<InnerProps<T>>,
   fetchSettings: FetchSettings<T>,
   saveSettings: SaveSettings<T>,
-  replaceSettings?: SaveSettings<T>,
 ): React.FC {
   const Wrapped: React.FC = () => {
     const [dataFromServer, setDataFromServer] = useState<DataFromServer<T> | null>(null);
@@ -38,14 +37,14 @@ function withS3Data<T>(
       fetchData();
     }, []);
 
-    const setData = (data: T): void => {
+    const update = (data: T): void => {
       if (!dataFromServer) {
         return;
       }
       setDataFromServer({ ...dataFromServer, value: data });
     };
 
-    const saveData = (): void => {
+    const sendToS3 = (): void => {
       if (!dataFromServer) {
         return;
       }
@@ -56,13 +55,13 @@ function withS3Data<T>(
         .then(() => setIsSaving(false));
     };
 
-    const replaceData = (data: T): void => {
-      if (!dataFromServer || !replaceSettings) {
+    const updateAndSendToS3 = (data: T): void => {
+      if (!dataFromServer) {
         return;
       }
       setIsSaving(true);
 
-      replaceSettings({ ...dataFromServer, value: data })
+      saveSettings({ ...dataFromServer, value: data })
         .then(fetchData)
         .then(() => setIsSaving(false));
     };
@@ -70,9 +69,9 @@ function withS3Data<T>(
     return dataFromServer ? (
       <Inner
         data={dataFromServer.value}
-        setData={setData}
-        saveData={saveData}
-        replaceData={replaceData}
+        update={update}
+        sendToS3={sendToS3}
+        updateAndSendToS3={updateAndSendToS3}
         saving={saving}
       />
     ) : null; // TODO: add spinner?


### PR DESCRIPTION
`withS3Data` is a small helper for maintaining state from S3, used by several pages.
The new amounts page has the new requirement to update _and_ send to S3 in one go. This isn't currently possible (because behind the scenes it's using the `useState` hook).

This PR renames the existing functions and adds a new one, so we now have:
```
update: (data: T) => void;
sendToS3: () => void;
updateAndSendToS3: (data: T) => void;
```