### PR TITLE
Prevent changing banner design to draft if in use

### DIFF
--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -242,11 +242,12 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
       .updateExpression("SET #status = :status")
       .expressionAttributeValues(
         Map(
-          ":status" -> jsonToDynamo(status.asJson)
+          ":status" -> jsonToDynamo(status.asJson),
+          ":name" -> AttributeValue.builder.s(designName).build
         ).asJava)
       .expressionAttributeNames(Map(
-        // status is a reserved keyword in dynamodb
-        "#status" -> "status"
+        "#status" -> "status",
+        "#name" -> "name"
       ).asJava)
       .conditionExpression("#name = :name") // only update if it already exists in the table
       .build()

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -89,7 +89,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new BannerDeployController2(authAction, controllerComponents, stage, runtime),
     new ChannelSwitchesController(authAction, controllerComponents, stage, runtime),
     new CampaignsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoCampaignsService),
-    new BannerDesignsController(authAction, controllerComponents, stage, runtime, dynamoBannerDesigns),
+    new BannerDesignsController(authAction, controllerComponents, stage, runtime, dynamoBannerDesigns, dynamoTestsService),
     new CapiController(authAction, capiService),
     new AppsMeteringSwitchesController(authAction, controllerComponents, stage, runtime),
     new DefaultPromosController(authAction,controllerComponents, stage, runtime),

--- a/conf/routes
+++ b/conf/routes
@@ -200,10 +200,10 @@ GET   /frontend/banner-designs                         controllers.banner.Banner
 GET   /frontend/banner-designs/:designName             controllers.banner.BannerDesignsController.get(designName: String)
 POST  /frontend/banner-designs/update                  controllers.banner.BannerDesignsController.update
 POST  /frontend/banner-designs/create                  controllers.banner.BannerDesignsController.create
-POST  /frontend/banner-designs/lock/:testName          controllers.banner.BannerDesignsController.lock(testName: String)
-POST  /frontend/banner-designs/unlock/:testName        controllers.banner.BannerDesignsController.unlock(testName: String)
-POST  /frontend/banner-designs/takecontrol/:testName   controllers.banner.BannerDesignsController.forceLock(testName: String)
-POST  /frontend/banner-designs/status/:rawStatus       controllers.banner.BannerDesignsController.setStatus(rawStatus: String)
+POST  /frontend/banner-designs/lock/:designName        controllers.banner.BannerDesignsController.lock(designName: String)
+POST  /frontend/banner-designs/unlock/:designName      controllers.banner.BannerDesignsController.unlock(designName: String)
+POST  /frontend/banner-designs/takecontrol/:designName controllers.banner.BannerDesignsController.forceLock(designName: String)
+POST  /frontend/banner-designs/status/:designName/:rawStatus controllers.banner.BannerDesignsController.setStatus(designName: String, rawStatus: String)
 
 # ----- capi ----- #
 GET   /capi/tags                                       controllers.CapiController.getTags()

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -156,7 +156,7 @@ const BannerDesigns: React.FC = () => {
 
   const onStatusChange = (bannerDesignName: string | undefined, status: Status): void => {
     if (bannerDesignName) {
-      updateBannerDesignStatus([bannerDesignName], status)
+      updateBannerDesignStatus(bannerDesignName, status)
         .then(() => refreshDesign(bannerDesignName))
         .catch(error => {
           alert(`Error while setting banner design status to ${status}: ${error}`);

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -177,12 +177,14 @@ export function createBannerDesign(design: BannerDesign): Promise<Response> {
 }
 
 export function updateBannerDesignStatus(
-  designNames: string[],
+  designName: string,
   status: BannerDesignStatus,
 ): Promise<Response> {
-  return saveSettings(
-    `/frontend/${FrontendSettingsType.bannerDesigns}/status/${status}`,
-    designNames,
+  return makeFetch(
+    `/frontend/${FrontendSettingsType.bannerDesigns}/status/${designName}/${status}`,
+    {
+      method: 'POST',
+    },
   );
 }
 


### PR DESCRIPTION
If a design is already in use by a test variant then we must not change its status.

- Refactors the status change endpoint to only take a single design name (in the path). This simplifies things on the backend, and we're unlikely to need the ability to batch change statuses.
- The status endpoint first fetches all banner tests and checks if the design is already in use. If it is, a 400 is returned and the user sees the list of test names

![Screenshot 2023-09-27 at 09 03 18](https://github.com/guardian/support-admin-console/assets/1513454/372c4c8d-12a2-4d15-89fe-ad903f1fb663)
