### PR TITLE
Remove nulls when serializing to dynamodb

### DIFF
--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -190,14 +190,13 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
     */
   private def buildUpdateTestExpression(item: Map[String, AttributeValue]): String = {
     case class Updates(changes: List[String], removes: List[String])
-    // Unlock the test at the same time
-    val removes = List("lockStatus")
+    val removes = List("lockStatus")  // Unlock the test at the same time
+
     val updates = item.foldLeft[Updates](Updates(Nil,removes)) { case (acc, (key, value)) =>
       if (value.nul()) {
-        // Remove the attribute
+        // Remove the attribute rather than setting it to null
         acc.copy(removes = s"$key" +: acc.removes)
       } else {
-        // Update the attribute
         acc.copy(changes = s"$key = :$key" +: acc.changes)
       }
     }

--- a/app/utils/Circe.scala
+++ b/app/utils/Circe.scala
@@ -18,7 +18,7 @@ object Circe {
 
   // Converts Circe Json to Dynamodb Attributes
   def jsonToDynamo(json: Json): AttributeValue =
-    json.fold(
+    json.deepDropNullValues.fold(
       jsonNull = AttributeValue.builder().nul(true).build,
       jsonBoolean = bool => AttributeValue.builder.bool(bool).build,
       jsonNumber = n => AttributeValue.builder.n(n.toString).build,

--- a/test/utils/CirceSpec.scala
+++ b/test/utils/CirceSpec.scala
@@ -7,13 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import io.circe.parser._
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
-
 class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
-  import diffson.lcs._
-  import diffson.circe._
-  import diffson.jsonpatch._
-  import diffson.jsonpatch.lcsdiff._
-
   val rawJson =
     """
       |{
@@ -28,6 +22,11 @@ class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
       |""".stripMargin
 
   it should "convert json to dynamo attributes, and back again" in {
+    import diffson.lcs._
+    import diffson.circe._
+    import diffson.jsonpatch._
+    import diffson.jsonpatch.lcsdiff._
+
     val initialJson: Json = parse(rawJson).toOption.get
 
     val dynamoAttributes: AttributeValue = Circe.jsonToDynamo(initialJson)

--- a/test/utils/CirceSpec.scala
+++ b/test/utils/CirceSpec.scala
@@ -5,18 +5,15 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.parser._
-import io.circe.syntax.EncoderOps
-import models.{BannerTest, BannerUI, BannerVariant}
-import models.Channel.Banner1
-import models.Status.Draft
-import models.UserCohort.AllNonSupporters
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
-import diffson.lcs._
-import diffson.circe._
-import diffson.jsonpatch._
-import diffson.jsonpatch.lcsdiff._
+
 
 class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
+  import diffson.lcs._
+  import diffson.circe._
+  import diffson.jsonpatch._
+  import diffson.jsonpatch.lcsdiff._
+
   val rawJson =
     """
       |{
@@ -39,66 +36,6 @@ class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     implicit val patience = new Patience[Json]
     val jsonDiff = diffson.diff(resultJson, initialJson)
-
-    jsonDiff should be(JsonPatch(Nil))
-  }
-
-  it should "drop nulls when serializing to dynamo attributes" in {
-    // The model contains None values, which will be serialized to JSON nulls and then dropped
-    val bannerTest = BannerTest(
-      name = "test",
-      channel = Some(Banner1),
-      status = Some(Draft),
-      lockStatus = None,
-      priority = None,
-      nickname = None,
-      userCohort = AllNonSupporters,
-      variants = List(
-        BannerVariant(
-          name = "variant1",
-          template = BannerUI.ContributionsBanner,
-          bannerContent = None,
-          mobileBannerContent = None,
-          separateArticleCount = None,
-          tickerSettings = None
-        )
-      )
-    )
-
-    val expectedJsonWithNoNulls = parse(
-      """
-        |{
-        |  "name" : "test",
-        |  "channel" : "Banner1",
-        |  "locations" : [],
-        |  "status" : "Draft",
-        |  "userCohort" : "AllNonSupporters",
-        |  "campaignName" : "NOT_IN_CAMPAIGN",
-        |  "variants" : [
-        |    {
-        |      "name" : "variant1",
-        |      "template" : "ContributionsBanner"
-        |    }
-        |  ],
-        |  "contextTargeting" : {
-        |    "tagIds" : [],
-        |    "sectionIds" : [],
-        |    "excludedTagIds" : [],
-        |    "excludedSectionIds" : []
-        |  },
-        |  "signedInStatus" : "All"
-        |}
-        |""".stripMargin
-    ).toOption.get
-
-    val jsonWithNulls = bannerTest.asJson
-
-    val dynamoAttributes: AttributeValue = Circe.jsonToDynamo(jsonWithNulls)
-
-    val resultJson: Json = Circe.dynamoToJson(dynamoAttributes)
-
-    implicit val patience = new Patience[Json]
-    val jsonDiff = diffson.diff(resultJson, expectedJsonWithNoNulls)
 
     jsonDiff should be(JsonPatch(Nil))
   }

--- a/test/utils/CirceSpec.scala
+++ b/test/utils/CirceSpec.scala
@@ -5,7 +5,16 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.parser._
+import io.circe.syntax.EncoderOps
+import models.{BannerTest, BannerUI, BannerVariant}
+import models.Channel.Banner1
+import models.Status.Draft
+import models.UserCohort.AllNonSupporters
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import diffson.lcs._
+import diffson.circe._
+import diffson.jsonpatch._
+import diffson.jsonpatch.lcsdiff._
 
 class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
   val rawJson =
@@ -22,11 +31,6 @@ class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
       |""".stripMargin
 
   it should "convert json to dynamo attributes, and back again" in {
-    import diffson.lcs._
-    import diffson.circe._
-    import diffson.jsonpatch._
-    import diffson.jsonpatch.lcsdiff._
-
     val initialJson: Json = parse(rawJson).toOption.get
 
     val dynamoAttributes: AttributeValue = Circe.jsonToDynamo(initialJson)
@@ -35,6 +39,66 @@ class CirceSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     implicit val patience = new Patience[Json]
     val jsonDiff = diffson.diff(resultJson, initialJson)
+
+    jsonDiff should be(JsonPatch(Nil))
+  }
+
+  it should "drop nulls when serializing to dynamo attributes" in {
+    // The model contains None values, which will be serialized to JSON nulls and then dropped
+    val bannerTest = BannerTest(
+      name = "test",
+      channel = Some(Banner1),
+      status = Some(Draft),
+      lockStatus = None,
+      priority = None,
+      nickname = None,
+      userCohort = AllNonSupporters,
+      variants = List(
+        BannerVariant(
+          name = "variant1",
+          template = BannerUI.ContributionsBanner,
+          bannerContent = None,
+          mobileBannerContent = None,
+          separateArticleCount = None,
+          tickerSettings = None
+        )
+      )
+    )
+
+    val expectedJsonWithNoNulls = parse(
+      """
+        |{
+        |  "name" : "test",
+        |  "channel" : "Banner1",
+        |  "locations" : [],
+        |  "status" : "Draft",
+        |  "userCohort" : "AllNonSupporters",
+        |  "campaignName" : "NOT_IN_CAMPAIGN",
+        |  "variants" : [
+        |    {
+        |      "name" : "variant1",
+        |      "template" : "ContributionsBanner"
+        |    }
+        |  ],
+        |  "contextTargeting" : {
+        |    "tagIds" : [],
+        |    "sectionIds" : [],
+        |    "excludedTagIds" : [],
+        |    "excludedSectionIds" : []
+        |  },
+        |  "signedInStatus" : "All"
+        |}
+        |""".stripMargin
+    ).toOption.get
+
+    val jsonWithNulls = bannerTest.asJson
+
+    val dynamoAttributes: AttributeValue = Circe.jsonToDynamo(jsonWithNulls)
+
+    val resultJson: Json = Circe.dynamoToJson(dynamoAttributes)
+
+    implicit val patience = new Patience[Json]
+    val jsonDiff = diffson.diff(resultJson, expectedJsonWithNoNulls)
 
     jsonDiff should be(JsonPatch(Nil))
   }


### PR DESCRIPTION
Currently when fields in the scala model are `None`, they're serialized to Dynamodb as `Null`.
This adds complexity to support-dotcom-components, where the typescript and zod validation have to allow for both `undefined` _or_ `null`.
We can simplify this by just never writing nulls to dynamodb.

This will require an initial migration of all existing data in dynamodb to remove nulls