### PR TITLE
Upgrade to MUI (material UI) 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
-        "@material-ui/core": "^4.11.4",
-        "@material-ui/icons": "^4.11.2",
-        "@material-ui/lab": "^4.0.0-alpha.58",
-        "@mui/material": "^5.10.15",
+        "@mui/icons-material": "^5.15.10",
+        "@mui/lab": "^5.0.0-alpha.165",
+        "@mui/material": "^5.15.10",
+        "@mui/styles": "^5.15.10",
         "@mui/x-data-grid": "^5.17.12",
         "@remirror/pm": "^1.0.11",
         "@remirror/react": "^1.0.21",
@@ -32,7 +32,7 @@
       },
       "devDependencies": {
         "@types/jest": "24.0.18",
-        "@types/material-ui": "^0.21.7",
+        "@types/material-ui": "^0.21.16",
         "@types/react": "~17.0.58",
         "@types/react-dom": "^18.2.19",
         "@types/react-router-dom": "^5.1.9",
@@ -571,11 +571,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -732,12 +732,6 @@
         }
       }
     },
-    "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "license": "MIT"
-    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
@@ -844,6 +838,40 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@icons/material": {
       "version": "0.2.4",
@@ -1276,207 +1304,25 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@material-ui/core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.5",
-        "@material-ui/system": "^4.12.2",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/icons": {
-      "version": "4.11.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@material-ui/core": "^4.0.0",
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/lab": {
-      "version": "4.0.0-alpha.60",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
-        "clsx": "^1.0.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@material-ui/core": "^4.12.1",
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/styles": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/system": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.3",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "peerDependencies": {
-        "@types/react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/utils": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/@mui/base": {
-      "version": "5.0.0-alpha.107",
-      "license": "MIT",
+      "version": "5.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.36.tgz",
+      "integrity": "sha512-6A8fYiXgjqTO6pgj31Hc8wm1M3rFYCxDRh09dBVk0L0W4cb2lnurRJa3cAyic6hHY+we1S58OdGYRbKmOsDpGQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "@popperjs/core": "^2.11.6",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -1489,69 +1335,110 @@
         }
       }
     },
-    "node_modules/@mui/base/node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@mui/base/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@mui/base/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/@mui/base/node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/base/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT"
-    },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.10.15",
-      "license": "MIT",
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.10.tgz",
+      "integrity": "sha512-qPv7B+LeMatYuzRjB3hlZUHqinHx/fX4YFBiaS19oC02A1e9JFuDKDvlyRQQ5oRSbJJt0QlaLTlr0IcauVcJRQ==",
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.10.tgz",
+      "integrity": "sha512-9cF8oUHZKo9oQ7EQ3pxPELaZuZVmphskU4OI6NiJNDVN7zcuvrEsuWjYo1Zh4fLiC39Nrvm30h/B51rcUjvSGA==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab": {
+      "version": "5.0.0-alpha.165",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.165.tgz",
+      "integrity": "sha512-8/zJStT10nh9yrAzLOPTICGhpf5YiGp/JpM0bdTP7u5AE+YT+X2u6QwMxuCrVeW8/WVLAPFg0vtzyfgPcN5T7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.36",
+        "@mui/system": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": ">=5.15.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.10.15",
-      "license": "MIT",
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.10.tgz",
+      "integrity": "sha512-YJJGHjwDOucecjDEV5l9ISTCo+l9YeWrho623UajzoHRYxuKUmwrGVYOW4PKwGvCx9SU9oklZnbbi2Clc5XZHw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.107",
-        "@mui/core-downloads-tracker": "^5.10.15",
-        "@mui/system": "^5.10.15",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "@types/react-transition-group": "^4.4.5",
-        "clsx": "^1.2.1",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.36",
+        "@mui/core-downloads-tracker": "^5.15.10",
+        "@mui/system": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
         "react-transition-group": "^4.4.5"
@@ -1561,7 +1448,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -1582,44 +1469,18 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/@types/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@mui/material/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@mui/material/node_modules/csstype": {
-      "version": "3.1.1",
-      "license": "MIT"
-    },
-    "node_modules/@mui/material/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/@mui/material/node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@mui/material/node_modules/react-is": {
       "version": "18.2.0",
@@ -1644,11 +1505,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.10.15",
-      "license": "MIT",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.9.tgz",
+      "integrity": "sha512-/aMJlDOxOTAXyp4F2rIukW1O0anodAMCkv1DfBh/z9vaKHY3bd5fFf42wmP+0GRmwMinC5aWPpNfHXOED1fEtg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/utils": "^5.10.15",
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.15.9",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1656,7 +1518,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -1668,24 +1530,14 @@
         }
       }
     },
-    "node_modules/@mui/private-theming/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/@mui/styled-engine": {
-      "version": "5.10.14",
-      "license": "MIT",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.9.tgz",
+      "integrity": "sha512-NRKtYkL5PZDH7dEmaLEIiipd3mxNnQSO+Yo8rFNBNptY8wzQnQ+VjayTq39qH7Sast5cwHKYFusUrQyD+SS4Og==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@emotion/cache": "^11.10.5",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@emotion/cache": "^11.11.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1693,7 +1545,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
@@ -1710,31 +1562,31 @@
       }
     },
     "node_modules/@mui/styled-engine/node_modules/csstype": {
-      "version": "3.1.1",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "node_modules/@mui/styled-engine/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
+    "node_modules/@mui/styles": {
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.15.10.tgz",
+      "integrity": "sha512-VUl9rCK89lkCZ+ctYv1hSCN9gBke9CfnXF9BtGPkw9jTxPkrW6fQQYep2wcHdzLORE3w96oq9BbSXDqrOnSEPA==",
       "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "5.10.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/private-theming": "^5.10.15",
-        "@mui/styled-engine": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "clsx": "^1.2.1",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@emotion/hash": "^0.9.1",
+        "@mui/private-theming": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.10.0",
+        "jss-plugin-camel-case": "^10.10.0",
+        "jss-plugin-default-unit": "^10.10.0",
+        "jss-plugin-global": "^10.10.0",
+        "jss-plugin-nested": "^10.10.0",
+        "jss-plugin-props-sort": "^10.10.0",
+        "jss-plugin-rule-value-function": "^10.10.0",
+        "jss-plugin-vendor-prefixer": "^10.10.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1742,7 +1594,56 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styles/node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@mui/styles/node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mui/styles/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@mui/system": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.9.tgz",
+      "integrity": "sha512-SxkaaZ8jsnIJ77bBXttfG//LUf6nTfOcaOuIgItqfHv60ZCQy/Hu7moaob35kBb+guxVJnoSZ+7vQJrA/E7pKg==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.9",
+        "@mui/styled-engine": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -1763,34 +1664,24 @@
       }
     },
     "node_modules/@mui/system/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@mui/system/node_modules/csstype": {
-      "version": "3.1.1",
-      "license": "MIT"
-    },
-    "node_modules/@mui/system/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@mui/types": {
-      "version": "7.2.1",
-      "license": "MIT",
+      "version": "7.2.13",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.13.tgz",
+      "integrity": "sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==",
       "peerDependencies": {
-        "@types/react": "*"
+        "@types/react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -1799,12 +1690,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.10.15",
-      "license": "MIT",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.9.tgz",
+      "integrity": "sha512-yDYfr61bCYUz1QtwvpqYy/3687Z8/nS4zv7lv/ih/6ZFGMl1iolEvxRmR84v2lOYxlds+kq1IVYbXxDKh8Z9sg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "@babel/runtime": "^7.23.9",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -1813,34 +1704,17 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@mui/utils/node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/utils/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/@mui/utils/node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/@mui/utils/node_modules/react-is": {
       "version": "18.2.0",
@@ -1879,17 +1753,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@mui/x-data-grid/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1931,8 +1794,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.2",
-      "license": "MIT",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3539,6 +3403,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/create-react-class": {
+      "version": "15.6.7",
+      "resolved": "https://registry.npmjs.org/@types/create-react-class/-/create-react-class-15.6.7.tgz",
+      "integrity": "sha512-fM/HDjJCUCzjfn9Bi6s0xz0QF0ZKhpSeOhnewa6PjsSXQ4hyeLwTZKG83V2yk3vBNSneS7OvgS+BNFEKVrt45w==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/d3-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
@@ -3723,9 +3596,10 @@
       "license": "MIT"
     },
     "node_modules/@types/material-ui": {
-      "version": "0.21.7",
+      "version": "0.21.16",
+      "resolved": "https://registry.npmjs.org/@types/material-ui/-/material-ui-0.21.16.tgz",
+      "integrity": "sha512-US8P5IsLguspYFDtkG4097KZDyqz/GqBm0uftcZ2h2fTzyzLqJuFk8BliEQ9VS3EviRDJaB6l29gps3hkCTm7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/react": "*",
         "@types/react-addons-linked-state-mixin": "*"
@@ -3777,8 +3651,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.4",
-      "license": "MIT"
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/prosemirror-collab": {
       "version": "1.1.2",
@@ -3909,12 +3784,12 @@
       }
     },
     "node_modules/@types/react-addons-linked-state-mixin": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.22.tgz",
-      "integrity": "sha512-DF9utM6VjuIaY388R6XWWDs7CIDTH7on1k1yR+hqaL/T4/OqSCW5uij28APq9KI82CZf0/qtBJI+pjvXcOh0kQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/@types/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.27.tgz",
+      "integrity": "sha512-yVxzQcKDiq32uziGQ/ka586qSFxz2ePYZ3dTCp4JHJKk/E6M0LP0R28ft3oFAnTGJRFBAB3if3pkP8w57Y04IA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@types/create-react-class": "*",
         "@types/react": "*"
       }
     },
@@ -3941,15 +3816,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-is": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
-      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/react-router": {
       "version": "5.1.18",
       "dev": true,
@@ -3972,8 +3838,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.4",
-      "license": "MIT",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -5503,13 +5370,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/clsx": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5918,6 +5778,7 @@
     },
     "node_modules/csstype": {
       "version": "2.6.18",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -10421,12 +10282,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==",
-      "license": "MIT"
-    },
     "node_modules/postcss": {
       "version": "8.4.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
@@ -10653,12 +10508,13 @@
       }
     },
     "node_modules/prop-types": {
-      "version": "15.7.2",
-      "license": "MIT",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/property-information": {
@@ -11261,20 +11117,6 @@
         "react": ">=15"
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
@@ -11512,9 +11354,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.0",
@@ -14796,11 +14638,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -14920,11 +14762,6 @@
         "@emotion/utils": "^1.0.0"
       }
     },
-    "@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
     "@emotion/is-prop-valid": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
