### PR TITLE
Banner Design Tool: Validate image fields more thoroughly

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -16,6 +16,11 @@ type Props = {
   onChange: (design: BannerDesign) => void;
 };
 
+const imageUrlValidation = {
+  value: /^https:\/\/i\.guim\.co\.uk\//,
+  message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
+};
+
 const BannerDesignForm: React.FC<Props> = ({
   design,
   setValidationStatus,
@@ -64,6 +69,7 @@ const BannerDesignForm: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
             })}
             error={errors.mobileUrl !== undefined}
             helperText={errors.mobileUrl?.message}
@@ -78,6 +84,7 @@ const BannerDesignForm: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
             })}
             error={errors.tabletDesktopUrl !== undefined}
             helperText={errors.tabletDesktopUrl?.message}
@@ -92,6 +99,7 @@ const BannerDesignForm: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
             })}
             error={errors.wideUrl !== undefined}
             helperText={errors.wideUrl?.message}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds more thorough validation for banner design image fields. They should be hosted by the Guardian's image service, e.g. https://i.guim.co.uk.

![Screen Recording 2023-09-11 at 12 20 06 mov](https://github.com/guardian/support-admin-console/assets/379839/649a90d3-156c-4f2b-bf82-bcad50fc795e)

## How to test

Set an image to be a non valid string, see the form validation error.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
