### PR TITLE
Add article count copy editor field

### DIFF
--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -17,6 +17,7 @@ object SeparateArticleCountType extends Enum[SeparateArticleCountType] with Circ
 
 case class SeparateArticleCount(
   `type`: SeparateArticleCountType,
+  copy: Option[String]
 )
 
 case class EpicVariant(

--- a/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import { SeparateArticleCount } from '../../models/epic';
+import { TextField } from '@material-ui/core';
+import { useForm } from 'react-hook-form';
+
+interface FormData {
+  copy: string;
+}
 
 interface VariantEditorSeparateArticleCountEditorProps {
   separateArticleCount?: SeparateArticleCount;
@@ -18,6 +24,18 @@ const VariantEditorSeparateArticleCountEditor: React.FC<VariantEditorSeparateArt
     updateSeparateArticleCount(Boolean(separateArticleCount) ? undefined : { type: 'above' });
   };
 
+  const defaultValues: FormData = {
+    copy: separateArticleCount?.copy ?? '',
+  };
+
+  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+
+  const onSubmit = ({ copy }: FormData): void => {
+    updateSeparateArticleCount(
+      separateArticleCount ? { ...separateArticleCount, copy } : undefined,
+    );
+  };
+
   return (
     <div>
       <FormControlLabel
@@ -30,6 +48,18 @@ const VariantEditorSeparateArticleCountEditor: React.FC<VariantEditorSeparateArt
           />
         }
         label="Above"
+      />
+      <TextField
+        inputRef={register()}
+        error={errors.copy !== undefined}
+        helperText={errors.copy?.message}
+        onBlur={handleSubmit(onSubmit)}
+        name="copy"
+        label="Article count copy"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled || !Boolean(separateArticleCount)}
+        fullWidth
       />
     </div>
   );

--- a/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
@@ -32,7 +32,9 @@ const VariantEditorSeparateArticleCountEditor: React.FC<VariantEditorSeparateArt
 
   const onSubmit = ({ copy }: FormData): void => {
     updateSeparateArticleCount(
-      separateArticleCount ? { ...separateArticleCount, copy } : undefined,
+      separateArticleCount
+        ? { ...separateArticleCount, copy: copy === '' ? undefined : copy }
+        : undefined,
     );
   };
 

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -17,6 +17,7 @@ import { ControlProportionSettings } from '../components/channelManagement/helpe
 
 export interface SeparateArticleCount {
   type: 'above';
+  copy?: string;
 }
 
 export interface EpicVariant extends Variant {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the "copy" property to Epic test models [(already exists here)](https://github.com/guardian/support-dotcom-components/blob/0594dce2d06307b0b01e25a304e26255ce7f99c7/packages/shared/src/types/abTests/epic.ts#L30) and creates an editor field for it. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Edit a variant of an epic test - update the "Article count copy" under "Separate article count". Preview and see this copy. Save, reload and see the copy is still there.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-admin-console/assets/114918544/7783146d-7e12-4351-a3eb-52deefdf18e2)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
