### PR TITLE
Enable contribution type checkboxes in amounts form

### DIFF
--- a/public/src/components/amounts/AmountsVariantEditor.tsx
+++ b/public/src/components/amounts/AmountsVariantEditor.tsx
@@ -249,7 +249,6 @@ export const AmountsVariantEditor: React.FC<AmountsVariantEditorProps> = ({
                     checked={currentContributionDisplay.includes(k as ContributionType)}
                     onChange={e => updateDisplayContribution(e)}
                     name={k}
-                    disabled={true}
                   />
                 }
                 label={k}


### PR DESCRIPTION
## What does this change?
Enables the contributionType checkboxes in an amounts variant form, to allow Marketing to self-serve the display of contribution type amounts in Epic, Banner and support site amounts cards

The work to enable amounts cards to respect this display choice in Banners and the support site is ongoing. Epic amounts cards already use this data for displaying contribution type amounts

## Images

**Before change**
![Screenshot 2023-10-12 at 17 32 55](https://github.com/guardian/support-admin-console/assets/5357530/880c6731-7cec-48ed-a176-bfa3a60b71c5)

**After change**
![Screenshot 2023-10-12 at 17 34 01](https://github.com/guardian/support-admin-console/assets/5357530/f5085ec3-0987-45b4-b7c5-ad6bb38093bc)
