### PR TITLE
Banner design archive

### DIFF
--- a/app/controllers/banner/BannerDesignsController.scala
+++ b/app/controllers/banner/BannerDesignsController.scala
@@ -214,10 +214,10 @@ class BannerDesignsController(
         logger.info(s"${request.user.email} is archiving banner design: $designName")
         dynamoDesigns
           .getRawDesign(designName)
-          .flatMap { design =>
-            dynamoArchivedDesigns.putRaw(design)
-              .flatMap(_ => dynamoDesigns.deleteBannerDesign(designName))
-          }
+          // write to the archive table
+          .flatMap(dynamoArchivedDesigns.putRaw)
+          // now delete from the main table
+          .flatMap(_ => dynamoDesigns.deleteBannerDesign(designName))
           .map(_ => Ok("archived"))
       }
     }

--- a/app/controllers/banner/BannerDesignsController.scala
+++ b/app/controllers/banner/BannerDesignsController.scala
@@ -2,11 +2,11 @@ package controllers.banner
 
 import com.gu.googleauth.AuthAction
 import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoNoLockError}
-import models.{BannerDesign, BannerTest, Channel, LockStatus}
+import models.{BannerDesign, BannerTest, Channel}
 import play.api.libs.circe.Circe
 import play.api.mvc.{AbstractController, AnyContent, ControllerComponents, Result}
-import services.{DynamoBannerDesigns, DynamoChannelTests, S3Json, VersionedS3Data}
-import services.S3Client.{S3ClientError, S3ObjectSettings}
+import services.{DynamoBannerDesigns, DynamoChannelTests, DynamoArchivedBannerDesigns}
+import services.S3Client.S3ObjectSettings
 import utils.Circe.noNulls
 import zio.{IO, ZEnv, ZIO}
 import com.typesafe.scalalogging.LazyLogging
@@ -22,7 +22,8 @@ class BannerDesignsController(
     stage: String,
     runtime: zio.Runtime[ZEnv],
     dynamoDesigns: DynamoBannerDesigns,
-    dynamoTests: DynamoChannelTests
+    dynamoTests: DynamoChannelTests,
+    dynamoArchivedDesigns: DynamoArchivedBannerDesigns
 )(implicit ec: ExecutionContext)
     extends AbstractController(components)
     with Circe
@@ -204,6 +205,20 @@ class BannerDesignsController(
             ZIO.succeed(BadRequest(s"Invalid status for design: $rawStatus"))
         }
 
+      }
+    }
+
+  def archive(designName: String) =
+    authAction.async { request =>
+      run {
+        logger.info(s"${request.user.email} is archiving banner design: $designName")
+        dynamoDesigns
+          .getRawDesign(designName)
+          .flatMap { design =>
+            dynamoArchivedDesigns.putRaw(design)
+              .flatMap(_ => dynamoDesigns.deleteBannerDesign(designName))
+          }
+          .map(_ => Ok("archived"))
       }
     }
 

--- a/app/services/DynamoArchivedBannerDesigns.scala
+++ b/app/services/DynamoArchivedBannerDesigns.scala
@@ -1,0 +1,31 @@
+package services
+
+import com.typesafe.scalalogging.StrictLogging
+import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoPutError}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ConditionalCheckFailedException, PutItemRequest}
+import zio.blocking.effectBlocking
+import zio.{ZEnv, ZIO}
+
+class DynamoArchivedBannerDesigns(stage: String, client: DynamoDbClient) extends DynamoService(stage, client) with StrictLogging {
+
+  protected val tableName = s"support-admin-console-archived-banner-designs-$stage"
+
+  private def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
+    effectBlocking {
+      val result = client.putItem(putRequest)
+      logger.info(s"PutItemResponse: $result")
+      ()
+    }.mapError {
+      case err: ConditionalCheckFailedException => DynamoDuplicateNameError(err)
+      case other => DynamoPutError(other)
+    }
+
+  def putRaw(item: java.util.Map[String, AttributeValue]): ZIO[ZEnv, DynamoError, Unit] =
+    put(
+      PutItemRequest
+        .builder
+        .item(item)
+        .build()
+    )
+}

