### PR TITLE
Fix banner design labels for highlighted text and background colours

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
@@ -33,7 +33,7 @@ export const HighlightedTextColoursEditor: React.FC<Props> = ({
       <ColourInput
         colour={colours.text}
         name="colours.highlightedText.text"
-        label="Background Colour"
+        label="Text Colour"
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...colours, text: colour })}
         onValidationChange={onValidationChange}
@@ -42,7 +42,7 @@ export const HighlightedTextColoursEditor: React.FC<Props> = ({
       <ColourInput
         colour={colours.highlight}
         name="colours.highlightedText.highlight"
-        label="Body Text Colour"
+        label="Background Colour"
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...colours, highlight: colour })}
         onValidationChange={onValidationChange}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This fixes a small bug where the labels for highlighted text and background colours were inverted

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

| Before | After |
| --- | --- |
| ![Screenshot 2023-10-12 at 15 37 49](https://github.com/guardian/support-admin-console/assets/99180049/35476f14-85b6-49c1-8117-9f3d50a284b8) | ![Screenshot 2023-10-12 at 16 20 25](https://github.com/guardian/support-admin-console/assets/99180049/654e5f9a-67cb-4b74-8253-f9c0194244ca) |

Banner for reference
![Screenshot 2023-10-12 at 15 38 25](https://github.com/guardian/support-admin-console/assets/99180049/67fa5fad-f37f-4c83-b0b9-8c49e8ce3cc2)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
