### PR TITLE
Turn on automated backups for DynamoDB tables (via DevX feature)

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -169,6 +169,10 @@ Object {
         "TableName": "support-admin-console-archived-channel-tests-PROD",
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -297,6 +301,10 @@ Object {
         "TableName": "support-admin-console-banner-designs-PROD",
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -338,6 +346,10 @@ Object {
         },
         "TableName": "support-admin-console-campaigns-PROD",
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -445,6 +457,10 @@ Object {
         },
         "TableName": "support-admin-console-channel-tests-PROD",
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -11,7 +11,7 @@ import {
   GuPutS3ObjectsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
 import type { App, CfnElement } from 'aws-cdk-lib';
-import { Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy, Tags } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, ProjectionType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import type { Policy } from 'aws-cdk-lib/aws-iam';
@@ -60,6 +60,9 @@ export class AdminConsole extends GuStack {
     const defaultChild = table.node.defaultChild as unknown as CfnElement;
     defaultChild.overrideLogicalId(id);
 
+    // Enable automated backups via https://github.com/guardian/aws-backup
+    Tags.of(table).add('devx-backup-enabled', 'true');
+
     return table;
   }
 
@@ -80,6 +83,9 @@ export class AdminConsole extends GuStack {
     // Give it a better name
     const defaultChild = table.node.defaultChild as unknown as CfnElement;
     defaultChild.overrideLogicalId(id);
+
+    // Enable automated backups via https://github.com/guardian/aws-backup
+    Tags.of(table).add('devx-backup-enabled', 'true');
 
     return table;
   }
@@ -106,6 +112,9 @@ export class AdminConsole extends GuStack {
     const defaultChild = table.node.defaultChild as unknown as CfnElement;
     defaultChild.overrideLogicalId(id);
 
+    // Enable automated backups via https://github.com/guardian/aws-backup
+    Tags.of(table).add('devx-backup-enabled', 'true');
+
     return table;
   }
 
@@ -126,6 +135,9 @@ export class AdminConsole extends GuStack {
     // Give it a better name
     const defaultChild = table.node.defaultChild as unknown as CfnElement;
     defaultChild.overrideLogicalId(id);
+
+    // Enable automated backups via https://github.com/guardian/aws-backup
+    Tags.of(table).add('devx-backup-enabled', 'true');
 
     return table;
   }


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up all of `support-admin-console`'s DynamoDB tables using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering.

I can see that these tables already have continuous backups (PITR) turned on; we recommend enabling these new backups as well[^1]. 

## How to test

I think snapshot testing should be sufficient here. I will also double check that these backups are taken as expected (this should happen the night after this PR is merged).

## How can we measure success?

We will be able to recover (most) data stored in this table in the unlikely event that it is deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.

[^1]: Although PITR offers some benefits, it is very easy for the backups created by this feature to be lost accidentally (or deleted by an attacker). This new tooling makes it much harder for backups to be lost or deleted, so we believe that it’s a worthwhile additional layer of protection to put in place.