### PR TITLE
Remove footer from Epic model and UI

### DIFF
--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -25,7 +25,6 @@ case class EpicVariant(
   heading: Option[String],
   paragraphs: List[String],
   highlightedText: Option[String] = None,
-  footer: Option[String] = None,
   showTicker: Boolean = false,  // Deprecated - use tickerSettings instead
   tickerSettings: Option[TickerSettings] = None,
   image: Option[Image] = None,

--- a/public/src/components/channelManagement/campaigns/TestDataDialog.tsx
+++ b/public/src/components/channelManagement/campaigns/TestDataDialog.tsx
@@ -237,12 +237,6 @@ const variantFields = {
       exclude: ['Header'],
       optional: true,
     },
-    footer: {
-      label: 'Footer',
-      type: 'string-block',
-      exclude: ['Header', 'Banner1', 'Banner2'],
-      optional: true,
-    },
     cta: {
       label: 'Main CTA',
       type: 'object',

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -75,7 +75,6 @@ const PARAGRAPHS_MAX_LENGTH = 2000;
 const HEADER_DEFAULT_HELPER_TEXT = `Assitive text`;
 const BODY_DEFAULT_HELPER_TEXT = `Maximum ${PARAGRAPHS_MAX_LENGTH} characters.`;
 const HIGHTLIGHTED_TEXT_DEFAULT_HELPER_TEXT = `Final sentence of body copy.`;
-const FOOTER_DEFAULT_HELPER_TEXT = `Bold text below the button.`;
 
 interface FormData {
   heading?: string;
@@ -83,7 +82,6 @@ interface FormData {
   highlightedText?: string;
   image?: Image;
   bylineWithImage?: BylineWithImage;
-  footer?: string;
 }
 
 interface EpicTestVariantEditorProps {
@@ -106,7 +104,6 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
     allowMultipleVariants,
     allowVariantHeader,
     allowVariantHighlightedText,
-    allowVariantFooter,
     allowVariantImageUrl,
     allowVariantCustomPrimaryCta,
     allowVariantCustomSecondaryCta,
@@ -130,7 +127,6 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
     highlightedText: variant.highlightedText,
     image: variant.image,
     bylineWithImage: variant.bylineWithImage,
-    footer: variant.footer,
   };
 
   /**
@@ -160,7 +156,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.heading, errors.paragraphs, errors.highlightedText, errors.image, errors.footer]);
+  }, [errors.heading, errors.paragraphs, errors.highlightedText, errors.image]);
 
   const noHtml = platform !== 'DOTCOM';
   const htmlValidator = noHtml ? noHtmlValidator : () => undefined;
@@ -322,45 +318,6 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                 rteMenuConstraints={{
                   noHtml,
                   noBold: true,
-                  noCurrencyTemplate,
-                  noCountryNameTemplate,
-                  noArticleCountTemplate,
-                  noPriceTemplates: true,
-                  noDateTemplate,
-                  noDayTemplate,
-                }}
-              />
-            );
-          }}
-        />
-      )}
-
-      {allowVariantFooter && (
-        <Controller
-          name="footer"
-          control={control}
-          rules={{
-            validate: lineValidator,
-          }}
-          render={data => {
-            return (
-              <RichTextEditorSingleLine
-                error={errors.footer !== undefined}
-                helperText={
-                  errors.footer
-                    ? errors.footer.message || errors.footer.type
-                    : FOOTER_DEFAULT_HELPER_TEXT
-                }
-                copyData={data.value}
-                updateCopy={pars => {
-                  data.onChange(pars);
-                  handleSubmit(setValidatedFields)();
-                }}
-                name="footer"
-                label="Footer"
-                disabled={!editMode}
-                rteMenuConstraints={{
-                  noHtml,
                   noCurrencyTemplate,
                   noCountryNameTemplate,
                   noArticleCountTemplate,

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -47,7 +47,6 @@ export interface EpicEditorConfig {
   allowVariantHeader: boolean;
   allowVariantHighlightedText: boolean;
   allowVariantImageUrl: boolean;
-  allowVariantFooter: boolean;
   allowVariantCustomPrimaryCta: boolean;
   allowVariantCustomSecondaryCta: boolean;
   allowVariantSeparateArticleCount: boolean;
@@ -72,7 +71,6 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHeader: true,
   allowVariantHighlightedText: true,
   allowVariantImageUrl: true,
-  allowVariantFooter: true,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: true,
   allowVariantSeparateArticleCount: true,
@@ -98,7 +96,6 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHeader: true,
   allowVariantHighlightedText: false,
   allowVariantImageUrl: false,
-  allowVariantFooter: false,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: true,
   allowVariantSeparateArticleCount: false,
@@ -125,7 +122,6 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHeader: true,
   allowVariantHighlightedText: true,
   allowVariantImageUrl: false,
-  allowVariantFooter: false,
   allowVariantCustomPrimaryCta: false,
   allowVariantCustomSecondaryCta: false,
   allowVariantSeparateArticleCount: false,
@@ -151,7 +147,6 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHeader: true,
   allowVariantHighlightedText: true,
   allowVariantImageUrl: false,
-  allowVariantFooter: false,
   allowVariantCustomPrimaryCta: true,
   allowVariantCustomSecondaryCta: false,
   allowVariantSeparateArticleCount: false,

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -24,7 +24,6 @@ export interface EpicVariant extends Variant {
   heading?: string;
   paragraphs: string[];
   highlightedText?: string;
-  footer?: string;
   showTicker: boolean;
   tickerSettings?: TickerSettings;
   image?: Image;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the footer configuration from the Epic. It is not used in the actual Epic. The field is still in SDC models, which can be removed in a followup.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Edit an epic - footer config not present. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/support-admin-console/assets/114918544/1dae70fb-6a68-4770-b3fb-090168f75abe)

After
![image](https://github.com/guardian/support-admin-console/assets/114918544/ea11fff6-9537-4d9f-a492-6eac18817b57)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
