### PR TITLE
Add Environment Moment 2023 banner to RRCP and tests

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -31,6 +31,7 @@ object BannerUI {
   case object Scotus2023MomentBanner extends BannerTemplate
   case object EuropeMomentLocalLanguageBanner extends BannerTemplate
   case object SupporterMomentBanner extends BannerTemplate
+  case object EnvironmentMoment2023Banner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   import cats.syntax.functor._  // for the widen syntax

--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -31,7 +31,7 @@ object BannerUI {
   case object Scotus2023MomentBanner extends BannerTemplate
   case object EuropeMomentLocalLanguageBanner extends BannerTemplate
   case object SupporterMomentBanner extends BannerTemplate
-  case object EnvironmentMoment2023Banner extends BannerTemplate
+  case object EnvironmentMomentBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   import cats.syntax.functor._  // for the widen syntax

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -295,7 +295,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.WorldPressFreedomDayBanner ||
             template === BannerTemplate.Scotus2023MomentBanner ||
             template === BannerTemplate.EuropeMomentLocalLanguageBanner ||
-            template === BannerTemplate.SupporterMomentBanner) && (
+            template === BannerTemplate.SupporterMomentBanner ||
+            template === BannerTemplate.EnvironmentMoment2023Banner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -296,7 +296,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.Scotus2023MomentBanner ||
             template === BannerTemplate.EuropeMomentLocalLanguageBanner ||
             template === BannerTemplate.SupporterMomentBanner ||
-            template === BannerTemplate.EnvironmentMoment2023Banner) && (
+            template === BannerTemplate.EnvironmentMomentBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -27,6 +27,10 @@ interface BannerUiSelectorProps {
 
 const templatesWithLabels = [
   {
+    template: BannerTemplate.EnvironmentMoment2023Banner,
+    label: 'Environment Moment 2023',
+  },
+  {
     template: BannerTemplate.EuropeMomentLocalLanguageBanner,
     label: 'Europe Moment Local Language 2023',
   },
@@ -57,28 +61,9 @@ const templatesWithLabels = [
     template: BannerTemplate.WorldPressFreedomDayBanner,
     label: 'World Press Freedom Day',
   },
-<<<<<<< HEAD
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
   { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },
   { template: BannerTemplate.EnvironmentBanner, label: 'Environment' },
-=======
-  {
-    template: BannerTemplate.Scotus2023MomentBanner,
-    label: 'US Supreme Court 2023 Moment',
-  },
-  {
-    template: BannerTemplate.EuropeMomentLocalLanguageBanner,
-    label: 'Europe Moment Local Language 2023',
-  },
-  {
-    template: BannerTemplate.SupporterMomentBanner,
-    label: 'Supporter Moment 2023', // temp comment to fix github issue
-  },
-  {
-    template: BannerTemplate.EnvironmentMoment2023Banner,
-    label: 'Environment Moment 2023',
-  },
->>>>>>> 7255f9d (Added Environment Moment 2023 banner added to RRCP and tests)
 ];
 
 interface BannerTemplateSelectorProps {

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -57,9 +57,28 @@ const templatesWithLabels = [
     template: BannerTemplate.WorldPressFreedomDayBanner,
     label: 'World Press Freedom Day',
   },
+<<<<<<< HEAD
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
   { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },
   { template: BannerTemplate.EnvironmentBanner, label: 'Environment' },
+=======
+  {
+    template: BannerTemplate.Scotus2023MomentBanner,
+    label: 'US Supreme Court 2023 Moment',
+  },
+  {
+    template: BannerTemplate.EuropeMomentLocalLanguageBanner,
+    label: 'Europe Moment Local Language 2023',
+  },
+  {
+    template: BannerTemplate.SupporterMomentBanner,
+    label: 'Supporter Moment 2023', // temp comment to fix github issue
+  },
+  {
+    template: BannerTemplate.EnvironmentMoment2023Banner,
+    label: 'Environment Moment 2023',
+  },
+>>>>>>> 7255f9d (Added Environment Moment 2023 banner added to RRCP and tests)
 ];
 
 interface BannerTemplateSelectorProps {

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -27,7 +27,7 @@ interface BannerUiSelectorProps {
 
 const templatesWithLabels = [
   {
-    template: BannerTemplate.EnvironmentMoment2023Banner,
+    template: BannerTemplate.EnvironmentMomentBanner,
     label: 'Environment Moment 2023',
   },
   {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -168,9 +168,9 @@ const bannerModules = {
     path: 'supporterMoment/SupporterMomentBanner.js',
     name: 'SupporterMomentBanner',
   },
-  [BannerTemplate.EnvironmentMoment2023Banner]: {
-    path: 'environmentMoment2023/EnvironmentMoment2023Banner.js',
-    name: 'EnvironmentMoment2023Banner',
+  [BannerTemplate.EnvironmentMomentBanner]: {
+    path: 'environmentMoment/EnvironmentMomentBanner.js',
+    name: 'EnvironmentMomentBanner',
   },
   DesignableBanner: {
     path: 'designableBanner/DesignableBanner.js',

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -169,7 +169,7 @@ const bannerModules = {
     name: 'SupporterMomentBanner',
   },
   [BannerTemplate.EnvironmentMoment2023Banner]: {
-    path: 'environmentMoment2023/EnvironmentMoment2023Banner.js',
+    path: 'environmentMoment2023/environmentMoment2023.js',
     name: 'EnvironmentMoment2023Banner',
   },
   DesignableBanner: {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -169,7 +169,7 @@ const bannerModules = {
     name: 'SupporterMomentBanner',
   },
   [BannerTemplate.EnvironmentMoment2023Banner]: {
-    path: 'environmentMoment2023/environmentMoment2023.js',
+    path: 'environmentMoment2023/EnvironmentMoment2023Banner.js',
     name: 'EnvironmentMoment2023Banner',
   },
   DesignableBanner: {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -168,6 +168,10 @@ const bannerModules = {
     path: 'supporterMoment/SupporterMomentBanner.js',
     name: 'SupporterMomentBanner',
   },
+  [BannerTemplate.EnvironmentMoment2023Banner]: {
+    path: 'environmentMoment2023/EnvironmentMoment2023Banner.js',
+    name: 'EnvironmentMoment2023Banner',
+  },
   DesignableBanner: {
     path: 'designableBanner/DesignableBanner.js',
     name: 'DesignableBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -27,6 +27,7 @@ export enum BannerTemplate {
   Scotus2023MomentBanner = 'Scotus2023MomentBanner',
   EuropeMomentLocalLanguageBanner = 'EuropeMomentLocalLanguageBanner',
   SupporterMomentBanner = 'SupporterMomentBanner',
+  EnvironmentMoment2023Banner = 'EnvironmentMoment2023Banner',
 }
 
 export interface BannerDesignName {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -27,7 +27,7 @@ export enum BannerTemplate {
   Scotus2023MomentBanner = 'Scotus2023MomentBanner',
   EuropeMomentLocalLanguageBanner = 'EuropeMomentLocalLanguageBanner',
   SupporterMomentBanner = 'SupporterMomentBanner',
-  EnvironmentMoment2023Banner = 'EnvironmentMoment2023Banner',
+  EnvironmentMomentBanner = 'EnvironmentMomentBanner',
 }
 
 export interface BannerDesignName {


### PR DESCRIPTION
## What does this change?

Creates a 'Environment Moment 2023' banner using the moments template banner setup within a dropdown in the RRCP

[Trello] https://trello.com/c/6u9ECzb4/1539-environment-moment-2023-banner-build

[SupportDotcom Environment Moment 2023 Banner PR] https://github.com/guardian/support-dotcom-components/pull/970