### PR TITLE
Write to default-promos.json for Digital Checkout via RRCP

### DIFF
--- a/app/models/DefaultPromos.scala
+++ b/app/models/DefaultPromos.scala
@@ -5,7 +5,8 @@ import io.circe.{Decoder, Encoder}
 
 case class DefaultPromos(
   guardianWeekly: Seq[String],
-  paper: Seq[String]
+  paper: Seq[String],
+  digital: Seq[String]
 )
 
 object DefaultPromos {

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -8,7 +8,7 @@ import {
   SupportFrontendSettingsType,
 } from '../utils/requests';
 
-type ProductName = 'guardianWeekly' | 'paper';
+type ProductName = 'guardianWeekly' | 'paper' | 'digital';
 
 type DefaultPromos = {
   [key in ProductName]: string[];
@@ -34,6 +34,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
 }: InnerProps<DefaultPromos>) => {
   const [gwPromosString, setGwPromosString] = useState<string>(data.guardianWeekly.join(', '));
   const [paperPromosString, setpaperPromosString] = useState<string>(data.paper.join(', '));
+  const [digitalPromoString, setdigitalPromosString] = useState<string>(data.digital.join(', '));
 
   const classes = useStyles();
 
@@ -72,6 +73,23 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
         }}
         type="text"
         label="Paper"
+      />
+      <TextField
+        value={digitalPromoString}
+        name="digitalDefaultPromos"
+        fullWidth={true}
+        onChange={e => {
+          const inputValue = e.target.value;
+          setdigitalPromosString(inputValue);
+
+          const parsedInputValue = parsePromoInput(inputValue);
+          update({
+            ...data,
+            digital: parsedInputValue,
+          });
+        }}
+        type="text"
+        label="Digital"
       />
       <Button
         onClick={sendToS3}


### PR DESCRIPTION
## What does this change?

Add functionality in RRCP to write to `default-promos.json` for digital checkout.

Extract shown below ->
`{
  "digital" : [
    "KINDLE10",
  ],
}`

[**Trello Card**](https://trello.com/c/GNnH4UQY/1683-editions-write-to-default-promosjson-for-digital-checkout-from-rrcp)

## How to test

Check info is written to `default-promos.json` in the `support-admin-console` bucket in S3.

## Images

|before|after|
|----|----|
|![image](https://github.com/guardian/support-admin-console/assets/76729591/5c9e22ec-6515-47a0-a91f-4e7438babc82)|![image](https://github.com/guardian/support-admin-console/assets/76729591/5e570d2d-9079-4882-b49c-e051bc61639b)|

## Accessibility
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)

