### PR TITLE
Supporting changes for giving banner designs a status

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -1,5 +1,23 @@
 package models
 
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{
+  deriveEnumerationDecoder,
+  deriveEnumerationEncoder
+}
+
+sealed trait BannerDesignStatus
+
+object BannerDesignStatus {
+  case object Live extends BannerDesignStatus
+
+  case object Draft extends BannerDesignStatus
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val statusEncoder = deriveEnumerationEncoder[BannerDesignStatus]
+  implicit val statusDecoder = deriveEnumerationDecoder[BannerDesignStatus]
+}
+
 case class BannerDesignImage(
     mobileUrl: String,
     tabletDesktopUrl: String,
@@ -9,6 +27,7 @@ case class BannerDesignImage(
 
 case class BannerDesign(
     name: String,
+    status: BannerDesignStatus,
     image: BannerDesignImage,
     lockStatus: Option[LockStatus],
 )

--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -230,4 +230,31 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     logger.info(s"About to batch delete: $deleteRequests")
     putAllBatched(deleteRequests)
   }
+
+  def updateStatuses(
+      designNames: List[String],
+      status: BannerDesignStatus): ZIO[ZEnv, DynamoError, Unit] = {
+    val items = designNames.map { designName =>
+      TransactWriteItem.builder
+        .update(
+          Update.builder
+            .tableName(tableName)
+            .key(buildKey(designName))
+            .expressionAttributeValues(
+              Map(
+                ":status" -> AttributeValue.builder.s(status.toString).build,
+                ":name" -> AttributeValue.builder.s(designName).build
+              ).asJava)
+            .expressionAttributeNames(Map(
+              "#status" -> "status",
+              "#name" -> "name"
+            ).asJava)
+            .updateExpression("SET #status = :status")
+            .conditionExpression("#name = :name") // only update if it already exists in the table
+            .build()
+        )
+        .build()
+    }
+    putAllBatchedTransaction(items)
+  }
 }

--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -149,7 +149,8 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
                          email: String): ZIO[ZEnv, DynamoError, Unit] = {
     val item = jsonToDynamo(bannerDesign.asJson).m().asScala.toMap -
       "lockStatus" - // Unlock by removing lockStatus
-      "name" // key field
+      "name" - // key field"
+      "status" // status updates happen separately
 
     val updateExpression = buildUpdateBannerDesignExpression(item)
 

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -112,34 +112,6 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
       case other => DynamoPutError(other)
     }
 
-  private def putAllTransaction(items: List[TransactWriteItem]): ZIO[ZEnv, DynamoPutError, Unit] =
-    effectBlocking {
-      val request = TransactWriteItemsRequest
-        .builder
-        .transactItems(items.asJava)
-        .build()
-
-      val result = client.transactWriteItems(request)
-      logger.info(s"TransactWriteItemsResponse: $result")
-      ()
-    }.mapError(DynamoPutError)
-
-  /**
-    * Dynamodb limits us to batches of 25 items.
-    * This function groups items into batches of 25. Each batch is sent as a transaction, and if any transaction
-    * fails then an error is returned to the client (no retries).
-    * It uses a zio stream to do this, pausing between batches to avoid any throttling and timing out after 1 minute.
-    */
-  private def putAllBatchedTransaction(items: List[TransactWriteItem]): ZIO[ZEnv, DynamoPutError, Unit] = {
-    val batches = items.grouped(BATCH_SIZE).toList
-    ZStream.fromIterable(batches)
-      .fixed(2.seconds) // wait 2 seconds between batches
-      .timeoutError(DynamoPutError(new Throwable("Timed out writing batches to dynamodb")))(1.minute)
-      .mapM(putAllTransaction)
-      .runCollect
-      .unit
-  }
-
   def getTest[T <: ChannelTest[T] : Decoder](testName: String, channel: Channel): ZIO[ZEnv, DynamoGetError, T] =
     get(testName, channel)
       .map(item => dynamoMapToJson(item).as[T])

--- a/app/services/DynamoService.scala
+++ b/app/services/DynamoService.scala
@@ -3,7 +3,13 @@ package services
 import com.typesafe.scalalogging.StrictLogging
 import models.DynamoErrors.DynamoPutError
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import software.amazon.awssdk.services.dynamodb.model.{BatchWriteItemRequest, ReturnConsumedCapacity, WriteRequest}
+import software.amazon.awssdk.services.dynamodb.model.{
+  BatchWriteItemRequest,
+  ReturnConsumedCapacity,
+  TransactWriteItem,
+  TransactWriteItemsRequest,
+  WriteRequest
+}
 import zio.{ZEnv, ZIO}
 import zio.blocking.effectBlocking
 import zio.stream.ZStream
@@ -12,15 +18,16 @@ import zio.duration.durationInt
 import scala.jdk.CollectionConverters._
 
 // Shared functionality for DynamoDb services
