### PR TITLE
feat: add supporter plus default promo code

### DIFF
--- a/app/models/DefaultPromos.scala
+++ b/app/models/DefaultPromos.scala
@@ -6,7 +6,8 @@ import io.circe.{Decoder, Encoder}
 case class DefaultPromos(
   guardianWeekly: Seq[String],
   paper: Seq[String],
-  digital: Seq[String]
+  digital: Seq[String],
+  supporterPlus: Option[Seq[String]],
 )
 
 object DefaultPromos {

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -9,7 +9,7 @@ import {
   SupportFrontendSettingsType,
 } from '../utils/requests';
 
-type ProductName = 'guardianWeekly' | 'paper' | 'digital';
+type ProductName = 'guardianWeekly' | 'paper' | 'digital' | 'supporterPlus';
 
 type DefaultPromos = {
   [key in ProductName]: string[];
@@ -36,6 +36,9 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
   const [gwPromosString, setGwPromosString] = useState<string>(data.guardianWeekly.join(', '));
   const [paperPromosString, setpaperPromosString] = useState<string>(data.paper.join(', '));
   const [digitalPromoString, setdigitalPromosString] = useState<string>(data.digital.join(', '));
+  const [supporterPlusPromoString, setSupporterPlusPromosString] = useState<string>(
+    (data.supporterPlus ?? []).join(', '),
+  );
 
   const classes = useStyles();
 
@@ -91,6 +94,23 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
         }}
         type="text"
         label="Digital"
+      />
+      <TextField
+        value={supporterPlusPromoString}
+        name="supporterPlusDefaultPromos"
+        fullWidth={true}
+        onChange={e => {
+          const inputValue = e.target.value;
+          setSupporterPlusPromosString(inputValue);
+
+          const parsedInputValue = parsePromoInput(inputValue);
+          update({
+            ...data,
+            supporterPlus: parsedInputValue,
+          });
+        }}
+        type="text"
+        label="Supporter Plus"
       />
       <Button
         onClick={sendToS3}


### PR DESCRIPTION
[Part 1/3](https://github.com/guardian/support-frontend/issues/5897)

## What does this change?
Adds the Supporter Plus option for a default `promoCode`.

## How to test
- Add `promoCode`
- Check s3

## Images
<img width="265" alt="Screenshot 2024-04-10 at 12 02 21" src="https://github.com/guardian/support-admin-console/assets/31692/53b9eb37-4635-411e-a84d-1c8600a163f5">
<img width="644" alt="Screenshot 2024-04-10 at 12 02 36" src="https://github.com/guardian/support-admin-console/assets/31692/71bd37ef-943b-44d4-90d9-6bf0c851ec61">
