### PR TITLE
Ensure test exists before locking

### DIFF
--- a/app/controllers/ChannelTestsController.scala
+++ b/app/controllers/ChannelTestsController.scala
@@ -191,7 +191,7 @@ abstract class ChannelTestsController[T <: ChannelTest[T] : Decoder : Encoder](
         .map(_ => Ok("locked"))
         .catchSome { case DynamoNoLockError(error) =>
           logger.warn(s"Failed to lock $channel/'$testName' because it is already locked: ${error.getMessage}")
-          IO.succeed(Conflict(s"$channel test '$testName' is already locked for edit by another user"))
+          IO.succeed(Conflict(s"$channel test '$testName' is already locked for edit by another user, or it doesn't exist"))
         }
     }
   }


### PR DESCRIPTION
We've had a couple of instances of the following bug:

1. user opens the banner tests page
2. user opens the banner tests page in another tab and archives a test
3. user then tries to edit the same test from the original page (which still shows that test), which triggers a request to lock the test
4. the backend creates a new entry in dynamodb for the archived test, because dynamo UpdateItemRequests will create a row if it's not there!

This PR fixes that by checking the item exists in dynamodb before performing the update

![Screenshot 2024-01-30 at 09 10 56](https://github.com/guardian/support-admin-console/assets/1513454/88bf1817-7a3b-4d51-9aa7-c06789dee26a)
