### PR TITLE
Fix tag + section pickers

### DIFF
--- a/public/src/components/channelManagement/epicTests/sectionsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/sectionsEditor.tsx
@@ -70,7 +70,7 @@ export const SectionsEditor: React.FC<SectionEditorProps> = ({
         <TextField {...params} variant="outlined" label={label} />
       )}
       renderOption={(props, option): JSX.Element => {
-        return <div>{option.name ? option.name : option.id}</div>;
+        return <li {...props}>{option.name ? option.name : option.id}</li>;
       }}
       onChange={(event, values: Section[], reason): void => {
         if (reason === 'selectOption' || reason === 'removeOption') {

--- a/public/src/components/channelManagement/epicTests/tagsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/tagsEditor.tsx
@@ -101,7 +101,7 @@ export const TagsEditor: React.FC<TagEditorProps> = ({
         <TextField {...params} variant="outlined" label={label} />
       )}
       renderOption={(props, option): JSX.Element => {
-        return <div>{option.name ? `${option.name} (${option.id})` : option.id}</div>;
+        return <li {...props}>{option.name ? `${option.name} (${option.id})` : option.id}</li>;
       }}
       onChange={(event, values: Tag[], reason): void => {
         if (reason === 'selectOption' || reason === 'removeOption') {


### PR DESCRIPTION
The ability to select items from the dropdown broke with the recent MUI upgrade.
This is because the API has changed slightly.
The `renderOption` prop now expects a `<li>` element with the props - https://mui.com/material-ui/api/autocomplete/#autocomplete-prop-renderOption

### Before:
<img width="169" alt="Screenshot 2024-02-26 at 09 42 40" src="https://github.com/guardian/support-admin-console/assets/1513454/a3934693-ad0c-42e6-b089-2610257473ab">

### After:
<img width="169" alt="Screenshot 2024-02-26 at 09 42 54" src="https://github.com/guardian/support-admin-console/assets/1513454/f390c211-e240-4830-a14b-d7f9ebbc2d98">