--- a/app/services/DynamoArchivedBannerDesigns.scala
+++ b/app/services/DynamoArchivedBannerDesigns.scala
@@ -7,6 +7,9 @@ import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, Condition
 import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
 
+import java.text.SimpleDateFormat
+import java.util.Date
+
 class DynamoArchivedBannerDesigns(stage: String, client: DynamoDbClient) extends DynamoService(stage, client) with StrictLogging {
 
   protected val tableName = s"support-admin-console-archived-banner-designs-$stage"
@@ -21,11 +24,15 @@ class DynamoArchivedBannerDesigns(stage: String, client: DynamoDbClient) extends
       case other => DynamoPutError(other)
     }
 
-  def putRaw(item: java.util.Map[String, AttributeValue]): ZIO[ZEnv, DynamoError, Unit] =
+  def putRaw(item: java.util.Map[String, AttributeValue]): ZIO[ZEnv, DynamoError, Unit] = {
+    val date = new SimpleDateFormat("yyyy-MM-dd").format(new Date())
+    // sort key is date
+    item.put("date", AttributeValue.builder.s(date).build())
     put(
       PutItemRequest
         .builder
         .item(item)
         .build()
     )
+  }
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -11,7 +11,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.{Athena, Aws, CapiService, DynamoArchivedChannelTests, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoSuperMode, S3}
+import services.{Athena, Aws, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoSuperMode, S3}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
@@ -71,6 +71,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
   val athena = new Athena()
 
   val dynamoBannerDesigns = new DynamoBannerDesigns(stage, dynamoClient)
+  val dynamoArchivedBannerDesigns = new DynamoArchivedBannerDesigns(stage, dynamoClient)
 
   override lazy val router: Router = new Routes(
     httpErrorHandler,
@@ -89,7 +90,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new BannerDeployController2(authAction, controllerComponents, stage, runtime),
     new ChannelSwitchesController(authAction, controllerComponents, stage, runtime),
     new CampaignsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoCampaignsService),