@@ -15013,6 +14850,36 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+    },
+    "@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "requires": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "requires": {
+        "@floating-ui/dom": "^1.6.1"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "@icons/material": {
       "version": "0.2.4",
@@ -15360,190 +15227,89 @@
     "@lingui/detect-locale": {
       "version": "3.13.0"
     },
-    "@material-ui/core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
-      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.5",
-        "@material-ui/system": "^4.12.2",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      }
-    },
-    "@material-ui/icons": {
-      "version": "4.11.2",
-      "requires": {
-        "@babel/runtime": "^7.4.4"
-      }
-    },
-    "@material-ui/lab": {
-      "version": "4.0.0-alpha.60",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
-        "clsx": "^1.0.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "@material-ui/styles": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
-      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.3",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@material-ui/system": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
-      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.3",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@material-ui/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
-    },
-    "@material-ui/utils": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
-      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      }
-    },
     "@mui/base": {
-      "version": "5.0.0-alpha.107",
+      "version": "5.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.36.tgz",
+      "integrity": "sha512-6A8fYiXgjqTO6pgj31Hc8wm1M3rFYCxDRh09dBVk0L0W4cb2lnurRJa3cAyic6hHY+we1S58OdGYRbKmOsDpGQ==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "@popperjs/core": "^2.11.6",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
       },
       "dependencies": {
-        "@popperjs/core": {
-          "version": "2.11.6",
-          "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-          "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
-        },
         "clsx": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-        },
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.13.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+          "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
         }
       }
     },
     "@mui/core-downloads-tracker": {
-      "version": "5.10.15"
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.10.tgz",
+      "integrity": "sha512-qPv7B+LeMatYuzRjB3hlZUHqinHx/fX4YFBiaS19oC02A1e9JFuDKDvlyRQQ5oRSbJJt0QlaLTlr0IcauVcJRQ=="
+    },
+    "@mui/icons-material": {
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.10.tgz",
+      "integrity": "sha512-9cF8oUHZKo9oQ7EQ3pxPELaZuZVmphskU4OI6NiJNDVN7zcuvrEsuWjYo1Zh4fLiC39Nrvm30h/B51rcUjvSGA==",
+      "requires": {
+        "@babel/runtime": "^7.23.9"
+      }
+    },
+    "@mui/lab": {
+      "version": "5.0.0-alpha.165",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.165.tgz",
+      "integrity": "sha512-8/zJStT10nh9yrAzLOPTICGhpf5YiGp/JpM0bdTP7u5AE+YT+X2u6QwMxuCrVeW8/WVLAPFg0vtzyfgPcN5T7g==",
+      "requires": {
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.36",
+        "@mui/system": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+          "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
+        }
+      }
     },
     "@mui/material": {
-      "version": "5.10.15",
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.10.tgz",
+      "integrity": "sha512-YJJGHjwDOucecjDEV5l9ISTCo+l9YeWrho623UajzoHRYxuKUmwrGVYOW4PKwGvCx9SU9oklZnbbi2Clc5XZHw==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.107",
-        "@mui/core-downloads-tracker": "^5.10.15",
-        "@mui/system": "^5.10.15",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "@types/react-transition-group": "^4.4.5",
-        "clsx": "^1.2.1",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.36",
+        "@mui/core-downloads-tracker": "^5.15.10",
+        "@mui/system": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
         "react-transition-group": "^4.4.5"
       },
       "dependencies": {
-        "@types/react-transition-group": {
-          "version": "4.4.5",
-          "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
-          "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
-          "requires": {
-            "@types/react": "*"
-          }
-        },
         "clsx": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+          "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
         },
         "csstype": {
-          "version": "3.1.1"
-        },
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.13.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-            }
-          }
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "react-is": {
           "version": "18.2.0",
@@ -15564,118 +15330,118 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.10.15",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.9.tgz",
+      "integrity": "sha512-/aMJlDOxOTAXyp4F2rIukW1O0anodAMCkv1DfBh/z9vaKHY3bd5fFf42wmP+0GRmwMinC5aWPpNfHXOED1fEtg==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/utils": "^5.10.15",
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.15.9",
         "prop-types": "^15.8.1"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          }
-        }
       }
     },
     "@mui/styled-engine": {
-      "version": "5.10.14",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.9.tgz",
+      "integrity": "sha512-NRKtYkL5PZDH7dEmaLEIiipd3mxNnQSO+Yo8rFNBNptY8wzQnQ+VjayTq39qH7Sast5cwHKYFusUrQyD+SS4Og==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@emotion/cache": "^11.10.5",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@emotion/cache": "^11.11.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.1.1"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        }
+      }
+    },
+    "@mui/styles": {
+      "version": "5.15.10",
+      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.15.10.tgz",
+      "integrity": "sha512-VUl9rCK89lkCZ+ctYv1hSCN9gBke9CfnXF9BtGPkw9jTxPkrW6fQQYep2wcHdzLORE3w96oq9BbSXDqrOnSEPA==",
+      "requires": {
+        "@babel/runtime": "^7.23.9",
+        "@emotion/hash": "^0.9.1",
+        "@mui/private-theming": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.10.0",
+        "jss-plugin-camel-case": "^10.10.0",
+        "jss-plugin-default-unit": "^10.10.0",
+        "jss-plugin-global": "^10.10.0",
+        "jss-plugin-nested": "^10.10.0",
+        "jss-plugin-props-sort": "^10.10.0",
+        "jss-plugin-rule-value-function": "^10.10.0",
+        "jss-plugin-vendor-prefixer": "^10.10.0",
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "@emotion/hash": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+          "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
         },
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          }
+        "clsx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+          "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
     "@mui/system": {
-      "version": "5.10.15",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.9.tgz",
+      "integrity": "sha512-SxkaaZ8jsnIJ77bBXttfG//LUf6nTfOcaOuIgItqfHv60ZCQy/Hu7moaob35kBb+guxVJnoSZ+7vQJrA/E7pKg==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/private-theming": "^5.10.15",
-        "@mui/styled-engine": "^5.10.14",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "clsx": "^1.2.1",
-        "csstype": "^3.1.1",
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.9",
+        "@mui/styled-engine": "^5.15.9",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "dependencies": {
         "clsx": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+          "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
         },
         "csstype": {
-          "version": "3.1.1"
-        },
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          }
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
     "@mui/types": {
-      "version": "7.2.1",
+      "version": "7.2.13",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.13.tgz",
+      "integrity": "sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==",
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.10.15",
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.9.tgz",
+      "integrity": "sha512-yDYfr61bCYUz1QtwvpqYy/3687Z8/nS4zv7lv/ih/6ZFGMl1iolEvxRmR84v2lOYxlds+kq1IVYbXxDKh8Z9sg==",
       "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "@babel/runtime": "^7.23.9",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
       "dependencies": {
-        "@types/prop-types": {
-          "version": "15.7.5",
-          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-          "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
-        },
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.13.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-            }
-          }
-        },
         "react-is": {
           "version": "18.2.0",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -15697,16 +15463,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
           "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-        },
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          }
         }
       }
     },
@@ -15737,7 +15493,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.2"
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@remirror/core": {
       "version": "1.3.3",
@@ -16841,6 +16599,15 @@
         "@types/node": "*"
       }
     },
+    "@types/create-react-class": {
+      "version": "15.6.7",
+      "resolved": "https://registry.npmjs.org/@types/create-react-class/-/create-react-class-15.6.7.tgz",
+      "integrity": "sha512-fM/HDjJCUCzjfn9Bi6s0xz0QF0ZKhpSeOhnewa6PjsSXQ4hyeLwTZKG83V2yk3vBNSneS7OvgS+BNFEKVrt45w==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/d3-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
@@ -17012,7 +16779,9 @@
       "version": "3.0.3"
     },
     "@types/material-ui": {
-      "version": "0.21.7",
+      "version": "0.21.16",
+      "resolved": "https://registry.npmjs.org/@types/material-ui/-/material-ui-0.21.16.tgz",
+      "integrity": "sha512-US8P5IsLguspYFDtkG4097KZDyqz/GqBm0uftcZ2h2fTzyzLqJuFk8BliEQ9VS3EviRDJaB6l29gps3hkCTm7Q==",
       "dev": true,
       "requires": {
         "@types/react": "*",
@@ -17058,7 +16827,9 @@
       "version": "1.16.6"
     },
     "@types/prop-types": {
-      "version": "15.7.4"
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "@types/prosemirror-collab": {
       "version": "1.1.2",
@@ -17181,11 +16952,12 @@
       }
     },
     "@types/react-addons-linked-state-mixin": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.22.tgz",
-      "integrity": "sha512-DF9utM6VjuIaY388R6XWWDs7CIDTH7on1k1yR+hqaL/T4/OqSCW5uij28APq9KI82CZf0/qtBJI+pjvXcOh0kQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/@types/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.27.tgz",
+      "integrity": "sha512-yVxzQcKDiq32uziGQ/ka586qSFxz2ePYZ3dTCp4JHJKk/E6M0LP0R28ft3oFAnTGJRFBAB3if3pkP8w57Y04IA==",
       "dev": true,
       "requires": {
+        "@types/create-react-class": "*",
         "@types/react": "*"
       }
     },
@@ -17210,14 +16982,6 @@
         "@types/react": "*"
       }
     },
-    "@types/react-is": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
-      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-router": {
       "version": "5.1.18",
       "dev": true,
@@ -17238,7 +17002,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.4",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "requires": {
         "@types/react": "*"
       }
@@ -18337,9 +18103,6 @@
         "shallow-clone": "^3.0.0"
       }
     },
-    "clsx": {
-      "version": "1.1.1"
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -18642,7 +18405,8 @@
       }
     },
     "csstype": {
-      "version": "2.6.18"
+      "version": "2.6.18",
+      "dev": true
     },
     "d3-color": {
       "version": "1.4.1"
@@ -21889,11 +21653,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
-    },
     "postcss": {
       "version": "8.4.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
@@ -22045,11 +21804,13 @@
       }
     },
     "prop-types": {
-      "version": "15.7.2",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "react-is": "^16.13.1"
       }
     },
     "property-information": {
@@ -22452,15 +22213,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-transition-group": {
-      "version": "4.4.2",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      }
-    },
     "react-universal-interface": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
@@ -22666,9 +22418,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@types/jest": "24.0.18",
-    "@types/material-ui": "^0.21.7",
+    "@types/material-ui": "^0.21.16",
     "@types/react": "~17.0.58",
     "@types/react-dom": "^18.2.19",
     "@types/react-router-dom": "^5.1.9",
@@ -29,10 +29,10 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@material-ui/core": "^4.11.4",
-    "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^4.0.0-alpha.58",
-    "@mui/material": "^5.10.15",
+    "@mui/icons-material": "^5.15.10",
+    "@mui/lab": "^5.0.0-alpha.165",
+    "@mui/material": "^5.15.10",
+    "@mui/styles": "^5.15.10",
     "@mui/x-data-grid": "^5.17.12",
     "@remirror/pm": "^1.0.11",
     "@remirror/react": "^1.0.21",

