### PR TITLE
Spike to use lz-string compression to send to DCR storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "date-fns": "^2.29.3",
         "immutability-helper": "^3.0.1",
         "lodash": "^4.17.21",
+        "lz-string": "^1.5.0",
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.0.0",
         "react-dom": "^17.0.2",
@@ -9438,6 +9439,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -21186,6 +21195,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "date-fns": "^2.29.3",
     "immutability-helper": "^3.0.1",
     "lodash": "^4.17.21",
+    "lz-string": "^1.5.0",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^17.0.2",

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -33,6 +33,7 @@ import { useStyles } from '../helpers/testEditorStyles';
 import { EpicTestPreviewButton } from './epicTestPreview';
 import { ValidatedTestEditor, ValidatedTestEditorProps } from '../validatedTestEditor';
 import { TestEditorProps } from '../testsForm';
+import lzstring from 'lz-string';
 
 const copyHasTemplate = (test: EpicTest, template: string): boolean =>
   test.variants.some(
@@ -179,30 +180,41 @@ export const getEpicTestEditor = (
       controlProportionSettings?: ControlProportionSettings,
     ): void => updateTest({ ...test, controlProportionSettings });
 
-    const renderVariantEditor = (variant: EpicVariant): React.ReactElement => (
-      <TestVariantEditorWithPreviewTab
-        variantEditor={
-          <EpicTestVariantEditor
-            epicEditorConfig={epicEditorConfig}
-            key={variant.name}
-            variant={variant}
-            editMode={userHasTestLocked}
-            onVariantChange={onVariantChange}
-            onDelete={(): void => onVariantDelete(variant.name)}
-            onValidationChange={(isValid: boolean): void =>
-              setValidationStatusForField(variant.name, isValid)
-            }
-          />
-        }
-        variantPreview={
-          epicEditorConfig.allowVariantPreview ? (
-            <EpicVariantPreview variant={variant} moduleName={epicEditorConfig.moduleName} />
-          ) : (
-            undefined
-          )
-        }
-      />
-    );
+    const renderVariantEditor = (variant: EpicVariant): React.ReactElement => {
+      const compressedProps = lzstring.compressToEncodedURIComponent(JSON.stringify({ variant }));
+      return (
+        <TestVariantEditorWithPreviewTab
+          variantEditor={
+            <EpicTestVariantEditor
+              epicEditorConfig={epicEditorConfig}
+              key={variant.name}
+              variant={variant}
+              editMode={userHasTestLocked}
+              onVariantChange={onVariantChange}
+              onDelete={(): void => onVariantDelete(variant.name)}
+              onValidationChange={(isValid: boolean): void =>
+                setValidationStatusForField(variant.name, isValid)
+              }
+            />
+          }
+          variantPreview={
+            <div>
+              <p>Preview</p>
+              <iframe
+                src={`http://localhost:4002/iframe.html?id=components-epic--default&viewMode=story&shortcuts=false&singleStory=true&args=json:${compressedProps}`}
+                width="800"
+                height="400"
+              ></iframe>
+            </div>
+            // epicEditorConfig.allowVariantPreview ? (
+            //   <EpicVariantPreview variant={variant} moduleName={epicEditorConfig.moduleName} />
+            // ) : (
+            //   undefined
+            // )
+          }
+        />
+      );
+    };
 
     const renderVariantSummary = (variant: EpicVariant): React.ReactElement => (
       <TestEditorVariantSummary


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
`lz-string` compresses Epic variant props and sends that to a [`lz-string` enabled storybook](https://github.com/guardian/dotcom-rendering/pull/9388) in DCR.

This would allow `support-dotcom-components` to be developed in DCR without migrating over [the modules roll-up build pipeline](https://github.com/guardian/support-dotcom-components/tree/main/packages/modules) nor having to create a new one.

## How to test
TBD

## How can we measure success?
TBD
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
TBD
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![Screenshot 2023-11-02 at 16 06 48](https://github.com/guardian/support-admin-console/assets/31692/7a09c4af-a7cd-4f60-8f48-a308b11f1956)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
