### PR TITLE
Toggle the ticker from the banner design preview

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
+import { BannerDesign } from '../../../models/bannerDesign';
+import { Checkbox, FormControlLabel } from '@material-ui/core';
+import { BannerVariant } from '../../../models/banner';
+import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
+import { getDefaultVariant } from '../bannerTests/utils/defaults';
+
+interface Props {
+  design: BannerDesign;
+}
+
+interface TickerToggleProps {
+  shouldShowTicker: boolean;
+  setShouldShowTicker: (shouldShowTicker: boolean) => void;
+}
+
+const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerToggleProps) => {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={shouldShowTicker}
+          onChange={() => setShouldShowTicker(!shouldShowTicker)}
+          color="primary"
+        />
+      }
+      label={'Show ticker?'}
+    />
+  );
+};
+
+const buildVariantForPreview = (design: BannerDesign, shouldShowTicker: boolean): BannerVariant => {
+  const tickerSettings = shouldShowTicker
+    ? {
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '£',
+        copy: {
+          countLabel: 'contributions in May',
+          goalReachedPrimary: "We've met our goal - thank you!",
+          goalReachedSecondary: '',
+        },
+        name: TickerName.US,
+      }
+    : undefined;
+
+  return {
+    ...getDefaultVariant(),
+    template: { designName: design.name },
+    tickerSettings,
+  };
+};
+
+const BannerDesignPreview: React.FC<Props> = ({ design }: Props) => {
+  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
+
+  return (
+    <BannerVariantPreview
+      variant={buildVariantForPreview(design, shouldShowTicker)}
+      design={design}
+      controls={
+        <TickerToggle
+          shouldShowTicker={shouldShowTicker}
+          setShouldShowTicker={setShouldShowTicker}
+        />
+      }
+    />
+  );
+};
+
+export { BannerDesignPreview };

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -157,7 +157,11 @@ const StickyTopBar: React.FC<Props> = ({
               </Button>
             </>
           )}
-          <BannerVariantPreview variant={buildVariantForPreview(design)} design={design} />
+          <BannerVariantPreview
+            variant={buildVariantForPreview(design)}
+            design={design}
+            shouldShowTickerToggle={true}
+          />
         </div>
       </div>
     </header>

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -1,22 +1,44 @@
-import React from 'react';
-import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
+import React, { useState } from 'react';
+import {
+  Theme,
+  Typography,
+  makeStyles,
+  Button,
+  FormControlLabel,
+  Checkbox,
+} from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';
 import { LockDetails } from './LockDetails';
 import LockIcon from '@material-ui/icons/Lock';
 import CloseIcon from '@material-ui/icons/Close';
 import SaveIcon from '@material-ui/icons/Save';
 import { grey } from '@material-ui/core/colors';
