### PR TITLE
Add additional color fields to choice card design form

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -46,7 +46,12 @@ object BannerDesignVisual {
 
   case class ChoiceCards(
     kind: String = "ChoiceCards",
-    buttonColour: Option[HexColour]
+    buttonColour: Option[HexColour],
+    buttonTextColour: Option[HexColour],
+    buttonBorderColour: Option[HexColour],
+    buttonSelectColour: Option[HexColour],
+    buttonSelectTextColour: Option[HexColour],
+    buttonSelectBorderColour: Option[HexColour]
   ) extends BannerDesignVisual
 
   import io.circe.generic.extras.auto._

--- a/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
@@ -52,14 +52,58 @@ export const BannerVisualEditor: React.FC<Props> = ({
           />
         )}
         {visual?.kind === 'ChoiceCards' && (
-          <OptionalColourInput
-            colour={visual.buttonColour}
-            name="visual.buttonColour"
-            label="Button Colour"
-            isDisabled={isDisabled}
-            onChange={buttonColour => onChange({ ...visual, buttonColour })}
-            onValidationChange={onValidationChange}
-          />
+          <>
+            <OptionalColourInput
+              colour={visual.buttonColour}
+              name="visual.buttonColour"
+              label="Button background colour"
+              isDisabled={isDisabled}
+              onChange={buttonColour => onChange({ ...visual, buttonColour })}
+              onValidationChange={onValidationChange}
+            />
+            <OptionalColourInput
+              colour={visual.buttonTextColour}
+              name="visual.buttonTextColour"
+              label="Button text colour"
+              isDisabled={isDisabled}
+              onChange={buttonTextColour => onChange({ ...visual, buttonTextColour })}
+              onValidationChange={onValidationChange}
+            />
+            <OptionalColourInput
+              colour={visual.buttonBorderColour}
+              name="visual.buttonBorderColour"
+              label="Button border colour"
+              isDisabled={isDisabled}
+              onChange={buttonBorderColour => onChange({ ...visual, buttonBorderColour })}
+              onValidationChange={onValidationChange}
+            />
+            <OptionalColourInput
+              colour={visual.buttonSelectColour}
+              name="visual.buttonSelectColour"
+              label="Selected button background colour"
+              isDisabled={isDisabled}
+              onChange={buttonSelectColour => onChange({ ...visual, buttonSelectColour })}
+              onValidationChange={onValidationChange}
+            />
+            <OptionalColourInput
+              colour={visual.buttonSelectTextColour}
+              name="visual.buttonSelectTextColour"
+              label="Selected button text colour"
+              isDisabled={isDisabled}
+              onChange={buttonSelectTextColour => onChange({ ...visual, buttonSelectTextColour })}
+              onValidationChange={onValidationChange}
+            />
+            <OptionalColourInput
+              colour={visual.buttonSelectBorderColour}
+              name="visual.buttonSelectBorderColour"
+              label="Selected button border colour"
+              isDisabled={isDisabled}
+              onChange={buttonSelectBorderColour =>
+                onChange({ ...visual, buttonSelectBorderColour })
+              }
+              onValidationChange={onValidationChange}
+            />
+          </>
         )}
       </div>
     </div>

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -20,6 +20,11 @@ export const defaultBannerImage: BannerDesignImage = {
 export const defaultBannerChoiceCardsDesign: ChoiceCardsDesign = {
   kind: 'ChoiceCards',
   buttonColour: stringToHexColour('FFFFFF'),
+  buttonTextColour: stringToHexColour('767676'),
+  buttonBorderColour: stringToHexColour('999999'),
+  buttonSelectColour: stringToHexColour('E3F6FF'),
+  buttonSelectTextColour: stringToHexColour('062962'),
+  buttonSelectBorderColour: stringToHexColour('017ABC'),
 };
 
 export const createDefaultBannerDesign = (name: string): BannerDesign => ({

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -52,6 +52,11 @@ export interface BannerDesignImage extends BannerDesignHeaderImage {
 export interface ChoiceCardsDesign {
   kind: 'ChoiceCards';
   buttonColour?: HexColour;
+  buttonTextColour?: HexColour;
+  buttonBorderColour?: HexColour;
+  buttonSelectColour?: HexColour;
+  buttonSelectTextColour?: HexColour;
+  buttonSelectBorderColour?: HexColour;
 }
 export type BannerDesignVisual = BannerDesignImage | ChoiceCardsDesign;
 


### PR DESCRIPTION
## What does this change?
Extends the banner design tool so users can style the amounts card with colours

See related PR in SDC: https://github.com/guardian/support-dotcom-components/pull/1026

## Screenshots

![Screenshot 2023-12-20 at 16 33 42](https://github.com/guardian/support-admin-console/assets/5357530/642b8e75-930e-4259-b189-d708db2bd78b)

![Screenshot 2023-12-20 at 16 32 37](https://github.com/guardian/support-admin-console/assets/5357530/c5e82635-daf9-4d73-917d-dd9c6540e5f0)
