### PR TITLE
Banner Design - make logo colour not optional

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -72,7 +72,7 @@ case class BannerDesignBasicColours(
   bodyText: HexColour,
   headerText: HexColour,
   articleCountText: HexColour,
-  logo: Option[HexColour]
+  logo: HexColour
 )
 
 case class BannerDesignHighlightedTextColours(

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { BasicColours } from '../../../models/bannerDesign';
 import { ColourInput } from './ColourInput';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { stringToHexColour } from '../../../utils/bannerDesigns';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -64,7 +63,7 @@ export const BasicColoursEditor: React.FC<Props> = ({
         onValidationChange={onValidationChange}
       />
       <ColourInput
-        colour={basicColours.logo ?? stringToHexColour('000000')}
+        colour={basicColours.logo}
         name="colours.basic.logo"
         label="Guardian Logo Colour"
         isDisabled={isDisabled}

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -37,6 +37,7 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
       bodyText: stringToHexColour('000000'),
       headerText: stringToHexColour('000000'),
       articleCountText: stringToHexColour('000000'),
+      logo: stringToHexColour('000000'),
     },
     highlightedText: {
       text: stringToHexColour('000000'),

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -12,7 +12,7 @@ export interface BasicColours {
   bodyText: HexColour;
   headerText: HexColour;
   articleCountText: HexColour;
-  logo?: HexColour;
+  logo: HexColour;
 }
 
 export interface HighlightedTextColours {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Set a default (black) colour for the logo so new banner designs get this, and make the setting non-optional. We have manually assigned each design a logo colour and saved it. The only reason to make it optional was because it would not be initially set.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
