### PR TITLE
Choice Cards Moment 2023 banner add to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -32,6 +32,7 @@ object BannerUI {
   case object EuropeMomentLocalLanguageBanner extends BannerTemplate
   case object SupporterMomentBanner extends BannerTemplate
   case object EnvironmentMomentBanner extends BannerTemplate
+  case object ChoiceCardsMomentBanner extends BannerTemplate
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   import cats.syntax.functor._  // for the widen syntax

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -296,7 +296,8 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.Scotus2023MomentBanner ||
             template === BannerTemplate.EuropeMomentLocalLanguageBanner ||
             template === BannerTemplate.SupporterMomentBanner ||
-            template === BannerTemplate.EnvironmentMomentBanner) && (
+            template === BannerTemplate.EnvironmentMomentBanner ||
+            template === BannerTemplate.ChoiceCardsMomentBanner) && (
             <Controller
               name="highlightedText"
               control={control}

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -27,6 +27,10 @@ interface BannerUiSelectorProps {
 
 const templatesWithLabels = [
   {
+    template: BannerTemplate.ChoiceCardsMomentBanner,
+    label: 'Choice Cards Moment 2023',
+  },
+  {
     template: BannerTemplate.EnvironmentMomentBanner,
     label: 'Environment Moment 2023',
   },

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -59,14 +59,14 @@ const templatesWithLabels = [
   },
   {
     template: BannerTemplate.ChoiceCardsButtonsBannerBlue,
-    label: 'Choice cards banner - BUTTONS',
+    label: 'Choice Cards Buttons',
   },
   {
     template: BannerTemplate.WorldPressFreedomDayBanner,
     label: 'World Press Freedom Day',
   },
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
-  { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations moment' },
+  { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations' },
   { template: BannerTemplate.EnvironmentBanner, label: 'Environment' },
 ];
 

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -148,6 +148,10 @@ const bannerModules = {
     path: 'ukraineMoment/UkraineMomentBanner.js',
     name: 'UkraineMomentBanner',
   },
+  [BannerTemplate.ChoiceCardsMomentBanner]: {
+    path: 'choiceCardsMoment/ChoiceCardsMomentBanner.js',
+    name: 'ChoiceCardsMomentBanner',
+  },
   [BannerTemplate.ChoiceCardsButtonsBannerBlue]: {
     path: 'choiceCardsButtonsBanner/ChoiceCardsButtonsBannerBlue.js',
     name: 'ChoiceCardsButtonsBannerBlue',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -28,6 +28,7 @@ export enum BannerTemplate {
   EuropeMomentLocalLanguageBanner = 'EuropeMomentLocalLanguageBanner',
   SupporterMomentBanner = 'SupporterMomentBanner',
   EnvironmentMomentBanner = 'EnvironmentMomentBanner',
+  ChoiceCardsMomentBanner = 'ChoiceCardsMomentBanner',
 }
 
 export interface BannerDesignName {


### PR DESCRIPTION
## What does this change?

- Creates a 'Choice Cards Moment 2023' banner using the moments template banner setup within a dropdown in the RRCP
- Rename 'Choice cards banner - BUTTONS' -> 'ChoiceCardsButtons'
- Rename 'Investigations moment' -> 'Investigations'

[Trello] https://trello.com/c/YkJt8HJq/1553-banner-cleanup-in-rrcp-and-storybook-2-of-3-rename-used-banners-in-rrcp-create-moment-template-choice-card

[SupportDotcom Choice Cards Moment 2023 Banner PR] https://github.com/guardian/support-dotcom-components/pull/972