-import { LockStatus } from '../helpers/shared';
+import { LockStatus, TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
 import LiveSwitch from '../../shared/liveSwitch';
 import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
 import { getDefaultVariant } from '../bannerTests/utils/defaults';
 import { BannerVariant } from '../../../models/banner';
 import { BannerDesign, Status } from '../../../models/bannerDesign';
 
-const buildVariantForPreview = (design: BannerDesign): BannerVariant => {
+const buildVariantForPreview = (design: BannerDesign, shouldShowTicker: boolean): BannerVariant => {
+  const tickerSettings = shouldShowTicker
+    ? {
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '£',
+        copy: {
+          countLabel: 'contributions in May',
+          goalReachedPrimary: "We've met our goal - thank you!",
+          goalReachedSecondary: '',
+        },
+        name: TickerName.US,
+      }
+    : undefined;
+
   return {
     ...getDefaultVariant(),
     template: { designName: design.name },
+    tickerSettings,
   };
 };
 
@@ -83,6 +105,26 @@ interface Props {
   onStatusChange: (status: Status) => void;
 }
 
+interface TickerToggleProps {
+  shouldShowTicker: boolean;
+  setShouldShowTicker: (shouldShowTicker: boolean) => void;
+}
+
+const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerToggleProps) => {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={shouldShowTicker}
+          onChange={() => setShouldShowTicker(!shouldShowTicker)}
+          color="primary"
+        />
+      }
+      label={'Show ticker?'}
+    />
+  );
+};
+
 const StickyTopBar: React.FC<Props> = ({
   name,
   design,
@@ -94,6 +136,8 @@ const StickyTopBar: React.FC<Props> = ({
   onStatusChange,
 }: Props) => {
   const classes = useStyles();
+
+  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
 
   return (
     <header className={classes.container}>
@@ -158,9 +202,14 @@ const StickyTopBar: React.FC<Props> = ({
             </>
           )}
           <BannerVariantPreview
-            variant={buildVariantForPreview(design)}
+            variant={buildVariantForPreview(design, shouldShowTicker)}
             design={design}
-            shouldShowTickerToggle={true}
+            controls={
+              <TickerToggle
+                shouldShowTicker={shouldShowTicker}
+                setShouldShowTicker={setShouldShowTicker}
+              />
+            }
           />
         </div>
       </div>

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -1,46 +1,15 @@
-import React, { useState } from 'react';
-import {
-  Theme,
-  Typography,
-  makeStyles,
-  Button,
-  FormControlLabel,
-  Checkbox,
-} from '@material-ui/core';
+import React from 'react';
+import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';
 import { LockDetails } from './LockDetails';
 import LockIcon from '@material-ui/icons/Lock';
 import CloseIcon from '@material-ui/icons/Close';
 import SaveIcon from '@material-ui/icons/Save';
 import { grey } from '@material-ui/core/colors';
-import { LockStatus, TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
+import { LockStatus } from '../helpers/shared';
 import LiveSwitch from '../../shared/liveSwitch';
-import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
-import { getDefaultVariant } from '../bannerTests/utils/defaults';
-import { BannerVariant } from '../../../models/banner';
 import { BannerDesign, Status } from '../../../models/bannerDesign';
-
-const buildVariantForPreview = (design: BannerDesign, shouldShowTicker: boolean): BannerVariant => {
-  const tickerSettings = shouldShowTicker
-    ? {
-        countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
-        currencySymbol: '£',
-        copy: {
-          countLabel: 'contributions in May',
-          goalReachedPrimary: "We've met our goal - thank you!",
-          goalReachedSecondary: '',
-        },
-        name: TickerName.US,
-      }
-    : undefined;
-
-  return {
-    ...getDefaultVariant(),
-    template: { designName: design.name },
-    tickerSettings,
-  };
-};
+import { BannerDesignPreview } from './BannerDesignPreview';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -105,26 +74,6 @@ interface Props {
   onStatusChange: (status: Status) => void;
 }
 
-interface TickerToggleProps {
-  shouldShowTicker: boolean;
-  setShouldShowTicker: (shouldShowTicker: boolean) => void;
-}
-
-const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerToggleProps) => {
-  return (
-    <FormControlLabel
-      control={
-        <Checkbox
-          checked={shouldShowTicker}
-          onChange={() => setShouldShowTicker(!shouldShowTicker)}
-          color="primary"
-        />
-      }
-      label={'Show ticker?'}
-    />
-  );
-};
-
 const StickyTopBar: React.FC<Props> = ({
   name,
   design,
@@ -136,8 +85,6 @@ const StickyTopBar: React.FC<Props> = ({
   onStatusChange,
 }: Props) => {
   const classes = useStyles();
-
-  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
 
   return (
     <header className={classes.container}>
@@ -201,16 +148,7 @@ const StickyTopBar: React.FC<Props> = ({
               </Button>
             </>
           )}
-          <BannerVariantPreview
-            variant={buildVariantForPreview(design, shouldShowTicker)}
-            design={design}
-            controls={
-              <TickerToggle
-                shouldShowTicker={shouldShowTicker}
-                setShouldShowTicker={setShouldShowTicker}
-              />
-            }
-          />
+          <BannerDesignPreview design={design} />
         </div>
       </div>
     </header>

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, makeStyles, Theme } from '@material-ui/core';
+import { Button, Checkbox, FormControlLabel, makeStyles, Theme } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
 import {
@@ -179,7 +179,7 @@ const bannerModules = {
   },
 };
 
-const useStyles = makeStyles(({ palette }: Theme) => ({
+const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   drawer: {
     height: 'auto',
     bottom: 0,
@@ -202,10 +202,10 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
   controlsContainer: {
     position: 'fixed',
     backgroundColor: palette.grey[100],
-    borderRadius: '5px',
-    top: '10px',
-    left: '10px',
-    padding: '20px',
+    borderRadius: '4px',
+    top: spacing(3),
+    left: spacing(3),
+    padding: spacing(3),
   },
 }));
 
@@ -229,6 +229,25 @@ const DEFAULT_TICKER_SETTINGS: TickerSettingsWithData = {
     goalReachedSecondary: '',
   },
   name: TickerName.US_2022,
+};
+
+interface TickerToggleProps {
+  shouldShowTicker: boolean;
+  setShouldShowTicker: (shouldShowTicker: boolean) => void;
+}
+const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerToggleProps) => {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={shouldShowTicker}
+          onChange={() => setShouldShowTicker(!shouldShowTicker)}
+          color="primary"
+        />
+      }
+      label={'Show ticker?'}
+    />
+  );
 };
 
 const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
@@ -281,21 +300,18 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
             classes={{ paper: classes.drawer }}
           >
             <div>
-              {shouldShowTickerToggle && (
-                <div className={classes.controlsContainer}>
-                  <label htmlFor="ticker-checkbox">Show ticker?</label>
-                  <input
-                    type="checkbox"
-                    id="ticker-checkbox"
-                    checked={shouldShowTicker}
-                    onChange={() => setShouldShowTicker(!shouldShowTicker)}
-                  />
-                </div>
-              )}
               <div className={classes.hint} onClick={toggleDrawer(false)}>
                 <Typography>Click anywhere outside the banner to close</Typography>
               </div>
               <Banner {...props} />
+              {shouldShowTickerToggle && (
+                <div className={classes.controlsContainer}>
+                  <TickerToggle
+                    shouldShowTicker={shouldShowTicker}
+                    setShouldShowTicker={setShouldShowTicker}
+                  />
+                </div>
+              )}
             </div>
           </Drawer>
         </React.Fragment>

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -256,9 +256,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   shouldShowTickerToggle = false,
 }: BannerVariantPreviewProps) => {
   // The default state of showTicker is derived from whether the variant has tickerSettings
-  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(
-    Boolean(variant.tickerSettings),
-  );
+  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
   const classes = useStyles();
 
   const [drawerOpen, setDrawerOpen] = useState<boolean>();

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Checkbox, FormControlLabel, makeStyles, Theme } from '@material-ui/core';
+import { Button, makeStyles, Theme } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
 import {
@@ -13,7 +13,6 @@ import { useModule } from '../../../hooks/useModule';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 import { mockAmountsCardData, SelectedAmountsVariant } from '../../../utils/models';
 import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
-import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
 
 // Mock prices data
 interface ProductPriceData {
@@ -212,50 +211,14 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
 interface BannerVariantPreviewProps {
   variant: BannerVariant;
   design?: BannerDesign;
-  shouldShowTickerToggle?: boolean;
+  controls?: React.ReactElement;
 }
-
-const DEFAULT_TICKER_SETTINGS: TickerSettingsWithData = {
-  tickerData: {
-    total: 50_000,
-    goal: 100_000,
-  },
-  countType: TickerCountType.money,
-  endType: TickerEndType.hardstop,
-  currencySymbol: '£',
-  copy: {
-    countLabel: 'contributions in May',
-    goalReachedPrimary: "We've met our goal - thank you!",
-    goalReachedSecondary: '',
-  },
-  name: TickerName.US,
-};
-
-interface TickerToggleProps {
-  shouldShowTicker: boolean;
-  setShouldShowTicker: (shouldShowTicker: boolean) => void;
-}
-const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerToggleProps) => {
-  return (
-    <FormControlLabel
-      control={
-        <Checkbox
-          checked={shouldShowTicker}
-          onChange={() => setShouldShowTicker(!shouldShowTicker)}
-          color="primary"
-        />
-      }
-      label={'Show ticker?'}
-    />
-  );
-};
 
 const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   variant,
   design,
-  shouldShowTickerToggle = false,
+  controls,
 }: BannerVariantPreviewProps) => {
-  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
   const classes = useStyles();
 
   const [drawerOpen, setDrawerOpen] = useState<boolean>();
@@ -278,10 +241,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
     setDrawerOpen(open);
   };
 
-  const tickerSettings =
-    tickerSettingsWithData || (shouldShowTicker ? DEFAULT_TICKER_SETTINGS : undefined);
-
-  const props = buildProps(variant, tickerSettings, design);
+  const props = buildProps(variant, tickerSettingsWithData, design);
 
   return (
     <div>
@@ -301,14 +261,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
                 <Typography>Click anywhere outside the banner to close</Typography>
               </div>
               <Banner {...props} />
-              {shouldShowTickerToggle && (
-                <div className={classes.controlsContainer}>
-                  <TickerToggle
-                    shouldShowTicker={shouldShowTicker}
-                    setShouldShowTicker={setShouldShowTicker}
-                  />
-                </div>
-              )}
+              {controls && <div className={classes.controlsContainer}>{controls}</div>}
             </div>
           </Drawer>
         </React.Fragment>

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -228,7 +228,7 @@ const DEFAULT_TICKER_SETTINGS: TickerSettingsWithData = {
     goalReachedPrimary: "We've met our goal - thank you!",
     goalReachedSecondary: '',
   },
-  name: TickerName.US_2022,
+  name: TickerName.US,
 };
 
 interface TickerToggleProps {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -255,7 +255,6 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   design,
   shouldShowTickerToggle = false,
 }: BannerVariantPreviewProps) => {
-  // The default state of showTicker is derived from whether the variant has tickerSettings
   const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
   const classes = useStyles();
 

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
-import { Theme, makeStyles, Button } from '@material-ui/core';
+import { Button, makeStyles, Theme } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import Drawer from '@material-ui/core/Drawer';
 import {
+  BannerContent,
   BannerTemplate,
   BannerVariant,
-  BannerContent,
   isBannerTemplate,
 } from '../../../models/banner';
 import Typography from '@material-ui/core/Typography';
 import { useModule } from '../../../hooks/useModule';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
-import { SelectedAmountsVariant, mockAmountsCardData } from '../../../utils/models';
+import { mockAmountsCardData, SelectedAmountsVariant } from '../../../utils/models';
 import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
+import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
 
 // Mock prices data
 interface ProductPriceData {
@@ -198,17 +199,47 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
     fontStyle: 'italic',
     fontSize: '20px',
   },
+  controlsContainer: {
+    position: 'fixed',
+    backgroundColor: palette.grey[100],
+    borderRadius: '5px',
+    top: '10px',
+    left: '10px',
+    padding: '20px',
+  },
 }));
 
 interface BannerVariantPreviewProps {
   variant: BannerVariant;
   design?: BannerDesign;
+  shouldShowTickerToggle?: boolean;
 }
