### PR TITLE
More banner colours

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -18,35 +18,67 @@ object BannerDesignStatus {
   implicit val statusDecoder = deriveEnumerationDecoder[BannerDesignStatus]
 }
 
+sealed trait GuardianRoundelDesign
+object GuardianRoundelDesign {
+  case object default extends GuardianRoundelDesign
+  case object brand extends GuardianRoundelDesign
+  case object inverse extends GuardianRoundelDesign
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val encoder = deriveEnumerationEncoder[GuardianRoundelDesign]
+  implicit val decoder = deriveEnumerationDecoder[GuardianRoundelDesign]
+}
+
 case class BannerDesignImage(
-    mobileUrl: String,
-    tabletDesktopUrl: String,
-    wideUrl: String,
-    altText: String
+  mobileUrl: String,
+  tabletDesktopUrl: String,
+  wideUrl: String,
+  altText: String
 )
 
 case class HexColour(
-    r: String,
-    g: String,
-    b: String,
-    kind: String,
+  r: String,
+  g: String,
+  b: String,
+  kind: String,
 )
 
 case class BannerDesignBasicColours(
-    background: HexColour,
-    bodyText: HexColour,
+  background: HexColour,
+  bodyText: HexColour,
+  headerText: HexColour,
+  articleCountText: HexColour,
+)
+
+case class BannerDesignHighlightedTextColours(
+  text: HexColour,
+  highlight: HexColour
+)
+
+case class CtaStateDesign(
+  text: HexColour,
+  background: HexColour,
+  border: Option[HexColour]
+)
+
+case class CtaDesign(
+  default: CtaStateDesign,
+  hover: CtaStateDesign
 )
 
 case class BannerDesignColours(
-    basic: BannerDesignBasicColours,
+  basic: BannerDesignBasicColours,
+  highlightedText: BannerDesignHighlightedTextColours,
+  primaryCta: CtaDesign,
+  secondaryCta: CtaDesign,
+  closeButton: CtaDesign,
+  guardianRoundel: Option[GuardianRoundelDesign]
 )
 
 case class BannerDesign(
-    name: String,
-    status: BannerDesignStatus,
-    image: BannerDesignImage,
-    colours: BannerDesignColours,
-    lockStatus: Option[LockStatus],
+  name: String,
+  status: BannerDesignStatus,
+  image: BannerDesignImage,
+  colours: BannerDesignColours,
+  lockStatus: Option[LockStatus],
 )
-
-object BannerDesign {}

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
-import { BannerDesign, BannerDesignImage, BasicColours } from '../../../models/bannerDesign';
+import {
+  BannerDesign,
+  BannerDesignImage,
+  BasicColours,
+  CtaDesign,
+  HighlightedTextColours,
+} from '../../../models/bannerDesign';
 import { useStyles } from '../helpers/testEditorStyles';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { ImageEditor } from './ImageEditor';
 import { BasicColoursEditor } from './BasicColoursEditor';
+import { HighlightedTextColoursEditor } from './HighlightedTextColoursEditor';
+import { CtaColoursEditor } from './CtaColoursEditor';
 
 type Props = {
   design: BannerDesign;
@@ -51,6 +59,28 @@ const BannerDesignForm: React.FC<Props> = ({
     });
   };
 
