### PR TITLE
Add header image form to designable banner page

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -27,6 +27,13 @@ object GuardianRoundelDesign {
   implicit val decoder = deriveEnumerationDecoder[GuardianRoundelDesign]
 }
 
+case class HeaderImage(
+  mobileUrl: String,
+  tabletDesktopUrl: String,
+  wideUrl: String,
+  altText: String
+)
+
 sealed trait BannerDesignVisual
 object BannerDesignVisual {
   case class Image(
@@ -99,6 +106,7 @@ case class BannerDesign(
   name: String,
   status: BannerDesignStatus,
   visual: Option[BannerDesignVisual],
+  headerImage: Option[HeaderImage],
   colours: BannerDesignColours,
   lockStatus: Option[LockStatus],
 )

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Accordion, AccordionDetails, AccordionSummary } from '@material-ui/core';
 import {
   BannerDesign,
-  BannerDesignImage,
+  BannerDesignHeaderImage,
   BannerDesignVisual,
   BasicColours,
   CtaDesign,
@@ -91,7 +91,7 @@ const BannerDesignForm: React.FC<Props> = ({
     });
   };
 
-  const onHeaderImageChange = (headerImage?: BannerDesignImage): void => {
+  const onHeaderImageChange = (headerImage?: BannerDesignHeaderImage): void => {
     onChange({
       ...design,
       headerImage,
@@ -170,7 +170,7 @@ const BannerDesignForm: React.FC<Props> = ({
 
       <Accordion className={classes.accordion}>
         <AccordionSummary className={classes.sectionHeader} expandIcon={<ExpandMoreIcon />}>
-          Image or Choice Cards
+          Main Image or Choice Cards
         </AccordionSummary>
         <AccordionDetails>
           <BannerVisualEditor

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Accordion, AccordionDetails, AccordionSummary } from '@material-ui/core';
 import {
   BannerDesign,
+  BannerDesignImage,
   BannerDesignVisual,
   BasicColours,
   CtaDesign,
@@ -16,6 +17,7 @@ import { CtaColoursEditor } from './CtaColoursEditor';
 import TypedRadioGroup from '../TypedRadioGroup';
 import { BannerDesignUsage } from './BannerDesignUsage';
 import { TickerDesignEditor } from './TickerDesignEditor';
+import { HeaderImageEditor } from './HeaderImageEditor';
 import { BannerVisualEditor } from './BannerVisualEditor';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { InfoOutlined } from '@material-ui/icons';
@@ -86,6 +88,13 @@ const BannerDesignForm: React.FC<Props> = ({
     onChange({
       ...design,
       visual,
+    });
+  };
+
+  const onHeaderImageChange = (headerImage?: BannerDesignImage): void => {
+    onChange({
+      ...design,
+      headerImage,
     });
   };
 
@@ -169,6 +178,20 @@ const BannerDesignForm: React.FC<Props> = ({
             isDisabled={isDisabled}
             onValidationChange={onValidationChange}
             onChange={onVisualChange}
+          />
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion className={classes.accordion}>
+        <AccordionSummary className={classes.sectionHeader} expandIcon={<ExpandMoreIcon />}>
+          Header image
+        </AccordionSummary>
+        <AccordionDetails>
+          <HeaderImageEditor
+            headerImage={design.headerImage}
+            isDisabled={isDisabled}
+            onValidationChange={onValidationChange}
+            onChange={onHeaderImageChange}
           />
         </AccordionDetails>
       </Accordion>

--- a/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
@@ -33,7 +33,7 @@ export const BannerVisualEditor: React.FC<Props> = ({
     <div>
       <Select value={visual?.kind || 'None'} onChange={onVisualTypeChange} disabled={isDisabled}>
         <MenuItem value="Image" key="Image">
-          Image
+          Main Image
         </MenuItem>
         <MenuItem value="ChoiceCards" key="ChoiceCards">
           Amounts Choice Cards

--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -1,0 +1,104 @@
+import { TextField } from '@material-ui/core';
+import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { BannerDesignImage } from '../../../models/bannerDesign';
+
+const imageUrlValidation = {
+  value: /^https:\/\/i\.guim\.co\.uk\//,
+  message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
+};
+
+interface Props {
+  headerImage?: BannerDesignImage;
+  isDisabled: boolean;
+  onValidationChange: (fieldName: string, isValid: boolean) => void;
+  onChange: (headerImage: BannerDesignImage) => void;
+}
+
+export const HeaderImageEditor: React.FC<Props> = ({
+  headerImage,
+  isDisabled,
+  onValidationChange,
+  onChange,
+}: Props) => {
+  const { register, handleSubmit, errors, reset } = useForm<BannerDesignImage>({
+    mode: 'onChange',
+    defaultValues: headerImage,
+  });
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    onValidationChange('headerImage', isValid);
+    console.log(errors);
+  }, [errors]);
+
+  useEffect(() => {
+    // necessary to reset fields if user discards changes
+    reset(headerImage);
+  }, [headerImage]);
+
+  return (
+    <div>
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+          pattern: imageUrlValidation,
+        })}
+        error={errors?.mobileUrl !== undefined}
+        helperText={errors?.mobileUrl?.message}
+        onBlur={handleSubmit(onChange)}
+        name="mobileUrl"
+        label="Header Image URL (Mobile)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+          pattern: imageUrlValidation,
+        })}
+        error={errors?.tabletDesktopUrl !== undefined}
+        helperText={errors?.tabletDesktopUrl?.message}
+        onBlur={handleSubmit(onChange)}
+        name="tabletDesktopUrl"
+        label="Header Image URL (Tablet & Desktop)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+          pattern: imageUrlValidation,
+        })}
+        error={errors?.wideUrl !== undefined}
+        helperText={errors?.wideUrl?.message}
+        onBlur={handleSubmit(onChange)}
+        name="wideUrl"
+        label="Header Image URL (Wide)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+      <TextField
+        inputRef={register({
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        error={errors?.altText !== undefined}
+        helperText={errors?.altText?.message}
+        onBlur={handleSubmit(onChange)}
+        name="altText"
+        label="Header Image Description (alt text)"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth
+      />
+    </div>
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -1,19 +1,26 @@
-import { TextField } from '@material-ui/core';
+import { FormControl, FormControlLabel, RadioGroup, Radio, TextField } from '@material-ui/core';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { BannerDesignImage } from '../../../models/bannerDesign';
+import { BannerDesignHeaderImage } from '../../../models/bannerDesign';
 
 const imageUrlValidation = {
   value: /^https:\/\/i\.guim\.co\.uk\//,
   message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
 };
 
+export const DEFAULT_HEADER_IMAGE_SETTINGS: BannerDesignHeaderImage = {
+  mobileUrl: '',
+  tabletDesktopUrl: '',
+  wideUrl: '',
+  altText: '',
+};
+
 interface Props {
-  headerImage?: BannerDesignImage;
+  headerImage?: BannerDesignHeaderImage;
   isDisabled: boolean;
   onValidationChange: (fieldName: string, isValid: boolean) => void;
-  onChange: (headerImage: BannerDesignImage) => void;
+  onChange: (headerImage: BannerDesignHeaderImage | undefined) => void;
 }
 
 export const HeaderImageEditor: React.FC<Props> = ({
@@ -22,83 +29,133 @@ export const HeaderImageEditor: React.FC<Props> = ({
   onValidationChange,
   onChange,
 }: Props) => {
-  const { register, handleSubmit, errors, reset } = useForm<BannerDesignImage>({
+  const defaultValues: BannerDesignHeaderImage = {
+    mobileUrl: headerImage?.mobileUrl ?? '',
+    tabletDesktopUrl: headerImage?.tabletDesktopUrl ?? '',
+    wideUrl: headerImage?.wideUrl ?? '',
+    altText: headerImage?.altText ?? '',
+  };
+
+  const { register, handleSubmit, errors, reset } = useForm<BannerDesignHeaderImage>({
     mode: 'onChange',
-    defaultValues: headerImage,
+    defaultValues,
   });
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
-    onValidationChange('headerImage', isValid);
-    console.log(errors);
-  }, [errors]);
+    onValidationChange('BannerHeaderImage', isValid);
+  }, [errors.mobileUrl, errors.tabletDesktopUrl, errors.wideUrl, errors.altText]);
 
   useEffect(() => {
-    // necessary to reset fields if user discards changes
-    reset(headerImage);
-  }, [headerImage]);
+    reset(defaultValues);
+  }, [
+    defaultValues.mobileUrl,
+    defaultValues.tabletDesktopUrl,
+    defaultValues.wideUrl,
+    defaultValues.altText,
+  ]);
+
+  const onSubmit = ({
+    mobileUrl,
+    tabletDesktopUrl,
+    wideUrl,
+    altText,
+  }: BannerDesignHeaderImage): void => {
+    onChange({ mobileUrl, tabletDesktopUrl, wideUrl, altText });
+  };
+
+  const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.value === 'enabled') {
+      onChange(DEFAULT_HEADER_IMAGE_SETTINGS);
+    } else {
+      onChange(undefined);
+    }
+  };
 
   return (
     <div>
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-          pattern: imageUrlValidation,
-        })}
-        error={errors?.mobileUrl !== undefined}
-        helperText={errors?.mobileUrl?.message}
-        onBlur={handleSubmit(onChange)}
-        name="mobileUrl"
-        label="Header Image URL (Mobile)"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth
-      />
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-          pattern: imageUrlValidation,
-        })}
-        error={errors?.tabletDesktopUrl !== undefined}
-        helperText={errors?.tabletDesktopUrl?.message}
-        onBlur={handleSubmit(onChange)}
-        name="tabletDesktopUrl"
-        label="Header Image URL (Tablet & Desktop)"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth
-      />
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-          pattern: imageUrlValidation,
-        })}
-        error={errors?.wideUrl !== undefined}
-        helperText={errors?.wideUrl?.message}
-        onBlur={handleSubmit(onChange)}
-        name="wideUrl"
-        label="Header Image URL (Wide)"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth
-      />
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
-        error={errors?.altText !== undefined}
-        helperText={errors?.altText?.message}
-        onBlur={handleSubmit(onChange)}
-        name="altText"
-        label="Header Image Description (alt text)"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth
-      />
+      <FormControl>
+        <RadioGroup value={headerImage ? 'enabled' : 'disabled'} onChange={onRadioGroupChange}>
+          <FormControlLabel
+            value="disabled"
+            key="disabled"
+            control={<Radio />}
+            label="Do not include a header image"
+            disabled={isDisabled}
+          />
+          <FormControlLabel
+            value="enabled"
+            key="enabled"
+            control={<Radio />}
+            label="Define the header image"
+            disabled={isDisabled}
+          />
+        </RadioGroup>
+      </FormControl>
+
+      {headerImage && (
+        <>
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
+            })}
+            error={errors?.mobileUrl !== undefined}
+            helperText={errors?.mobileUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="mobileUrl"
+            label="Header Image URL (Mobile)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
+            })}
+            error={errors?.tabletDesktopUrl !== undefined}
+            helperText={errors?.tabletDesktopUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="tabletDesktopUrl"
+            label="Header Image URL (Tablet & Desktop)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: imageUrlValidation,
+            })}
+            error={errors?.wideUrl !== undefined}
+            helperText={errors?.wideUrl?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="wideUrl"
+            label="Header Image URL (Wide)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
+            error={errors?.altText !== undefined}
+            helperText={errors?.altText?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="altText"
+            label="Header Image Description (alt text)"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -54,6 +54,7 @@ export type BannerDesignVisual = BannerDesignImage | ChoiceCardsDesign;
 
 export type BannerDesignProps = {
   visual?: BannerDesignVisual;
+  headerImage?: BannerDesignImage;
   colours: {
     basic: BasicColours;
     highlightedText: HighlightedTextColours;

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -38,12 +38,15 @@ export interface TickerDesign {
   goalMarker: HexColour;
 }
 
-export interface BannerDesignImage {
-  kind: 'Image';
+export interface BannerDesignHeaderImage {
   mobileUrl: string;
   tabletDesktopUrl: string;
   wideUrl: string;
   altText: string;
+}
+
+export interface BannerDesignImage extends BannerDesignHeaderImage {
+  kind: 'Image';
 }
 
 export interface ChoiceCardsDesign {
@@ -54,7 +57,7 @@ export type BannerDesignVisual = BannerDesignImage | ChoiceCardsDesign;
 
 export type BannerDesignProps = {
   visual?: BannerDesignVisual;
-  headerImage?: BannerDesignImage;
+  headerImage?: BannerDesignHeaderImage;
   colours: {
     basic: BasicColours;
     highlightedText: HighlightedTextColours;


### PR DESCRIPTION
## What does this change?
Extends the designable banner page to allow users to self-serve a header image

## How to test

- In the CODE designable banner page, live view a design which makes use of this new component
- In the CODE banner channels, create and preview banner tests which uses the design: one with header copy, another without header copy
