### PR TITLE
ColourInput component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.0.0",
         "react-dom": "^17.0.2",
-        "react-hook-form": "^6.7.2",
+        "react-hook-form": "^6.15.8",
         "react-qr-code": "^2.0.7",
         "react-router-dom": "^5.0.1",
         "recharts": "2.0.8",
@@ -11130,10 +11130,11 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "6.8.1",
-      "license": "MIT",
+      "version": "6.15.8",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
+      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==",
       "peerDependencies": {
-        "react": "^16.8.0"
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/react-is": {
@@ -22351,7 +22352,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-hook-form": {
-      "version": "6.8.1",
+      "version": "6.15.8",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
+      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^6.7.2",
+    "react-hook-form": "^6.15.8",
     "react-qr-code": "^2.0.7",
     "react-router-dom": "^5.0.1",
     "recharts": "2.0.8",

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -9,12 +9,9 @@ import {
   DEFAULT_BANNER_DESIGN,
 } from './utils/defaults';
 import { useStyles } from '../helpers/testEditorStyles';
-import {
-  hexColourToString,
-  hexColourStringRegex,
-  stringToHexColour,
-} from '../../../utils/bannerDesigns';
+import { hexColourToString, stringToHexColour } from '../../../utils/bannerDesigns';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import { ColourInput } from './ColourInput';
 
 type Props = {
   design: BannerDesign;
@@ -26,11 +23,6 @@ type Props = {
 const imageUrlValidation = {
   value: /^https:\/\/i\.guim\.co\.uk\//,
   message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
-};
-
-const colourValidation = {
-  value: hexColourStringRegex,
-  message: 'Colours must be a valid 6 character hex code e.g. FF0000',
 };
 
 export const useLocalStyles = makeStyles(({}: Theme) => ({
@@ -75,7 +67,7 @@ const BannerDesignForm: React.FC<Props> = ({
     },
   };
 
-  const { register, handleSubmit, errors, reset } = useForm<FormData>({
+  const { control, register, handleSubmit, errors, reset } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -106,6 +98,7 @@ const BannerDesignForm: React.FC<Props> = ({
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
   }, [
+    // TODO - can we just use errors here?
     errors?.image?.mobileUrl,
     errors?.image?.tabletDesktopUrl,
     errors?.image?.wideUrl,
@@ -187,35 +180,21 @@ const BannerDesignForm: React.FC<Props> = ({
           Basic Colours
         </Typography>
         <div>
-          <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: colourValidation,
-            })}
-            error={errors?.colours?.basic?.background !== undefined}
-            helperText={errors?.colours?.basic?.background?.message}
-            onBlur={handleSubmit(onSubmit)}
+          <ColourInput
+            control={control}
+            error={errors?.colours?.basic?.background?.message}
             name="colours.basic.background"
             label="Background Colour"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
-          />
-          <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: colourValidation,
-            })}
-            error={errors?.colours?.basic?.bodyText !== undefined}
-            helperText={errors?.colours?.basic?.bodyText?.message}
+            isDisabled={isDisabled}
             onBlur={handleSubmit(onSubmit)}
+          />
+          <ColourInput
+            control={control}
+            error={errors?.colours?.basic?.bodyText?.message}
             name="colours.basic.bodyText"
             label="Body Text Colour"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
+            isDisabled={isDisabled}
+            onBlur={handleSubmit(onSubmit)}
           />
         </div>
       </div>

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -98,7 +98,6 @@ const BannerDesignForm: React.FC<Props> = ({
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
   }, [
-    // TODO - can we just use errors here?
     errors?.image?.mobileUrl,
     errors?.image?.tabletDesktopUrl,
     errors?.image?.wideUrl,

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { TextField } from '@material-ui/core';
+import { hexColourStringRegex } from '../../../utils/bannerDesigns';
+import { Control, useController } from 'react-hook-form';
+
+const colourValidation = {
+  value: hexColourStringRegex,
+  message: 'Colours must be a valid 6 character hex code e.g. FF0000',
+};
+
+interface Props {
+  control: Control;
+  name: string;
+  label: string;
+  error?: string;
+  isDisabled: boolean;
+  onBlur: () => void;
+}
+
+export const ColourInput: React.FC<Props> = ({
+  control,
+  name,
+  label,
+  error,
+  isDisabled,
+  onBlur,
+}: Props) => {
+  const {
+    field: { ref, onChange, value },
+  } = useController({
+    name,
+    control,
+    rules: {
+      required: true,
+      pattern: colourValidation,
+    },
+  });
+
+  return (
+    <TextField
+      name={name}
+      value={value}
+      onBlur={onBlur}
+      onChange={x => {
+        onChange(x.target.value);
+      }}
+      inputRef={ref}
+      label={label}
+      error={error !== undefined}
+      helperText={error}
+      margin="normal"
+      variant="outlined"
+      fullWidth
+      disabled={isDisabled}
+    />
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -42,9 +42,7 @@ export const ColourInput: React.FC<Props> = ({
       name={name}
       value={value}
       onBlur={onBlur}
-      onChange={x => {
-        onChange(x.target.value);
-      }}
+      onChange={onChange}
       inputRef={ref}
       label={label}
       error={error !== undefined}


### PR DESCRIPTION
We're going to have a lot of colour inputs in the banner design tool.
This PR refactors the existing colour inputs into a new component.
The component does validation of the string, but does not handle transformation to/from the `HexColour` model. We did explore this, but it conflicts with react-hook-form, which wants to work with simple types like strings.