### PR TITLE
Banner design tool: change validation

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -1,28 +1,16 @@
-import React, { useEffect } from 'react';
-import { TextField, Typography } from '@material-ui/core';
-import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
-import { useForm } from 'react-hook-form';
-import { BannerDesign } from '../../../models/bannerDesign';
-import {
-  BannerDesignFormData,
-  BannerDesignFormData as FormData,
-  DEFAULT_BANNER_DESIGN,
-} from './utils/defaults';
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { BannerDesign, BannerDesignImage, BasicColours } from '../../../models/bannerDesign';
 import { useStyles } from '../helpers/testEditorStyles';
-import { hexColourToString, stringToHexColour } from '../../../utils/bannerDesigns';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { ColourInput } from './ColourInput';
+import { ImageUrlsEditor } from './ImageUrlsEditor';
+import { BasicColoursEditor } from './BasicColoursEditor';
 
 type Props = {
   design: BannerDesign;
   setValidationStatus: (scope: string, isValid: boolean) => void;
   isDisabled: boolean;
   onChange: (design: BannerDesign) => void;
-};
-
-const imageUrlValidation = {
-  value: /^https:\/\/i\.guim\.co\.uk\//,
-  message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
 };
 
 export const useLocalStyles = makeStyles(({}: Theme) => ({
@@ -42,69 +30,26 @@ const BannerDesignForm: React.FC<Props> = ({
   const classes = useStyles();
   const localClasses = useLocalStyles();
 
-  const onValidationChange = (isValid: boolean): void => {
-    const validationScope = design.name;
-    setValidationStatus(validationScope, isValid);
+  const onValidationChange = (fieldName: string, isValid: boolean): void => {
+    setValidationStatus(fieldName, isValid);
   };
 
-  const defaultValues: BannerDesignFormData = {
-    image: {
-      mobileUrl: design.image.mobileUrl || DEFAULT_BANNER_DESIGN.image.mobileUrl,
-      tabletDesktopUrl:
-        design.image.tabletDesktopUrl || DEFAULT_BANNER_DESIGN.image.tabletDesktopUrl,
-      wideUrl: design.image.wideUrl || DEFAULT_BANNER_DESIGN.image.wideUrl,
-      altText: design.image.altText || DEFAULT_BANNER_DESIGN.image.altText,
-    },
-    colours: {
-      basic: {
-        background:
-          hexColourToString(design.colours.basic.background) ||
-          DEFAULT_BANNER_DESIGN.colours.basic.background,
-        bodyText:
-          hexColourToString(design.colours.basic.bodyText) ||
-          DEFAULT_BANNER_DESIGN.colours.basic.bodyText,
+  const onImageChange = (image: BannerDesignImage): void => {
+    onChange({
+      ...design,
+      image,
+    });
+  };
+
+  const onBasicColoursChange = (basicColours: BasicColours): void => {
+    onChange({
+      ...design,
+      colours: {
+        ...design.colours,
+        basic: basicColours,
       },
-    },
+    });
   };
-
-  const { control, register, handleSubmit, errors, reset } = useForm<FormData>({
-    mode: 'onChange',
-    defaultValues,
-  });
-
-  useEffect(() => {
-    reset(defaultValues);
-  }, [design]);
-
-  const onSubmit = (formData: FormData): void => {
-    try {
-      onChange({
-        ...design,
-        image: formData.image,
-        colours: {
-          basic: {
-            background: stringToHexColour(formData.colours.basic.background),
-            bodyText: stringToHexColour(formData.colours.basic.bodyText),
-          },
-        },
-      });
-    } catch (e) {
-      // We don't expect to get here as the form validation should have caught invalid hex colour strings
-      alert(`Something went wrong saving banner design: ${e}`);
-    }
-  };
-
-  useEffect(() => {
-    const isValid = Object.keys(errors).length === 0;
-    onValidationChange(isValid);
-  }, [
-    errors?.image?.mobileUrl,
-    errors?.image?.tabletDesktopUrl,
-    errors?.image?.wideUrl,
-    errors?.image?.altText,
-    errors?.colours?.basic?.bodyText,
-    errors?.colours?.basic?.background,
-  ]);
 
   return (
     <div className={classes.container}>
@@ -112,90 +57,23 @@ const BannerDesignForm: React.FC<Props> = ({
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Images
         </Typography>
-        <div>
-          <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
-            })}
-            error={errors?.image?.mobileUrl !== undefined}
-            helperText={errors?.image?.mobileUrl?.message}
-            onBlur={handleSubmit(onSubmit)}
-            name="image.mobileUrl"
-            label="Banner Image URL (Mobile)"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
-          />
-          <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
-            })}
-            error={errors?.image?.tabletDesktopUrl !== undefined}
-            helperText={errors?.image?.tabletDesktopUrl?.message}
-            onBlur={handleSubmit(onSubmit)}
-            name="image.tabletDesktopUrl"
-            label="Banner Image URL (Tablet & Desktop)"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
-          />
-          <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
-            })}
-            error={errors?.image?.wideUrl !== undefined}
-            helperText={errors?.image?.wideUrl?.message}
-            onBlur={handleSubmit(onSubmit)}
-            name="image.wideUrl"
-            label="Banner Image URL (Wide)"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
-          />
-          <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-            })}
-            error={errors?.image?.altText !== undefined}
-            helperText={errors?.image?.altText?.message}
-            onBlur={handleSubmit(onSubmit)}
-            name="image.altText"
-            label="Banner Image Description (alt text)"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
-          />
-        </div>
+        <ImageUrlsEditor
+          image={design.image}
+          isDisabled={isDisabled}
+          onValidationChange={isValid => onValidationChange('imageUrls', isValid)}
+          onChange={onImageChange}
+        />
       </div>
       <div className={[classes.sectionContainer, localClasses.colourSectionContainer].join(' ')}>
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Basic Colours
         </Typography>
