### PR TITLE
Remove feature flag around Banner Designs

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -16,7 +16,6 @@ import {
   uiIsDesign,
 } from '../../../models/banner';
 import { BannerDesign } from '../../../models/bannerDesign';
-import { shouldShowBannerDesignsFeature } from '../../../utils/features';
 
 interface BannerUiSelectorProps {
   ui: BannerUi;
@@ -158,29 +157,27 @@ const BannerUiSelector: React.FC<BannerUiSelectorProps> = ({
 
   return (
     <>
-      {shouldShowBannerDesignsFeature() && (
-        <div>
-          <FormControl>
-            <FormLabel>UI Type</FormLabel>
-            <RadioGroup
-              name="controlled-radio-buttons-group"
-              value={uiType}
-              onChange={onUiTypeChange}
-            >
-              <FormControlLabel
-                value="Template"
-                control={<Radio disabled={!editMode} />}
-                label="Template"
-              />
-              <FormControlLabel
-                value="Design"
-                control={<Radio disabled={!editMode} />}
-                label="Design"
-              />
-            </RadioGroup>
-          </FormControl>
-        </div>
-      )}
+      <div>
+        <FormControl>
+          <FormLabel>UI Type</FormLabel>
+          <RadioGroup
+            name="controlled-radio-buttons-group"
+            value={uiType}
+            onChange={onUiTypeChange}
+          >
+            <FormControlLabel
+              value="Template"
+              control={<Radio disabled={!editMode} />}
+              label="Template"
+            />
+            <FormControlLabel
+              value="Design"
+              control={<Radio disabled={!editMode} />}
+              label="Design"
+            />
+          </RadioGroup>
+        </FormControl>
+      </div>
 
       {uiIsDesign(ui) ? (
         <BannerDesignSelector

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -7,7 +7,6 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import RRControlPanelLogo from './rrControlPanelLogo';
-import { shouldShowBannerDesignsFeature } from '../utils/features';
 
 const useStyles = makeStyles({
   list: {
@@ -196,14 +195,12 @@ export default function NavDrawer(): React.ReactElement {
             <span className={classes.super}>🦸</span>
           </ListItem>
         </Link>
-        {shouldShowBannerDesignsFeature() && (
-          <Link key="Banner Designs" to="/banner-designs" className={classes.link}>
-            <ListItem className={classes.listItem} button key="Banner Designs">
-              <ListItemText primary="Banner Designs" />
-              <span className={classes.super}>🎨</span>
-            </ListItem>
-          </Link>
-        )}
+        <Link key="Banner Designs" to="/banner-designs" className={classes.link}>
+          <ListItem className={classes.listItem} button key="Banner Designs">
+            <ListItemText primary="Banner Designs" />
+            <span className={classes.super}>🎨</span>
+          </ListItem>
+        </Link>
       </div>
 
       <div>

--- a/public/src/utils/features.ts
+++ b/public/src/utils/features.ts
@@ -1,6 +1,0 @@
-import { getStage } from './stage';
-
-export const shouldShowBannerDesignsFeature = (): boolean => {
-  const stage = getStage();
-  return stage !== 'PROD';
-};


### PR DESCRIPTION
## What does this change?

Removes the feature flag check for banner designs, so we now:

* Show banner designs in the sidebar nav
* Support picking a design for a variant

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