+
+const DEFAULT_TICKER_SETTINGS: TickerSettingsWithData = {
+  tickerData: {
+    total: 50_000,
+    goal: 100_000,
+  },
+  countType: TickerCountType.money,
+  endType: TickerEndType.hardstop,
+  currencySymbol: '£',
+  copy: {
+    countLabel: 'contributions in May',
+    goalReachedPrimary: "We've met our goal - thank you!",
+    goalReachedSecondary: '',
+  },
+  name: TickerName.US_2022,
+};
 
 const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   variant,
   design,
+  shouldShowTickerToggle = false,
 }: BannerVariantPreviewProps) => {
+  // The default state of showTicker is derived from whether the variant has tickerSettings
+  const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(
+    Boolean(variant.tickerSettings),
+  );
   const classes = useStyles();
 
   const [drawerOpen, setDrawerOpen] = useState<boolean>();
@@ -231,7 +262,10 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
     setDrawerOpen(open);
   };
 
-  const props = buildProps(variant, tickerSettingsWithData, design);
+  const tickerSettings =
+    tickerSettingsWithData || (shouldShowTicker ? DEFAULT_TICKER_SETTINGS : undefined);
+
+  const props = buildProps(variant, tickerSettings, design);
 
   return (
     <div>
@@ -247,6 +281,17 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
             classes={{ paper: classes.drawer }}
           >
             <div>
+              {shouldShowTickerToggle && (
+                <div className={classes.controlsContainer}>
+                  <label htmlFor="ticker-checkbox">Show ticker?</label>
+                  <input
+                    type="checkbox"
+                    id="ticker-checkbox"
+                    checked={shouldShowTicker}
+                    onChange={() => setShouldShowTicker(!shouldShowTicker)}
+                  />
+                </div>
+              )}
               <div className={classes.hint} onClick={toggleDrawer(false)}>
                 <Typography>Click anywhere outside the banner to close</Typography>
               </div>


### PR DESCRIPTION
## What does this change?

When live previewing a banner design, support toggling the ticker on and off (this setting usually comes from the variant, which is hardcoded in this case).

![Screen Recording 2023-10-13 at 17 33 31 mov](https://github.com/guardian/support-admin-console/assets/379839/4eef815e-61a8-4001-8e07-fb8f075eac00)

## How to test

Live preview a banner design (locally or in CODE). Toggle the ticker with the control which pops up.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
