### PR TITLE
Do not show draft banner designs in variant editor

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -53,7 +53,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   const fetchBannerDesigns = (): void => {
     fetchFrontendSettings(FrontendSettingsType.bannerDesigns).then(
       (response: BannerDesignsResponse) => {
-        setDesigns(response.bannerDesigns);
+        setDesigns(response.bannerDesigns.filter(design => design.status === 'Live'));
       },
     );
   };


### PR DESCRIPTION
it should not be possible to use a draft design in a banner test variant