### PR TITLE
Choice Cards Buttons Banner Remove

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -14,7 +14,6 @@ object BannerUI {
   case object AusEoyMomentBanner extends BannerTemplate
   case object AusAnniversaryMomentBanner extends BannerTemplate
   case object AuBrandMomentBanner extends BannerTemplate
-  case object ChoiceCardsButtonsBannerBlue extends BannerTemplate
   case object ClimateCrisisMomentBanner extends BannerTemplate
   case object ContributionsBanner extends BannerTemplate
   case object ContributionsBannerWithSignIn extends BannerTemplate

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -287,7 +287,6 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
 
           {(template === BannerTemplate.AusAnniversaryMomentBanner ||
             template === BannerTemplate.ContributionsBanner ||
-            template === BannerTemplate.ChoiceCardsButtonsBannerBlue ||
             template === BannerTemplate.GuardianWeeklyBanner ||
             template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.GlobalNewYearMomentBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -58,10 +58,6 @@ const templatesWithLabels = [
     label: 'Contributions - with sign in link',
   },
   {
-    template: BannerTemplate.ChoiceCardsButtonsBannerBlue,
-    label: 'Choice Cards Buttons',
-  },
-  {
     template: BannerTemplate.WorldPressFreedomDayBanner,
     label: 'World Press Freedom Day',
   },

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -152,10 +152,6 @@ const bannerModules = {
     path: 'choiceCardsMoment/ChoiceCardsMomentBanner.js',
     name: 'ChoiceCardsMomentBanner',
   },
-  [BannerTemplate.ChoiceCardsButtonsBannerBlue]: {
-    path: 'choiceCardsButtonsBanner/ChoiceCardsButtonsBannerBlue.js',
-    name: 'ChoiceCardsButtonsBannerBlue',
-  },
   [BannerTemplate.WorldPressFreedomDayBanner]: {
     path: 'worldPressFreedomDay/WorldPressFreedomDayBanner.js',
     name: 'WorldPressFreedomDayBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -17,7 +17,6 @@ export enum BannerTemplate {
   AusAnniversaryMomentBanner = 'AusAnniversaryMomentBanner',
   ContributionsBanner = 'ContributionsBanner',
   ContributionsBannerWithSignIn = 'ContributionsBannerWithSignIn',
-  ChoiceCardsButtonsBannerBlue = 'ChoiceCardsButtonsBannerBlue',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',
   InvestigationsMomentBanner = 'InvestigationsMomentBanner',
   EnvironmentBanner = 'EnvironmentBanner',


### PR DESCRIPTION
## What does this change?

- Removes old ‘Choice Cards Buttons’ Banner from RRCP as its not Moment template spaced. 
- Use 'Choice Cards Moment 2023' instead.
- MUST move across all live RRCP Prod banners FIRST (list asof 6/10/23 at bottom)

![image](https://github.com/guardian/support-admin-console/assets/76729591/5e1fe878-fd6b-4f40-be4e-6cd8cfb0e3de)

LIVE RRCP Prod banners affected->
![image](https://github.com/guardian/support-admin-console/assets/76729591/0c498c6f-5569-42d6-9119-109950221e9f)

[Trello] https://trello.com/c/hDqNaSqJ/1554-banner-cleanup-in-rrcp-and-storybook-3-of-3-rrcp-to-use-choicecardbuttons-moment-banners-only