-    new BannerDesignsController(authAction, controllerComponents, stage, runtime, dynamoBannerDesigns, dynamoTestsService),
+    new BannerDesignsController(authAction, controllerComponents, stage, runtime, dynamoBannerDesigns, dynamoTestsService, dynamoArchivedBannerDesigns),
     new CapiController(authAction, capiService),
     new AppsMeteringSwitchesController(authAction, controllerComponents, stage, runtime),
     new DefaultPromosController(authAction,controllerComponents, stage, runtime),

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -13,6 +13,8 @@ Object {
       "GuDynamoDBWritePolicy",
       "GuDynamoDBReadPolicy",
       "GuDynamoDBWritePolicy",
+      "GuDynamoDBReadPolicy",
+      "GuDynamoDBWritePolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuGetS3ObjectsPolicy",
@@ -138,6 +140,60 @@ Object {
         },
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "ArchivedBannerDesignsDynamoTable": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AttributeDefinitions": Array [
+          Object {
+            "AttributeName": "name",
+            "AttributeType": "S",
+          },
+          Object {
+            "AttributeName": "date",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": Array [
+          Object {
+            "AttributeName": "name",
+            "KeyType": "HASH",
+          },
+          Object {
+            "AttributeName": "date",
+            "KeyType": "RANGE",
+          },
+        ],
+        "PointInTimeRecoverySpecification": Object {
+          "PointInTimeRecoveryEnabled": true,
+        },
+        "TableName": "support-admin-console-archived-banner-designs-PROD",
+        "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-admin-console",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
     },
     "ArchivedChannelTestsDynamoTable": Object {
       "DeletionPolicy": "Retain",
@@ -533,6 +589,51 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "DynamoReadArchivedBannerDesignsDynamoTable44A0398A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:GetRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    Object {
+                      "Ref": "ArchivedBannerDesignsDynamoTable",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoReadArchivedBannerDesignsDynamoTable44A0398A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleAdminconsole347DA627",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "DynamoReadArchivedChannelTestsDynamoTable1835BCEF": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -835,6 +936,50 @@ Object {
           "Version": "2012-10-17",
         },
         "PolicyName": "DynamoReadsupermodeindexendFE67AC4E",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleAdminconsole347DA627",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DynamoWriteArchivedBannerDesignsDynamoTableB6640A8F": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    Object {
+                      "Ref": "ArchivedBannerDesignsDynamoTable",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoWriteArchivedBannerDesignsDynamoTableB6640A8F",
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleAdminconsole347DA627",

--- a/conf/routes
+++ b/conf/routes
@@ -205,6 +205,7 @@ POST  /frontend/banner-designs/lock/:designName        controllers.banner.Banner
 POST  /frontend/banner-designs/unlock/:designName      controllers.banner.BannerDesignsController.unlock(designName: String)
 POST  /frontend/banner-designs/takecontrol/:designName controllers.banner.BannerDesignsController.forceLock(designName: String)
 POST  /frontend/banner-designs/status/:designName/:rawStatus controllers.banner.BannerDesignsController.setStatus(designName: String, rawStatus: String)
+POST  /frontend/banner-designs/archive/:designName     controllers.banner.BannerDesignsController.archive(designName: String)
 
 # ----- capi ----- #
 GET   /capi/tags                                       controllers.CapiController.getTags()

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -29,6 +29,7 @@ type Props = {
   onLock: (designName: string, force: boolean) => void;
   onUnlock: (designName: string) => void;
   onSave: (designName: string) => void;
+  onArchive: (designName: string) => void;
   userHasLock: boolean;
   lockStatus: LockStatus;
   onChange: (design: BannerDesign) => void;
@@ -41,6 +42,7 @@ const BannerDesignEditor: React.FC<Props> = ({
   onLock,
   onUnlock,
   onSave,
+  onArchive,
   userHasLock,
   lockStatus,
   onChange,
@@ -67,6 +69,7 @@ const BannerDesignEditor: React.FC<Props> = ({
         onLock={onLock}
         onUnlock={onUnlock}
         onSave={onSaveWithValidation}
+        onArchive={onArchive}
         userHasLock={userHasLock}
         lockStatus={lockStatus}
         design={design}

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -112,19 +112,19 @@ const StickyTopBar: React.FC<Props> = ({
           onClick={open}
         >
           {/* eslint-disable-next-line react/prop-types */}
-          <Typography className={classes.buttonText}>Archive test</Typography>
+          <Typography className={classes.buttonText}>Archive banner design</Typography>
         </Button>
         <Dialog
           open={isOpen}
           onClose={close}
-          aria-labelledby="archive-test-dialog-title"
-          aria-describedby="archive-test-dialog-description"
+          aria-labelledby="archive-dialog-title"
+          aria-describedby="archive-dialog-description"
         >
-          <DialogTitle id="archive-test-dialog-title">Are you sure?</DialogTitle>
+          <DialogTitle id="archive-dialog-title">Are you sure?</DialogTitle>
           <DialogContent>
-            <DialogContentText id="archive-test-dialog-description">
-              Archiving this test will remove it from the banner tool - you can only restore it with
-              an engineer&apos;s help.
+            <DialogContentText id="archive-dialog-description">
+              Archiving this design will remove it from the banner design tool - you can only
+              restore with an engineer&apos;s help.
             </DialogContentText>
           </DialogContent>
           <DialogActions>
@@ -132,7 +132,7 @@ const StickyTopBar: React.FC<Props> = ({
               Cancel
             </Button>
             <Button color="primary" onClick={() => onArchive(name)}>
-              Archive test
+              Archive design
             </Button>
           </DialogActions>
         </Dialog>

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
-import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
+import {
+  Theme,
+  Typography,
+  makeStyles,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';
 import { LockDetails } from './LockDetails';
 import LockIcon from '@material-ui/icons/Lock';
@@ -10,6 +20,8 @@ import { LockStatus } from '../helpers/shared';
 import LiveSwitch from '../../shared/liveSwitch';
 import { BannerDesign, Status } from '../../../models/bannerDesign';
 import { BannerDesignPreview } from './BannerDesignPreview';
+import useOpenable from '../../../hooks/useOpenable';
+import ArchiveIcon from '@material-ui/icons/Archive';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -69,6 +81,7 @@ interface Props {
   onLock: (name: string, force: boolean) => void;
   onUnlock: (name: string) => void;
   onSave: (name: string) => void;
+  onArchive: (designName: string) => void;
   lockStatus: LockStatus;
   userHasLock: boolean;
   onStatusChange: (status: Status) => void;
@@ -80,11 +93,52 @@ const StickyTopBar: React.FC<Props> = ({
   onLock,
   onUnlock,
   onSave,
+  onArchive,
   userHasLock,
   lockStatus,
   onStatusChange,
 }: Props) => {
   const classes = useStyles();
+
+  const ArchiveButton: React.FC = () => {
+    const [isOpen, open, close] = useOpenable();
+
+    return (
+      <>
+        <Button
+          variant="outlined"
+          startIcon={<ArchiveIcon style={{ color: grey[700] }} />}
+          size="medium"
+          onClick={open}
+        >
+          {/* eslint-disable-next-line react/prop-types */}
+          <Typography className={classes.buttonText}>Archive test</Typography>
+        </Button>
+        <Dialog
+          open={isOpen}
+          onClose={close}
+          aria-labelledby="archive-test-dialog-title"
+          aria-describedby="archive-test-dialog-description"
+        >
+          <DialogTitle id="archive-test-dialog-title">Are you sure?</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="archive-test-dialog-description">
+              Archiving this test will remove it from the banner tool - you can only restore it with
+              an engineer&apos;s help.
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button color="primary" onClick={close}>
+              Cancel
+            </Button>
+            <Button color="primary" onClick={() => onArchive(name)}>
+              Archive test
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  };
 
   return (
     <header className={classes.container}>
@@ -130,6 +184,7 @@ const StickyTopBar: React.FC<Props> = ({
           )}
           {userHasLock && (
             <>
+              {design.status === 'Draft' && <ArchiveButton />}
               <Button
                 variant="outlined"
                 size="medium"

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -5,6 +5,7 @@ import BannerDesignEditor from './BannerDesignEditor';
 import { useParams } from 'react-router-dom';
 
 import {
+  archiveBannerDesign,
   BannerDesignsResponse,
   createBannerDesign,
   fetchBannerDesign,
@@ -67,13 +68,17 @@ const BannerDesigns: React.FC = () => {
 
   const classes = useStyles();
 
-  useEffect(() => {
+  const refreshDesigns = () => {
     fetchFrontendSettings(FrontendSettingsType.bannerDesigns).then(
       (response: BannerDesignsResponse) => {
         setBannerDesigns(response.bannerDesigns);
         setUserEmail(response.userEmail);
       },
     );
+  };
+
+  useEffect(() => {
+    refreshDesigns();
   }, []);
 
   useEffect(() => {
@@ -154,6 +159,14 @@ const BannerDesigns: React.FC = () => {
     }
   };
 
+  const onArchive = (designName: string): void => {
+    archiveBannerDesign(designName)
+      .then(() => refreshDesigns())
+      .catch(error => {
+        alert(`Error while archiving design: ${error}`);
+      });
+  };
+
   const onStatusChange = (bannerDesignName: string | undefined, status: Status): void => {
     if (bannerDesignName) {
       updateBannerDesignStatus(bannerDesignName, status)
@@ -184,6 +197,7 @@ const BannerDesigns: React.FC = () => {
             onLock={onLock}
             onUnlock={onUnlock}
             onSave={onSave}
+            onArchive={onArchive}
             userHasLock={selectedBannerDesign.lockStatus?.email === userEmail}
             lockStatus={selectedBannerDesign.lockStatus || { locked: false }}
             onChange={onDesignChange}

--- a/public/src/components/channelManagement/testEditorActionButtons.tsx
+++ b/public/src/components/channelManagement/testEditorActionButtons.tsx
@@ -114,20 +114,19 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
           onClick={open}
           disabled={isDisabled}
         >
-          {/* eslint-disable-next-line react/prop-types */}
           <Typography className={classes.buttonText}>Archive test</Typography>
         </Button>
         <Dialog
           open={isOpen}
           onClose={close}
-          aria-labelledby="archive-test-dialog-title"
-          aria-describedby="archive-test-dialog-description"
+          aria-labelledby="archive-dialog-title"
+          aria-describedby="archive-dialog-description"
         >
-          <DialogTitle id="archive-test-dialog-title">Are you sure?</DialogTitle>
+          <DialogTitle id="archive-dialog-title">Are you sure?</DialogTitle>
           <DialogContent>
-            <DialogContentText id="archive-test-dialog-description">
-              Archiving this test will remove it from the banner tool - you can only restore it with
-              an engineer&apos;s help.
+            <DialogContentText id="archive-dialog-description">
+              Archiving this design will remove it from the banner design tool - you can only
+              restore it with an engineer&apos;s help.
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/public/src/components/channelManagement/testEditorActionButtons.tsx
+++ b/public/src/components/channelManagement/testEditorActionButtons.tsx
@@ -114,19 +114,20 @@ const TestEditorActionButtons: React.FC<TestEditorActionButtonsProps> = ({
           onClick={open}
           disabled={isDisabled}
         >
+          {/* eslint-disable-next-line react/prop-types */}
           <Typography className={classes.buttonText}>Archive test</Typography>
         </Button>
         <Dialog
           open={isOpen}
           onClose={close}
-          aria-labelledby="archive-dialog-title"
-          aria-describedby="archive-dialog-description"
+          aria-labelledby="archive-test-dialog-title"
+          aria-describedby="archive-test-dialog-description"
         >
-          <DialogTitle id="archive-dialog-title">Are you sure?</DialogTitle>
+          <DialogTitle id="archive-test-dialog-title">Are you sure?</DialogTitle>
           <DialogContent>
-            <DialogContentText id="archive-dialog-description">
-              Archiving this design will remove it from the banner design tool - you can only
-              restore it with an engineer&apos;s help.
+            <DialogContentText id="archive-test-dialog-description">
+              Archiving this test will remove it from the banner tool - you can only restore it with
+              an engineer&apos;s help.
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/public/src/utils/requests.tsx
+++ b/public/src/utils/requests.tsx
@@ -188,6 +188,12 @@ export function updateBannerDesignStatus(
   );
 }
 
+export function archiveBannerDesign(designName: string): Promise<Response> {
+  return makeFetch(`/frontend/${FrontendSettingsType.bannerDesigns}/archive/${designName}`, {
+    method: 'POST',
+  });
+}
+
 export function getBannerDesignUsage(
   designName: string,
 ): Promise<{ name: string; channel: string }[]> {


### PR DESCRIPTION
Adds the ability to archive individual banner designs.
The button is only available if the design status is `Draft`.
Stores archived tests in a separate Dynamodb table (as with channel tests). The table is keyed on `name` and `date`, because we're likely to get duplicate names as time goes on

<img width="599" alt="Screenshot 2023-12-18 at 10 44 18" src="https://github.com/guardian/support-admin-console/assets/1513454/643e4a2b-1be6-499f-93f4-3d167d487c58">
<img width="565" alt="Screenshot 2023-12-18 at 10 44 25" src="https://github.com/guardian/support-admin-console/assets/1513454/fd97ca3e-8e2c-46b6-b38f-cec30aa9b107">
