### PR TITLE
Disable contribution tabs selection for Region amounts tests

### DIFF
--- a/public/src/components/amounts/AmountsTestEditor.tsx
+++ b/public/src/components/amounts/AmountsTestEditor.tsx
@@ -363,9 +363,9 @@ export const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
 
         {!checkIfTestIsCountryTier() && (
           <Typography className={classes.note}>
-            Note: users arriving at the Supporter+ landing page from Apple News/Google AMP article
-            CTAs will be presented with the &quot;control&quot; variant of their region&apos;s
-            amount test.
+            Note: users arriving at the checkout page from Apple News/Google AMP article
+            CTAs will only see their region&apos;s amounts test, with options for single, 
+            monthly and annual contributions.
           </Typography>
         )}
 

--- a/public/src/components/amounts/AmountsTestEditor.tsx
+++ b/public/src/components/amounts/AmountsTestEditor.tsx
@@ -264,6 +264,7 @@ export const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
         variant={variant}
         updateVariant={updateVariant}
         deleteVariant={deleteVariant}
+        isCountryTest={checkIfTestIsCountryTier()}
       />
     );
   };

--- a/public/src/components/amounts/AmountsTestEditor.tsx
+++ b/public/src/components/amounts/AmountsTestEditor.tsx
@@ -44,6 +44,9 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   numberInput: {
     width: '160px',
   },
+  note: {
+    fontStyle: 'italic',
+  }
 }));
 
 interface AmountsTestEditorProps {
@@ -356,6 +359,10 @@ export const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
               )}
             />
           </>
+        )}
+
+        {!checkIfTestIsCountryTier() && (
+          <Typography className={classes.note}>Note: users arriving at the Supporter+ landing page from Apple News/Google AMP article CTAs will be presented with the "control" variant of their region's amount test.</Typography>
         )}
 
         <LiveSwitch

--- a/public/src/components/amounts/AmountsTestEditor.tsx
+++ b/public/src/components/amounts/AmountsTestEditor.tsx
@@ -363,9 +363,9 @@ export const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
 
         {!checkIfTestIsCountryTier() && (
           <Typography className={classes.note}>
-            Note: users arriving at the checkout page from Apple News/Google AMP article
-            CTAs will only see their region&apos;s amounts test, with options for single, 
-            monthly and annual contributions.
+            Note: users arriving at the checkout page from Apple News/Google AMP article CTAs will
+            only see their region&apos;s amounts test, with options for single, monthly and annual
+            contributions.
           </Typography>
         )}
 

--- a/public/src/components/amounts/AmountsTestEditor.tsx
+++ b/public/src/components/amounts/AmountsTestEditor.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
   note: {
     fontStyle: 'italic',
-  }
+  },
 }));
 
 interface AmountsTestEditorProps {
@@ -362,7 +362,11 @@ export const AmountsTestEditor: React.FC<AmountsTestEditorProps> = ({
         )}
 
         {!checkIfTestIsCountryTier() && (
-          <Typography className={classes.note}>Note: users arriving at the Supporter+ landing page from Apple News/Google AMP article CTAs will be presented with the "control" variant of their region's amount test.</Typography>
+          <Typography className={classes.note}>
+            Note: users arriving at the Supporter+ landing page from Apple News/Google AMP article
+            CTAs will be presented with the &quot;control&quot; variant of their region&apos;s
+            amount test.
+          </Typography>
         )}
 
         <LiveSwitch

--- a/public/src/components/amounts/AmountsVariantEditor.tsx
+++ b/public/src/components/amounts/AmountsVariantEditor.tsx
@@ -50,12 +50,14 @@ interface AmountsVariantEditorProps {
   variant: AmountsVariant;
   updateVariant: (variant: AmountsVariant) => void;
   deleteVariant: (variant: AmountsVariant) => void;
+  isCountryTest: boolean;
 }
 
 export const AmountsVariantEditor: React.FC<AmountsVariantEditorProps> = ({
   variant,
   updateVariant,
   deleteVariant,
+  isCountryTest,
 }: AmountsVariantEditorProps) => {
   const classes = useStyles();
 
@@ -252,6 +254,7 @@ export const AmountsVariantEditor: React.FC<AmountsVariantEditorProps> = ({
                   />
                 }
                 label={k}
+                disabled={!isCountryTest}
               />
             );
           })}


### PR DESCRIPTION
## What does this change?
We need to make sure that user journeys involving Apple News and Google AMP amounts cards always include the three contribution tabs when arriving on the Supporter+ landing page. To make sure this happens we intend to add a check in the support-frontend code so that a user arriving from AN or AMP will see the control variant of the regional test applicable to that user, and that the regional test always includes all three contribution type tabs (single, monthly, annual).

This PR enforces the requirement that Marketing colleagues are unable to remove any of the contribution type tabs from the regional amounts card tests. If they do need to suppress a tab - eg for the US 2023 EOY campaign, where monthly options will be removed from web Epic and Banner amounts cards - they can do this by creating a country-specific test which will allow them to do this.

## How to test
Preview changes in Code