+  const onHighlightedTextColoursChange = (highlightedTextColours: HighlightedTextColours): void => {
+    onChange({
+      ...design,
+      colours: {
+        ...design.colours,
+        highlightedText: highlightedTextColours,
+      },
+    });
+  };
+
+  const onCtaColoursChange = (name: 'primaryCta' | 'secondaryCta' | 'closeButton') => (
+    cta: CtaDesign,
+  ): void => {
+    onChange({
+      ...design,
+      colours: {
+        ...design.colours,
+        [name]: cta,
+      },
+    });
+  };
+
   return (
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
@@ -73,6 +103,47 @@ const BannerDesignForm: React.FC<Props> = ({
           isDisabled={isDisabled}
           onChange={onBasicColoursChange}
           onValidationChange={onValidationChange}
+        />
+      </div>
+      <div className={[classes.sectionContainer, localClasses.colourSectionContainer].join(' ')}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Highlighted Text Colours
+        </Typography>
+        <HighlightedTextColoursEditor
+          colours={design.colours.highlightedText}
+          isDisabled={isDisabled}
+          onChange={onHighlightedTextColoursChange}
+          onValidationChange={onValidationChange}
+        />
+      </div>
+      <div className={[classes.sectionContainer, localClasses.colourSectionContainer].join(' ')}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          CTA Colours
+        </Typography>
+
+        <CtaColoursEditor
+          cta={design.colours.primaryCta}
+          isDisabled={isDisabled}
+          onChange={onCtaColoursChange('primaryCta')}
+          onValidationChange={onValidationChange}
+          name={'colours.primaryCta'}
+          label="Primary CTA"
+        />
+        <CtaColoursEditor
+          cta={design.colours.secondaryCta}
+          isDisabled={isDisabled}
+          onChange={onCtaColoursChange('secondaryCta')}
+          onValidationChange={onValidationChange}
+          name={'colours.secondaryCta'}
+          label="Secondary CTA"
+        />
+        <CtaColoursEditor
+          cta={design.colours.closeButton}
+          isDisabled={isDisabled}
+          onChange={onCtaColoursChange('closeButton')}
+          onValidationChange={onValidationChange}
+          name={'colours.closeButton'}
+          label="Close button"
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -5,6 +5,7 @@ import {
   BannerDesignImage,
   BasicColours,
   CtaDesign,
+  GuardianRoundel,
   HighlightedTextColours,
 } from '../../../models/bannerDesign';
 import { useStyles } from '../helpers/testEditorStyles';
@@ -13,6 +14,7 @@ import { ImageEditor } from './ImageEditor';
 import { BasicColoursEditor } from './BasicColoursEditor';
 import { HighlightedTextColoursEditor } from './HighlightedTextColoursEditor';
 import { CtaColoursEditor } from './CtaColoursEditor';
+import TypedRadioGroup from '../TypedRadioGroup';
 
 type Props = {
   design: BannerDesign;
@@ -81,6 +83,16 @@ const BannerDesignForm: React.FC<Props> = ({
     });
   };
 
+  const onRoundelChange = (roundel: GuardianRoundel): void => {
+    onChange({
+      ...design,
+      colours: {
+        ...design.colours,
+        guardianRoundel: roundel,
+      },
+    });
+  };
+
   return (
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
@@ -144,6 +156,21 @@ const BannerDesignForm: React.FC<Props> = ({
           onValidationChange={onValidationChange}
           name={'colours.closeButton'}
           label="Close button"
+        />
+      </div>
+      <div className={[classes.sectionContainer, localClasses.colourSectionContainer].join(' ')}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Roundel style
+        </Typography>
+        <TypedRadioGroup
+          selectedValue={design.colours.guardianRoundel}
+          onChange={onRoundelChange}
+          isDisabled={isDisabled}
+          labels={{
+            default: 'Default',
+            brand: 'Brand',
+            inverse: 'Inverse',
+          }}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -24,6 +24,7 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, background: colour })}
         onValidationChange={onValidationChange}
+        required={true}
       />
       <ColourInput
         colour={basicColours.bodyText}
@@ -32,6 +33,7 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, bodyText: colour })}
         onValidationChange={onValidationChange}
+        required={true}
       />
       <ColourInput
         colour={basicColours.headerText}
@@ -40,6 +42,7 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, headerText: colour })}
         onValidationChange={onValidationChange}
+        required={true}
       />
       <ColourInput
         colour={basicColours.articleCountText}
@@ -48,6 +51,7 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, articleCountText: colour })}
         onValidationChange={onValidationChange}
