### PR TITLE
Display banner design usage

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -198,6 +198,7 @@ GET   /frontend/campaign/:campaignName/tests           controllers.CampaignsCont
 # ----- banner designs ----- #
 GET   /frontend/banner-designs                         controllers.banner.BannerDesignsController.getAll
 GET   /frontend/banner-designs/:designName             controllers.banner.BannerDesignsController.get(designName: String)
+GET   /frontend/banner-designs/usage/:designName       controllers.banner.BannerDesignsController.usage(designName: String)
 POST  /frontend/banner-designs/update                  controllers.banner.BannerDesignsController.update
 POST  /frontend/banner-designs/create                  controllers.banner.BannerDesignsController.create
 POST  /frontend/banner-designs/lock/:designName        controllers.banner.BannerDesignsController.lock(designName: String)

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -15,6 +15,7 @@ import { BasicColoursEditor } from './BasicColoursEditor';
 import { HighlightedTextColoursEditor } from './HighlightedTextColoursEditor';
 import { CtaColoursEditor } from './CtaColoursEditor';
 import TypedRadioGroup from '../TypedRadioGroup';
+import { BannerDesignUsage } from './BannerDesignUsage';
 
 type Props = {
   design: BannerDesign;
@@ -95,6 +96,12 @@ const BannerDesignForm: React.FC<Props> = ({
 
   return (
     <div className={classes.container}>
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Usage
+        </Typography>
+        <BannerDesignUsage designName={design.name} />
+      </div>
       <div className={classes.sectionContainer}>
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Images

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignUsage.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignUsage.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { getBannerDesignUsage } from '../../../utils/requests';
+import { List, ListItemText } from '@material-ui/core';
+import { ListItemButton } from '@mui/material';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { OpenInNew } from '@material-ui/icons';
+
+export const useLocalStyles = makeStyles(({ spacing }: Theme) => ({
+  list: {
+    marginTop: spacing(2),
+    maxWidth: '500px',
+  },
+  item: {
+    '& > :first-child': {
+      marginRight: spacing(2),
+    },
+  },
+}));
+
+interface Test {
+  name: string;
+  channel: string;
+}
+
+interface Props {
+  designName: string;
+}
+
+export const BannerDesignUsage: React.FC<Props> = ({ designName }: Props) => {
+  const localClasses = useLocalStyles();
+  const [testNames, setTestNames] = useState<Test[]>([]);
+
+  useEffect(() => {
+    getBannerDesignUsage(designName).then(tests => setTestNames(tests));
+  }, [designName]);
+
+  const TestButton = (test: Test) => {
+    const channelPart = test.channel === 'Banner1' ? 'banner-tests' : 'banner-tests2';
+    const path = channelPart + '/' + test.name;
+    return (
+      <ListItemButton className={localClasses.item} href={`/${path}`} target="_blank">
+        <OpenInNew />
+        <ListItemText primary={test.name} />
+      </ListItemButton>
+    );
+  };
+
+  return (
+    <List className={localClasses.list}>
+      {testNames.length === 0
+        ? 'Not currently used by any banner tests'
+        : testNames.map(test => (
+            <TestButton
+              key={`${test.channel}/${test.name}`}
+              name={test.name}
+              channel={test.channel}
+            />
+          ))}
+    </List>
+  );
+};

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -188,6 +188,12 @@ export function updateBannerDesignStatus(
   );
 }
 
+export function getBannerDesignUsage(
+  designName: string,
+): Promise<{ name: string; channel: string }[]> {
+  return fetchSettings(`/frontend/${FrontendSettingsType.bannerDesigns}/usage/${designName}`);
+}
+
 export function saveFrontendSettings(
   settingsType: FrontendSettingsType,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
When you select a design it fetches a list of tests that currently use that design, and links to them.

![Screenshot 2023-10-06 at 15 12 32](https://github.com/guardian/support-admin-console/assets/1513454/efcbc2a7-b291-4c66-a9cc-7df7e7154a9c)
![Screenshot 2023-10-06 at 15 12 37](https://github.com/guardian/support-admin-console/assets/1513454/1eff9e97-ea3a-4153-9070-0f199d8376ce)
