### PR TITLE
Better names for Guardian roundel

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -245,9 +245,9 @@ const BannerDesignForm: React.FC<Props> = ({
             onChange={onRoundelChange}
             isDisabled={isDisabled}
             labels={{
-              default: 'Default',
-              brand: 'Brand',
-              inverse: 'Inverse',
+              default: 'Default - white text on black background',
+              inverse: 'Inverse - black text on white background',
+              brand: 'Brand - white text on blue background',
             }}
           />
         </AccordionDetails>


### PR DESCRIPTION
Make it clearer what the 3 options mean:
![Screenshot 2023-10-16 at 14 35 49](https://github.com/guardian/support-admin-console/assets/1513454/e99119d7-9024-4d32-8e24-3802fba5f3d7)

I did try bringing `source` in as a dependency so that it can display the options next to the radios, but it leads to a dependency nightmare that I don't want to address right now.
Users can just use the 'Live preview' button to view the design.