-        <div>
-          <ColourInput
-            control={control}
-            error={errors?.colours?.basic?.background?.message}
-            name="colours.basic.background"
-            label="Background Colour"
-            isDisabled={isDisabled}
-            onBlur={handleSubmit(onSubmit)}
-          />
-          <ColourInput
-            control={control}
-            error={errors?.colours?.basic?.bodyText?.message}
-            name="colours.basic.bodyText"
-            label="Body Text Colour"
-            isDisabled={isDisabled}
-            onBlur={handleSubmit(onSubmit)}
-          />
-        </div>
+        <BasicColoursEditor
+          basicColours={design.colours.basic}
+          isDisabled={isDisabled}
+          onChange={onBasicColoursChange}
+          onValidationChange={onValidationChange}
+        />
       </div>
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -3,7 +3,7 @@ import { Typography } from '@material-ui/core';
 import { BannerDesign, BannerDesignImage, BasicColours } from '../../../models/bannerDesign';
 import { useStyles } from '../helpers/testEditorStyles';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { ImageUrlsEditor } from './ImageUrlsEditor';
+import { ImageEditor } from './ImageEditor';
 import { BasicColoursEditor } from './BasicColoursEditor';
 
 type Props = {
@@ -57,7 +57,7 @@ const BannerDesignForm: React.FC<Props> = ({
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Images
         </Typography>
-        <ImageUrlsEditor
+        <ImageEditor
           image={design.image}
           isDisabled={isDisabled}
           onValidationChange={isValid => onValidationChange('imageUrls', isValid)}

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { BasicColours } from '../../../models/bannerDesign';
+import { ColourInput } from './ColourInput';
+
+interface Props {
+  basicColours: BasicColours;
+  isDisabled: boolean;
+  onChange: (colours: BasicColours) => void;
+  onValidationChange: (fieldName: string, isValid: boolean) => void;
+}
+
+export const BasicColoursEditor: React.FC<Props> = ({
+  basicColours,
+  isDisabled,
+  onValidationChange,
+  onChange,
+}: Props) => {
+  return (
+    <div>
+      <ColourInput
+        colour={basicColours.background}
+        name="colours.basic.background"
+        label="Background Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...basicColours, background: colour })}
+        onValidationChange={onValidationChange}
+      />
+      <ColourInput
+        colour={basicColours.bodyText}
+        name="colours.basic.bodyText"
+        label="Body Text Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...basicColours, bodyText: colour })}
+        onValidationChange={onValidationChange}
+      />
+    </div>
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { TextField } from '@material-ui/core';
-import { hexColourStringRegex } from '../../../utils/bannerDesigns';
-import { Control, useController } from 'react-hook-form';
+import {
+  hexColourStringRegex,
+  hexColourToString,
+  stringToHexColour,
+} from '../../../utils/bannerDesigns';
+import { useForm } from 'react-hook-form';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import { HexColour } from '../../../models/bannerDesign';
 
 const colourValidation = {
   value: hexColourStringRegex,
@@ -11,43 +16,49 @@ const colourValidation = {
 };
 
 interface Props {
-  control: Control;
+  colour: HexColour;
   name: string;
   label: string;
-  error?: string;
   isDisabled: boolean;
-  onBlur: () => void;
+  onChange: (colour: HexColour) => void;
+  onValidationChange: (fieldName: string, isValid: boolean) => void;
 }
 
 export const ColourInput: React.FC<Props> = ({
-  control,
+  colour,
   name,
   label,
-  error,
   isDisabled,
-  onBlur,
+  onChange,
+  onValidationChange,
 }: Props) => {
-  const {
-    field: { ref, onChange, value },
-  } = useController({
-    name,
-    control,
-    rules: {
-      required: EMPTY_ERROR_HELPER_TEXT,
-      pattern: colourValidation,
-    },
+  const defaultValues = { colour: hexColourToString(colour) };
+  const { register, reset, handleSubmit, errors } = useForm<{ colour: string }>({
+    mode: 'onChange',
+    defaultValues,
   });
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange(name, isValid);
+  }, [errors]);
+
+  useEffect(() => {
+    // necessary to reset fields if user discards changes
+    reset(defaultValues);
+  }, [colour]);
 
   return (
     <TextField
-      name={name}
-      value={value}
-      onBlur={onBlur}
-      onChange={onChange}
-      inputRef={ref}
+      inputRef={register({
+        required: EMPTY_ERROR_HELPER_TEXT,
+        pattern: colourValidation,
+      })}
+      name="colour"
+      onBlur={handleSubmit(({ colour }) => onChange(stringToHexColour(colour)))}
       label={label}
-      error={error !== undefined}
-      helperText={error}
+      error={errors?.colour !== undefined}
+      helperText={errors?.colour?.message}
       margin="normal"
       variant="outlined"
       fullWidth

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -16,7 +16,7 @@ interface Props {
   onChange: (image: BannerDesignImage) => void;
 }
 
-export const ImageUrlsEditor: React.FC<Props> = ({
+export const ImageEditor: React.FC<Props> = ({
   image,
   isDisabled,
   onValidationChange,

--- a/public/src/components/channelManagement/bannerDesigns/ImageUrlsEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageUrlsEditor.tsx
@@ -1,0 +1,98 @@
+import { TextField } from '@material-ui/core';
+import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { BannerDesignImage } from '../../../models/bannerDesign';
+
+const imageUrlValidation = {
+  value: /^https:\/\/i\.guim\.co\.uk\//,
+  message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
+};
+
+interface Props {
+  image: BannerDesignImage;
+  isDisabled: boolean;
+  onValidationChange: (isValid: boolean) => void;
+  onChange: (image: BannerDesignImage) => void;
+}
+
+export const ImageUrlsEditor: React.FC<Props> = ({
+  image,
+  isDisabled,
+  onValidationChange,
+  onChange,
+}: Props) => {
+  const { register, handleSubmit, errors } = useForm<BannerDesignImage>({
+    mode: 'onChange',
+    defaultValues: image,
+  });
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange(isValid);
+  }, [errors]);
+
+  return (
+    <div>
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+          pattern: imageUrlValidation,
+        })}
+        error={errors?.mobileUrl !== undefined}
+        helperText={errors?.mobileUrl?.message}
+        onBlur={handleSubmit(onChange)}
+        name="mobileUrl"
+        label="Banner Image URL (Mobile)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+          pattern: imageUrlValidation,
+        })}
+        error={errors?.tabletDesktopUrl !== undefined}
+        helperText={errors?.tabletDesktopUrl?.message}
+        onBlur={handleSubmit(onChange)}
+        name="tabletDesktopUrl"
+        label="Banner Image URL (Tablet & Desktop)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+          pattern: imageUrlValidation,
+        })}
+        error={errors?.wideUrl !== undefined}
+        helperText={errors?.wideUrl?.message}
+        onBlur={handleSubmit(onChange)}
+        name="wideUrl"
+        label="Banner Image URL (Wide)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        error={errors?.altText !== undefined}
+        helperText={errors?.altText?.message}
+        onBlur={handleSubmit(onChange)}
+        name="altText"
+        label="Banner Image Description (alt text)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+    </div>
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/ImageUrlsEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageUrlsEditor.tsx
@@ -22,7 +22,7 @@ export const ImageUrlsEditor: React.FC<Props> = ({
   onValidationChange,
   onChange,
 }: Props) => {
-  const { register, handleSubmit, errors } = useForm<BannerDesignImage>({
+  const { register, handleSubmit, errors, reset } = useForm<BannerDesignImage>({
     mode: 'onChange',
     defaultValues: image,
   });
@@ -31,6 +31,11 @@ export const ImageUrlsEditor: React.FC<Props> = ({
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
   }, [errors]);
+
+  useEffect(() => {
+    // necessary to reset fields if user discards changes
+    reset(image);
+  }, [image]);
 
   return (
     <div>

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,21 +1,6 @@
 import { BannerDesign } from '../../../../models/bannerDesign';
 import { stringToHexColour } from '../../../../utils/bannerDesigns';
 
-export type BannerDesignFormData = {
-  image: {
-    mobileUrl: string;
-    tabletDesktopUrl: string;
-    wideUrl: string;
-    altText: string;
-  };
-  colours: {
-    basic: {
-      background: string;
-      bodyText: string;
-    };
-  };
-};
-
 export const DEFAULT_BANNER_DESIGN = {
   image: {
     mobileUrl:

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -1,6 +1,6 @@
 import { LockStatus } from '../components/channelManagement/helpers/shared';
 
-interface BannerDesignImage {
+export interface BannerDesignImage {
   mobileUrl: string;
   tabletDesktopUrl: string;
   wideUrl: string;
@@ -13,13 +13,15 @@ export interface HexColour {
   kind: 'hex';
 }
 
+export interface BasicColours {
+  background: HexColour;
+  bodyText: HexColour;
+}
+
 export type BannerDesignProps = {
   image: BannerDesignImage;
   colours: {
-    basic: {
-      background: HexColour;
-      bodyText: HexColour;
-    };
+    basic: BasicColours;
   };
 };
 


### PR DESCRIPTION
This PR proposes removing react-hook-form from the top-level of the banner design tool.
This is because react-hook-form makes it hard to nest components.

We already have a hook for monitoring the overall validation status of the form, to prevent the user from submitting invalid data. This hook stores validation status per field name. `BannerDesignForm` now makes better use of this, instead of using react-hook-form.

This means we no longer need the `BannerDesignFormData` model, which mirrors the `BannerDesign` model.

react-hook-form is still useful inside some nested components where we want to validate input fields.

The downside is that we now mix our own validation (`useValidation` at the top level) and react-hook-form in certain subcomponents. This is a bit confusing, but is similar to the approach in the channel test tools