### PR TITLE
Fix image editor

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -26,6 +26,8 @@ export const ImageEditor: React.FC<Props> = ({
     mode: 'onChange',
     defaultValues: image,
   });
+  // We have to register the kind field, or it will be lost onChange
+  register('kind', { required: true, setValueAs: () => 'Image' });
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;


### PR DESCRIPTION
currently when you edit any image fields it loses the `kind` field -
![Screenshot 2023-10-11 at 09 01 39](https://github.com/guardian/support-admin-console/assets/1513454/f04ea09a-b110-446e-97b4-fdc329bf5ff4)
