### PR TITLE
Make SupporterPlus default promo a required field

### DIFF
--- a/app/models/DefaultPromos.scala
+++ b/app/models/DefaultPromos.scala
@@ -7,7 +7,7 @@ case class DefaultPromos(
   guardianWeekly: Seq[String],
   paper: Seq[String],
   digital: Seq[String],
-  supporterPlus: Option[Seq[String]],
+  supporterPlus: Seq[String],
 )
 
 object DefaultPromos {

--- a/public/src/components/defaultPromos.tsx
+++ b/public/src/components/defaultPromos.tsx
@@ -37,7 +37,7 @@ const DefaultPromos: React.FC<InnerProps<DefaultPromos>> = ({
   const [paperPromosString, setpaperPromosString] = useState<string>(data.paper.join(', '));
   const [digitalPromoString, setdigitalPromosString] = useState<string>(data.digital.join(', '));
   const [supporterPlusPromoString, setSupporterPlusPromosString] = useState<string>(
-    (data.supporterPlus ?? []).join(', '),
+    data.supporterPlus.join(', '),
   );
 
   const classes = useStyles();


### PR DESCRIPTION
[Part 2](https://github.com/guardian/support-frontend/issues/5897)

~Depends on [Part 1](https://github.com/guardian/support-admin-console/pull/567)~

As we know this data was introduced [via here](https://github.com/guardian/support-admin-console/pull/567/files#r1559256856) now exists, we can make it required.