### PR TITLE
Add iOS and Android to device types

### DIFF
--- a/app/models/DeviceType.scala
+++ b/app/models/DeviceType.scala
@@ -8,6 +8,8 @@ sealed trait DeviceType
 case object All extends DeviceType
 case object Desktop extends DeviceType
 case object Mobile extends DeviceType
+case object iOS extends DeviceType
+case object Android extends DeviceType
 
 object DeviceType {
   implicit val customConfig: Configuration = Configuration.default.withDefaults

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -256,7 +256,7 @@ export interface TickerSettings {
 
 export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
 
-export type DeviceType = 'Mobile' | 'Desktop' | 'All';
+export type DeviceType = 'Mobile' | 'Desktop' | 'All' | 'iOS' | 'Android';
 
 export interface Image {
   mainUrl: string;

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -98,7 +98,9 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
             labels={{
               All: 'All',
               Desktop: 'Desktop',
-              Mobile: 'Mobile',
+              Mobile: 'Mobile (All)',
+              iOS: 'Mobile (iOS)',
+              Android: 'Mobile (Android)',
             }}
           />
         </div>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds iOS and Android as new device types in order to target by mobile OS. The "Mobile" device type is still present which will target both. Also adds these options to the RRCP editor for banners, epics and headers.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Edit a banner, change device type to 'Mobile (iOS)', save and reload. This option should be saved.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-admin-console/assets/114918544/796026fd-4d37-48cc-a035-cc4ff08e7a70)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
