### PR TITLE
Use CODE data for design previews

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -4,7 +4,7 @@ import { BannerDesign } from '../../../models/bannerDesign';
 import { Checkbox, FormControlLabel } from '@material-ui/core';
 import { BannerVariant } from '../../../models/banner';
 import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
-import { getDefaultVariant } from '../bannerTests/utils/defaults';
+import { DEV_AND_CODE_DEFAULT_VARIANT } from '../bannerTests/utils/defaults';
 
 interface Props {
   design: BannerDesign;
@@ -46,7 +46,7 @@ const buildVariantForPreview = (design: BannerDesign, shouldShowTicker: boolean)
     : undefined;
 
   return {
-    ...getDefaultVariant(),
+    ...DEV_AND_CODE_DEFAULT_VARIANT, // always use CODE config for design previews
     template: { designName: design.name },
     tickerSettings,
   };

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -4,7 +4,6 @@ import { BannerDesign } from '../../../models/bannerDesign';
 import { Checkbox, FormControlLabel } from '@material-ui/core';
 import { BannerVariant } from '../../../models/banner';
 import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
-import { DEV_AND_CODE_DEFAULT_VARIANT } from '../bannerTests/utils/defaults';
 
 interface Props {
   design: BannerDesign;
@@ -30,8 +29,25 @@ const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerTogglePro
   );
 };
 
-const buildVariantForPreview = (design: BannerDesign, shouldShowTicker: boolean): BannerVariant => {
-  const tickerSettings = shouldShowTicker
+const buildVariantForPreview = (
+  design: BannerDesign,
+  shouldShowTicker: boolean,
+): BannerVariant => ({
+  name: 'CONTROL',
+  template: { designName: design.name },
+  bannerContent: {
+    heading: 'We chose a different approach. Will you support it?',
+    paragraphs: [
+      'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+    ],
+    highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+    cta: {
+      text: 'Support the Guardian',
+      baseUrl: 'https://support.theguardian.com/contribute',
+    },
+  },
+  separateArticleCount: true,
+  tickerSettings: shouldShowTicker
     ? {
         countType: TickerCountType.money,
         endType: TickerEndType.hardstop,
@@ -43,14 +59,8 @@ const buildVariantForPreview = (design: BannerDesign, shouldShowTicker: boolean)
         },
         name: TickerName.US,
       }
-    : undefined;
-
-  return {
-    ...DEV_AND_CODE_DEFAULT_VARIANT, // always use CODE config for design previews
-    template: { designName: design.name },
-    tickerSettings,
-  };
-};
+    : undefined,
+});
 
 const BannerDesignPreview: React.FC<Props> = ({ design }: Props) => {
   const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -13,7 +13,7 @@ export const DEFAULT_SECONDARY_CTA: Cta = {
   baseUrl: 'https://support.theguardian.com/contribute',
 };
 
-export const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
+const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
   template: BannerTemplate.ContributionsBanner,
   bannerContent: {

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -13,7 +13,7 @@ export const DEFAULT_SECONDARY_CTA: Cta = {
   baseUrl: 'https://support.theguardian.com/contribute',
 };
 
-const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
+export const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
   template: BannerTemplate.ContributionsBanner,
   bannerContent: {


### PR DESCRIPTION
The PROD data isn't very useful -
<img width="801" alt="Screenshot 2023-10-17 at 11 18 32" src="https://github.com/guardian/support-admin-console/assets/1513454/bee5acb2-a76e-4743-9cc8-be4c01cd7c47">

Rather than reusing the defaults (which are used by the banner tests tool), this PR moves the definition to `BannerDesignPreview`