### PR TITLE
Support previewing a design directly

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -69,7 +69,7 @@ const BannerDesignEditor: React.FC<Props> = ({
         onSave={onSaveWithValidation}
         userHasLock={userHasLock}
         lockStatus={lockStatus}
-        status={design.status}
+        design={design}
         onStatusChange={onStatusChange}
       />
       <div className={classes.scrollableContainer}>

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -8,7 +8,17 @@ import SaveIcon from '@material-ui/icons/Save';
 import { grey } from '@material-ui/core/colors';
 import { LockStatus } from '../helpers/shared';
 import LiveSwitch from '../../shared/liveSwitch';
-import { Status } from '../../../models/bannerDesign';
+import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
+import { getDefaultVariant } from '../bannerTests/utils/defaults';
+import { BannerVariant } from '../../../models/banner';
+import { BannerDesign, Status } from '../../../models/bannerDesign';
+
+const buildVariantForPreview = (design: BannerDesign): BannerVariant => {
+  return {
+    ...getDefaultVariant(),
+    template: { designName: design.name },
+  };
+};
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -64,7 +74,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
 
 interface Props {
   name: string;
-  status: Status;
+  design: BannerDesign;
   onLock: (name: string, force: boolean) => void;
   onUnlock: (name: string) => void;
   onSave: (name: string) => void;
@@ -75,7 +85,7 @@ interface Props {
 
 const StickyTopBar: React.FC<Props> = ({
   name,
-  status,
+  design,
   onLock,
   onUnlock,
   onSave,
@@ -96,7 +106,7 @@ const StickyTopBar: React.FC<Props> = ({
         <div className={classes.switchContainer}>
           <LiveSwitch
             label="Status"
-            isLive={status === 'Live'}
+            isLive={design.status === 'Live'}
             onChange={(isLive: boolean) => onStatusChange(isLive ? 'Live' : 'Draft')}
             isDisabled={userHasLock && lockStatus.locked}
           />
@@ -147,6 +157,7 @@ const StickyTopBar: React.FC<Props> = ({
               </Button>
             </>
           )}
+          <BannerVariantPreview variant={buildVariantForPreview(design)} design={design} />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## What does this change?

Adds live previewing to the banner design page, using a hardcoded variant configuration. In a future PR I'd like to add limited configuration of the variant (toggling the ticker for example) but for now I think this is a good first step.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

<img width="1512" alt="Screenshot 2023-10-13 at 09 38 39" src="https://github.com/guardian/support-admin-console/assets/379839/ee72ea71-ddf7-4b90-a827-bc1997389fe8">

## How to test

Run locally or on CODE. Click that live preview button!

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
