### PR TITLE
Create apple news epic choice cards editor

### DIFF
--- a/public/src/components/channelManagement/epicTests/appleChoiceCardsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/appleChoiceCardsEditor.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { EpicVariant } from '../../../models/epic';
+import { Cta } from '../helpers/shared';
+import { FormControl, FormControlLabel, Radio, RadioGroup } from '@material-ui/core';
+import VariantEditorCtaFieldsEditor from '../variantEditorCtaFieldsEditor';
+import { DEFAULT_PRIMARY_CTA } from './utils/defaults';
+
+interface AppleNewsChoiceCardsProps {
+  variant: EpicVariant;
+  editMode: boolean;
+  updateShowChoiceCards: (updatedshowChoiceCards?: boolean) => void;
+  updatePrimaryCta: (updatedCta?: Cta) => void;
+  onValidationChange: (isValid: boolean) => void;
+}
+
+export const AppleNewsChoiceCards: React.FC<AppleNewsChoiceCardsProps> = ({
+  variant,
+  updateShowChoiceCards,
+  editMode,
+  updatePrimaryCta,
+  onValidationChange,
+}: AppleNewsChoiceCardsProps) => {
+  const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.value === 'choiceCardsEnabled') {
+      updateShowChoiceCards(true);
+    } else {
+      updateShowChoiceCards(false);
+    }
+  };
+
+  const primaryCtaEnabled = !variant.showChoiceCards;
+
+  return (
+    <FormControl>
+      <RadioGroup
+        value={variant.showChoiceCards ? 'choiceCardsEnabled' : 'choiceCardsDisabled'}
+        onChange={onRadioGroupChange}
+      >
+        <FormControlLabel
+          value="choiceCardsEnabled"
+          key="choiceCardsEnabled"
+          control={<Radio />}
+          label="Enable choice cards"
+          disabled={!editMode}
+        />
+        <FormControlLabel
+          value="choiceCardsDisabled"
+          key="choiceCardsDisabled"
+          control={<Radio />}
+          label="Enable primary button"
+          disabled={!editMode}
+        />
+      </RadioGroup>
+      {primaryCtaEnabled && (
+        <VariantEditorCtaFieldsEditor
+          cta={variant.cta ?? DEFAULT_PRIMARY_CTA}
+          updateCta={updatePrimaryCta}
+          onValidationChange={onValidationChange}
+          isDisabled={!editMode}
+        />
+      )}
+    </FormControl>
+  );
+};

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -37,6 +37,7 @@ import VariantEditorSeparateArticleCountEditor from '../variantEditorSeparateArt
 import { ImageEditorToggle } from '../imageEditor';
 import { BylineWithImageEditorToggle } from '../bylineWithImageEditor';
 import { EpicVariant, SeparateArticleCount } from '../../../models/epic';
+import { AppleNewsChoiceCards } from './appleChoiceCardsEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const getUseStyles = (shouldAddPadding: boolean) => {
@@ -475,30 +476,18 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
       )}
 
       {allowAppleNewsChoiceCards && (
-        <>
-          <div className={classes.sectionContainer}>
-            <Typography className={classes.sectionHeader} variant="h4">
-              Apple News Choice Cards
-            </Typography>
-
-            <EpicTestChoiceCardsEditor
-              showChoiceCards={variant.showChoiceCards}
-              updateShowChoiceCards={updateShowChoiceCards}
-              isDisabled={!editMode}
-            />
-          </div>
-          <div className={classes.sectionContainer}>
-            <EpicTestVariantEditorCtasEditor
-              primaryCta={variant.cta}
-              secondaryCta={variant.secondaryCta}
-              updatePrimaryCta={updatePrimaryCta}
-              updateSecondaryCta={updateSecondaryCta}
-              isDisabled={!editMode || !!variant.showChoiceCards}
-              onValidationChange={onValidationChange}
-              supportSecondaryCta={allowVariantCustomSecondaryCta}
-            />
-          </div>
-        </>
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.sectionHeader} variant="h4">
+            Apple News Choice Cards
+          </Typography>
+          <AppleNewsChoiceCards
+            variant={variant}
+            editMode={editMode}
+            updateShowChoiceCards={updateShowChoiceCards}
+            updatePrimaryCta={updatePrimaryCta}
+            onValidationChange={onValidationChange}
+          />
+        </div>
       )}
     </div>
   );

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -207,6 +207,8 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
     return BODY_DEFAULT_HELPER_TEXT;
   };
 
+  const allowAppleNewsChoiceCards = platform === 'APPLE_NEWS';
+
   return (
     <div className={classes.container}>
       {allowVariantHeader && (
@@ -470,6 +472,33 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             isDisabled={!editMode}
           />
         </div>
+      )}
+
+      {allowAppleNewsChoiceCards && (
+        <>
+          <div className={classes.sectionContainer}>
+            <Typography className={classes.sectionHeader} variant="h4">
+              Apple News Choice Cards
+            </Typography>
+
+            <EpicTestChoiceCardsEditor
+              showChoiceCards={variant.showChoiceCards}
+              updateShowChoiceCards={updateShowChoiceCards}
+              isDisabled={!editMode}
+            />
+          </div>
+          <div className={classes.sectionContainer}>
+            <EpicTestVariantEditorCtasEditor
+              primaryCta={variant.cta}
+              secondaryCta={variant.secondaryCta}
+              updatePrimaryCta={updatePrimaryCta}
+              updateSecondaryCta={updateSecondaryCta}
+              isDisabled={!editMode || !!variant.showChoiceCards}
+              onValidationChange={onValidationChange}
+              supportSecondaryCta={allowVariantCustomSecondaryCta}
+            />
+          </div>
+        </>
       )}
     </div>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "config",
     "scripts",
     "**/*.spec.tsx",
-    "cdk"
+    "cdk",
+    "**/*.bundle.js"
   ]
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Create a custom editor for the apple news epic choice cards / primary button. This will enable toggling between "choice cards" (ie 3 buttons) and 1 primary button in epics.

Doing this in the tooling allows RRCP users to toggle this instead of developers hardcoding it. See [trello ticket](https://trello.com/c/ltCYDwK1/173-apple-news-changes-to-epic-for-3-tier) for background on why we want this changed and https://github.com/guardian/apple-news/pull/307 for the change in the apple news epics to support this.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Create new apple news epic - "show choice cards" radio button should be toggled by default. Toggle to "Enable primary button" and default config should be set. Save and reload to see config saved correctly. Test in Apple news...

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="377" alt="image" src="https://github.com/guardian/support-admin-console/assets/114918544/3ea43e07-2159-4dc4-b7c9-004d207df859">

<img width="440" alt="image" src="https://github.com/guardian/support-admin-console/assets/114918544/6efbe7dd-a050-4d1d-a8b2-5c45acbd4ca6">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
