### PR TITLE
Add a reminder toggle to banner design preview

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -69,11 +69,7 @@ const buildVariantForPreview = (
     },
     secondaryCta: shouldShowReminder
       ? {
-          type: SecondaryCtaType.Custom,
-          cta: {
-            text: 'Support monthly',
-            baseUrl: 'https://support.theguardian.com/contribute/recurring',
-          },
+          type: SecondaryCtaType.ContributionsReminder,
         }
       : undefined,
   },

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -3,18 +3,21 @@ import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
 import { BannerDesign } from '../../../models/bannerDesign';
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { BannerVariant } from '../../../models/banner';
-import { TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
+import { SecondaryCtaType, TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
 
 interface Props {
   design: BannerDesign;
 }
 
-interface TickerToggleProps {
-  shouldShowTicker: boolean;
-  setShouldShowTicker: (shouldShowTicker: boolean) => void;
+interface ToggleProps {
+  shouldShow: boolean;
+  setShouldShow: (shouldShow: boolean) => void;
 }
 
-const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerToggleProps) => {
+const TickerToggle = ({
+  shouldShow: shouldShowTicker,
+  setShouldShow: setShouldShowTicker,
+}: ToggleProps) => {
   return (
     <FormControlLabel
       control={
@@ -29,9 +32,28 @@ const TickerToggle = ({ shouldShowTicker, setShouldShowTicker }: TickerTogglePro
   );
 };
 
+const ReminderToggle = ({
+  shouldShow: shouldShowReminder,
+  setShouldShow: setShouldShowReminder,
+}: ToggleProps) => {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={shouldShowReminder}
+          onChange={() => setShouldShowReminder(!shouldShowReminder)}
+          color="primary"
+        />
+      }
+      label={'Show reminder?'}
+    />
+  );
+};
+
 const buildVariantForPreview = (
   design: BannerDesign,
   shouldShowTicker: boolean,
+  shouldShowReminder: boolean,
 ): BannerVariant => ({
   name: 'CONTROL',
   template: { designName: design.name },
@@ -45,6 +67,15 @@ const buildVariantForPreview = (
       text: 'Support the Guardian',
       baseUrl: 'https://support.theguardian.com/contribute',
     },
+    secondaryCta: shouldShowReminder
+      ? {
+          type: SecondaryCtaType.Custom,
+          cta: {
+            text: 'Support monthly',
+            baseUrl: 'https://support.theguardian.com/contribute/recurring',
+          },
+        }
+      : undefined,
   },
   separateArticleCount: true,
   tickerSettings: shouldShowTicker
@@ -64,16 +95,17 @@ const buildVariantForPreview = (
 
 const BannerDesignPreview: React.FC<Props> = ({ design }: Props) => {
   const [shouldShowTicker, setShouldShowTicker] = useState<boolean>(false);
+  const [shouldShowReminder, setShouldShowReminder] = useState<boolean>(false);
 
   return (
     <BannerVariantPreview
-      variant={buildVariantForPreview(design, shouldShowTicker)}
+      variant={buildVariantForPreview(design, shouldShowTicker, shouldShowReminder)}
       design={design}
       controls={
-        <TickerToggle
-          shouldShowTicker={shouldShowTicker}
-          setShouldShowTicker={setShouldShowTicker}
-        />
+        <>
+          <TickerToggle shouldShow={shouldShowTicker} setShouldShow={setShouldShowTicker} />
+          <ReminderToggle shouldShow={shouldShowReminder} setShouldShow={setShouldShowReminder} />
+        </>
       }
     />
   );


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a toggle allowing users to preview banner designs if they had a reminder

[Trello](https://trello.com/c/H5kulyTF/456-banner-design-tool-preview-reminders)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Go to `/banner-designs`, click `Live preview` and see "Show reminder?" toggle. Click and see reminder show in banner preview.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-admin-console/assets/114918544/a40ae717-8166-49d7-8399-745b3be674b0)

![image](https://github.com/guardian/support-admin-console/assets/114918544/5fa6eeb3-744d-47d5-b7e5-2fb2127922e9)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
