### PR TITLE
First designable banner colour fields

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -29,6 +29,7 @@ case class HexColour(
     r: String,
     g: String,
     b: String,
+    kind: String,
 )
 
 case class BannerDesignBasicColours(

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -25,10 +25,26 @@ case class BannerDesignImage(
     altText: String
 )
 
+case class HexColour(
+    r: String,
+    g: String,
+    b: String,
+)
+
+case class BannerDesignBasicColours(
+    background: HexColour,
+    bodyText: HexColour,
+)
+
+case class BannerDesignColours(
+    basic: BannerDesignBasicColours,
+)
+
 case class BannerDesign(
     name: String,
     status: BannerDesignStatus,
     image: BannerDesignImage,
+    colours: BannerDesignColours,
     lockStatus: Option[LockStatus],
 )
 

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -2,9 +2,10 @@ import React, { useEffect } from 'react';
 import { TextField, Typography } from '@material-ui/core';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
-import { BannerDesign } from '../../../models/bannerDesign';
+import { BannerDesign, hexColourToString } from '../../../models/bannerDesign';
 import {
-  BannerDesignImageFormData as ImageFormData,
+  BannerDesignFormData,
+  BannerDesignFormData as FormData,
   DEFAULT_BANNER_DESIGN,
 } from './utils/defaults';
 import { useStyles } from '../helpers/testEditorStyles';
@@ -34,14 +35,27 @@ const BannerDesignForm: React.FC<Props> = ({
     setValidationStatus(validationScope, isValid);
   };
 
-  const defaultValues: ImageFormData = {
-    mobileUrl: design.image.mobileUrl || DEFAULT_BANNER_DESIGN.mobileUrl,
-    tabletDesktopUrl: design.image.tabletDesktopUrl || DEFAULT_BANNER_DESIGN.tabletDesktopUrl,
-    wideUrl: design.image.wideUrl || DEFAULT_BANNER_DESIGN.wideUrl,
-    altText: design.image.altText || DEFAULT_BANNER_DESIGN.altText,
+  const defaultValues: BannerDesignFormData = {
+    image: {
+      mobileUrl: design.image.mobileUrl || DEFAULT_BANNER_DESIGN.image.mobileUrl,
+      tabletDesktopUrl:
+        design.image.tabletDesktopUrl || DEFAULT_BANNER_DESIGN.image.tabletDesktopUrl,
+      wideUrl: design.image.wideUrl || DEFAULT_BANNER_DESIGN.image.wideUrl,
+      altText: design.image.altText || DEFAULT_BANNER_DESIGN.image.altText,
+    },
+    colours: {
+      basic: {
+        background:
+          hexColourToString(design.colours.basic.background) ||
+          DEFAULT_BANNER_DESIGN.colours.basic.background,
+        bodyText:
+          hexColourToString(design.colours.basic.bodyText) ||
+          DEFAULT_BANNER_DESIGN.colours.basic.bodyText,
+      },
+    },
   };
 
-  const { register, handleSubmit, errors, reset } = useForm<ImageFormData>({
+  const { register, handleSubmit, errors, reset } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -50,14 +64,38 @@ const BannerDesignForm: React.FC<Props> = ({
     reset(defaultValues);
   }, [design]);
 
-  const onSubmit = (formData: ImageFormData): void => {
-    onChange({ ...design, image: formData });
+  const onSubmit = (formData: FormData): void => {
+    onChange({
+      ...design,
+      image: formData.image,
+      colours: {
+        basic: {
+          background: {
+            r: 'FF',
+            g: '00',
+            b: '00',
+            kind: 'hex',
+          },
+          bodyText: {
+            r: '00',
+            g: 'FF',
+            b: '00',
+            kind: 'hex',
+          },
+        },
+      },
+    });
   };
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.mobileUrl, errors.tabletDesktopUrl, errors.wideUrl, errors.altText]);
+  }, [
+    errors?.image?.mobileUrl,
+    errors?.image?.tabletDesktopUrl,
+    errors?.image?.wideUrl,
+    errors?.image?.altText,
+  ]);
 
   return (
     <div className={classes.container}>
@@ -71,10 +109,10 @@ const BannerDesignForm: React.FC<Props> = ({
               required: EMPTY_ERROR_HELPER_TEXT,
               pattern: imageUrlValidation,
             })}
-            error={errors.mobileUrl !== undefined}
-            helperText={errors.mobileUrl?.message}
+            error={errors?.image?.mobileUrl !== undefined}
+            helperText={errors?.image?.mobileUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="mobileUrl"
+            name="image.mobileUrl"
             label="Banner Image URL (Mobile)"
             margin="normal"
             variant="outlined"
@@ -86,10 +124,10 @@ const BannerDesignForm: React.FC<Props> = ({
               required: EMPTY_ERROR_HELPER_TEXT,
               pattern: imageUrlValidation,
             })}
-            error={errors.tabletDesktopUrl !== undefined}
-            helperText={errors.tabletDesktopUrl?.message}
+            error={errors?.image?.tabletDesktopUrl !== undefined}
+            helperText={errors?.image?.tabletDesktopUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="tabletDesktopUrl"
+            name="image.tabletDesktopUrl"
             label="Banner Image URL (Tablet & Desktop)"
             margin="normal"
             variant="outlined"
@@ -101,10 +139,10 @@ const BannerDesignForm: React.FC<Props> = ({
               required: EMPTY_ERROR_HELPER_TEXT,
               pattern: imageUrlValidation,
             })}
-            error={errors.wideUrl !== undefined}
-            helperText={errors.wideUrl?.message}
+            error={errors?.image?.wideUrl !== undefined}
+            helperText={errors?.image?.wideUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="wideUrl"
+            name="image.wideUrl"
             label="Banner Image URL (Wide)"
             margin="normal"
             variant="outlined"
@@ -115,11 +153,48 @@ const BannerDesignForm: React.FC<Props> = ({
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
             })}
-            error={errors.altText !== undefined}
-            helperText={errors.altText?.message}
+            error={errors?.image?.altText !== undefined}
+            helperText={errors?.image?.altText?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="altText"
+            name="image.altText"
             label="Banner Image Description (alt text)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+        </div>
+      </div>
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Basic Colours
+        </Typography>
+        <div>
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
+            })}
+            error={errors?.colours?.basic?.background !== undefined}
+            helperText={errors?.colours?.basic?.background?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="colours.basic.background"
+            label="Background Colour"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
+            })}
+            error={errors?.colours?.basic?.bodyText !== undefined}
+            helperText={errors?.colours?.basic?.bodyText?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="colours.basic.bodyText"
+            label="Body Text Colour"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -25,7 +25,7 @@ const imageUrlValidation = {
 
 const colourValidation = {
   value: hexColourStringRegex,
-  message: 'Colours must be valid 6 character hex code e.g. FF0000',
+  message: 'Colours must be a valid 6 character hex code e.g. FF0000',
 };
 
 const BannerDesignForm: React.FC<Props> = ({

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -75,7 +75,6 @@ const BannerDesignForm: React.FC<Props> = ({
   }, [design]);
 
   const onSubmit = (formData: FormData): void => {
-    console.log('formData', formData);
     try {
       onChange({
         ...design,
@@ -101,6 +100,8 @@ const BannerDesignForm: React.FC<Props> = ({
     errors?.image?.tabletDesktopUrl,
     errors?.image?.wideUrl,
     errors?.image?.altText,
+    errors?.colours?.basic?.bodyText,
+    errors?.colours?.basic?.background,
   ]);
 
   return (

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_BANNER_DESIGN,
 } from './utils/defaults';
 import { useStyles } from '../helpers/testEditorStyles';
+import { convertStringToHexColour, hexColourStringRegex } from '../../../utils/bannerDesigns';
 
 type Props = {
   design: BannerDesign;
@@ -20,6 +21,11 @@ type Props = {
 const imageUrlValidation = {
   value: /^https:\/\/i\.guim\.co\.uk\//,
   message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
+};
+
+const colourValidation = {
+  value: hexColourStringRegex,
+  message: 'Colours must be valid 6 character hex code e.g. FF0000',
 };
 
 const BannerDesignForm: React.FC<Props> = ({
@@ -65,26 +71,21 @@ const BannerDesignForm: React.FC<Props> = ({
   }, [design]);
 
   const onSubmit = (formData: FormData): void => {
-    onChange({
-      ...design,
-      image: formData.image,
-      colours: {
-        basic: {
-          background: {
-            r: 'FF',
-            g: '00',
-            b: '00',
-            kind: 'hex',
-          },
-          bodyText: {
-            r: '00',
-            g: 'FF',
-            b: '00',
-            kind: 'hex',
+    try {
+      onChange({
+        ...design,
+        image: formData.image,
+        colours: {
+          basic: {
+            background: convertStringToHexColour(formData.colours.basic.background),
+            bodyText: convertStringToHexColour(formData.colours.basic.bodyText),
           },
         },
-      },
-    });
+      });
+    } catch (e) {
+      // We don't expect to get here as the form validation should have caught invalid hex colour strings
+      alert(`Something went wrong saving banner design: ${e}`);
+    }
   };
 
   useEffect(() => {
@@ -173,7 +174,7 @@ const BannerDesignForm: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
+              pattern: colourValidation,
             })}
             error={errors?.colours?.basic?.background !== undefined}
             helperText={errors?.colours?.basic?.background?.message}
@@ -188,7 +189,7 @@ const BannerDesignForm: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
+              pattern: colourValidation,
             })}
             error={errors?.colours?.basic?.bodyText !== undefined}
             helperText={errors?.colours?.basic?.bodyText?.message}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -14,6 +14,7 @@ import {
   hexColourStringRegex,
   stringToHexColour,
 } from '../../../utils/bannerDesigns';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 
 type Props = {
   design: BannerDesign;
@@ -32,6 +33,14 @@ const colourValidation = {
   message: 'Colours must be a valid 6 character hex code e.g. FF0000',
 };
 
+export const useLocalStyles = makeStyles(({}: Theme) => ({
+  colourSectionContainer: {
+    '& input': {
+      textTransform: 'uppercase',
+    },
+  },
+}));
+
 const BannerDesignForm: React.FC<Props> = ({
   design,
   setValidationStatus,
@@ -39,6 +48,7 @@ const BannerDesignForm: React.FC<Props> = ({
   onChange,
 }: Props) => {
   const classes = useStyles();
+  const localClasses = useLocalStyles();
 
   const onValidationChange = (isValid: boolean): void => {
     const validationScope = design.name;
@@ -172,7 +182,7 @@ const BannerDesignForm: React.FC<Props> = ({
           />
         </div>
       </div>
-      <div className={classes.sectionContainer}>
+      <div className={[classes.sectionContainer, localClasses.colourSectionContainer].join(' ')}>
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Basic Colours
         </Typography>

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -2,14 +2,18 @@ import React, { useEffect } from 'react';
 import { TextField, Typography } from '@material-ui/core';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
-import { BannerDesign, hexColourToString } from '../../../models/bannerDesign';
+import { BannerDesign } from '../../../models/bannerDesign';
 import {
   BannerDesignFormData,
   BannerDesignFormData as FormData,
   DEFAULT_BANNER_DESIGN,
 } from './utils/defaults';
 import { useStyles } from '../helpers/testEditorStyles';
-import { convertStringToHexColour, hexColourStringRegex } from '../../../utils/bannerDesigns';
+import {
+  hexColourToString,
+  hexColourStringRegex,
+  stringToHexColour,
+} from '../../../utils/bannerDesigns';
 
 type Props = {
   design: BannerDesign;
@@ -71,14 +75,15 @@ const BannerDesignForm: React.FC<Props> = ({
   }, [design]);
 
   const onSubmit = (formData: FormData): void => {
+    console.log('formData', formData);
     try {
       onChange({
         ...design,
         image: formData.image,
         colours: {
           basic: {
-            background: convertStringToHexColour(formData.colours.basic.background),
-            bodyText: convertStringToHexColour(formData.colours.basic.bodyText),
+            background: stringToHexColour(formData.colours.basic.background),
+            bodyText: stringToHexColour(formData.colours.basic.bodyText),
           },
         },
       });

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -110,7 +110,7 @@ const StickyTopBar: React.FC<Props> = ({
                 startIcon={<EditIcon className={classes.icon} />}
                 onClick={() => onLock(name, false)}
               >
-                <Typography className={classes.buttonText}>Edit test</Typography>
+                <Typography className={classes.buttonText}>Edit design</Typography>
               </Button>
             </>
           )}

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,4 +1,5 @@
 import { BannerDesign } from '../../../../models/bannerDesign';
+import { stringToHexColour } from '../../../../utils/bannerDesigns';
 
 export type BannerDesignFormData = {
   image: {
@@ -25,7 +26,6 @@ export const DEFAULT_BANNER_DESIGN = {
       'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
     altText: 'Image description',
   },
-  // TODO: Don't duplicate this data in the default BannerDesign below
   colours: {
     basic: {
       background: '222527',
@@ -40,18 +40,8 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
   image: DEFAULT_BANNER_DESIGN.image,
   colours: {
     basic: {
-      background: {
-        r: '22',
-        g: '25',
-        b: '27',
-        kind: 'hex',
-      },
-      bodyText: {
-        r: 'FF',
-        g: 'FF',
-        b: 'FF',
-        kind: 'hex',
-      },
+      background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.background),
+      bodyText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.bodyText),
     },
   },
 });

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,24 +1,57 @@
 import { BannerDesign } from '../../../../models/bannerDesign';
 
-export type BannerDesignImageFormData = {
-  mobileUrl: string;
-  tabletDesktopUrl: string;
-  wideUrl: string;
-  altText: string;
+export type BannerDesignFormData = {
+  image: {
+    mobileUrl: string;
+    tabletDesktopUrl: string;
+    wideUrl: string;
+    altText: string;
+  };
+  colours: {
+    basic: {
+      background: string;
+      bodyText: string;
+    };
+  };
 };
 
-export const DEFAULT_BANNER_DESIGN: BannerDesignImageFormData = {
-  mobileUrl:
-    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
-  tabletDesktopUrl:
-    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
-  wideUrl:
-    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
-  altText: 'Image description',
+export const DEFAULT_BANNER_DESIGN = {
+  image: {
+    mobileUrl:
+      'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    tabletDesktopUrl:
+      'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    wideUrl:
+      'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    altText: 'Image description',
+  },
+  // TODO: Don't duplicate this data in the default BannerDesign below
+  colours: {
+    basic: {
+      background: '222527',
+      bodyText: 'FFFFFF',
+    },
+  },
 };
 
 export const createDefaultBannerDesign = (name: string): BannerDesign => ({
   name,
   status: 'Draft',
-  image: DEFAULT_BANNER_DESIGN,
+  image: DEFAULT_BANNER_DESIGN.image,
+  colours: {
+    basic: {
+      background: {
+        r: '22',
+        g: '25',
+        b: '27',
+        kind: 'hex',
+      },
+      bodyText: {
+        r: 'FF',
+        g: 'FF',
+        b: 'FF',
+        kind: 'hex',
+      },
+    },
+  },
 });

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -84,10 +84,6 @@ const buildProps = (
   tickerSettingsWithData?: TickerSettingsWithData,
   design?: BannerDesign,
 ): BannerProps => {
-  const designProps = design && {
-    image: design.image,
-  };
-
   return {
     tracking: {
       ophanPageId: 'ophanPageId',
@@ -111,7 +107,7 @@ const buildProps = (
     separateArticleCount: variant.separateArticleCount,
     prices: mockPricesData,
     choiceCardAmounts: mockAmountsCardData,
-    design: designProps,
+    design,
   };
 };
 

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -31,5 +31,3 @@ export type BannerDesign = {
   isNew?: boolean;
   lockStatus?: LockStatus;
 } & BannerDesignProps;
-
-export const hexColourToString = (h: HexColour): string => `${h.r}${h.g}${h.b}`;

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -6,9 +6,41 @@ interface BannerDesignImage {
   wideUrl: string;
   altText: string;
 }
+type HexChar =
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | 'A'
+  | 'B'
+  | 'C'
+  | 'D'
+  | 'E'
+  | 'F';
+
+type HexValue = `${HexChar}${HexChar}`;
+
+export interface HexColour {
+  r: HexValue;
+  g: HexValue;
+  b: HexValue;
+  kind: 'hex';
+}
 
 export type BannerDesignProps = {
   image: BannerDesignImage;
+  colours: {
+    basic: {
+      background: HexColour;
+      bodyText: HexColour;
+    };
+  };
 };
 
 export type Status = 'Live' | 'Draft';

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -6,30 +6,10 @@ interface BannerDesignImage {
   wideUrl: string;
   altText: string;
 }
-type HexChar =
-  | '0'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | 'A'
-  | 'B'
-  | 'C'
-  | 'D'
-  | 'E'
-  | 'F';
-
-type HexValue = `${HexChar}${HexChar}`;
-
 export interface HexColour {
-  r: HexValue;
-  g: HexValue;
-  b: HexValue;
+  r: string;
+  g: string;
+  b: string;
   kind: 'hex';
 }
 
@@ -51,3 +31,5 @@ export type BannerDesign = {
   isNew?: boolean;
   lockStatus?: LockStatus;
 } & BannerDesignProps;
+
+export const hexColourToString = (h: HexColour): string => `${h.r}${h.g}${h.b}`;

--- a/public/src/utils/bannerDesigns.test.ts
+++ b/public/src/utils/bannerDesigns.test.ts
@@ -1,10 +1,10 @@
-import { convertStringToHexColour } from './bannerDesigns';
+import { stringToHexColour } from './bannerDesigns';
 
-describe('convertStringToHexColour', () => {
+describe('stringToHexColour', () => {
   it('returns a HexColour object for a valid hex colour string', () => {
     const hexColourString = 'FF00EF';
 
-    const result = convertStringToHexColour(hexColourString);
+    const result = stringToHexColour(hexColourString);
 
     expect(result).toEqual({
       r: 'FF',
@@ -17,6 +17,6 @@ describe('convertStringToHexColour', () => {
   it('throws an error for an invalid hex colour string', () => {
     const hexColourString = 'xxx';
 
-    expect(() => convertStringToHexColour(hexColourString)).toThrow('Invalid hex colour string!');
+    expect(() => stringToHexColour(hexColourString)).toThrow('Invalid hex colour string!');
   });
 });

--- a/public/src/utils/bannerDesigns.test.ts
+++ b/public/src/utils/bannerDesigns.test.ts
@@ -1,0 +1,22 @@
+import { convertStringToHexColour } from './bannerDesigns';
+
+describe('convertStringToHexColour', () => {
+  it('returns a HexColour object for a valid hex colour string', () => {
+    const hexColourString = 'FF00EF';
+
+    const result = convertStringToHexColour(hexColourString);
+
+    expect(result).toEqual({
+      r: 'FF',
+      g: '00',
+      b: 'EF',
+      kind: 'hex',
+    });
+  });
+
+  it('throws an error for an invalid hex colour string', () => {
+    const hexColourString = 'xxx';
+
+    expect(() => convertStringToHexColour(hexColourString)).toThrow('Invalid hex colour string!');
+  });
+});

--- a/public/src/utils/bannerDesigns.ts
+++ b/public/src/utils/bannerDesigns.ts
@@ -17,7 +17,7 @@ export const hexColourStringRegex = /^([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/;
 const isValidHexColourString = (colourString: string): boolean =>
   hexColourStringRegex.test(colourString);
 
-export const convertStringToHexColour = (colourString: string): HexColour => {
+export const stringToHexColour = (colourString: string): HexColour => {
   if (isValidHexColourString(colourString)) {
     const matches = hexColourStringRegex.exec(colourString);
     return {
@@ -30,3 +30,5 @@ export const convertStringToHexColour = (colourString: string): HexColour => {
     throw new Error('Invalid hex colour string!');
   }
 };
+
+export const hexColourToString = (h: HexColour): string => `${h.r}${h.g}${h.b}`;

--- a/public/src/utils/bannerDesigns.ts
+++ b/public/src/utils/bannerDesigns.ts
@@ -1,5 +1,5 @@
 import { BannerVariant, uiIsDesign } from '../models/banner';
-import { BannerDesign } from '../models/bannerDesign';
+import { BannerDesign, HexColour } from '../models/bannerDesign';
 
 export const getDesignForVariant = (
   variant: BannerVariant,
@@ -9,5 +9,24 @@ export const getDesignForVariant = (
 
   if (uiIsDesign(template)) {
     return designs.find(d => d.name === template.designName);
+  }
+};
+
+export const hexColourStringRegex = /^([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/;
+
+const isValidHexColourString = (colourString: string): boolean =>
+  hexColourStringRegex.test(colourString);
+
+export const convertStringToHexColour = (colourString: string): HexColour => {
+  if (isValidHexColourString(colourString)) {
+    const matches = hexColourStringRegex.exec(colourString);
+    return {
+      r: matches?.[1] as string,
+      g: matches?.[2] as string,
+      b: matches?.[3] as string,
+      kind: 'hex',
+    };
+  } else {
+    throw new Error('Invalid hex colour string!');
   }
 };

--- a/public/src/utils/bannerDesigns.ts
+++ b/public/src/utils/bannerDesigns.ts
@@ -12,7 +12,7 @@ export const getDesignForVariant = (
   }
 };
 
-export const hexColourStringRegex = /^([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/;
+export const hexColourStringRegex = /^([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/i;
 
 const isValidHexColourString = (colourString: string): boolean =>
   hexColourStringRegex.test(colourString);
@@ -21,9 +21,9 @@ export const stringToHexColour = (colourString: string): HexColour => {
   if (isValidHexColourString(colourString)) {
     const matches = hexColourStringRegex.exec(colourString);
     return {
-      r: matches?.[1] as string,
-      g: matches?.[2] as string,
-      b: matches?.[3] as string,
+      r: (matches?.[1] as string).toUpperCase(),
+      g: (matches?.[2] as string).toUpperCase(),
+      b: (matches?.[3] as string).toUpperCase(),
       kind: 'hex',
     };
   } else {


### PR DESCRIPTION
## What does this change?

This PR adds the first designable banner colour fields: body text and background colour.

SDC counterpart: guardian/support-dotcom-components#966

Colours are entered as hex strings, validated and parsed into hex colour objects before sending to the server.

![Screen Recording 2023-10-02 at 10 15 48 mov](https://github.com/guardian/support-admin-console/assets/379839/e8cb8984-3d1d-48c8-b3b4-132591bf8151)

Note: I ran into the same eslint support issue for template types that I'd had on SDC. For now I'm going to avoid upgrading a bunch of libraries and have typed the individual colour codes as strings. I'd like to change this in the near future.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
