### PR TITLE
Added wrapping to UI elements in RRCP

### DIFF
--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -19,8 +19,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     gap: spacing(12),
     flexWrap: 'wrap',
   },
-  sectionContainer: {
-  },
+  sectionContainer: {},
   heading: {
     fontSize: 16,
     color: palette.grey[900],

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -21,7 +21,6 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     flexWrap: 'wrap',
   },
   sectionContainer: {
-
   },
   heading: {
     fontSize: 16,

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Region } from '../../utils/models';

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -17,15 +17,11 @@ import TypedRadioGroup from './TypedRadioGroup';
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
     display: 'flex',
-
-    '& > * + *': {
-      marginLeft: spacing(12),
-    },
+    gap: spacing(12),
+    flexWrap: 'wrap',
   },
   sectionContainer: {
-    '& > * + *': {
-      marginTop: spacing(2),
-    },
+
   },
   heading: {
     fontSize: 16,

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     gap: spacing(12),
     flexWrap: 'wrap',
   },
-  sectionContainer: {},
   heading: {
     fontSize: 16,
     color: palette.grey[900],
@@ -67,19 +66,17 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
 
   return (
     <div className={classes.container}>
-      <div className={classes.sectionContainer}>
-        <Typography className={classes.heading}>Region</Typography>
-        <TestEditorTargetRegionsSelector
-          selectedRegions={selectedRegions}
-          onRegionsUpdate={onRegionsUpdate}
-          supportedRegions={supportedRegions}
-          isDisabled={isDisabled}
-          platform={platform}
-        />
-      </div>
+      <Typography className={classes.heading}>Region</Typography>
+      <TestEditorTargetRegionsSelector
+        selectedRegions={selectedRegions}
+        onRegionsUpdate={onRegionsUpdate}
+        supportedRegions={supportedRegions}
+        isDisabled={isDisabled}
+        platform={platform}
+      />
 
       {showSupporterStatusSelector && (
-        <div className={classes.sectionContainer}>
+        <>
           <Typography className={classes.heading}>Supporter Status</Typography>
           <TypedRadioGroup
             selectedValue={selectedCohort}
@@ -91,11 +88,11 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
               AllExistingSupporters: 'Existing supporters',
             }}
           />
-        </div>
+        </>
       )}
 
       {showDeviceTypeSelector && (
-        <div className={classes.sectionContainer}>
+        <>
           <Typography className={classes.heading}>Device Type</Typography>
           <TypedRadioGroup
             selectedValue={selectedDeviceType}
@@ -109,10 +106,10 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
               Android: 'Mobile (Android)',
             }}
           />
-        </div>
+        </>
       )}
 
-      <div className={classes.sectionContainer}>
+      <>
         <Typography className={classes.heading}>Signed In Status</Typography>
         <TypedRadioGroup
           selectedValue={selectedSignedInStatus ?? 'All'}
@@ -124,10 +121,10 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
             SignedOut: 'Signed out',
           }}
         />
-      </div>
+      </>
 
       {showConsentStatusSelector && (
-        <div className={classes.sectionContainer}>
+        <>
           <Typography className={classes.heading}>Consent Status</Typography>
           <TypedRadioGroup
             selectedValue={selectedConsentStatus ?? 'All'}
@@ -139,7 +136,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
               HasNotConsented: 'Has not consented',
             }}
           />
-        </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## What does this change?
Since adding additional target audience options, we have noticed that on a smaller screen the options are horizontally scrollable which isn't great UI. This PR is to add wrapping to those elements so on smaller screens they are stacked.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
On RRCP, head to Banner 1 (either choose and existing test or create one) and resize the screen. The Target options should stack and not be scrollable horizontally.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/support-admin-console/assets/115992455/407b61c9-6509-48a9-a663-1845f68af64b)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
