### PR TITLE
Support providing an SDC URL via the env (for banner previewing)

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -5,14 +5,16 @@ import play.api.mvc._
 
 class Application(authAction: AuthAction[AnyContent],
                   components: ControllerComponents,
-                  stage: String)
+                  stage: String,
+                  sdcUrlOverride: Option[String])
     extends AbstractController(components) {
   def healthcheck = Action {
     Ok("healthy")
   }
 
   def index = authAction {
-    Ok(views.html.index(stage)).withHeaders(CACHE_CONTROL -> "no-cache")
+    Ok(views.html.index(stage, sdcUrlOverride))
+      .withHeaders(CACHE_CONTROL -> "no-cache")
   }
 
   // Handler for endpoints with a resource name in the path. The client takes care of using the name

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(stage: String)
+@(stage: String, sdcUrlOverride: Option[String])
 <!DOCTYPE html>
 <html>
   <head>
@@ -13,7 +13,11 @@
   <body>
     <div id="root"></div>
     <script>
-      window.guardian = { stage: "@stage"};
+      window.guardian = {};
+      window.guardian.stage = "@stage";
+      @if(sdcUrlOverride.isDefined) {
+        window.guardian.sdcUrlOverride = "@sdcUrlOverride.get";
+      }
     </script>
     <script src="@routes.Assets.at("build/app.bundle.js")"></script>
   </body>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -73,9 +73,11 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
   val dynamoBannerDesigns = new DynamoBannerDesigns(stage, dynamoClient)
   val dynamoArchivedBannerDesigns = new DynamoArchivedBannerDesigns(stage, dynamoClient)
 
+  val sdcUrlOverride: Option[String] = sys.env.get("SDC_URL")
+
   override lazy val router: Router = new Routes(
     httpErrorHandler,
-    new Application(authAction, controllerComponents, stage),
+    new Application(authAction, controllerComponents, stage, sdcUrlOverride),
     new Login(authConfig, wsClient, requiredGoogleGroups, googleGroupChecker, controllerComponents),
     new SwitchesController(authAction, controllerComponents, stage, runtime),
     new AmountsController(authAction, controllerComponents, stage, runtime),

--- a/public/src/hooks/useModule.ts
+++ b/public/src/hooks/useModule.ts
@@ -6,6 +6,19 @@ import { withPreviewStyles } from '../components/channelManagement/previewContai
 
 const moduleVersion = 3;
 
+const getSdcBaseUrl = (): string => {
+  // If override explicitly provided, use it
+  if (window.guardian.sdcUrlOverride) {
+    return `${window.guardian.sdcUrlOverride}/modules/v${moduleVersion}`;
+  }
+
+  // Otherwise, use the stage to determine the base URL
+  const stage = getStage();
+  return stage === 'PROD'
+    ? `https://contributions.guardianapis.com/modules/v${moduleVersion}`
+    : `https://contributions.code.dev-guardianapis.com/modules/v${moduleVersion}`;
+};
+
 /**
  * Hook for importing a remote module, for live previews.
  */
@@ -20,12 +33,7 @@ export const useModule = <T>(path: string, name: string): React.FC<T> | undefine
       emotionReactJsxRuntime,
     };
 
-    const stage = getStage();
-
-    const baseUrl =
-      stage === 'PROD'
-        ? `https://contributions.guardianapis.com/modules/v${moduleVersion}`
-        : `https://contributions.code.dev-guardianapis.com/modules/v${moduleVersion}`;
+    const baseUrl = getSdcBaseUrl();
 
     window.remoteImport(`${baseUrl}/${path}`).then(bannerModule => {
       setModule(() => withPreviewStyles(bannerModule[name]));

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -58,6 +58,7 @@ declare global {
         emotionReact: any;
         emotionReactJsxRuntime: any;
       };
+      sdcUrlOverride: string | undefined;
     };
   }
   /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## What does this change?

Adds support for specifying an SDC URL as an environment variable, for live previewing banners with a locally running SDC.

Run the server with e.g.:
```
$ SDC_URL=http://localhost:8082 sbt run
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've tested on CODE and verified that the banner preview feature works as expected (and the component is loaded from SDC CODE) and also verified locally that components are fetched from the URL specified in the environment variable.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
