### PR TITLE
Updating Ticker

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -85,7 +85,6 @@ case class TickerDesign(
   text: HexColour,
   filledProgress: HexColour,
   progressBarBackground: HexColour,
-  goalMarker: HexColour
 )
 
 case class BannerDesignColours(

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -25,7 +25,7 @@ case class EpicVariant(
   heading: Option[String],
   paragraphs: List[String],
   highlightedText: Option[String] = None,
-  showTicker: Boolean = false,  // Deprecated - use tickerSettings instead
+  showTicker: Boolean = false,  // Deprecated - use tickerSettings instead (can this now be removed?)
   tickerSettings: Option[TickerSettings] = None,
   image: Option[Image] = None,
   cta: Option[Cta],

--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -2,19 +2,10 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 
-sealed trait TickerEndType
-object TickerEndType {
-  case object unlimited extends TickerEndType
-  case object hardstop extends TickerEndType
-
-  implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val encoder = deriveEnumerationEncoder[TickerEndType]
-  implicit val decoder = deriveEnumerationDecoder[TickerEndType]
-}
-
 sealed trait TickerCountType
 object TickerCountType {
   case object money extends TickerCountType
+  case object people extends TickerCountType
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val encoder = deriveEnumerationEncoder[TickerCountType]
@@ -38,7 +29,6 @@ case class TickerCopy(
 )
 
 case class TickerSettings(
-  endType: TickerEndType,
   countType: TickerCountType,
   currencySymbol: String,
   copy: TickerCopy,

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -3,7 +3,7 @@ import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
 import { BannerDesign } from '../../../models/bannerDesign';
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { BannerVariant } from '../../../models/banner';
-import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
+import { TickerCountType, TickerName } from '../helpers/shared';
 
 interface Props {
   design: BannerDesign;
@@ -50,8 +50,7 @@ const buildVariantForPreview = (
   tickerSettings: shouldShowTicker
     ? {
         countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
-        currencySymbol: '£',
+        currencySymbol: '$',
         copy: {
           countLabel: 'contributions in May',
           goalReachedPrimary: "We've met our goal - thank you!",

--- a/public/src/components/channelManagement/bannerDesigns/TickerDesignEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/TickerDesignEditor.tsx
@@ -55,14 +55,6 @@ export const TickerDesignEditor: React.FC<Props> = ({
         onChange={colour => onChange({ ...ticker, filledProgress: colour })}
         onValidationChange={onValidationChange}
       />
-      <ColourInput
-        colour={ticker.goalMarker}
-        name="ticker.goalMarker"
-        label="Goal Marker Colour"
-        isDisabled={isDisabled}
-        onChange={colour => onChange({ ...ticker, goalMarker: colour })}
-        onValidationChange={onValidationChange}
-      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -80,7 +80,6 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
       text: stringToHexColour('052962'),
       filledProgress: stringToHexColour('052962'),
       progressBarBackground: stringToHexColour('FFFFFF'),
-      goalMarker: stringToHexColour('000000'),
     },
   },
 });

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -225,12 +225,9 @@ export interface TestEditorState {
   validationStatus: ValidationStatus;
 }
 
-export enum TickerEndType {
-  unlimited = 'unlimited',
-  hardstop = 'hardstop',
-}
 export enum TickerCountType {
   money = 'money',
+  people = 'people',
 }
 export enum TickerName {
   US = 'US',
@@ -243,7 +240,6 @@ interface TickerCopy {
   goalReachedSecondary: string;
 }
 export interface TickerSettings {
-  endType: TickerEndType;
   countType: TickerCountType;
   currencySymbol: string;
   copy: TickerCopy;

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { TickerCountType, TickerEndType, TickerName, TickerSettings } from './helpers/shared';
+import { TickerCountType, TickerName, TickerSettings } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
@@ -35,7 +35,6 @@ interface FormData {
 }
 
 const DEFAULT_TICKER_SETTINGS: TickerSettings = {
-  endType: TickerEndType.unlimited,
   countType: TickerCountType.money,
   copy: {
     countLabel: 'contributions',
@@ -97,9 +96,9 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
     updateTickerSettings(isChecked ? DEFAULT_TICKER_SETTINGS : undefined);
   };
 
-  const onEndTypeChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const selectedType = event.target.value as TickerEndType;
-    tickerSettings && updateTickerSettings({ ...tickerSettings, endType: selectedType });
+  const onCountTypeChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const selectedCountType = event.target.value as TickerCountType;
+    tickerSettings && updateTickerSettings({ ...tickerSettings, countType: selectedCountType });
   };
 
   const onNameChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -220,21 +219,21 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             <FormControl component="fieldset">
               <FormLabel component="legend">Ticker end type</FormLabel>
               <RadioGroup
-                value={tickerSettings.endType}
-                onChange={onEndTypeChanged}
-                aria-label="ticker-end-type"
-                name="ticker-end-type"
+                value={tickerSettings.countType}
+                onChange={onCountTypeChanged}
+                aria-label="ticker-count-type"
+                name="ticker-count-type"
               >
                 <FormControlLabel
-                  value={TickerEndType.hardstop}
+                  value={TickerCountType.money}
                   control={<Radio />}
-                  label="Hard stop"
+                  label="money"
                   disabled={isDisabled}
                 />
                 <FormControlLabel
-                  value={TickerEndType.unlimited}
+                  value={TickerCountType.people}
                   control={<Radio />}
-                  label="Unlimited"
+                  label="people"
                   disabled={isDisabled}
                 />
               </RadioGroup>

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -34,7 +34,6 @@ export interface TickerDesign {
   text: HexColour;
   filledProgress: HexColour;
   progressBarBackground: HexColour;
-  goalMarker: HexColour;
 }
 
 export interface BannerDesignHeaderImage {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The ticker design has change on SDC to keep in line with the System Design. This includes some changes on the RRCP:
- removed the EndType option as we only support 'hardstop' and unlimited is not required any more
- removed the goalMarker. This is no longer required on the new designs of the ticker
- added in count type option. Initially we only support 'money' where now we want to also support 'people'
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
On RRCP, under Banner 1 Tests, on an existing test or a new test head to a varient and scroll to the bottom. There is a check box option for Tickers, where when ticked, you can see the different options available to edit the Ticker.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/support-admin-console/assets/115992455/7ce1bb3a-5b33-4e23-a3d4-ec7693a9c973)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
