### PR TITLE
Add consent targeting to RRCP

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -63,6 +63,7 @@ case class BannerTest(
     deviceType: Option[DeviceType] = None,
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
     signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
+    consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest =

--- a/app/models/ConsentStatus.scala
+++ b/app/models/ConsentStatus.scala
@@ -1,0 +1,16 @@
+package models
+
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{ deriveEnumerationDecoder, deriveEnumerationEncoder }
+import io.circe.{Decoder, Encoder}
+
+sealed trait ConsentStatus
+
+object ConsentStatus {
+  case object All extends ConsentStatus
+  case object HasConsented extends ConsentStatus
+  case object HasNotConsented extends ConsentStatus
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val decoder: Decoder[ConsentStatus] = deriveEnumerationDecoder[ConsentStatus]
+  implicit val encoder: Encoder[ConsentStatus] = deriveEnumerationEncoder[ConsentStatus]
+}

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -60,6 +60,7 @@ case class EpicTest(
   deviceType: Option[DeviceType] = None,
   campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
   signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
+  consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -32,6 +32,7 @@ case class HeaderTest(
   deviceType: Option[DeviceType] = None,
   campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
   signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
+  consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
 ) extends ChannelTest[HeaderTest] {
 
   override def withChannel(channel: Channel): HeaderTest = this.copy(channel = Some(channel))

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { Region } from '../../../utils/models';
-import {ArticlesViewedSettings, ConsentStatus, DeviceType, SignedInStatus, UserCohort} from '../helpers/shared';
+import {
+  ArticlesViewedSettings,
+  ConsentStatus,
+  DeviceType,
+  SignedInStatus,
+  UserCohort,
+} from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@mui/material';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
@@ -130,7 +136,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
 
   const onConsentStatusChange = (consentStatus: ConsentStatus): void => {
     onTestChange({ ...test, consentStatus });
-  }
+  };
 
   const onArticlesViewedSettingsChange = (
     updatedArticlesViewedSettings?: ArticlesViewedSettings,

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Region } from '../../../utils/models';
-import { ArticlesViewedSettings, DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
+import {ArticlesViewedSettings, ConsentStatus, DeviceType, SignedInStatus, UserCohort} from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@mui/material';
 import BannerTestVariantEditor from './bannerTestVariantEditor';
@@ -127,6 +127,10 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
     onTestChange({ ...test, signedInStatus });
   };
+
+  const onConsentStatusChange = (consentStatus: ConsentStatus): void => {
+    onTestChange({ ...test, consentStatus });
+  }
 
   const onArticlesViewedSettingsChange = (
     updatedArticlesViewedSettings?: ArticlesViewedSettings,
@@ -263,6 +267,8 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             showDeviceTypeSelector={true}
             selectedSignedInStatus={test.signedInStatus}
             onSignedInStatusChange={onSignedInStatusChange}
+            selectedConsentStatus={test.consentStatus}
+            onConsentStatusChange={onConsentStatusChange}
           />
         </div>
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -275,6 +275,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             onSignedInStatusChange={onSignedInStatusChange}
             selectedConsentStatus={test.consentStatus}
             onConsentStatusChange={onConsentStatusChange}
+            showConsentStatusSelector={true}
           />
         </div>
 

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -339,6 +339,7 @@ export const getEpicTestEditor = (
               onSignedInStatusChange={onSignedInStatusChange}
               selectedConsentStatus={test.consentStatus}
               onConsentStatusChange={onConsentChange}
+              showConsentStatusSelector={false}
               platform={epicEditorConfig.platform}
             />
           </div>

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -7,7 +7,8 @@ import {
   EpicEditorConfig,
   DeviceType,
   SignedInStatus,
-  PageContextTargeting, ConsentStatus,
+  PageContextTargeting,
+  ConsentStatus,
 } from '../helpers/shared';
 import { FormControlLabel, Switch, Typography } from '@mui/material';
 import CampaignSelector from '../CampaignSelector';

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -7,7 +7,7 @@ import {
   EpicEditorConfig,
   DeviceType,
   SignedInStatus,
-  PageContextTargeting,
+  PageContextTargeting, ConsentStatus,
 } from '../helpers/shared';
 import { FormControlLabel, Switch, Typography } from '@mui/material';
 import CampaignSelector from '../CampaignSelector';
@@ -156,6 +156,10 @@ export const getEpicTestEditor = (
 
     const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
       onTestChange({ ...test, signedInStatus });
+    };
+
+    const onConsentChange = (consentStatus: ConsentStatus): void => {
+      onTestChange({ ...test, consentStatus });
     };
 
     const onArticlesViewedSettingsChange = (
@@ -332,6 +336,8 @@ export const getEpicTestEditor = (
               showDeviceTypeSelector={epicEditorConfig.allowDeviceTypeTargeting}
               selectedSignedInStatus={test.signedInStatus}
               onSignedInStatusChange={onSignedInStatusChange}
+              selectedConsentStatus={test.consentStatus}
+              onConsentStatusChange={onConsentChange}
               platform={epicEditorConfig.platform}
             />
           </div>

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 
-import {ConsentStatus, DeviceType, SignedInStatus, UserCohort} from '../helpers/shared';
+import { ConsentStatus, DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
 
 import { Typography } from '@mui/material';
 import HeaderTestVariantEditor from './headerTestVariantEditor';

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -187,6 +187,7 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
           onSignedInStatusChange={onSignedInStatusChange}
           selectedConsentStatus={test.consentStatus}
           onConsentStatusChange={onConsentChange}
+          showConsentStatusSelector={false}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Region } from '../../../utils/models';
 
-import { DeviceType, SignedInStatus, UserCohort } from '../helpers/shared';
+import {ConsentStatus, DeviceType, SignedInStatus, UserCohort} from '../helpers/shared';
 
 import { Typography } from '@mui/material';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
@@ -71,6 +71,10 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
 
   const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
     onTestChange({ ...test, signedInStatus });
+  };
+
+  const onConsentChange = (consentStatus: ConsentStatus): void => {
+    onTestChange({ ...test, consentStatus });
   };
 
   const renderVariantEditor = (variant: HeaderVariant): React.ReactElement => (
@@ -181,6 +185,8 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
           showDeviceTypeSelector={true}
           selectedSignedInStatus={test.signedInStatus}
           onSignedInStatusChange={onSignedInStatusChange}
+          selectedConsentStatus={test.consentStatus}
+          onConsentStatusChange={onConsentChange}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -27,6 +27,7 @@ export interface Test {
   userCohort?: string;
   channel?: string;
   signedInStatus?: SignedInStatus;
+  consentStatus?: ConsentStatus;
 }
 
 export interface EpicEditorConfig {
@@ -252,6 +253,8 @@ export interface TickerSettings {
 export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
 
 export type DeviceType = 'Mobile' | 'Desktop' | 'All' | 'iOS' | 'Android';
+
+export type ConsentStatus = 'HasConsented' | 'HasNotConsented' | 'All';
 
 export interface Image {
   mainUrl: string;

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -3,7 +3,13 @@ import React from 'react';
 import { Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Region } from '../../utils/models';
-import {DeviceType, SignedInStatus, UserCohort, TestPlatform, ConsentStatus} from './helpers/shared';
+import {
+  DeviceType,
+  SignedInStatus,
+  UserCohort,
+  TestPlatform,
+  ConsentStatus,
+} from './helpers/shared';
 
 import TestEditorTargetRegionsSelector from './testEditorTargetRegionsSelector';
 import TypedRadioGroup from './TypedRadioGroup';

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Region } from '../../utils/models';
-import { DeviceType, SignedInStatus, UserCohort, TestPlatform } from './helpers/shared';
+import {DeviceType, SignedInStatus, UserCohort, TestPlatform, ConsentStatus} from './helpers/shared';
 
 import TestEditorTargetRegionsSelector from './testEditorTargetRegionsSelector';
 import TypedRadioGroup from './TypedRadioGroup';
@@ -41,6 +41,8 @@ interface TestEditorTargetAudienceSelectorProps {
   showDeviceTypeSelector: boolean;
   selectedSignedInStatus?: SignedInStatus;
   onSignedInStatusChange: (signedInStatus: SignedInStatus) => void;
+  selectedConsentStatus?: ConsentStatus;
+  onConsentStatusChange: (consentStatus: ConsentStatus) => void;
   platform?: TestPlatform;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
@@ -56,6 +58,8 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   showDeviceTypeSelector,
   selectedSignedInStatus,
   onSignedInStatusChange,
+  selectedConsentStatus,
+  onConsentStatusChange,
   platform,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
@@ -117,6 +121,20 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
             All: 'All',
             SignedIn: 'Signed in',
             SignedOut: 'Signed out',
+          }}
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.heading}>Consent Status</Typography>
+        <TypedRadioGroup
+          selectedValue={selectedConsentStatus ?? 'All'}
+          onChange={onConsentStatusChange}
+          isDisabled={isDisabled}
+          labels={{
+            All: 'All',
+            HasConsented: 'Has consented',
+            HasNotConsented: 'Has not consented',
           }}
         />
       </div>

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -49,6 +49,7 @@ interface TestEditorTargetAudienceSelectorProps {
   onSignedInStatusChange: (signedInStatus: SignedInStatus) => void;
   selectedConsentStatus?: ConsentStatus;
   onConsentStatusChange: (consentStatus: ConsentStatus) => void;
+  showConsentStatusSelector: boolean;
   platform?: TestPlatform;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
@@ -65,7 +66,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   selectedSignedInStatus,
   onSignedInStatusChange,
   selectedConsentStatus,
-  onConsentStatusChange,
+  onConsentStatusChange, showConsentStatusSelector,
   platform,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
@@ -131,6 +132,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
         />
       </div>
 
+      {showConsentStatusSelector && (
       <div className={classes.sectionContainer}>
         <Typography className={classes.heading}>Consent Status</Typography>
         <TypedRadioGroup
@@ -143,7 +145,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
             HasNotConsented: 'Has not consented',
           }}
         />
-      </div>
+      </div> )}
     </div>
   );
 };

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -66,7 +66,8 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   selectedSignedInStatus,
   onSignedInStatusChange,
   selectedConsentStatus,
-  onConsentStatusChange, showConsentStatusSelector,
+  onConsentStatusChange,
+  showConsentStatusSelector,
   platform,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
@@ -133,19 +134,20 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
       </div>
 
       {showConsentStatusSelector && (
-      <div className={classes.sectionContainer}>
-        <Typography className={classes.heading}>Consent Status</Typography>
-        <TypedRadioGroup
-          selectedValue={selectedConsentStatus ?? 'All'}
-          onChange={onConsentStatusChange}
-          isDisabled={isDisabled}
-          labels={{
-            All: 'All',
-            HasConsented: 'Has consented',
-            HasNotConsented: 'Has not consented',
-          }}
-        />
-      </div> )}
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.heading}>Consent Status</Typography>
+          <TypedRadioGroup
+            selectedValue={selectedConsentStatus ?? 'All'}
+            onChange={onConsentStatusChange}
+            isDisabled={isDisabled}
+            labels={{
+              All: 'All',
+              HasConsented: 'Has consented',
+              HasNotConsented: 'Has not consented',
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -8,7 +8,8 @@ import {
   DeviceType,
   Status,
   TickerSettings,
-  PageContextTargeting, ConsentStatus,
+  PageContextTargeting,
+  ConsentStatus,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -8,7 +8,7 @@ import {
   DeviceType,
   Status,
   TickerSettings,
-  PageContextTargeting,
+  PageContextTargeting, ConsentStatus,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
@@ -55,6 +55,7 @@ export interface BannerTest extends Test {
   deviceType?: DeviceType;
   campaignName?: string;
   contextTargeting: PageContextTargeting;
+  consentStatus?: ConsentStatus;
 }
 
 export function uiIsDesign(ui: BannerUi): ui is BannerDesignName {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -56,7 +56,6 @@ export interface BannerTest extends Test {
   deviceType?: DeviceType;
   campaignName?: string;
   contextTargeting: PageContextTargeting;
-  consentStatus?: ConsentStatus;
 }
 
 export function uiIsDesign(ui: BannerUi): ui is BannerDesignName {

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -9,7 +9,6 @@ import {
   Status,
   TickerSettings,
   PageContextTargeting,
-  ConsentStatus,
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds user consent as a targeting options to the RRCP. This means we can target users depending on whether they have accepted or rejected cookies.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Create (or edit) a banner test and select which consent option you would like, save and reload. The option should be saved.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/support-admin-console/assets/115992455/42af0d88-4eac-45df-a0fd-8241f4ba1da3)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
