### PR TITLE
Remove Investigations banner

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -22,7 +22,6 @@ object BannerUI {
   case object EnvironmentBanner extends BannerTemplate
   case object GlobalNewYearMomentBanner extends BannerTemplate
   case object GuardianWeeklyBanner extends BannerTemplate
-  case object InvestigationsMomentBanner extends BannerTemplate
   case object PostElectionAuMomentAlbaneseBanner extends BannerTemplate
   case object PostElectionAuMomentHungBanner extends BannerTemplate
   case object PostElectionAuMomentMorrisonBanner extends BannerTemplate

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -289,7 +289,6 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             template === BannerTemplate.ContributionsBanner ||
             template === BannerTemplate.ChoiceCardsButtonsBannerBlue ||
             template === BannerTemplate.GuardianWeeklyBanner ||
-            template === BannerTemplate.InvestigationsMomentBanner ||
             template === BannerTemplate.GlobalNewYearMomentBanner ||
             template === BannerTemplate.UkraineMomentBanner ||
             template === BannerTemplate.WorldPressFreedomDayBanner ||

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -66,7 +66,6 @@ const templatesWithLabels = [
     label: 'World Press Freedom Day',
   },
   { template: BannerTemplate.GuardianWeeklyBanner, label: 'Guardian Weekly' },
-  { template: BannerTemplate.InvestigationsMomentBanner, label: 'Investigations' },
   { template: BannerTemplate.EnvironmentBanner, label: 'Environment' },
 ];
 

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -132,10 +132,6 @@ const bannerModules = {
     path: 'contributions/ContributionsBannerWithSignIn.js',
     name: 'ContributionsBannerWithSignIn',
   },
-  [BannerTemplate.InvestigationsMomentBanner]: {
-    path: 'investigationsMoment/InvestigationsMomentBanner.js',
-    name: 'InvestigationsMomentBanner',
-  },
   [BannerTemplate.EnvironmentBanner]: {
     path: 'environment/EnvironmentBanner.js',
     name: 'EnvironmentBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -19,7 +19,6 @@ export enum BannerTemplate {
   ContributionsBannerWithSignIn = 'ContributionsBannerWithSignIn',
   ChoiceCardsButtonsBannerBlue = 'ChoiceCardsButtonsBannerBlue',
   GuardianWeeklyBanner = 'GuardianWeeklyBanner',
-  InvestigationsMomentBanner = 'InvestigationsMomentBanner',
   EnvironmentBanner = 'EnvironmentBanner',
   GlobalNewYearMomentBanner = 'GlobalNewYearMomentBanner',
   UkraineMomentBanner = 'UkraineMomentBanner',


### PR DESCRIPTION
## What does this change?

- Removes old ‘Investigations’ Banner from RRCP as its not Moment template spaced.