--- a/public/src/components/amounts/AmountsForm.tsx
+++ b/public/src/components/amounts/AmountsForm.tsx
@@ -11,7 +11,8 @@ import {
 } from '../../utils/requests';
 import withS3Data, { InnerProps, DataFromServer } from '../../hocs/withS3Data';
 
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   body: {

--- a/public/src/components/amounts/AmountsTestEditor.tsx
+++ b/public/src/components/amounts/AmountsTestEditor.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 
-import { Typography, Button, TextField } from '@material-ui/core';
-import { Autocomplete } from '@material-ui/lab';
-import SaveIcon from '@material-ui/icons/Save';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Typography, Button, TextField } from '@mui/material';
+import { Autocomplete } from '@mui/lab';
+import SaveIcon from '@mui/icons-material/Save';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import LiveSwitch from '../shared/liveSwitch';
 
 import { AmountsVariantEditor } from './AmountsVariantEditor';

--- a/public/src/components/amounts/AmountsTestsList.tsx
+++ b/public/src/components/amounts/AmountsTestsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { List, ListItem, makeStyles, Typography } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
+import { List, ListItem, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { red } from '@mui/material/colors';
 import { AmountsTests, AmountsTest } from '../../utils/models';
 import { CreateTestButton } from './CreateTestButton';
 

--- a/public/src/components/amounts/AmountsVariantEditor.tsx
+++ b/public/src/components/amounts/AmountsVariantEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import {
   Checkbox,
   Divider,
@@ -9,7 +10,7 @@ import {
   FormLabel,
   Radio,
   RadioGroup,
-} from '@material-ui/core';
+} from '@mui/material';
 import { AmountsVariantEditorRow } from './AmountsVariantEditorRow';
 import { DeleteVariantButton } from './DeleteVariantButton';
 

--- a/public/src/components/amounts/AmountsVariantEditor.tsx
+++ b/public/src/components/amounts/AmountsVariantEditor.tsx
@@ -23,7 +23,7 @@ import {
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
-    padding: `${spacing(3)}px ${spacing(4)}px`,
+    padding: `${spacing(3)} ${spacing(4)}`,
     border: `1px solid ${palette.grey[700]}`,
     borderRadius: 4,
     backgroundColor: 'white',

--- a/public/src/components/amounts/AmountsVariantEditorRow.tsx
+++ b/public/src/components/amounts/AmountsVariantEditorRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import LiveSwitch from '../shared/liveSwitch';
 import { ContributionType } from '../../utils/models';
 

--- a/public/src/components/amounts/AmountsVariantEditorRowAmount.tsx
+++ b/public/src/components/amounts/AmountsVariantEditorRowAmount.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Menu, MenuItem } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
+import { Button, Menu, MenuItem } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { red } from '@mui/material/colors';
 
 const useStyles = makeStyles(() => ({
   default: {

--- a/public/src/components/amounts/AmountsVariantEditorRowInput.tsx
+++ b/public/src/components/amounts/AmountsVariantEditorRowInput.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Button, makeStyles, TextField, Theme } from '@material-ui/core';
+import { Button, TextField, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   textField: {

--- a/public/src/components/amounts/AmountsVariantEditorRowInput.tsx
+++ b/public/src/components/amounts/AmountsVariantEditorRowInput.tsx
@@ -55,6 +55,7 @@ export const AmountsVariantEditorRowInput: React.FC<AmountsVariantEditorRowInput
   return (
     <div>
       <TextField
+        variant={'standard'}
         className={classes.textField}
         error={!!currentError}
         helperText={currentError}

--- a/public/src/components/amounts/CreateTestButton.tsx
+++ b/public/src/components/amounts/CreateTestButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
 import { CreateTestDialog } from './CreateTestDialog';
 import useOpenable from '../../hooks/useOpenable';
 

--- a/public/src/components/amounts/CreateTestDialog.tsx
+++ b/public/src/components/amounts/CreateTestDialog.tsx
@@ -6,10 +6,10 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   TextField,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 
 const useStyles = makeStyles(() => ({
   dialogHeader: {

--- a/public/src/components/amounts/CreateVariantButton.tsx
+++ b/public/src/components/amounts/CreateVariantButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
 import { CreateVariantDialog } from './CreateVariantDialog';
 import useOpenable from '../../hooks/useOpenable';
 

--- a/public/src/components/amounts/CreateVariantDialog.tsx
+++ b/public/src/components/amounts/CreateVariantDialog.tsx
@@ -6,10 +6,10 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   TextField,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 
 const useStyles = makeStyles(() => ({
   dialogHeader: {

--- a/public/src/components/amounts/DeleteTestButton.tsx
+++ b/public/src/components/amounts/DeleteTestButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
 import DeleteTestDialog from './DeleteTestDialog';
 import useOpenable from '../../hooks/useOpenable';
 

--- a/public/src/components/amounts/DeleteTestDialog.tsx
+++ b/public/src/components/amounts/DeleteTestDialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-} from '@material-ui/core';
+} from '@mui/material';
 
 interface DeleteTestDialogProps {
   testName: string;

--- a/public/src/components/amounts/DeleteVariantButton.tsx
+++ b/public/src/components/amounts/DeleteVariantButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { DeleteVariantDialog } from './DeleteVariantDialog';
 import useOpenable from '../../hooks/useOpenable';
 

--- a/public/src/components/amounts/DeleteVariantDialog.tsx
+++ b/public/src/components/amounts/DeleteVariantDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-} from '@material-ui/core';
+} from '@mui/material';
 
 interface DeleteVariantDialogProps {
   variantName: string;

--- a/public/src/components/appsMeteringSwitches.tsx
+++ b/public/src/components/appsMeteringSwitches.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 import { AppsSettingsType, fetchAppsSettings, saveAppsSettings } from '../utils/requests';
-import Switch from '@material-ui/core/Switch';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Button from '@material-ui/core/Button';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
 import withS3Data, { InnerProps } from '../hocs/withS3Data';
 
 const useStyles = makeStyles(() => ({

--- a/public/src/components/channelManagement/CampaignSelector.tsx
+++ b/public/src/components/channelManagement/CampaignSelector.tsx
@@ -3,7 +3,8 @@ import { fetchFrontendSettings, FrontendSettingsType } from '../../utils/request
 import { Campaign, unassignedCampaign } from './campaigns/CampaignsForm';
 import { Test } from './helpers/shared';
 
-import { Select, MenuItem, FormControl, makeStyles } from '@material-ui/core';
+import { Select, MenuItem, FormControl, SelectChangeEvent } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
   dialogHeader: {
@@ -92,8 +93,8 @@ const CampaignSelector: React.FC<CampaignSelectorProps> = ({
           renderValue={(campaign): string => {
             return campaign as string;
           }}
-          onChange={(event: React.ChangeEvent<{ value: unknown }>): void => {
-            setCampaignName(event.target.value as string | undefined);
+          onChange={(event: SelectChangeEvent<string | undefined>): void => {
+            setCampaignName(event.target.value);
           }}
           disabled={disabled}
         >

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 import {
   fetchFrontendSettings,
   FrontendSettingsType,
   saveFrontendSettings,
 } from '../../utils/requests';
-import Switch from '@material-ui/core/Switch';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Button from '@material-ui/core/Button';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
 import withS3Data, { DataFromServer, InnerProps } from '../../hocs/withS3Data';
 
 const useStyles = makeStyles(() => ({

--- a/public/src/components/channelManagement/TypedRadioGroup.tsx
+++ b/public/src/components/channelManagement/TypedRadioGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormControlLabel, FormGroup, Radio, RadioGroup } from '@material-ui/core';
+import { FormControlLabel, FormGroup, Radio, RadioGroup } from '@mui/material';
 
 // For mapping each value in T to a user-friendly label
 type LabeledValues<T extends string> = {

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
-import { Button, Theme, makeStyles } from '@material-ui/core';
+import { Button, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { BannerChannel } from './bannerDeployDashboard';
 import BannerChannelDeployerTable from './bannerDeployChannelDeployerTable';
 

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTable.tsx
@@ -12,8 +12,8 @@ import {
   TableCell,
   Toolbar,
   Typography,
-  makeStyles,
-} from '@material-ui/core';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { BannerChannel } from './bannerDeployDashboard';
 import { BannerDeploys, BannersToRedeploy } from './bannerDeployChannelDeployer';
 import BannerDeployChannelDeployerTableRow from './bannerDeployChannelDeployerTableRow';

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployChannelDeployerTableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Checkbox, TableRow, TableCell } from '@material-ui/core';
+import { Checkbox, TableRow, TableCell } from '@mui/material';
 
 type BannerDeployChannelDeployerTableRowProps = {
   region: string;

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
     overflow: 'auto',
   },
   container: {
-    padding: `${spacing(6)}px ${spacing(9)}px`,
+    padding: `${spacing(6)} ${spacing(9)}`,
 
     '& > * + *': {
       marginTop: spacing(4),

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Theme, makeStyles } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import BannerDeployeChannelDeployer from './bannerDeployChannelDeployer';
 

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import StickyTopBar from './StickyTopBar';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { LockStatus } from '../helpers/shared';
 import useValidation from '../hooks/useValidation';
 import BannerDesignForm from './BannerDesignForm';

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Accordion, AccordionDetails, AccordionSummary } from '@material-ui/core';
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
 import {
   BannerDesign,
   BannerDesignHeaderImage,
@@ -9,7 +9,8 @@ import {
   HighlightedTextColours,
   TickerDesign,
 } from '../../../models/bannerDesign';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { BasicColoursEditor } from './BasicColoursEditor';
 import { HighlightedTextColoursEditor } from './HighlightedTextColoursEditor';
 import { CtaColoursEditor } from './CtaColoursEditor';
@@ -17,8 +18,8 @@ import { BannerDesignUsage } from './BannerDesignUsage';
 import { TickerDesignEditor } from './TickerDesignEditor';
 import { HeaderImageEditor } from './HeaderImageEditor';
 import { BannerVisualEditor } from './BannerVisualEditor';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { InfoOutlined } from '@material-ui/icons';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { InfoOutlined } from '@mui/icons-material';
 
 type Props = {
   design: BannerDesign;

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignListItem.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignListItem.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { ListItem, Theme, makeStyles, Typography } from '@material-ui/core';
+import { ListItem, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { BannerDesign } from '../../../models/bannerDesign';
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from '@mui/icons-material/Edit';
 import useHover from '../../../hooks/useHover';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
 import { BannerDesign } from '../../../models/bannerDesign';
-import { Checkbox, FormControlLabel } from '@material-ui/core';
+import { Checkbox, FormControlLabel } from '@mui/material';
 import { BannerVariant } from '../../../models/banner';
 import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
 

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignUsage.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignUsage.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { getBannerDesignUsage } from '../../../utils/requests';
-import { List, ListItemText } from '@material-ui/core';
+import { List, ListItemText } from '@mui/material';
 import { ListItemButton } from '@mui/material';
-import { makeStyles, Theme } from '@material-ui/core/styles';
-import { OpenInNew } from '@material-ui/icons';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
+import { OpenInNew } from '@mui/icons-material';
 
 export const useLocalStyles = makeStyles(({ spacing }: Theme) => ({
   list: {

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { List, makeStyles } from '@material-ui/core';
+import { List } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { BannerDesign } from '../../../models/bannerDesign';
 import BannerDesignListItem from './BannerDesignListItem';
 

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignsSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 import BannerDesignsList from './BannerDesignsList';
 import { BannerDesign } from '../../../models/bannerDesign';
 import NewBannerDesignButton from './NewBannerDesignButton';

--- a/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerVisualEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BannerDesignVisual } from '../../../models/bannerDesign';
-import { MenuItem, Select } from '@material-ui/core';
+import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { defaultBannerChoiceCardsDesign, defaultBannerImage } from './utils/defaults';
 import { ImageEditor } from './ImageEditor';
 import { OptionalColourInput } from './ColourInput';
@@ -12,14 +12,16 @@ interface Props {
   onChange: (visual: BannerDesignVisual | undefined) => void;
 }
 
+type VisualType = 'Image' | 'ChoiceCards' | 'None';
+
 export const BannerVisualEditor: React.FC<Props> = ({
   visual,
   isDisabled,
   onValidationChange,
   onChange,
 }: Props) => {
-  const onVisualTypeChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    const value = event.target.value as 'Image' | 'ChoiceCards' | 'None';
+  const onVisualTypeChange = (event: SelectChangeEvent<VisualType>) => {
+    const value = event.target.value;
     if (value === 'Image') {
       onChange(defaultBannerImage);
     } else if (value === 'ChoiceCards') {

--- a/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BasicColoursEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { BasicColours } from '../../../models/bannerDesign';
 import { ColourInput } from './ColourInput';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { hexColourToString, stringToHexColour } from '../../../utils/bannerDesigns';
 import TypedRadioGroup from '../TypedRadioGroup';
 

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
 import debounce from 'lodash/debounce';
 import {
   hexColourStringRegex,
@@ -8,7 +8,8 @@ import {
 } from '../../../utils/bannerDesigns';
 import { useForm } from 'react-hook-form';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { HexColour } from '../../../models/bannerDesign';
 import { ClassNameMap, ClickAwayListener } from '@mui/material';
 import { HexColorPicker } from 'react-colorful';

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -6,10 +6,10 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   TextField,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 import {
   createDuplicateValidator,
   EMPTY_ERROR_HELPER_TEXT,

--- a/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CtaDesign } from '../../../models/bannerDesign';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { ColourInput, OptionalColourInput } from './ColourInput';
 
 const useLocalStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -1,4 +1,4 @@
-import { FormControl, FormControlLabel, RadioGroup, Radio, TextField } from '@material-ui/core';
+import { FormControl, FormControlLabel, RadioGroup, Radio, TextField } from '@mui/material';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';

--- a/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HighlightedTextColoursEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { HighlightedTextColours } from '../../../models/bannerDesign';
 import { ColourInput } from './ColourInput';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';

--- a/public/src/components/channelManagement/bannerDesigns/LockDetails.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/LockDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { formattedTimestamp } from '../helpers/utilities';
-import { makeStyles, Typography } from '@material-ui/core';
+import { Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
   lockDetailsText: {

--- a/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/NewBannerDesignButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
 import useOpenable from '../../../hooks/useOpenable';
 import CreateBannerDesignDialog from './CreateBannerDesignDialog';
 

--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -2,26 +2,26 @@ import React from 'react';
 import {
   Theme,
   Typography,
-  makeStyles,
   Button,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogContentText,
   DialogActions,
-} from '@material-ui/core';
-import EditIcon from '@material-ui/icons/Edit';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import EditIcon from '@mui/icons-material/Edit';
 import { LockDetails } from './LockDetails';
-import LockIcon from '@material-ui/icons/Lock';
-import CloseIcon from '@material-ui/icons/Close';
-import SaveIcon from '@material-ui/icons/Save';
-import { grey } from '@material-ui/core/colors';
+import LockIcon from '@mui/icons-material/Lock';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
+import { grey } from '@mui/material/colors';
 import { LockStatus } from '../helpers/shared';
 import LiveSwitch from '../../shared/liveSwitch';
 import { BannerDesign, Status } from '../../../models/bannerDesign';
 import { BannerDesignPreview } from './BannerDesignPreview';
 import useOpenable from '../../../hooks/useOpenable';
-import ArchiveIcon from '@material-ui/icons/Archive';
+import ArchiveIcon from '@mui/icons-material/Archive';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/bannerDesigns/TickerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/TickerDesignEditor.tsx
@@ -1,7 +1,8 @@
 import { TickerDesign } from '../../../models/bannerDesign';
 import React from 'react';
 import { ColourInput } from './ColourInput';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/bannerDesigns/index.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import BannerDesignsSidebar from './BannerDesignsSidebar';
 import BannerDesignEditor from './BannerDesignEditor';
 import { useParams } from 'react-router-dom';

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Region } from '../../../utils/models';
 import { ArticlesViewedSettings, DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
-import { Typography } from '@material-ui/core';
+import { Typography } from '@mui/material';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
 import CampaignSelector from '../CampaignSelector';
 import TestVariantsEditor from '../testVariantsEditor';

--- a/public/src/components/channelManagement/bannerTests/bannerTestNewVariantButton.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestNewVariantButton.tsx
@@ -7,14 +7,14 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   TextField,
   Theme,
   Typography,
-} from '@material-ui/core';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
-import AddIcon from '@material-ui/icons/Add';
-import CloseIcon from '@material-ui/icons/Close';
+import AddIcon from '@mui/icons-material/Add';
+import CloseIcon from '@mui/icons-material/Close';
 
 import useOpenable from '../../../hooks/useOpenable';
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -1,14 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import {
-  FormControlLabel,
-  makeStyles,
-  Radio,
-  RadioGroup,
-  Switch,
-  Theme,
-  Typography,
-} from '@material-ui/core';
+import { FormControlLabel, Radio, RadioGroup, Switch, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
 import {
   EMPTY_ERROR_HELPER_TEXT,

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';

--- a/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerUiSelector.tsx
@@ -7,7 +7,8 @@ import {
   Radio,
   RadioGroup,
   Select,
-} from '@material-ui/core';
+  SelectChangeEvent,
+} from '@mui/material';
 import {
   BannerDesignName,
   BannerTemplate,
@@ -52,7 +53,7 @@ const BannerTemplateSelector: React.FC<BannerTemplateSelectorProps> = ({
   onUiChange,
   editMode,
 }: BannerTemplateSelectorProps) => {
-  const onChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
+  const onChange = (event: SelectChangeEvent<BannerTemplate>): void => {
     const value = event.target.value as string;
     if (isBannerTemplate(value)) {
       onUiChange(value);
@@ -83,8 +84,8 @@ const BannerDesignSelector: React.FC<BannerDesignSelectorProps> = ({
   editMode,
   designs,
 }: BannerDesignSelectorProps) => {
-  const onChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
-    const designName = event.target.value as string;
+  const onChange = (event: SelectChangeEvent): void => {
+    const designName = event.target.value;
     const isValidBannerDesign = designs.map(d => d.name).includes(designName);
     if (isValidBannerDesign) {
       onUiChange({ designName });

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
-import { Button, makeStyles, Theme } from '@material-ui/core';
-import VisibilityIcon from '@material-ui/icons/Visibility';
-import Drawer from '@material-ui/core/Drawer';
+import { Button, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import Drawer from '@mui/material/Drawer';
 import {
   BannerContent,
   BannerTemplate,
   BannerVariant,
   isBannerTemplate,
 } from '../../../models/banner';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useModule } from '../../../hooks/useModule';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 import { mockAmountsCardData, SelectedAmountsVariant } from '../../../utils/models';

--- a/public/src/components/channelManagement/batchProcessTestButton.tsx
+++ b/public/src/components/channelManagement/batchProcessTestButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Test } from './helpers/shared';
-import ArchiveIcon from '@material-ui/icons/Archive';
+import ArchiveIcon from '@mui/icons-material/Archive';
 
 import BatchProcessTestDialog from './batchProcessTestDialog';
 import useOpenable from '../../hooks/useOpenable';

--- a/public/src/components/channelManagement/batchProcessTestDialog.tsx
+++ b/public/src/components/channelManagement/batchProcessTestDialog.tsx
@@ -12,10 +12,10 @@ import {
   ListItemText,
   Checkbox,
   Typography,
-  makeStyles,
-} from '@material-ui/core';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Test } from './helpers/shared';
-import CloseIcon from '@material-ui/icons/Close';
+import CloseIcon from '@mui/icons-material/Close';
 import useOpenable from '../../hooks/useOpenable';
 
 const useStyles = makeStyles(() => ({

--- a/public/src/components/channelManagement/bylineWithImageEditor.tsx
+++ b/public/src/components/channelManagement/bylineWithImageEditor.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
-import { Checkbox, makeStyles, TextField, Theme } from '@material-ui/core';
+import { Checkbox, TextField, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { useForm } from 'react-hook-form';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import { BylineWithImage } from './helpers/shared';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -1,13 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Theme,
-  makeStyles,
-  TextField,
-  FormControlLabel,
-  Switch,
-  Button,
-  Typography,
-} from '@material-ui/core';
+import { Theme, TextField, FormControlLabel, Switch, Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import StickyTopBar from './StickyCampaignBar';
 import { Campaign, unassignedCampaign } from './CampaignsForm';
 import { Test } from '../helpers/shared';

--- a/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsForm.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import CampaignsSidebar from './CampaignsSidebar';
 import CampaignsEditor from './CampaignsEditor';
 import { useParams } from 'react-router-dom';

--- a/public/src/components/channelManagement/campaigns/CampaignsList.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { List, ListItem, Theme, makeStyles, Button, Typography } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
+import { List, ListItem, Theme, Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { red } from '@mui/material/colors';
 import { Campaigns, Campaign, unassignedCampaign } from './CampaignsForm';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/components/channelManagement/campaigns/CampaignsSidebar.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsSidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { makeStyles, TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Campaigns, Campaign } from './CampaignsForm';
 import NewCampaignButton from './NewCampaignButton';
 import CampaignsList from './CampaignsList';

--- a/public/src/components/channelManagement/campaigns/ChannelCard.tsx
+++ b/public/src/components/channelManagement/campaigns/ChannelCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme, Button } from '@material-ui/core';
+import { Theme, Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Link } from 'react-router-dom';
 import TestCard from './TestCard';
 import { TestChannelItem } from './CampaignsEditor';

--- a/public/src/components/channelManagement/campaigns/CreateCampaignDialog.tsx
+++ b/public/src/components/channelManagement/campaigns/CreateCampaignDialog.tsx
@@ -6,10 +6,10 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   TextField,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 import {
   createDuplicateValidator,
   EMPTY_ERROR_HELPER_TEXT,

--- a/public/src/components/channelManagement/campaigns/NewCampaignButton.tsx
+++ b/public/src/components/channelManagement/campaigns/NewCampaignButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
 
 import { Campaign } from './CampaignsForm';
 import CreateCampaignDialog from './CreateCampaignDialog';

--- a/public/src/components/channelManagement/campaigns/StatusUpdateButton.tsx
+++ b/public/src/components/channelManagement/campaigns/StatusUpdateButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import { Test } from '../helpers/shared';
 import StatusUpdateDialog from './StatusUpdateDialog';

--- a/public/src/components/channelManagement/campaigns/StatusUpdateDialog.tsx
+++ b/public/src/components/channelManagement/campaigns/StatusUpdateDialog.tsx
@@ -8,11 +8,11 @@ import {
   List,
   ListItem,
   IconButton,
-  makeStyles,
   Switch,
   Typography,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 import { Test, Status } from '../helpers/shared';
 import { updateStatuses, FrontendSettingsType } from '../../../utils/requests';
 import { testChannelData, testChannelOrder } from './CampaignsEditor';

--- a/public/src/components/channelManagement/campaigns/StickyCampaignBar.tsx
+++ b/public/src/components/channelManagement/campaigns/StickyCampaignBar.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
-import { grey } from '@material-ui/core/colors';
-import { Link } from '@material-ui/icons';
+import { Theme, Typography, Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { grey } from '@mui/material/colors';
+import { Link } from '@mui/icons-material';
 import StatusUpdateButton from './StatusUpdateButton';
 import { Test } from '../helpers/shared';
 

--- a/public/src/components/channelManagement/campaigns/TestCard.tsx
+++ b/public/src/components/channelManagement/campaigns/TestCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme, Card, CardContent, CardActions, Button } from '@material-ui/core';
+import { Theme, Card, CardContent, CardActions, Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Link } from 'react-router-dom';
 import { Test, Variant } from '../helpers/shared';
 import TestDataButton from './TestDataButton';

--- a/public/src/components/channelManagement/campaigns/TestDataButton.tsx
+++ b/public/src/components/channelManagement/campaigns/TestDataButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, makeStyles } from '@material-ui/core';
+import { Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import { Test } from '../helpers/shared';
 import { formattedTimestamp } from '../helpers/utilities';

--- a/public/src/components/channelManagement/campaigns/TestDataDialog.tsx
+++ b/public/src/components/channelManagement/campaigns/TestDataDialog.tsx
@@ -6,9 +6,9 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 import { Test } from '../helpers/shared';
 
 const useStyles = makeStyles(() => ({

--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -13,10 +13,11 @@ import {
   MenuItem,
   InputLabel,
   FormControl,
-  makeStyles,
   Checkbox,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+  SelectChangeEvent,
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 
 import {
   createDuplicateValidator,
@@ -26,7 +27,7 @@ import {
 } from './helpers/validation';
 import { Campaign } from './campaigns/CampaignsForm';
 import { fetchFrontendSettings, FrontendSettingsType } from '../../utils/requests';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 const useStyles = makeStyles(() => ({
   dialogHeader: {
@@ -152,8 +153,8 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
                   }
                   return campaign as string;
                 }}
-                onChange={(event: React.ChangeEvent<{ value: unknown }>): void => {
-                  setCampaignName(event.target.value as string | undefined);
+                onChange={(event: SelectChangeEvent<string | undefined>): void => {
+                  setCampaignName(event.target.value);
                 }}
               >
                 <MenuItem value={undefined} key={'campaignName-none'}>

--- a/public/src/components/channelManagement/createVariantDialog.tsx
+++ b/public/src/components/channelManagement/createVariantDialog.tsx
@@ -7,10 +7,10 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   TextField,
-} from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import CloseIcon from '@mui/icons-material/Close';
 import {
   createDuplicateValidator,
   EMPTY_ERROR_HELPER_TEXT,

--- a/public/src/components/channelManagement/epicTests/appleChoiceCardsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/appleChoiceCardsEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EpicVariant } from '../../../models/epic';
 import { Cta } from '../helpers/shared';
-import { FormControl, FormControlLabel, Radio, RadioGroup } from '@material-ui/core';
+import { FormControl, FormControlLabel, Radio, RadioGroup } from '@mui/material';
 import VariantEditorCtaFieldsEditor from '../variantEditorCtaFieldsEditor';
 import { DEFAULT_PRIMARY_CTA } from './utils/defaults';
 

--- a/public/src/components/channelManagement/epicTests/epicTestChoiceCardsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestChoiceCardsEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
-import { makeStyles, Theme } from '@material-ui/core';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -9,7 +9,7 @@ import {
   SignedInStatus,
   PageContextTargeting,
 } from '../helpers/shared';
-import { FormControlLabel, Switch, Typography } from '@material-ui/core';
+import { FormControlLabel, Switch, Typography } from '@mui/material';
 import CampaignSelector from '../CampaignSelector';
 import TestVariantsEditor from '../testVariantsEditor';
 import TestEditorVariantSummary from '../testEditorVariantSummary';

--- a/public/src/components/channelManagement/epicTests/epicTestMaxViewsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestMaxViewsEditor.tsx
@@ -1,15 +1,8 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
-import {
-  FormControl,
-  makeStyles,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  TextField,
-  Theme,
-} from '@material-ui/core';
+import { FormControl, Radio, RadioGroup, FormControlLabel, TextField, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { notNumberValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { DEFAULT_MAX_EPIC_VIEWS } from './utils/defaults';
 import { MaxEpicViews } from '../../../models/epic';

--- a/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestPreview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Dialog, makeStyles, Theme, Typography } from '@material-ui/core';
+import { Button, Dialog, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import useOpenable from '../../../hooks/useOpenable';
 import EpicVariantPreview from './epicVariantPreview';
 import { EpicTest } from '../../../models/epic';

--- a/public/src/components/channelManagement/epicTests/epicTestSignInLinkEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestSignInLinkEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
 
 interface EpicTestSignInLinkEditorProps {
   showSignInLink?: boolean;

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import EpicTestChoiceCardsEditor from './epicTestChoiceCardsEditor';
 import EpicTestSignInLinkEditor from './epicTestSignInLinkEditor';

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';

--- a/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
+++ b/public/src/components/channelManagement/epicTests/epicVariantPreview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Theme, makeStyles } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import { EpicModuleName } from '../helpers/shared';
 import { EpicVariant } from '../../../models/epic';

--- a/public/src/components/channelManagement/epicTests/sectionsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/sectionsEditor.tsx
@@ -1,6 +1,6 @@
-import { Autocomplete } from '@material-ui/lab';
+import { Autocomplete } from '@mui/lab';
 import React, { useEffect } from 'react';
-import { TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
 
 interface Section {
   id: string;
@@ -69,11 +69,11 @@ export const SectionsEditor: React.FC<SectionEditorProps> = ({
       renderInput={(params): JSX.Element => (
         <TextField {...params} variant="outlined" label={label} />
       )}
-      renderOption={(option): JSX.Element => {
+      renderOption={(props, option): JSX.Element => {
         return <div>{option.name ? option.name : option.id}</div>;
       }}
       onChange={(event, values: Section[], reason): void => {
-        if (reason === 'select-option' || reason === 'remove-option') {
+        if (reason === 'selectOption' || reason === 'removeOption') {
           onUpdate(values.map(value => value.id));
           setInputValue('');
         }

--- a/public/src/components/channelManagement/epicTests/tagsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/tagsEditor.tsx
@@ -1,6 +1,6 @@
-import { Autocomplete } from '@material-ui/lab';
+import { Autocomplete } from '@mui/lab';
 import React, { useEffect, useCallback } from 'react';
-import { TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
 import throttle from 'lodash/throttle';
 
 interface Tag {
@@ -100,11 +100,11 @@ export const TagsEditor: React.FC<TagEditorProps> = ({
       renderInput={(params): JSX.Element => (
         <TextField {...params} variant="outlined" label={label} />
       )}
-      renderOption={(option): JSX.Element => {
+      renderOption={(props, option): JSX.Element => {
         return <div>{option.name ? `${option.name} (${option.id})` : option.id}</div>;
       }}
       onChange={(event, values: Tag[], reason): void => {
-        if (reason === 'select-option' || reason === 'remove-option') {
+        if (reason === 'selectOption' || reason === 'removeOption') {
           onUpdate(values.map(value => value.id));
           setInputValue('');
         }

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -3,7 +3,7 @@ import { Region } from '../../../utils/models';
 
 import { DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
 
-import { Typography } from '@material-ui/core';
+import { Typography } from '@mui/material';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
 import TestVariantsEditor from '../testVariantsEditor';
 import CampaignSelector from '../CampaignSelector';

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -1,15 +1,8 @@
 // Note: we developed this component expecting that headers would have the ability to display different copy and CTAs on small screens, thus requiring this form to include fields for that content. However it seems like current functionality of the GU frontend is to only show the main copy and CTAs, whatever the screen size may be. Code to include and action mobile-specific fields can be found in earlier commits in this PR: https://github.com/guardian/support-admin-console/pull/259
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import {
-  TextField,
-  Theme,
-  Typography,
-  makeStyles,
-  RadioGroup,
-  FormControlLabel,
-  Radio,
-} from '@material-ui/core';
+import { TextField, Theme, Typography, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import HeaderTestVariantEditorCtasEditor from './headerTestVariantEditorCtasEditor';
 import VariantEditorCopyLengthWarning from '../variantEditorCopyLengthWarning';
 import { templateValidatorForPlatform } from '../helpers/validation';

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditorCtasEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import VariantEditorCtaEditor from '../variantEditorCtaEditor';
 
 import { Cta } from '../helpers/shared';

--- a/public/src/components/channelManagement/helpers/testEditorStyles.ts
+++ b/public/src/components/channelManagement/helpers/testEditorStyles.ts
@@ -1,4 +1,5 @@
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 export const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/helpers/utilities.tsx
+++ b/public/src/components/channelManagement/helpers/utilities.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import VisibilityIcon from '@material-ui/icons/Visibility';
-import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 
-import { Typography } from '@material-ui/core';
+import { Typography } from '@mui/material';
 
 export const renderVisibilityIcons = (isOn: boolean): React.ReactNode => {
   return isOn ? <VisibilityIcon color={'action'} /> : <VisibilityOffIcon color={'disabled'} />;

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -1,9 +1,10 @@
 import { Image } from './helpers/shared';
 import React, { useEffect } from 'react';
-import { Checkbox, makeStyles, TextField, Theme } from '@material-ui/core';
+import { Checkbox, TextField, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { useForm } from 'react-hook-form';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/newTestButton.tsx
+++ b/public/src/components/channelManagement/newTestButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
 
 import CreateTestDialog from './createTestDialog';
 import useOpenable from '../../hooks/useOpenable';

--- a/public/src/components/channelManagement/richTextEditor/richTextEditorStyles.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditorStyles.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 
 export const useRTEStyles = makeStyles(() => ({
   fieldLabel: {

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Button, makeStyles, Typography } from '@material-ui/core';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { LockStatus, Test } from './helpers/shared';
 import TestList from './testList';
 import TestPriorityLabelList from './testPriorityLabelList';
@@ -8,8 +9,8 @@ import BatchProcessTestButton from './batchProcessTestButton';
 
 import TestListSidebarFilterSelector from './testListSidebarFilterSelector';
 import { RegionsAndAll } from '../../utils/models';
-import EditIcon from '@material-ui/icons/Edit';
-import SaveIcon from '@material-ui/icons/Save';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
 
 const useStyles = makeStyles(() => ({
   root: {

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { Theme, Typography, makeStyles, Button } from '@material-ui/core';
-import EditIcon from '@material-ui/icons/Edit';
+import { Theme, Typography, Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import EditIcon from '@mui/icons-material/Edit';
 import { LockStatus, Status } from '../helpers/shared';
-import CloseIcon from '@material-ui/icons/Close';
-import SaveIcon from '@material-ui/icons/Save';
-import LockIcon from '@material-ui/icons/Lock';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
+import LockIcon from '@mui/icons-material/Lock';
 import { TestLockDetails } from './testLockDetails';
 import { TestArchiveButton } from './testArchiveButton';
 import { TestCopyButton } from './testCopyButton';
-import { grey } from '@material-ui/core/colors';
-import { Link } from '@material-ui/icons';
+import { grey } from '@mui/material/colors';
+import { Link } from '@mui/icons-material';
 import { FrontendSettingsType } from '../../../utils/requests';
 import TestLiveSwitch from '../testLiveSwitch';
 

--- a/public/src/components/channelManagement/stickyTopBar/testArchiveButton.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/testArchiveButton.tsx
@@ -7,12 +7,12 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  makeStyles,
   Theme,
   Typography,
-} from '@material-ui/core';
-import ArchiveIcon from '@material-ui/icons/Archive';
-import { grey } from '@material-ui/core/colors';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import ArchiveIcon from '@mui/icons-material/Archive';
+import { grey } from '@mui/material/colors';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   buttonText: {

--- a/public/src/components/channelManagement/stickyTopBar/testCopyButton.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/testCopyButton.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import useOpenable from '../../../hooks/useOpenable';
-import { Button, makeStyles, Theme, Typography } from '@material-ui/core';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
-import { grey } from '@material-ui/core/colors';
+import { Button, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import FileCopyIcon from '@mui/icons-material/FileCopy';
+import { grey } from '@mui/material/colors';
 import CreateTestDialog from '../createTestDialog';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({

--- a/public/src/components/channelManagement/stickyTopBar/testLockDetails.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/testLockDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Typography } from '@material-ui/core';
+import { Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { formattedTimestamp } from '../helpers/utilities';
 
 const useStyles = makeStyles(() => ({

--- a/public/src/components/channelManagement/superMode/articleDataChart.tsx
+++ b/public/src/components/channelManagement/superMode/articleDataChart.tsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import { useEffect, useState } from 'react';
 import { addHours, subHours, formatISO9075 } from 'date-fns';
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  makeStyles,
-  Typography,
-} from '@material-ui/core';
+import { Dialog, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { SuperModeRow } from './useSuperModeRows';
-import CloseIcon from '@material-ui/icons/Close';
+import CloseIcon from '@mui/icons-material/Close';
 import { ArticleDetails } from './articleDetails';
 import { BarChart, Bar, CartesianGrid, XAxis, YAxis } from 'recharts';
 

--- a/public/src/components/channelManagement/superMode/articleDetails.tsx
+++ b/public/src/components/channelManagement/superMode/articleDetails.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import React, { useEffect, useState } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
   webTitle: {

--- a/public/src/components/channelManagement/superMode/superModeDashboard.tsx
+++ b/public/src/components/channelManagement/superMode/superModeDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { makeStyles, Typography } from '@material-ui/core';
+import { Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { SuperModeRow, useSuperModeRows } from './useSuperModeRows';
 import { ArticleDataChartDialog } from './articleDataChart';
 import { SuperModeTable } from './superModeTable';

--- a/public/src/components/channelManagement/testEditorActionButtons.tsx
+++ b/public/src/components/channelManagement/testEditorActionButtons.tsx
@@ -8,12 +8,12 @@ import {
   DialogTitle,
   Theme,
   Typography,
-  makeStyles,
-} from '@material-ui/core';
-import { grey } from '@material-ui/core/colors';
-import DeleteIcon from '@material-ui/icons/Delete';
-import ArchiveIcon from '@material-ui/icons/Archive';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { grey } from '@mui/material/colors';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArchiveIcon from '@mui/icons-material/Archive';
+import FileCopyIcon from '@mui/icons-material/FileCopy';
 import CreateTestDialog from './createTestDialog';
 import useOpenable from '../../hooks/useOpenable';
 

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -1,15 +1,8 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
-import {
-  FormControl,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  TextField,
-  Theme,
-  makeStyles,
-} from '@material-ui/core';
+import { FormControl, Radio, RadioGroup, FormControlLabel, TextField, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { ArticlesViewedSettings } from './helpers/shared';
 import { notNumberValidator, EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 

--- a/public/src/components/channelManagement/testEditorContextTargeting.tsx
+++ b/public/src/components/channelManagement/testEditorContextTargeting.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Theme, makeStyles } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import { TagsEditor } from './epicTests/tagsEditor';
 import { SectionsEditor } from './epicTests/sectionsEditor';

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Theme, Typography, makeStyles } from '@material-ui/core';
+import { Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Region } from '../../utils/models';
 import { DeviceType, SignedInStatus, UserCohort, TestPlatform } from './helpers/shared';
 

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Checkbox, FormControlLabel, FormGroup, Theme, makeStyles } from '@material-ui/core';
+import { Checkbox, FormControlLabel, FormGroup, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Region, regions, regionIds } from '../../utils/models';
 import { TestPlatform } from './helpers/shared';
 

--- a/public/src/components/channelManagement/testEditorVariantSummary.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummary.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Theme, Typography, AccordionSummary, makeStyles } from '@material-ui/core';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
+import { Theme, Typography, AccordionSummary } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import TestEditorVariantSummaryWebPreviewButton, {
   ArticleType,
 } from './testEditorVariantSummaryWebPreviewButton';

--- a/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
+++ b/public/src/components/channelManagement/testEditorVariantSummaryWebPreviewButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button } from '@material-ui/core';
-import VisibilityIcon from '@material-ui/icons/Visibility';
+import { Button } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import { TestPlatform, TestType } from './helpers/shared';
 import { getStage, Stage } from '../../utils/stage';
 

--- a/public/src/components/channelManagement/testList.tsx
+++ b/public/src/components/channelManagement/testList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { List, makeStyles } from '@material-ui/core';
+import { List } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 
 import { Test } from './helpers/shared';

--- a/public/src/components/channelManagement/testListSidebarFilterSelector.tsx
+++ b/public/src/components/channelManagement/testListSidebarFilterSelector.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { FormControl, InputLabel, Select, MenuItem, SelectChangeEvent } from '@mui/material';
 
 import { regions, regionIds, RegionsAndAll } from '../../utils/models';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles(() => ({
+  container: {
+    marginTop: '8px',
+  },
+}));
 
 interface TestListSidebarFilterSelectorProps {
   regionFilter: string;
@@ -12,8 +19,10 @@ const TestListSidebarFilterSelector: React.FC<TestListSidebarFilterSelectorProps
   regionFilter,
   handleRegionFilterChange,
 }: TestListSidebarFilterSelectorProps) => {
+  const classes = useStyles();
+
   return (
-    <FormControl fullWidth>
+    <FormControl className={classes.container} fullWidth>
       <InputLabel id="filter-region-select-label">Filter by Region</InputLabel>
       <Select
         labelId="filter-region-select-label"

--- a/public/src/components/channelManagement/testListSidebarFilterSelector.tsx
+++ b/public/src/components/channelManagement/testListSidebarFilterSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormControl, InputLabel, Select, MenuItem } from '@material-ui/core';
+import { FormControl, InputLabel, Select, MenuItem, SelectChangeEvent } from '@mui/material';
 
 import { regions, regionIds, RegionsAndAll } from '../../utils/models';
 
@@ -20,8 +20,8 @@ const TestListSidebarFilterSelector: React.FC<TestListSidebarFilterSelectorProps
         id="filter-region-select"
         value={regionFilter}
         label="Filter by Region"
-        onChange={(event: React.ChangeEvent<{ value: unknown }>): void =>
-          handleRegionFilterChange(event.target.value as RegionsAndAll)
+        onChange={(event: SelectChangeEvent<RegionsAndAll>): void =>
+          handleRegionFilterChange(event.target.value)
         }
       >
         <MenuItem key="ALL" value="ALL">

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { ListItem, Theme, makeStyles } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
+import { ListItem, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { red } from '@mui/material/colors';
 import { Test } from './helpers/shared';
 import TestListTestLiveLabel from './testListTestLiveLabel';
 import TestListTestName from './testListTestName';
 import TestListTestArticleCountLabel from './testListTestArticleCountLabel';
 import useHover from '../../hooks/useHover';
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from '@mui/icons-material/Edit';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   test: {

--- a/public/src/components/channelManagement/testListTestArticleCountLabel.tsx
+++ b/public/src/components/channelManagement/testListTestArticleCountLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, makeStyles } from '@material-ui/core';
+import { Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
   container: {

--- a/public/src/components/channelManagement/testListTestLiveLabel.tsx
+++ b/public/src/components/channelManagement/testListTestLiveLabel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Typography, Theme, makeStyles } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
+import { Typography, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { red } from '@mui/material/colors';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/testListTestName.tsx
+++ b/public/src/components/channelManagement/testListTestName.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, makeStyles } from '@material-ui/core';
+import { Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
   text: {

--- a/public/src/components/channelManagement/testLiveSwitch.tsx
+++ b/public/src/components/channelManagement/testLiveSwitch.tsx
@@ -6,13 +6,13 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  makeStyles,
   Switch,
   Theme,
   Typography,
-} from '@material-ui/core';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import useOpenable from '../../hooks/useOpenable';
-import CloseIcon from '@material-ui/icons/Close';
+import CloseIcon from '@mui/icons-material/Close';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/testNewVariantButton.tsx
+++ b/public/src/components/channelManagement/testNewVariantButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Button, makeStyles, Theme, Typography } from '@material-ui/core';
+import { Button, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
-import AddIcon from '@material-ui/icons/Add';
+import AddIcon from '@mui/icons-material/Add';
 import useOpenable from '../../hooks/useOpenable';
 import CreateVariantDialog from './createVariantDialog';
 

--- a/public/src/components/channelManagement/testPriorityLabelList.tsx
+++ b/public/src/components/channelManagement/testPriorityLabelList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { List, makeStyles } from '@material-ui/core';
+import { List } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 import TestPriorityLabelListLabel from './testPriorityLabelListLabel';
 

--- a/public/src/components/channelManagement/testPriorityLabelListLabel.tsx
+++ b/public/src/components/channelManagement/testPriorityLabelListLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Theme, makeStyles } from '@material-ui/core';
+import { Typography, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   container: {

--- a/public/src/components/channelManagement/testVariantEditorWithPreviewTab.tsx
+++ b/public/src/components/channelManagement/testVariantEditorWithPreviewTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Tabs, Tab, Theme, makeStyles } from '@material-ui/core';
+import { Tabs, Tab, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
     width: '100%',

--- a/public/src/components/channelManagement/testVariantEditorsAccordion.tsx
+++ b/public/src/components/channelManagement/testVariantEditorsAccordion.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import {
-  Theme,
-  makeStyles,
-  Accordion,
-  AccordionDetails,
-  AccordionActions,
-} from '@material-ui/core';
+import { Theme, Accordion, AccordionDetails, AccordionActions } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Variant } from './helpers/shared';
 import VariantDeleteButton from './variantDeleteButton';
 import VariantCloneButton from './variantCloneButton';

--- a/public/src/components/channelManagement/testVariantsEditor.tsx
+++ b/public/src/components/channelManagement/testVariantsEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Variant } from './helpers/shared';
 import TestNewVariantButton from './testNewVariantButton';
 import TestVariantEditorsAccordion from './testVariantEditorsAccordion';

--- a/public/src/components/channelManagement/testVariantsSplitEditor.tsx
+++ b/public/src/components/channelManagement/testVariantsSplitEditor.tsx
@@ -1,13 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
-import {
-  FormControl,
-  makeStyles,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  TextField,
-  Theme,
-} from '@material-ui/core';
+import { FormControl, Radio, RadioGroup, FormControlLabel, TextField, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Variant } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 import { useForm } from 'react-hook-form';

--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { makeStyles, Theme, Typography } from '@material-ui/core';
+import { Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import Sidebar from './sidebar';
 import { LockStatus, Status, Test } from './helpers/shared';
 import {

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -4,13 +4,13 @@ import {
   Checkbox,
   FormControl,
   FormLabel,
-  makeStyles,
   Radio,
   RadioGroup,
   TextField,
   Theme,
-} from '@material-ui/core';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import { TickerCountType, TickerEndType, TickerName, TickerSettings } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 

--- a/public/src/components/channelManagement/validatedTestEditor.tsx
+++ b/public/src/components/channelManagement/validatedTestEditor.tsx
@@ -2,7 +2,8 @@ import { Test } from './helpers/shared';
 import React, { useState } from 'react';
 import { TestEditorProps } from './testsForm';
 import StickyTopBar from './stickyTopBar/stickyTopBar';
-import { makeStyles, Theme } from '@material-ui/core';
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import useValidation from './hooks/useValidation';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({

--- a/public/src/components/channelManagement/variantCloneButton.tsx
+++ b/public/src/components/channelManagement/variantCloneButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@material-ui/core';
+import { Button } from '@mui/material';
 import { Variant } from './helpers/shared';
 import useOpenable from '../../hooks/useOpenable';
 import CreateVariantDialog from './createVariantDialog';

--- a/public/src/components/channelManagement/variantDeleteButton.tsx
+++ b/public/src/components/channelManagement/variantDeleteButton.tsx
@@ -6,7 +6,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-} from '@material-ui/core';
+} from '@mui/material';
 
 import useOpenable from '../../hooks/useOpenable';
 

--- a/public/src/components/channelManagement/variantEditorCopyLengthWarning.tsx
+++ b/public/src/components/channelManagement/variantEditorCopyLengthWarning.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Alert from '@material-ui/lab/Alert';
+import Alert from '@mui/lab/Alert';
 
 interface VariantEditorCopyLengthWarningProps {
   charLimit: number;

--- a/public/src/components/channelManagement/variantEditorCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorCtaEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Checkbox, FormControlLabel, makeStyles, Theme } from '@material-ui/core';
+import { Checkbox, FormControlLabel, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Cta } from './helpers/shared';
 import VariantEditorCtaFieldsEditor from './variantEditorCtaFieldsEditor';
 

--- a/public/src/components/channelManagement/variantEditorCtaFieldsEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorCtaFieldsEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
 import { Cta } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 

--- a/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
@@ -57,8 +57,15 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
     <div className={classes.container}>
       <div className={classes.selectContainer}>
         <FormControl className={classes.formControl}>
-          <InputLabel>{label}</InputLabel>
-          <Select value={cta?.type || 'None'} onChange={handleChange} disabled={isDisabled}>
+          <InputLabel id="secondaryCtaTypeLabel">{label}</InputLabel>
+          <Select
+            id={'secondaryCtaType'}
+            labelId={'secondaryCtaTypeLabel'}
+            label={label}
+            value={cta?.type || 'None'}
+            onChange={handleChange}
+            disabled={isDisabled}
+          >
             <MenuItem value={'None'}>None</MenuItem>
             <MenuItem value={SecondaryCtaType.Custom}>Custom</MenuItem>
             <MenuItem value={SecondaryCtaType.ContributionsReminder}>

--- a/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Theme, FormControl, InputLabel, Select, MenuItem, makeStyles } from '@material-ui/core';
+import { Theme, FormControl, InputLabel, Select, MenuItem, SelectChangeEvent } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { Cta, SecondaryCta, SecondaryCtaType } from './helpers/shared';
 import VariantEditorCtaFieldsEditor from './variantEditorCtaFieldsEditor';
 
@@ -36,8 +37,8 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
 }: VariantEditorSecondaryCtaEditorProps) => {
   const classes = useStyles();
 
-  const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
-    const value = event.target.value as SecondaryCtaType | 'None';
+  const handleChange = (event: SelectChangeEvent<SecondaryCtaType | 'None'>): void => {
+    const value = event.target.value;
 
     if (value === SecondaryCtaType.Custom) {
       updateCta({ type: SecondaryCtaType.Custom, cta: defaultCta });

--- a/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSeparateArticleCountEditor.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
 import { SeparateArticleCount } from '../../models/epic';
-import { TextField } from '@material-ui/core';
+import { TextField } from '@mui/material';
 import { useForm } from 'react-hook-form';
 
 interface FormData {

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexDirection: 'column',
     '& > * + *': {
-      marginTop: '5px',
+      marginTop: '16px',
     },
   },
 }));

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -1,4 +1,5 @@
-import { Button, TextField, makeStyles } from '@material-ui/core';
+import { Button, TextField } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import React, { useState } from 'react';
 import withS3Data, { InnerProps } from '../hocs/withS3Data';
 import { parsePromoInput } from '../utils/parsePromoInput';

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Drawer from '@material-ui/core/Drawer';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
+import Drawer from '@mui/material/Drawer';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
 import { Link } from 'react-router-dom';
-import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
-import makeStyles from '@material-ui/core/styles/makeStyles';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import { makeStyles } from '@mui/styles';
 import RRControlPanelLogo from './rrControlPanelLogo';
 
 const useStyles = makeStyles({

--- a/public/src/components/indexPage.tsx
+++ b/public/src/components/indexPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import makeStyles from '@material-ui/core/styles/makeStyles';
+import { makeStyles } from '@mui/styles';
 
 const styles = makeStyles({
   body: {

--- a/public/src/components/shared/liveSwitch.tsx
+++ b/public/src/components/shared/liveSwitch.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles, Switch, Theme, Typography } from '@material-ui/core';
+import { Switch, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 import {
   Typography,
@@ -12,10 +13,10 @@ import {
   IconButton,
   List,
   ListItem,
-} from '@material-ui/core';
-import SwitchUI from '@material-ui/core/Switch';
-import SaveIcon from '@material-ui/icons/Save';
-import Alert from '@material-ui/lab/Alert';
+} from '@mui/material';
+import SwitchUI from '@mui/material/Switch';
+import SaveIcon from '@mui/icons-material/Save';
+import Alert from '@mui/lab/Alert';
 
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -26,14 +27,14 @@ import {
 } from '../utils/requests';
 
 import withS3Data, { InnerProps, DataFromServer } from '../hocs/withS3Data';
-import AddIcon from '@material-ui/icons/Add';
-import DeleteIcon from '@material-ui/icons/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
 import {
   createDuplicateValidator,
   EMPTY_ERROR_HELPER_TEXT,
 } from './channelManagement/helpers/validation';
 import { useForm } from 'react-hook-form';
-import ListItemText from '@material-ui/core/ListItemText';
+import ListItemText from '@mui/material/ListItemText';
 
 enum SwitchState {
   On = 'On',

--- a/public/src/components/utilities/QrCodePage.tsx
+++ b/public/src/components/utilities/QrCodePage.tsx
@@ -5,12 +5,12 @@ import {
   Card,
   CardContent,
   FormControl,
-  makeStyles,
   Paper,
   TextField,
   Theme,
   Typography,
-} from '@material-ui/core';
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import QRCode from 'react-qr-code';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -37,6 +37,7 @@ import AppsMeteringSwitches from './components/appsMeteringSwitches';
 import { SuperModeDashboard } from './components/channelManagement/superMode/superModeDashboard';
 import BannerDesigns from './components/channelManagement/bannerDesigns/';
 import DefaultPromos from './components/defaultPromos';
+import { StyledEngineProvider } from '@mui/material';
 
 declare module '@mui/styles' {
   type DefaultTheme = Theme;
@@ -246,7 +247,9 @@ if (container) {
   const root = createRoot(container);
   root.render(
     <ThemeProvider theme={getTheme()}>
-      <AppRouter />
+      <StyledEngineProvider injectFirst>
+        <AppRouter />
+      </StyledEngineProvider>
     </ThemeProvider>,
   );
 } else {

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -40,7 +40,9 @@ import DefaultPromos from './components/defaultPromos';
 import { StyledEngineProvider } from '@mui/material';
 
 declare module '@mui/styles' {
-  type DefaultTheme = Theme;
+  // https://mui.com/material-ui/migration/v5-style-changes/#%E2%9C%85-add-module-augmentation-for-defaulttheme-typescript
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends Theme {}
 }
 
 type Stage = 'DEV' | 'CODE' | 'PROD';

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -18,25 +18,29 @@ import {
 
 import { HeaderTestsForm } from './components/channelManagement/headerTests/headerTestsForm';
 
-import { Theme, ThemeProvider } from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
-import AppBar from '@material-ui/core/AppBar';
-import { CSSProperties } from '@material-ui/core/styles/withStyles';
+import { Theme, ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import AppBar from '@mui/material/AppBar';
+import { CSSProperties } from '@mui/styles';
 import NavDrawer from './components/drawer';
-import Button from '@material-ui/core/Button';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
+import Button from '@mui/material/Button';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
 import IndexPage from './components/indexPage';
 import { getTheme } from './utils/theme';
 import ChannelSwitches from './components/channelManagement/ChannelSwitches';
 import CampaignsForm from './components/channelManagement/campaigns/CampaignsForm';
 import { FontWeightProperty } from 'csstype';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 import QrCodePage from './components/utilities/QrCodePage';
 import AppsMeteringSwitches from './components/appsMeteringSwitches';
 import { SuperModeDashboard } from './components/channelManagement/superMode/superModeDashboard';
 import BannerDesigns from './components/channelManagement/bannerDesigns/';
 import DefaultPromos from './components/defaultPromos';
+
+declare module '@mui/styles' {
+  type DefaultTheme = Theme;
+}
 
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
@@ -144,111 +148,107 @@ const AppRouter = () => {
   );
 
   return (
-    <ThemeProvider theme={getTheme()}>
-      <Router>
-        <div className={classes.root}>
-          <CssBaseline />
-          <Route
-            exact
-            path="/"
-            render={(): React.ReactElement => createComponent(<IndexPage />, 'Home Page')}
-          />
-          <Route
-            path="/switches"
-            render={(): React.ReactElement => createComponent(<Switchboard />, 'Switches')}
-          />
-          <Route
-            path="/amounts"
-            render={(): React.ReactElement => createComponent(<AmountsForm />, 'Amounts')}
-          />
-          <Route
-            path="/header-tests/:testName?"
-            render={(): React.ReactElement => createComponent(<HeaderTestsForm />, 'Header Tests')}
-          />
-          <Route
-            path="/epic-tests/:testName?"
-            render={(): React.ReactElement =>
-              createComponent(<ArticleEpicTestsForm />, 'Epic Tests')
-            }
-          />
-          <Route
-            path="/liveblog-epic-tests/:testName?"
-            render={(): React.ReactElement =>
-              createComponent(<LiveblogEpicTestsForm />, 'Liveblog Epic Tests')
-            }
-          />
-          <Route
-            path="/apple-news-epic-tests/:testName?"
-            render={(): React.ReactElement =>
-              createComponent(<AppleNewsEpicTestsForm />, 'Apple News Epics')
-            }
-          />
-          <Route
-            path="/amp-epic-tests/:testName?"
-            render={(): React.ReactElement => createComponent(<AMPEpicTestsForm />, 'AMP Epics')}
-          />
-          <Route
-            path="/banner-tests/:testName?"
-            render={(): React.ReactElement =>
-              createComponent(<BannerTestsForm1 />, 'Banner Tests 1')
-            }
-          />
-          <Route
-            path="/banner-tests2/:testName?"
-            render={(): React.ReactElement =>
-              createComponent(<BannerTestsForm2 />, 'Banner Tests 2')
-            }
-          />
-          <Route
-            path="/banner-deploy"
-            render={(): React.ReactElement =>
-              createComponent(<BannerDeployDashboard />, 'Banner Deploy')
-            }
-          />
-          <Route
-            path="/channel-switches"
-            render={(): React.ReactElement =>
-              createComponent(<ChannelSwitches />, 'Channel Switches')
-            }
-          />
-          <Route
-            path="/campaigns/:campaignName?"
-            render={(): React.ReactElement => createComponent(<CampaignsForm />, 'Campaigns')}
-          />
-          <Route
-            path="/qr-code"
-            render={(): React.ReactElement => createComponent(<QrCodePage />, 'QR Code Generator')}
-          />
-          <Route
-            path="/apps-metering-switches"
-            render={(): React.ReactElement =>
-              createComponent(<AppsMeteringSwitches />, 'Apps Metering Switches')
-            }
-          />
-          <Route
-            path="/super-mode"
-            render={(): React.ReactElement =>
-              createComponent(<SuperModeDashboard />, 'Epic Super Mode dashboard 🦸')
-            }
-          />
-          <Route
-            path="/default-promos"
-            render={(): React.ReactElement => createComponent(<DefaultPromos />, 'Default Promos')}
-          />
-          <Route
-            path="/banner-designs/:name?"
-            render={(): React.ReactElement => createComponent(<BannerDesigns />, 'Banner Designs')}
-          />
-        </div>
-      </Router>
-    </ThemeProvider>
+    <Router>
+      <div className={classes.root}>
+        <CssBaseline />
+        <Route
+          exact
+          path="/"
+          render={(): React.ReactElement => createComponent(<IndexPage />, 'Home Page')}
+        />
+        <Route
+          path="/switches"
+          render={(): React.ReactElement => createComponent(<Switchboard />, 'Switches')}
+        />
+        <Route
+          path="/amounts"
+          render={(): React.ReactElement => createComponent(<AmountsForm />, 'Amounts')}
+        />
+        <Route
+          path="/header-tests/:testName?"
+          render={(): React.ReactElement => createComponent(<HeaderTestsForm />, 'Header Tests')}
+        />
+        <Route
+          path="/epic-tests/:testName?"
+          render={(): React.ReactElement => createComponent(<ArticleEpicTestsForm />, 'Epic Tests')}
+        />
+        <Route
+          path="/liveblog-epic-tests/:testName?"
+          render={(): React.ReactElement =>
+            createComponent(<LiveblogEpicTestsForm />, 'Liveblog Epic Tests')
+          }
+        />
+        <Route
+          path="/apple-news-epic-tests/:testName?"
+          render={(): React.ReactElement =>
+            createComponent(<AppleNewsEpicTestsForm />, 'Apple News Epics')
+          }
+        />
+        <Route
+          path="/amp-epic-tests/:testName?"
+          render={(): React.ReactElement => createComponent(<AMPEpicTestsForm />, 'AMP Epics')}
+        />
+        <Route
+          path="/banner-tests/:testName?"
+          render={(): React.ReactElement => createComponent(<BannerTestsForm1 />, 'Banner Tests 1')}
+        />
+        <Route
+          path="/banner-tests2/:testName?"
+          render={(): React.ReactElement => createComponent(<BannerTestsForm2 />, 'Banner Tests 2')}
+        />
+        <Route
+          path="/banner-deploy"
+          render={(): React.ReactElement =>
+            createComponent(<BannerDeployDashboard />, 'Banner Deploy')
+          }
+        />
+        <Route
+          path="/channel-switches"
+          render={(): React.ReactElement =>
+            createComponent(<ChannelSwitches />, 'Channel Switches')
+          }
+        />
+        <Route
+          path="/campaigns/:campaignName?"
+          render={(): React.ReactElement => createComponent(<CampaignsForm />, 'Campaigns')}
+        />
+        <Route
+          path="/qr-code"
+          render={(): React.ReactElement => createComponent(<QrCodePage />, 'QR Code Generator')}
+        />
+        <Route
+          path="/apps-metering-switches"
+          render={(): React.ReactElement =>
+            createComponent(<AppsMeteringSwitches />, 'Apps Metering Switches')
+          }
+        />
+        <Route
+          path="/super-mode"
+          render={(): React.ReactElement =>
+            createComponent(<SuperModeDashboard />, 'Epic Super Mode dashboard 🦸')
+          }
+        />
+        <Route
+          path="/default-promos"
+          render={(): React.ReactElement => createComponent(<DefaultPromos />, 'Default Promos')}
+        />
+        <Route
+          path="/banner-designs/:name?"
+          render={(): React.ReactElement => createComponent(<BannerDesigns />, 'Banner Designs')}
+        />
+      </div>
+    </Router>
   );
 };
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(<AppRouter />);
+  root.render(
+    <ThemeProvider theme={getTheme()}>
+      <AppRouter />
+    </ThemeProvider>,
+  );
 } else {
   console.error('No root element found');
 }

--- a/public/src/utils/theme.ts
+++ b/public/src/utils/theme.ts
@@ -1,9 +1,9 @@
-import { createMuiTheme, Theme } from '@material-ui/core/styles';
-import purple from '@material-ui/core/colors/purple';
-import green from '@material-ui/core/colors/green';
+import { createTheme, Theme } from '@mui/material/styles';
+import purple from '@mui/material/colors/purple';
+import green from '@mui/material/colors/green';
 import { getStage } from './stage';
 
-const DEV_AND_CODE_THEME = createMuiTheme({
+const DEV_AND_CODE_THEME = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -14,7 +14,7 @@ const DEV_AND_CODE_THEME = createMuiTheme({
   },
 });
 
-const PROD_THEME = createMuiTheme({});
+const PROD_THEME = createTheme({});
 
 export const getTheme = (): Theme => {
   const stage = getStage();


### PR DESCRIPTION
This is quite a major upgrade, mostly changing imports.

The UI is mostly the same. I've made a few tweaks to keep things looking ok.

The biggest change is that the `main` colour now applies in more places. In PROD this is blue, in CODE it's purple.
Previously it only applied to the top bar and some buttons. It now applies to a few more buttons, e.g. in the left sidebar:
before:
![Screenshot 2024-02-21 at 15 19 02](https://github.com/guardian/support-admin-console/assets/1513454/dc0c0dba-b067-4986-bfa3-4df305449d9f)
after:
![Screenshot 2024-02-21 at 15 19 05](https://github.com/guardian/support-admin-console/assets/1513454/b8e3fcb2-49d5-448a-97f8-dd8bae7b5c7b)

Note - the recommendation is to [migrate to emotion](https://mui.com/material-ui/migration/migrating-from-jss/) when upgrading to MUI 5. I've created a health card to do this, as it's probably quite a big change.