### PR TITLE
Supporter Banner moment, add to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -34,6 +34,7 @@ object BannerUI {
   case object UkraineMomentBanner extends BannerTemplate
   case object WorldPressFreedomDayBanner extends BannerTemplate
   case object Scotus2023MomentBanner extends BannerTemplate
+  case object SupporterMomentBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   import cats.syntax.functor._  // for the widen syntax

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -297,7 +297,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.GlobalNewYearBanner ||
             template === BannerTemplate.UkraineMomentBanner ||
             template === BannerTemplate.WorldPressFreedomDayBanner ||
-            template === BannerTemplate.Scotus2023MomentBanner) && (
+            template === BannerTemplate.Scotus2023MomentBanner ||
+            template === BannerTemplate.SupporterMomentBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -59,6 +59,10 @@ const templatesWithLabels = [
     template: BannerTemplate.Scotus2023MomentBanner,
     label: 'US Supreme Court 2023 Moment',
   },
+  {
+    template: BannerTemplate.SupporterMomentBanner,
+    label: 'Supporter Moment 2023',
+  },
 ];
 
 interface BannerTemplateSelectorProps {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -174,6 +174,10 @@ const bannerModules = {
     path: 'usSupremeCourt2023/Scotus2023MomentBanner.js',
     name: 'Scotus2023MomentBanner',
   },
+  [BannerTemplate.SupporterMomentBanner]: {
+    path: 'supporterMoment/SupporterMomentBanner.js',
+    name: 'SupporterMomentBanner',
+  },
 };
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -31,6 +31,7 @@ export enum BannerTemplate {
   UkraineMomentBanner = 'UkraineMomentBanner',
   WorldPressFreedomDayBanner = 'WorldPressFreedomDayBanner',
   Scotus2023MomentBanner = 'Scotus2023MomentBanner',
+  SupporterMomentBanner = 'SupporterMomentBanner',
 }
 
 export interface BannerDesignName {


### PR DESCRIPTION
## What does this change?

Creates a 'Supporter Moment 2023' banner using the moments template banner setup within a dropdown in the RRCP

[Trello] https://trello.com/c/jRwJkWGV/1516-supporter-moment-choicecard-banner-create

[SupportDotcom Supporter Banner PR] https://github.com/guardian/support-dotcom-components/pull/947

## Images