+        required={true}
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -33,6 +33,22 @@ export const BasicColoursEditor: React.FC<Props> = ({
         onChange={colour => onChange({ ...basicColours, bodyText: colour })}
         onValidationChange={onValidationChange}
       />
+      <ColourInput
+        colour={basicColours.headerText}
+        name="colours.basic.headerText"
+        label="Header Text Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...basicColours, headerText: colour })}
+        onValidationChange={onValidationChange}
+      />
+      <ColourInput
+        colour={basicColours.articleCountText}
+        name="colours.basic.articleCountText"
+        label="Article Count Text Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...basicColours, articleCountText: colour })}
+        onValidationChange={onValidationChange}
+      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -16,12 +16,13 @@ const colourValidation = {
 };
 
 interface Props {
-  colour: HexColour;
+  colour?: HexColour;
   name: string;
   label: string;
   isDisabled: boolean;
   onChange: (colour: HexColour) => void;
   onValidationChange: (fieldName: string, isValid: boolean) => void;
+  required: boolean;
 }
 
 export const ColourInput: React.FC<Props> = ({
@@ -31,8 +32,9 @@ export const ColourInput: React.FC<Props> = ({
   isDisabled,
   onChange,
   onValidationChange,
+  required = true,
 }: Props) => {
-  const defaultValues = { colour: hexColourToString(colour) };
+  const defaultValues = { colour: colour ? hexColourToString(colour) : '' };
   const { register, reset, handleSubmit, errors } = useForm<{ colour: string }>({
     mode: 'onChange',
     defaultValues,
@@ -51,7 +53,7 @@ export const ColourInput: React.FC<Props> = ({
   return (
     <TextField
       inputRef={register({
-        required: EMPTY_ERROR_HELPER_TEXT,
+        required: required ?? EMPTY_ERROR_HELPER_TEXT,
         pattern: colourValidation,
       })}
       name="colour"
@@ -63,6 +65,7 @@ export const ColourInput: React.FC<Props> = ({
       variant="outlined"
       fullWidth
       disabled={isDisabled}
+      required={required}
     />
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -53,7 +53,7 @@ export const ColourInput: React.FC<Props> = ({
   return (
     <TextField
       inputRef={register({
-        required: required ?? EMPTY_ERROR_HELPER_TEXT,
+        required: required ? EMPTY_ERROR_HELPER_TEXT : false,
         pattern: colourValidation,
       })}
       name="colour"

--- a/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
@@ -18,7 +18,7 @@ export const useLocalStyles = makeStyles(({ palette }: Theme) => ({
     fontSize: 16,
     fontWeight: 500,
   },
-  sectionHeader: {
+  header: {
     fontSize: 16,
     fontWeight: 500,
     color: palette.grey[700],
@@ -46,7 +46,7 @@ export const CtaColoursEditor: React.FC<Props> = ({
 
   return (
     <>
-      <div className={classes.sectionHeader}>{label}</div>
+      <div className={classes.header}>{label}</div>
       <div className={classes.container}>
         <div className={classes.stateContainer}>
           <div className={classes.stateLabel}>Default</div>

--- a/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { CtaDesign } from '../../../models/bannerDesign';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { ColourInput } from './ColourInput';
+
+export const useLocalStyles = makeStyles(({ palette }: Theme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+    marginTop: '16px',
+  },
+  stateContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginRight: '16px',
+  },
+  stateLabel: {
+    fontSize: 16,
+    fontWeight: 500,
+  },
+  sectionHeader: {
+    fontSize: 16,
+    fontWeight: 500,
+    color: palette.grey[700],
+  },
+}));
+
+interface Props {
+  cta: CtaDesign;
+  isDisabled: boolean;
+  onChange: (cta: CtaDesign) => void;
+  onValidationChange: (fieldName: string, isValid: boolean) => void;
+  name: string;
+  label: string;
+}
+
+export const CtaColoursEditor: React.FC<Props> = ({
+  cta,
+  isDisabled,
+  onValidationChange,
+  onChange,
+  name,
+  label,
+}: Props) => {
+  const classes = useLocalStyles();
+
+  return (
+    <>
+      <div className={classes.sectionHeader}>{label}</div>
+      <div className={classes.container}>
+        <div className={classes.stateContainer}>
+          <div className={classes.stateLabel}>Default</div>
+
+          <ColourInput
+            colour={cta.default.text}
+            name={`${name}.text`}
+            label="Text Colour"
+            isDisabled={isDisabled}
+            onChange={colour => onChange({ ...cta, default: { ...cta.default, text: colour } })}
+            onValidationChange={onValidationChange}
+            required={true}
+          />
+          <ColourInput
+            colour={cta.default.background}
+            name={`${name}.background`}
+            label="Background Colour"
+            isDisabled={isDisabled}
+            onChange={colour =>
+              onChange({ ...cta, default: { ...cta.default, background: colour } })
+            }
+            onValidationChange={onValidationChange}
+            required={true}
+          />
+          <ColourInput
+            colour={cta.default.border}
+            name={`${name}.border`}
+            label="Border Colour"
+            isDisabled={isDisabled}
+            onChange={colour => onChange({ ...cta, default: { ...cta.default, border: colour } })}
+            onValidationChange={onValidationChange}
+            required={false}
+          />
+        </div>
+
+        <div className={classes.stateContainer}>
+          <div className={classes.stateLabel}>Hover</div>
+
+          <ColourInput
+            colour={cta.hover.text}
+            name={`${name}.text`}
+            label="Text Colour"
+            isDisabled={isDisabled}
+            onChange={colour => onChange({ ...cta, hover: { ...cta.hover, text: colour } })}
+            onValidationChange={onValidationChange}
+            required={true}
+          />
+          <ColourInput
+            colour={cta.hover.background}
+            name={`${name}.background`}
+            label="Background Colour"
+            isDisabled={isDisabled}
+            onChange={colour => onChange({ ...cta, hover: { ...cta.hover, background: colour } })}
+            onValidationChange={onValidationChange}
+            required={true}
+          />
+          <ColourInput
+            colour={cta.hover.border}
+            name={`${name}.border`}
+            label="Border Colour"
+            isDisabled={isDisabled}
+            onChange={colour => onChange({ ...cta, hover: { ...cta.hover, border: colour } })}
+            onValidationChange={onValidationChange}
+            required={false}
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { HighlightedTextColours } from '../../../models/bannerDesign';
+import { ColourInput } from './ColourInput';
+
+interface Props {
+  colours: HighlightedTextColours;
+  isDisabled: boolean;
+  onChange: (colours: HighlightedTextColours) => void;
+  onValidationChange: (fieldName: string, isValid: boolean) => void;
+}
+
+export const HighlightedTextColoursEditor: React.FC<Props> = ({
+  colours,
+  isDisabled,
+  onValidationChange,
+  onChange,
+}: Props) => {
+  return (
+    <div>
+      <ColourInput
+        colour={colours.text}
+        name="colours.highlightedText.text"
+        label="Background Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...colours, text: colour })}
+        onValidationChange={onValidationChange}
+        required={true}
+      />
+      <ColourInput
+        colour={colours.highlight}
+        name="colours.highlightedText.highlight"
+        label="Body Text Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...colours, highlight: colour })}
+        onValidationChange={onValidationChange}
+        required={true}
+      />
+    </div>
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -15,7 +15,47 @@ export const DEFAULT_BANNER_DESIGN = {
     basic: {
       background: '222527',
       bodyText: 'FFFFFF',
+      headerText: 'FFFFFF',
+      articleCountText: 'FFFFFF',
     },
+    highlightedText: {
+      text: 'FFFFFF',
+      highlight: 'FFE500',
+    },
+    primaryCta: {
+      default: {
+        text: 'FFFFFF',
+        background: '0077B6',
+      },
+      hover: {
+        text: 'FFFFFF',
+        background: '004E7C',
+      },
+    },
+    secondaryCta: {
+      default: {
+        text: '004E7C',
+        background: 'F1F8FC',
+        border: '004E7C',
+      },
+      hover: {
+        text: '004E7C',
+        background: 'E5E5E5',
+        border: '004E7C',
+      },
+    },
+    closeButton: {
+      default: {
+        text: '052962',
+        background: 'F1F8FC',
+        border: '052962',
+      },
+      hover: {
+        text: '052962',
+        background: 'E5E5E5',
+      },
+    },
+    guardianRoundel: 'default',
   },
 };
 
@@ -27,6 +67,48 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
     basic: {
       background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.background),
       bodyText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.bodyText),
+      headerText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.headerText),
+      articleCountText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.articleCountText),
     },
+    highlightedText: {
+      text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.highlightedText.text),
+      highlight: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.highlightedText.highlight),
+    },
+    primaryCta: {
+      default: {
+        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.default.text),
+        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.default.background),
+      },
+      hover: {
+        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.hover.text),
+        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.hover.background),
+      },
+    },
+    secondaryCta: {
+      default: {
+        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.default.text),
+        background: stringToHexColour(
+          DEFAULT_BANNER_DESIGN.colours.secondaryCta.default.background,
+        ),
+        border: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.default.border),
+      },
+      hover: {
+        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.hover.text),
+        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.hover.background),
+        border: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.hover.border),
+      },
+    },
+    closeButton: {
+      default: {
+        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.default.text),
+        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.default.background),
+        border: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.default.border),
+      },
+      hover: {
+        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.hover.text),
+        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.hover.background),
+      },
+    },
+    guardianRoundel: 'default',
   },
 });

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -1,7 +1,9 @@
 import { BannerDesign } from '../../../../models/bannerDesign';
 import { stringToHexColour } from '../../../../utils/bannerDesigns';
 
