### PR TITLE
Logo colour editor and remove roundel

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -16,17 +16,6 @@ object BannerDesignStatus {
   implicit val statusDecoder = deriveEnumerationDecoder[BannerDesignStatus]
 }
 
-sealed trait GuardianRoundelDesign
-object GuardianRoundelDesign {
-  case object default extends GuardianRoundelDesign
-  case object brand extends GuardianRoundelDesign
-  case object inverse extends GuardianRoundelDesign
-
-  implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val encoder = deriveEnumerationEncoder[GuardianRoundelDesign]
-  implicit val decoder = deriveEnumerationDecoder[GuardianRoundelDesign]
-}
-
 case class HeaderImage(
   mobileUrl: String,
   tabletDesktopUrl: String,
@@ -104,7 +93,6 @@ case class BannerDesignColours(
   primaryCta: CtaDesign,
   secondaryCta: CtaDesign,
   closeButton: CtaDesign,
-  guardianRoundel: Option[GuardianRoundelDesign],
   ticker: TickerDesign
 )
 

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -6,7 +6,6 @@ import {
   BannerDesignVisual,
   BasicColours,
   CtaDesign,
-  GuardianRoundel,
   HighlightedTextColours,
   TickerDesign,
 } from '../../../models/bannerDesign';
@@ -14,7 +13,6 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import { BasicColoursEditor } from './BasicColoursEditor';
 import { HighlightedTextColoursEditor } from './HighlightedTextColoursEditor';
 import { CtaColoursEditor } from './CtaColoursEditor';
-import TypedRadioGroup from '../TypedRadioGroup';
 import { BannerDesignUsage } from './BannerDesignUsage';
 import { TickerDesignEditor } from './TickerDesignEditor';
 import { HeaderImageEditor } from './HeaderImageEditor';
@@ -126,16 +124,6 @@ const BannerDesignForm: React.FC<Props> = ({
       colours: {
         ...design.colours,
         [name]: cta,
-      },
-    });
-  };
-
-  const onRoundelChange = (roundel: GuardianRoundel): void => {
-    onChange({
-      ...design,
-      colours: {
-        ...design.colours,
-        guardianRoundel: roundel,
       },
     });
   };
@@ -257,24 +245,6 @@ const BannerDesignForm: React.FC<Props> = ({
         </AccordionDetails>
       </Accordion>
 
-      <Accordion className={[classes.accordion, classes.colourSectionContainer].join(' ')}>
-        <AccordionSummary className={classes.sectionHeader} expandIcon={<ExpandMoreIcon />}>
-          Roundel style
-        </AccordionSummary>
-
-        <AccordionDetails>
-          <TypedRadioGroup
-            selectedValue={design.colours.guardianRoundel}
-            onChange={onRoundelChange}
-            isDisabled={isDisabled}
-            labels={{
-              default: 'Default - white text on black background',
-              inverse: 'Inverse - black text on white background',
-              brand: 'Brand - white text on blue background',
-            }}
-          />
-        </AccordionDetails>
-      </Accordion>
       <Accordion className={[classes.accordion, classes.colourSectionContainer].join(' ')}>
         <AccordionSummary className={classes.sectionHeader} expandIcon={<ExpandMoreIcon />}>
           Ticker Colours

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 import { BasicColours } from '../../../models/bannerDesign';
 import { ColourInput } from './ColourInput';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import { hexColourToString, stringToHexColour } from '../../../utils/bannerDesigns';
+import TypedRadioGroup from '../TypedRadioGroup';
 
-const useStyles = makeStyles(({ spacing }: Theme) => ({
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
     display: 'flex',
     flexDirection: 'column',
     '& > * + *': {
       marginTop: spacing(1),
     },
+  },
+  header: {
+    fontSize: 16,
+    fontWeight: 500,
+    color: palette.grey[700],
   },
 }));
 
@@ -62,13 +69,12 @@ export const BasicColoursEditor: React.FC<Props> = ({
         onChange={colour => onChange({ ...basicColours, articleCountText: colour })}
         onValidationChange={onValidationChange}
       />
-      <ColourInput
-        colour={basicColours.logo}
-        name="colours.basic.logo"
-        label="Guardian Logo Colour"
+      <div className={classes.header}>Guardian Logo Colour</div>
+      <TypedRadioGroup
+        selectedValue={hexColourToString(basicColours.logo)}
+        onChange={colour => onChange({ ...basicColours, logo: stringToHexColour(colour) })}
         isDisabled={isDisabled}
-        onChange={colour => onChange({ ...basicColours, logo: colour })}
-        onValidationChange={onValidationChange}
+        labels={{ '000000': 'Black', FFFFFF: 'White' }}
       />
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -76,7 +76,6 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
         background: stringToHexColour('E5E5E5'),
       },
     },
-    guardianRoundel: 'inverse',
     ticker: {
       text: stringToHexColour('052962'),
       filledProgress: stringToHexColour('052962'),

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -30,8 +30,6 @@ export interface CtaDesign {
   hover: CtaStateDesign;
 }
 
-export type GuardianRoundel = 'default' | 'brand' | 'inverse';
-
 export interface TickerDesign {
   text: HexColour;
   filledProgress: HexColour;
@@ -70,7 +68,6 @@ export type BannerDesignProps = {
     primaryCta: CtaDesign;
     secondaryCta: CtaDesign;
     closeButton: CtaDesign;
-    guardianRoundel: GuardianRoundel;
     ticker: TickerDesign;
   };
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changes the Guardian logo editor to constrict it to just black and white - the only colours the design system allows it to be. Also removes the code for the roundel config from banner designs.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Edit a design - can only pick black or white under "Guardian logo colour". Can save save. Roundel section is not present.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-admin-console/assets/114918544/fa403863-a20e-4759-9d50-569a54a6fa96)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
