### PR TITLE
Upgrade to Play 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ asciiGraphWidth := 999999999 // to ensure Snyk can read the the deeeeep dependen
 
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "com.gu.play-googleauth" %% "play-v28" % "4.0.0",
+  "com.gu.play-googleauth" %% "play-v30" % "4.0.0",
   "com.gu" %% "simple-configuration-ssm" % "1.5.7",
   "software.amazon.awssdk" % "s3" % awsVersion,
   "software.amazon.awssdk" % "dynamodb" % awsVersion,
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "com.dripower" %% "play-circe" % "2814.2",
+  "com.dripower" %% "play-circe" % "3014.1",
   "com.beachape" %% "enumeratum" % "1.7.0",
   "com.beachape" %% "enumeratum-circe" % "1.7.0",
   ws,

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ scalaVersion := "2.13.10"
 val circeVersion = "0.14.1"
 val awsVersion = "2.20.162"
 val zioVersion = "1.0.14"
-val jacksonVersion = "2.14.1"
 
 asciiGraphWidth := 999999999 // to ensure Snyk can read the the deeeeep dependency tree
 
@@ -29,20 +28,14 @@ libraryDependencies ++= Seq(
   ws,
   "dev.zio" %% "zio" % zioVersion,
   "dev.zio" %% "zio-streams" % zioVersion,
-  // Use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "org.scalatest" %% "scalatest" % "3.2.10" % "test",
   "org.gnieh" %% "diffson-circe" % "4.1.1" % "test",
 )
 
 dependencyOverrides ++= List(
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   // The version of netty-handler currently used by athena has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-handler" % "4.1.100.Final",
-  "io.netty" % "netty-codec-http2" % "4.1.100.Final",
-  // Fixes: https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-6094942
-  "ch.qos.logback" % "logback-classic" % "1.2.13"
+  "io.netty" % "netty-codec-http2" % "4.1.100.Final"
 )
 
 dynamoDBLocalPort := 8083

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.1
+sbt.version = 1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
We are now getting snyk warnings for Play 2's Akka dependency.
Play 3 [replaces Akka with Pekko](https://www.playframework.com/documentation/3.0.x/Migration30#Migration-from-Akka-to-Pekko), which resolves this.

Tested in CODE