### PR TITLE
Add editor for making epic a multi-armed bandit test

### DIFF
--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -60,7 +60,7 @@ case class EpicTest(
   deviceType: Option[DeviceType] = None,
   campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
   signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
-  isBanditTest: Option[Boolean],
+  isBanditTest: Option[Boolean] = None,
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -34,7 +34,7 @@ case class EpicVariant(
   showChoiceCards: Option[Boolean],
   bylineWithImage: Option[BylineWithImage],
   defaultChoiceCardFrequency: Option[String],
-  showSignInLink: Option[Boolean]
+  showSignInLink: Option[Boolean],
 )
 case class EpicTest(
   name: String,
@@ -60,6 +60,7 @@ case class EpicTest(
   deviceType: Option[DeviceType] = None,
   campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
   signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
+  isBanditTest: Option[Boolean],
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/public/src/components/channelManagement/epicTests/epicBanditEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicBanditEditor.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { EpicTest } from '../../../models/epic';
+
+interface EpicBanditEditorProps {
+  test: EpicTest;
+  isDisabled: boolean;
+  onExperimentMethodologyChange: (isBanditTest?: boolean) => void;
+}
+
+export const EpicBanditEditor: React.FC<EpicBanditEditorProps> = ({
+  test,
+  isDisabled,
+  onExperimentMethodologyChange,
+}: EpicBanditEditorProps) => {
+  const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.value === 'bandit') {
+      onExperimentMethodologyChange(true);
+    } else {
+      onExperimentMethodologyChange(false);
+    }
+  };
+
+  return (
+    <RadioGroup value={test.isBanditTest ? 'bandit' : 'abtest'} onChange={onRadioGroupChange}>
+      <FormControlLabel
+        value="abtest"
+        key="abtest"
+        control={<Radio />}
+        label="AB Testing"
+        disabled={isDisabled}
+      />
+      <FormControlLabel
+        value="bandit"
+        key="bandit"
+        control={<Radio />}
+        label="Multi-Armed Bandit"
+        disabled={isDisabled}
+      />
+    </RadioGroup>
+  );
+};

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -36,6 +36,8 @@ import { ValidatedTestEditor, ValidatedTestEditorProps } from '../validatedTestE
 import { TestEditorProps } from '../testsForm';
 import { EpicBanditEditor } from './epicBanditEditor';
 
+const BANDIT_FEATURE_SWITCH = false;
+
 const copyHasTemplate = (test: EpicTest, template: string): boolean =>
   test.variants.some(
     variant =>
@@ -252,16 +254,18 @@ export const getEpicTestEditor = (
           </div>
         )}
 
-        <div className={classes.sectionContainer}>
-          <Typography variant={'h3'} className={classes.sectionHeader}>
-            Experiment Methodology
-          </Typography>
-          <EpicBanditEditor
-            test={test}
-            isDisabled={!userHasTestLocked}
-            onExperimentMethodologyChange={onExperimentMethodologyChange}
-          />
-        </div>
+        {BANDIT_FEATURE_SWITCH && (
+          <div className={classes.sectionContainer}>
+            <Typography variant={'h3'} className={classes.sectionHeader}>
+              Experiment Methodology
+            </Typography>
+            <EpicBanditEditor
+              test={test}
+              isDisabled={!userHasTestLocked}
+              onExperimentMethodologyChange={onExperimentMethodologyChange}
+            />
+          </div>
+        )}
 
         {epicEditorConfig.allowCustomVariantSplit && canHaveCustomVariantSplit(test.variants) && (
           <div className={classes.sectionContainer}>

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -33,6 +33,7 @@ import { useStyles } from '../helpers/testEditorStyles';
 import { EpicTestPreviewButton } from './epicTestPreview';
 import { ValidatedTestEditor, ValidatedTestEditorProps } from '../validatedTestEditor';
 import { TestEditorProps } from '../testsForm';
+import { EpicBanditEditor } from './epicBanditEditor';
 
 const copyHasTemplate = (test: EpicTest, template: string): boolean =>
   test.variants.some(
@@ -85,6 +86,10 @@ export const getEpicTestEditor = (
         ...test,
         campaignName: campaign,
       });
+    };
+
+    const onExperimentMethodologyChange = (isBanditTest?: boolean): void => {
+      updateTest({ ...test, isBanditTest });
     };
 
     const onVariantsChange = (updatedVariantList: EpicVariant[]): void => {
@@ -242,6 +247,17 @@ export const getEpicTestEditor = (
           </div>
         )}
 
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Experiment Methodology
+          </Typography>
+          <EpicBanditEditor
+            test={test}
+            isDisabled={!userHasTestLocked}
+            onExperimentMethodologyChange={onExperimentMethodologyChange}
+          />
+        </div>
+
         {epicEditorConfig.allowCustomVariantSplit && canHaveCustomVariantSplit(test.variants) && (
           <div className={classes.sectionContainer}>
             <Typography variant={'h3'} className={classes.sectionHeader}>
@@ -253,7 +269,7 @@ export const getEpicTestEditor = (
                 controlProportionSettings={test.controlProportionSettings}
                 onControlProportionSettingsChange={onControlProportionSettingsChange}
                 onValidationChange={onVariantsSplitSettingsValidationChanged}
-                isDisabled={!userHasTestLocked}
+                isDisabled={!userHasTestLocked || !!test.isBanditTest}
               />
             </div>
           </div>

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -62,4 +62,5 @@ export interface EpicTest extends Test {
   controlProportionSettings?: ControlProportionSettings;
   deviceType?: DeviceType;
   campaignName?: string;
+  isBanditTest?: boolean;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new editor with a radio group to toggle an Epic to using "AB Testing" or "Multi-Armed Bandit". The setting is called "Experiment methodology". When the setting is "Multi-Armed Bandit" the Variants split editor is greyed out, as the bandit logic in SDC will handle the splitting. When multi-armed bandit is selected a field called `isBanditTest` is set to true in the data model.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Create a new epic and see by default the radio group has AB testing selected. Change to Multi-armed bandit, see that  Variants split editor is greyed out. Save. Reload and see that the setting is still on Multi-armed bandit.

This is hidden by a hardcoded feature switch for now.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

~~We may want to keep this on hold until our [null hypothesis](https://github.com/guardian/support-dotcom-components/pull/1099) test is over~~ This is hidden by a hardcoded feature switch for now.


<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-admin-console/assets/114918544/42718f6d-4c58-4b5f-9325-d1c3f78506ec)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
