### PR TITLE
Use DCR storybook for liveblog epic preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "date-fns": "^2.29.3",
         "immutability-helper": "^3.0.1",
         "lodash": "^4.17.21",
+        "lz-string": "^1.5.0",
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.0.0",
         "react-dom": "^17.0.2",
@@ -9438,6 +9439,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -21186,6 +21195,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "date-fns": "^2.29.3",
     "immutability-helper": "^3.0.1",
     "lodash": "^4.17.21",
+    "lz-string": "^1.5.0",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^17.0.2",

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -6,6 +6,7 @@ import { useModule } from '../../../hooks/useModule';
 import { EpicVariant } from '../../../models/epic';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 import { SelectedAmountsVariant, mockAmountsCardData } from '../../../utils/models';
+import lzstring from 'lz-string';
 
 // Article count TS defs
 export interface ArticleCounts {
@@ -103,6 +104,10 @@ const useStyles = makeStyles(({}: Theme) => ({
   container: {
     width: '620px',
   },
+  iframe: {
+    width: '620px',
+    height: '800px',
+  },
 }));
 
 interface EpicVariantPreviewProps {
@@ -110,10 +115,7 @@ interface EpicVariantPreviewProps {
   moduleName: EpicModuleName;
 }
 
-const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
-  variant,
-  moduleName,
-}: EpicVariantPreviewProps) => {
+const EpicVariantPreviewSDCModule = ({ variant, moduleName }: EpicVariantPreviewProps) => {
   const classes = useStyles();
 
   const tickerSettingsWithData = useTickerData(variant.tickerSettings);
@@ -123,6 +125,39 @@ const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
   const props = buildProps(variant, tickerSettingsWithData);
 
   return <div className={classes.container}>{Epic && <Epic {...props} />}</div>;
+};
+
+const EpicVariantPreviewStorybook = ({ variant }: { variant: EpicVariant }) => {
+  const classes = useStyles();
+
+  const tickerSettingsWithData = useTickerData(variant.tickerSettings);
+  const props = buildProps(variant, tickerSettingsWithData);
+  const compressedProps = lzstring.compressToEncodedURIComponent(JSON.stringify(props));
+
+  const storyName = 'components-marketing-contributionsliveblogepic--default';
+  const dcrStorybookUrl = 'https://5dfcbf3012392c0020e7140b-borimwnbdl.chromatic.com';
+
+  return (
+    <div>
+      <iframe
+        className={classes.iframe}
+        src={`${dcrStorybookUrl}/iframe.html?id=${storyName}&viewMode=story&shortcuts=false&singleStory=true&args=json:${compressedProps}`}
+        width="800"
+        height="400"
+      ></iframe>
+    </div>
+  );
+};
+
+const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
+  variant,
+  moduleName,
+}: EpicVariantPreviewProps) => {
+  if (moduleName === 'ContributionsLiveblogEpic') {
+    return <EpicVariantPreviewStorybook variant={variant} />;
+  } else {
+    return <EpicVariantPreviewSDCModule variant={variant} moduleName={moduleName} />;
+  }
 };
 
 export default EpicVariantPreview;

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -142,8 +142,6 @@ const EpicVariantPreviewStorybook = ({ variant }: { variant: EpicVariant }) => {
       <iframe
         className={classes.iframe}
         src={`${dcrStorybookUrl}/iframe.html?id=${storyName}&viewMode=story&shortcuts=false&singleStory=true&args=json:${compressedProps}`}
-        width="800"
-        height="400"
       ></iframe>
     </div>
   );

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -100,6 +100,11 @@ const buildProps = (
   hasConsentForArticleCount: true,
 });
 
+const StorybookNames: Record<EpicModuleName, string> = {
+  ContributionsLiveblogEpic: 'components-marketing-contributionsliveblogepic--default',
+  ContributionsEpic: 'components-marketing-contributionsepic--default',
+};
+
 const useStyles = makeStyles(({}: Theme) => ({
   container: {
     width: '620px',
@@ -115,6 +120,9 @@ interface EpicVariantPreviewProps {
   moduleName: EpicModuleName;
 }
 
+/**
+ * Uses a remote import of the SDC component
+ */
 const EpicVariantPreviewSDCModule = ({ variant, moduleName }: EpicVariantPreviewProps) => {
   const classes = useStyles();
 
@@ -127,14 +135,18 @@ const EpicVariantPreviewSDCModule = ({ variant, moduleName }: EpicVariantPreview
   return <div className={classes.container}>{Epic && <Epic {...props} />}</div>;
 };
 
-const EpicVariantPreviewStorybook = ({ variant }: { variant: EpicVariant }) => {
+/**
+ * Uses the DCR storybook to render the component, iframed.
+ * Props are passed in the args parameter in the url.
+ */
+const EpicVariantPreviewStorybook = ({ variant, moduleName }: EpicVariantPreviewProps) => {
   const classes = useStyles();
 
   const tickerSettingsWithData = useTickerData(variant.tickerSettings);
   const props = buildProps(variant, tickerSettingsWithData);
   const compressedProps = lzstring.compressToEncodedURIComponent(JSON.stringify(props));
 
-  const storyName = 'components-marketing-contributionsliveblogepic--default';
+  const storyName = StorybookNames[moduleName];
   const dcrStorybookUrl = 'https://5dfcbf3012392c0020e7140b-borimwnbdl.chromatic.com';
 
   return (
@@ -152,7 +164,8 @@ const EpicVariantPreview: React.FC<EpicVariantPreviewProps> = ({
   moduleName,
 }: EpicVariantPreviewProps) => {
   if (moduleName === 'ContributionsLiveblogEpic') {
-    return <EpicVariantPreviewStorybook variant={variant} />;
+    // Currently only the liveblog epic is in DCR
+    return <EpicVariantPreviewStorybook variant={variant} moduleName={moduleName} />;
   } else {
     return <EpicVariantPreviewSDCModule variant={variant} moduleName={moduleName} />;
   }


### PR DESCRIPTION
We're moving the liveblog epic component to DCR: https://github.com/guardian/dotcom-rendering/pull/9538
This means the live preview feature now needs to use the DCR storybook, which gets iframed into the tool.

Liveblog epic now in an iframe:
![Screenshot 2023-11-22 at 09 38 07](https://github.com/guardian/support-admin-console/assets/1513454/9843dc7d-1e5f-4705-856f-6e80dac4e6dd)

Normal epic still uses the SDC component:
![Screenshot 2023-11-22 at 09 38 20](https://github.com/guardian/support-admin-console/assets/1513454/f35a11db-a678-41af-9e8f-73dcb5f6e0bf)
