### PR TITLE
Default choice card background colour

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
@@ -3,7 +3,7 @@ import { BannerDesignVisual } from '../../../models/bannerDesign';
 import { MenuItem, Select } from '@material-ui/core';
 import { defaultBannerChoiceCardsDesign, defaultBannerImage } from './utils/defaults';
 import { ImageEditor } from './ImageEditor';
-import { ColourInput } from './ColourInput';
+import { OptionalColourInput } from './ColourInput';
 
 interface Props {
   visual?: BannerDesignVisual;
@@ -52,14 +52,13 @@ export const BannerVisualEditor: React.FC<Props> = ({
           />
         )}
         {visual?.kind === 'ChoiceCards' && (
-          <ColourInput
+          <OptionalColourInput
             colour={visual.buttonColour}
             name="visual.buttonColour"
             label="Button Colour"
             isDisabled={isDisabled}
             onChange={buttonColour => onChange({ ...visual, buttonColour })}
             onValidationChange={onValidationChange}
-            required={false}
           />
         )}
       </div>

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -37,7 +37,6 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, background: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={basicColours.bodyText}
@@ -46,7 +45,6 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, bodyText: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={basicColours.headerText}
@@ -55,7 +53,6 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, headerText: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={basicColours.articleCountText}
@@ -64,7 +61,6 @@ export const BasicColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, articleCountText: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CtaDesign } from '../../../models/bannerDesign';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { ColourInput } from './ColourInput';
+import { ColourInput, OptionalColourInput } from './ColourInput';
 
 const useLocalStyles = makeStyles(({ palette }: Theme) => ({
   container: {
@@ -58,7 +58,6 @@ export const CtaColoursEditor: React.FC<Props> = ({
             isDisabled={isDisabled}
             onChange={colour => onChange({ ...cta, default: { ...cta.default, text: colour } })}
             onValidationChange={onValidationChange}
-            required={true}
           />
           <ColourInput
             colour={cta.default.background}
@@ -69,16 +68,14 @@ export const CtaColoursEditor: React.FC<Props> = ({
               onChange({ ...cta, default: { ...cta.default, background: colour } })
             }
             onValidationChange={onValidationChange}
-            required={true}
           />
-          <ColourInput
+          <OptionalColourInput
             colour={cta.default.border}
             name={`${name}.border`}
             label="Border Colour"
             isDisabled={isDisabled}
             onChange={colour => onChange({ ...cta, default: { ...cta.default, border: colour } })}
             onValidationChange={onValidationChange}
-            required={false}
           />
         </div>
 
@@ -92,7 +89,6 @@ export const CtaColoursEditor: React.FC<Props> = ({
             isDisabled={isDisabled}
             onChange={colour => onChange({ ...cta, hover: { ...cta.hover, text: colour } })}
             onValidationChange={onValidationChange}
-            required={true}
           />
           <ColourInput
             colour={cta.hover.background}
@@ -101,16 +97,14 @@ export const CtaColoursEditor: React.FC<Props> = ({
             isDisabled={isDisabled}
             onChange={colour => onChange({ ...cta, hover: { ...cta.hover, background: colour } })}
             onValidationChange={onValidationChange}
-            required={true}
           />
-          <ColourInput
+          <OptionalColourInput
             colour={cta.hover.border}
             name={`${name}.border`}
             label="Border Colour"
             isDisabled={isDisabled}
             onChange={colour => onChange({ ...cta, hover: { ...cta.hover, border: colour } })}
             onValidationChange={onValidationChange}
-            required={false}
           />
         </div>
       </div>

--- a/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
@@ -37,7 +37,6 @@ export const HighlightedTextColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...colours, text: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={colours.highlight}
@@ -46,7 +45,6 @@ export const HighlightedTextColoursEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...colours, highlight: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/TickerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/TickerDesignEditor.tsx
@@ -37,7 +37,6 @@ export const TickerDesignEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...ticker, text: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={ticker.progressBarBackground}
@@ -46,7 +45,6 @@ export const TickerDesignEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...ticker, progressBarBackground: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={ticker.filledProgress}
@@ -55,7 +53,6 @@ export const TickerDesignEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...ticker, filledProgress: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
       <ColourInput
         colour={ticker.goalMarker}
@@ -64,7 +61,6 @@ export const TickerDesignEditor: React.FC<Props> = ({
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...ticker, goalMarker: colour })}
         onValidationChange={onValidationChange}
-        required={true}
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -19,7 +19,7 @@ export const defaultBannerImage: BannerDesignImage = {
 
 export const defaultBannerChoiceCardsDesign: ChoiceCardsDesign = {
   kind: 'ChoiceCards',
-  buttonColour: undefined,
+  buttonColour: stringToHexColour('FFFFFF'),
 };
 
 export const createDefaultBannerDesign = (name: string): BannerDesign => ({


### PR DESCRIPTION
## What does this change?

This PR sets the (optional) choice cards button background colour default to white (#FFFFFF).

It also fixes a small bug where unsetting the button background colour wasn't possible because an error was thrown.

## How to test

Create a new design - see that the default choice card bg colour is white.
Edit a design - unset the choice card bg colour and save, this now works.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