-export const DEFAULT_BANNER_DESIGN = {
+export const createDefaultBannerDesign = (name: string): BannerDesign => ({
+  name,
+  status: 'Draft',
   image: {
     mobileUrl:
       'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
@@ -13,102 +15,47 @@ export const DEFAULT_BANNER_DESIGN = {
   },
   colours: {
     basic: {
-      background: '222527',
-      bodyText: 'FFFFFF',
-      headerText: 'FFFFFF',
-      articleCountText: 'FFFFFF',
+      background: stringToHexColour('F1F8FC'),
+      bodyText: stringToHexColour('000000'),
+      headerText: stringToHexColour('000000'),
+      articleCountText: stringToHexColour('000000'),
     },
     highlightedText: {
-      text: 'FFFFFF',
-      highlight: 'FFE500',
+      text: stringToHexColour('000000'),
+      highlight: stringToHexColour('FFE500'),
     },
     primaryCta: {
       default: {
-        text: 'FFFFFF',
-        background: '0077B6',
+        text: stringToHexColour('FFFFFF'),
+        background: stringToHexColour('0077B6'),
       },
       hover: {
-        text: 'FFFFFF',
-        background: '004E7C',
+        text: stringToHexColour('FFFFFF'),
+        background: stringToHexColour('004E7C'),
       },
     },
     secondaryCta: {
       default: {
-        text: '004E7C',
-        background: 'F1F8FC',
-        border: '004E7C',
+        text: stringToHexColour('004E7C'),
+        background: stringToHexColour('F1F8FC'),
+        border: stringToHexColour('004E7C'),
       },
       hover: {
-        text: '004E7C',
-        background: 'E5E5E5',
-        border: '004E7C',
+        text: stringToHexColour('004E7C'),
+        background: stringToHexColour('E5E5E5'),
+        border: stringToHexColour('004E7C'),
       },
     },
     closeButton: {
       default: {
-        text: '052962',
-        background: 'F1F8FC',
-        border: '052962',
+        text: stringToHexColour('052962'),
+        background: stringToHexColour('F1F8FC'),
+        border: stringToHexColour('052962'),
       },
       hover: {
-        text: '052962',
-        background: 'E5E5E5',
+        text: stringToHexColour('052962'),
+        background: stringToHexColour('E5E5E5'),
       },
     },
-    guardianRoundel: 'default',
-  },
-};
-
-export const createDefaultBannerDesign = (name: string): BannerDesign => ({
-  name,
-  status: 'Draft',
-  image: DEFAULT_BANNER_DESIGN.image,
-  colours: {
-    basic: {
-      background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.background),
-      bodyText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.bodyText),
-      headerText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.headerText),
-      articleCountText: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.basic.articleCountText),
-    },
-    highlightedText: {
-      text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.highlightedText.text),
-      highlight: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.highlightedText.highlight),
-    },
-    primaryCta: {
-      default: {
-        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.default.text),
-        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.default.background),
-      },
-      hover: {
-        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.hover.text),
-        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.primaryCta.hover.background),
-      },
-    },
-    secondaryCta: {
-      default: {
-        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.default.text),
-        background: stringToHexColour(
-          DEFAULT_BANNER_DESIGN.colours.secondaryCta.default.background,
-        ),
-        border: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.default.border),
-      },
-      hover: {
-        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.hover.text),
-        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.hover.background),
-        border: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.secondaryCta.hover.border),
-      },
-    },
-    closeButton: {
-      default: {
-        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.default.text),
-        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.default.background),
-        border: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.default.border),
-      },
-      hover: {
-        text: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.hover.text),
-        background: stringToHexColour(DEFAULT_BANNER_DESIGN.colours.closeButton.hover.background),
-      },
-    },
-    guardianRoundel: 'default',
   },
 });

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -57,5 +57,6 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
         background: stringToHexColour('E5E5E5'),
       },
     },