-abstract class DynamoService(stage: String, client: DynamoDbClient) extends StrictLogging {
+abstract class DynamoService(stage: String, client: DynamoDbClient)
+    extends StrictLogging {
   protected val tableName: String
 
   // Sends a batch of write requests, and returns any unprocessed items
-  protected def putAll(writeRequests: List[WriteRequest]): ZIO[ZEnv, DynamoPutError, List[WriteRequest]] =
+  protected def putAll(writeRequests: List[WriteRequest])
+    : ZIO[ZEnv, DynamoPutError, List[WriteRequest]] =
     effectBlocking {
       val batchWriteRequest =
-        BatchWriteItemRequest
-          .builder
+        BatchWriteItemRequest.builder
           .requestItems(Map(tableName -> writeRequests.asJava).asJava)
           .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
           .build()
@@ -28,7 +35,9 @@ abstract class DynamoService(stage: String, client: DynamoDbClient) extends Stri
       val result = client.batchWriteItem(batchWriteRequest)
       logger.info(s"BatchWriteItemResponse: $result")
 
-      result.unprocessedItems().asScala
+      result
+        .unprocessedItems()
+        .asScala
         .get(tableName)
         .map(items => items.asScala.toList)
         .getOrElse(Nil)
@@ -36,28 +45,61 @@ abstract class DynamoService(stage: String, client: DynamoDbClient) extends Stri
     }.mapError(DynamoPutError)
 
   /**
-   * Dynamodb limits us to batches of 25 items, and may return unprocessed items in the response.
-   * This function groups items into batches of 25, and also checks the `unprocessedItems` in case we need to send
-   * any again.
-   * It uses an infinite zio stream to do this, pausing between batches to avoid any throttling. It stops processing
-   * the stream when the list of batches is empty.
-   */
+    * Dynamodb limits us to batches of 25 items, and may return unprocessed items in the response.
+    * This function groups items into batches of 25, and also checks the `unprocessedItems` in case we need to send
+    * any again.
+    * It uses an infinite zio stream to do this, pausing between batches to avoid any throttling. It stops processing
+    * the stream when the list of batches is empty.
+    */
   protected val BATCH_SIZE = 25
 
-  protected def putAllBatched(writeRequests: List[WriteRequest]): ZIO[ZEnv, DynamoPutError, Unit] = {
+  protected def putAllBatched(
+      writeRequests: List[WriteRequest]): ZIO[ZEnv, DynamoPutError, Unit] = {
     val batches = writeRequests.grouped(BATCH_SIZE).toList
-    ZStream(())
-      .forever
+    ZStream(()).forever
       .fixed(2.seconds) // wait 2 seconds between batches
-      .timeoutError(DynamoPutError(new Throwable("Timed out writing batches to dynamodb")))(1.minute)
+      .timeoutError(DynamoPutError(
+        new Throwable("Timed out writing batches to dynamodb")))(1.minute)
       .foldWhileM(batches)(_.nonEmpty) {
         case (nextBatch :: remainingBatches, _) =>
           putAll(nextBatch).map {
-            case Nil => remainingBatches
+            case Nil         => remainingBatches
             case unprocessed => unprocessed :: remainingBatches
           }
         case (Nil, _) => ZIO.succeed(Nil)
       }
       .unit // on success, the result value isn't meaningful
   }
+
+  /**
+    * Dynamodb limits us to batches of 25 items.
+    * This function groups items into batches of 25. Each batch is sent as a transaction, and if any transaction
+    * fails then an error is returned to the client (no retries).
+    * It uses a zio stream to do this, pausing between batches to avoid any throttling and timing out after 1 minute.
+    */
+  protected def putAllBatchedTransaction(
+      items: List[TransactWriteItem]): ZIO[ZEnv, DynamoPutError, Unit] = {
+    val batches = items.grouped(BATCH_SIZE).toList
+    ZStream
+      .fromIterable(batches)
+      .fixed(2.seconds) // wait 2 seconds between batches
+      .timeoutError(DynamoPutError(
+        new Throwable("Timed out writing batches to dynamodb")))(1.minute)
+      .mapM(putAllTransaction)
+      .runCollect
+      .unit
+  }
+
+  private def putAllTransaction(
+      items: List[TransactWriteItem]): ZIO[ZEnv, DynamoPutError, Unit] =
+    effectBlocking {
+      val request = TransactWriteItemsRequest.builder
+        .transactItems(items.asJava)
+        .build()
+
+      val result = client.transactWriteItems(request)
+      logger.info(s"TransactWriteItemsResponse: $result")
+      ()
+    }.mapError(DynamoPutError)
+
 }

--- a/conf/routes
+++ b/conf/routes
@@ -203,6 +203,7 @@ POST  /frontend/banner-designs/create                  controllers.banner.Banner
 POST  /frontend/banner-designs/lock/:testName          controllers.banner.BannerDesignsController.lock(testName: String)
 POST  /frontend/banner-designs/unlock/:testName        controllers.banner.BannerDesignsController.unlock(testName: String)
 POST  /frontend/banner-designs/takecontrol/:testName   controllers.banner.BannerDesignsController.forceLock(testName: String)
+POST  /frontend/banner-designs/status/:rawStatus       controllers.banner.BannerDesignsController.setStatus(rawStatus: String)
 
 # ----- capi ----- #
 GET   /capi/tags                                       controllers.CapiController.getTags()

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -19,5 +19,6 @@ export const DEFAULT_BANNER_DESIGN: BannerDesignImageFormData = {
 
 export const createDefaultBannerDesign = (name: string): BannerDesign => ({
   name,
+  status: 'Draft',
   image: DEFAULT_BANNER_DESIGN,
 });

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -11,8 +11,11 @@ export type BannerDesignProps = {
   image: BannerDesignImage;
 };
 
+type Status = 'Live' | 'Draft';
+
 export type BannerDesign = {
   name: string;
+  status: Status;
   isNew?: boolean;
   lockStatus?: LockStatus;
 } & BannerDesignProps;


### PR DESCRIPTION
## What does this change?

This PR makes some supporting changes for giving banner designs a status:

* Updates the models in Scala and TypeScript to have a status field (defaulting to Draft)
* Adds a new endpoint to update the status of a banner design
* Update the banner designs Dynamo store to support setting the status of a design

*Note: this PR doesn't contain any UI changes to allow users to set the status. This will be done in a subsequent PR.*

## How to test

I have tested the backend changes locally using curl and observed the status in Dynamo change.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
