### PR TITLE
Add new logo colour field (as optional)

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -72,6 +72,7 @@ case class BannerDesignBasicColours(
   bodyText: HexColour,
   headerText: HexColour,
   articleCountText: HexColour,
+  logo: Option[HexColour]
 )
 
 case class BannerDesignHighlightedTextColours(

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BasicColours } from '../../../models/bannerDesign';
 import { ColourInput } from './ColourInput';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import { stringToHexColour } from '../../../utils/bannerDesigns';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -60,6 +61,14 @@ export const BasicColoursEditor: React.FC<Props> = ({
         label="Article Count Text Colour"
         isDisabled={isDisabled}
         onChange={colour => onChange({ ...basicColours, articleCountText: colour })}
+        onValidationChange={onValidationChange}
+      />
+      <ColourInput
+        colour={basicColours.logo ?? stringToHexColour('000000')}
+        name="colours.basic.logo"
+        label="Guardian Logo Colour"
+        isDisabled={isDisabled}
+        onChange={colour => onChange({ ...basicColours, logo: colour })}
         onValidationChange={onValidationChange}
       />
     </div>

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -12,6 +12,7 @@ export interface BasicColours {
   bodyText: HexColour;
   headerText: HexColour;
   articleCountText: HexColour;
+  logo?: HexColour;
 }
 
 export interface HighlightedTextColours {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new field to configure the Guardian logo as a hex colour. In preparation of the change required for [this ticket](https://trello.com/c/rsoYILSv/74-rrcp-use-the-full-the-guardian-logo-at-the-bottom-right-and-remove-the-roundel-from-the-top-right). It will be an optional field and no banner changes will occur because of this PR.

The plan is to go through the banner designs and set correct values for this field. Then update the model in SDC to include this field.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Under Basic colours see "Guardian Logo Colour" field

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-admin-console/assets/114918544/d68c20b6-fefc-4f64-be10-e179eba9e149)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