+    guardianRoundel: 'inverse',
   },
 });

--- a/public/src/components/channelManagement/helpers/testEditorStyles.ts
+++ b/public/src/components/channelManagement/helpers/testEditorStyles.ts
@@ -18,7 +18,7 @@ export const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     },
   },
   sectionHeader: {
-    fontSize: 16,
+    fontSize: 18,
     fontWeight: 500,
     color: palette.grey[700],
   },

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -16,6 +16,8 @@ export interface HexColour {
 export interface BasicColours {
   background: HexColour;
   bodyText: HexColour;
+  headerText: HexColour;
+  articleCountText: HexColour;
 }
 
 interface CtaStateDesign {
@@ -33,12 +35,7 @@ export type GuardianRoundel = 'default' | 'brand' | 'inverse';
 export type BannerDesignProps = {
   image: BannerDesignImage;
   colours: {
-    basic: {
-      background: HexColour;
-      bodyText: HexColour;
-      headerText: HexColour;
-      articleCountText: HexColour;
-    };
+    basic: BasicColours;
     highlightedText: {
       text: HexColour;
       highlight: HexColour;

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -18,10 +18,35 @@ export interface BasicColours {
   bodyText: HexColour;
 }
 
+interface CtaStateDesign {
+  text: HexColour;
+  background: HexColour;
+  border?: HexColour;
+}
+export interface CtaDesign {
+  default: CtaStateDesign;
+  hover: CtaStateDesign;
+}
+
+export type GuardianRoundel = 'default' | 'brand' | 'inverse';
+
 export type BannerDesignProps = {
   image: BannerDesignImage;
   colours: {
-    basic: BasicColours;
+    basic: {
+      background: HexColour;
+      bodyText: HexColour;
+      headerText: HexColour;
+      articleCountText: HexColour;
+    };
+    highlightedText: {
+      text: HexColour;
+      highlight: HexColour;
+    };
+    primaryCta: CtaDesign;
+    secondaryCta: CtaDesign;
+    closeButton: CtaDesign;
+    guardianRoundel?: GuardianRoundel;
   };
 };
 

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -45,7 +45,7 @@ export type BannerDesignProps = {
     primaryCta: CtaDesign;
     secondaryCta: CtaDesign;
     closeButton: CtaDesign;
-    guardianRoundel?: GuardianRoundel;
+    guardianRoundel: GuardianRoundel;
   };
 };
 

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -20,6 +20,11 @@ export interface BasicColours {
   articleCountText: HexColour;
 }
 
+export interface HighlightedTextColours {
+  text: HexColour;
+  highlight: HexColour;
+}
+
 interface CtaStateDesign {
   text: HexColour;
   background: HexColour;
@@ -36,10 +41,7 @@ export type BannerDesignProps = {
   image: BannerDesignImage;
   colours: {
     basic: BasicColours;
-    highlightedText: {
-      text: HexColour;
-      highlight: HexColour;
-    };
+    highlightedText: HighlightedTextColours;
     primaryCta: CtaDesign;
     secondaryCta: CtaDesign;
     closeButton: CtaDesign;


### PR DESCRIPTION
Corresponding SDC PR: https://github.com/guardian/support-dotcom-components/pull/977

Adds the ability to edit lots more colours, including ctas.

![Screenshot 2023-10-05 at 16 50 08](https://github.com/guardian/support-admin-console/assets/1513454/7d457c98-e752-4a61-9f3c-458de4b8f843)
![Screenshot 2023-10-05 at 16 50 21](https://github.com/guardian/support-admin-console/assets/1513454/69e35634-4cae-4ec6-b00a-852b5c2da2ca)
![Screenshot 2023-10-05 at 16 50 29](https://github.com/guardian/support-admin-console/assets/1513454/f43a690f-4eed-428a-9fa5-55324af7de77)


Some things to consider later:

1. Make each section collapsible, as the form is now very long and there's a lot of info
2. Improve the `ColourInput` component to have a fixed width, and display the chosen colour next to the input
3. Display the different roundel designs next to the radios