### PR TITLE
Update banner design default images

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -74,7 +74,7 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
     ticker: {
       text: stringToHexColour('052962'),
       filledProgress: stringToHexColour('052962'),
-      progressBarBackground: stringToHexColour('ffffff'),
+      progressBarBackground: stringToHexColour('FFFFFF'),
       goalMarker: stringToHexColour('000000'),
     },
   },

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -8,11 +8,12 @@ import { stringToHexColour } from '../../../../utils/bannerDesigns';
 export const defaultBannerImage: BannerDesignImage = {
   kind: 'Image',
   mobileUrl:
-    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
   tabletDesktopUrl:
-    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
   wideUrl:
-    'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+
   altText: 'Image description',
 };
 


### PR DESCRIPTION
## What does this change?

Previously, although we support specifying images for different screen sizes, we were using the same default image URL for every screen size. This updates the defaults to use appropriate URLs for each size (image URLs taken from the 2022 global NY banner).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
