### PR TITLE
Colour picker (+ an onBlur fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lz-string": "^1.5.0",
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.0.0",
+        "react-colorful": "^5.6.1",
         "react-dom": "^17.0.2",
         "react-hook-form": "^6.15.8",
         "react-qr-code": "^2.0.7",
@@ -11117,6 +11118,15 @@
       },
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {
@@ -22349,6 +22359,12 @@
         "reactcss": "^1.2.0",
         "tinycolor2": "^1.4.1"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-dom": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lz-string": "^1.5.0",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.0.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^17.0.2",
     "react-hook-form": "^6.15.8",
     "react-qr-code": "^2.0.7",

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-
 import { TextField } from '@material-ui/core';
+import debounce from 'lodash/debounce';
 import {
   hexColourStringRegex,
   hexColourToString,
@@ -100,11 +100,11 @@ const GenericColourInput = <T extends unknown>({
     onChange(newColour);
   };
 
-  const handleColourChangeFromPicker = (colour: string) => {
+  const handleColourChangeFromPicker = debounce((colour: string) => {
     // Remove the leading '#' from the colour string given by the picker
     const colourWithNoLeadingHash = colour.slice(1);
     handleColourChange(colourWithNoLeadingHash);
-  };
+  }, 100);
 
   return (
     <div className={classes.container}>

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -10,36 +10,38 @@ import { useForm } from 'react-hook-form';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { HexColour } from '../../../models/bannerDesign';
-import { ClassNameMap } from '@mui/material';
+import { ClassNameMap, ClickAwayListener } from '@mui/material';
 import { HexColorPicker } from 'react-colorful';
 
-const useStyles = makeStyles<Theme, { colour: string }>(({ palette }: Theme) => ({
-  container: {
-    display: 'flex',
-    flexDirection: 'row',
-    marginTop: '16px',
-  },
-  colour: {
-    border: `1px solid ${palette.grey[500]}`,
-    borderRadius: '4px',
-    width: '55px',
-    height: '55px',
-    marginBottom: '8px',
-    backgroundColor: props => props.colour,
-    cursor: 'pointer',
-    position: 'relative',
-  },
-  field: {
-    width: '240px',
-    marginTop: 0,
-  },
-  picker: {
-    position: 'absolute',
-    bottom: 0,
-    left: '55px',
-    margin: '0px 10px',
-  },
-}));
+const useStyles = makeStyles<Theme, { colour: string; isDisabled: boolean }>(
+  ({ palette }: Theme) => ({
+    container: {
+      display: 'flex',
+      flexDirection: 'row',
+      marginTop: '16px',
+    },
+    colour: {
+      border: `1px solid ${palette.grey[500]}`,
+      borderRadius: '4px',
+      width: '55px',
+      height: '55px',
+      marginBottom: '8px',
+      backgroundColor: props => props.colour,
+      cursor: props => (props.isDisabled ? 'not-allowed' : 'pointer'),
+      position: 'relative',
+    },
+    field: {
+      width: '240px',
+      marginTop: 0,
+    },
+    picker: {
+      position: 'absolute',
+      bottom: 0,
+      left: '55px',
+      margin: '0px 10px',
+    },
+  }),
+);
 
 const colourValidation = {
   value: hexColourStringRegex,
@@ -117,17 +119,19 @@ const GenericColourInput = <T extends unknown>({
         disabled={isDisabled}
         required={required}
       />
-      <div className={classes.colour} onClick={() => setIsPickerOpen(true)}>
+      <div className={classes.colour} onClick={() => !isDisabled && setIsPickerOpen(true)}>
         {isPickerOpen && (
-          <div className={classes.picker}>
-            <HexColorPicker
-              color={colour ? `#${convertToString(colour)}` : 'rgb(0, 0, 0, 0)'}
-              onChange={(colour: string) => {
-                // Remove the leading '#' from the colour string
-                handleColourChange(colour.slice(1));
-              }}
-            />
-          </div>
+          <ClickAwayListener onClickAway={() => setIsPickerOpen(false)}>
+            <div className={classes.picker}>
+              <HexColorPicker
+                color={colour ? `#${convertToString(colour)}` : 'rgb(0, 0, 0, 0)'}
+                onChange={(colour: string) => {
+                  // Remove the leading '#' from the colour string
+                  handleColourChange(colour.slice(1));
+                }}
+              />
+            </div>
+          </ClickAwayListener>
         )}
       </div>
     </div>
@@ -141,7 +145,10 @@ export const ColourInput: React.FC<Props<HexColour>> = (props: Props<HexColour>)
       required={true}
       convertToString={hexColourToString}
       convertFromString={stringToHexColour}
-      styles={useStyles({ colour: `#${hexColourToString(props.colour)}` })}
+      styles={useStyles({
+        colour: `#${hexColourToString(props.colour)}`,
+        isDisabled: props.isDisabled,
+      })}
     />
   );
 };
@@ -157,7 +164,7 @@ export const OptionalColourInput: React.FC<Props<HexColour | undefined>> = (
       required={false}
       convertToString={maybeHexColourToString}
       convertFromString={stringToMaybeHexColour}
-      styles={useStyles({ colour: colourCss })}
+      styles={useStyles({ colour: colourCss, isDisabled: props.isDisabled })}
     />
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { TextField } from '@material-ui/core';
 import {
@@ -11,6 +11,7 @@ import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { HexColour } from '../../../models/bannerDesign';
 import { ClassNameMap } from '@mui/material';
+import { HexColorPicker } from 'react-colorful';
 
 const useStyles = makeStyles<Theme, { colour: string }>(({ palette }: Theme) => ({
   container: {
@@ -25,10 +26,18 @@ const useStyles = makeStyles<Theme, { colour: string }>(({ palette }: Theme) => 
     height: '55px',
     marginBottom: '8px',
     backgroundColor: props => props.colour,
+    cursor: 'pointer',
+    position: 'relative',
   },
   field: {
     width: '240px',
     marginTop: 0,
+  },
+  picker: {
+    position: 'absolute',
+    bottom: 0,
+    left: '55px',
+    margin: '0px 10px',
   },
 }));
 
@@ -65,6 +74,8 @@ const GenericColourInput = <T extends unknown>({
   convertToString,
   styles: classes,
 }: GenericProps<T>) => {
+  const [isPickerOpen, setIsPickerOpen] = useState<boolean>(false);
+
   const defaultValues = { colour: convertToString(colour) };
 
   const { register, reset, handleSubmit, errors } = useForm<{ colour: string }>({
@@ -82,6 +93,11 @@ const GenericColourInput = <T extends unknown>({
     reset(defaultValues);
   }, [colour]);
 
+  const handleColourChange = (colour: string) => {
+    const newColour = convertFromString(colour);
+    onChange(newColour);
+  };
+
   return (
     <div className={classes.container}>
       <TextField
@@ -91,10 +107,7 @@ const GenericColourInput = <T extends unknown>({
           pattern: colourValidation,
         })}
         name="colour"
-        onBlur={handleSubmit(({ colour }) => {
-          const newColour = convertFromString(colour);
-          onChange(newColour);
-        })}
+        onBlur={handleSubmit(({ colour }) => handleColourChange(colour))}
         label={label}
         error={errors?.colour !== undefined}
         helperText={errors?.colour?.message}
@@ -104,7 +117,19 @@ const GenericColourInput = <T extends unknown>({
         disabled={isDisabled}
         required={required}
       />
-      <div className={classes.colour} />
+      <div className={classes.colour} onClick={() => setIsPickerOpen(true)}>
+        {isPickerOpen && (
+          <div className={classes.picker}>
+            <HexColorPicker
+              color={colour ? `#${convertToString(colour)}` : 'rgb(0, 0, 0, 0)'}
+              onChange={(colour: string) => {
+                // Remove the leading '#' from the colour string
+                handleColourChange(colour.slice(1));
+              }}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -18,14 +18,14 @@ const useStyles = makeStyles<Theme, { colour: string }>(({ palette }: Theme) => 
     flexDirection: 'row',
     marginTop: '16px',
   },
-  colour: props => ({
+  colour: {
     border: `1px solid ${palette.grey[500]}`,
     borderRadius: '4px',
     width: '55px',
     height: '55px',
     marginBottom: '8px',
-    backgroundColor: props.colour,
-  }),
+    backgroundColor: props => props.colour,
+  },
   field: {
     width: '240px',
     marginTop: 0,
@@ -104,7 +104,7 @@ const GenericColourInput = <T extends unknown>({
         disabled={isDisabled}
         required={required}
       />
-      {colour && <div className={classes.colour} />}
+      <div className={classes.colour} />
     </div>
   );
 };
@@ -124,13 +124,15 @@ export const ColourInput: React.FC<Props<HexColour>> = (props: Props<HexColour>)
 export const OptionalColourInput: React.FC<Props<HexColour | undefined>> = (
   props: Props<HexColour | undefined>,
 ) => {
+  const colourCss = props.colour ? `#${hexColourToString(props.colour)}` : 'rgb(0, 0, 0, 0)';
+
   return (
     <GenericColourInput
       {...props}
       required={false}
       convertToString={maybeHexColourToString}
       convertFromString={stringToMaybeHexColour}
-      styles={useStyles({ colour: `#${maybeHexColourToString(props.colour)}` || 'FFFFFF' })}
+      styles={useStyles({ colour: colourCss })}
     />
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -100,6 +100,12 @@ const GenericColourInput = <T extends unknown>({
     onChange(newColour);
   };
 
+  const handleColourChangeFromPicker = (colour: string) => {
+    // Remove the leading '#' from the colour string given by the picker
+    const colourWithNoLeadingHash = colour.slice(1);
+    handleColourChange(colourWithNoLeadingHash);
+  };
+
   return (
     <div className={classes.container}>
       <TextField
@@ -125,10 +131,7 @@ const GenericColourInput = <T extends unknown>({
             <div className={classes.picker}>
               <HexColorPicker
                 color={colour ? `#${convertToString(colour)}` : 'rgb(0, 0, 0, 0)'}
-                onChange={(colour: string) => {
-                  // Remove the leading '#' from the colour string
-                  handleColourChange(colour.slice(1));
-                }}
+                onChange={handleColourChangeFromPicker}
               />
             </div>
           </ClickAwayListener>


### PR DESCRIPTION
## What does this change?

The primary purpose of this PR is to add a colour picker to the `ColourInput` component:

https://github.com/guardian/support-admin-console/assets/379839/e5726f1c-4a32-4c72-8d3c-664ba4dcd9d7

I've also snuck in a tiny fix to the `ColourInput` component where updating the colour preview was broken when you click away from an optional colour field when the colour isn't set. This now works as expected.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
