### PR TITLE
Make secondary cta dismissable in amp epic

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditorCtasEditor.tsx
@@ -51,6 +51,7 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
           label="Secondary button"
           isDisabled={isDisabled}
           cta={secondaryCta}
+          allowVariantCustomSecondaryCta={true}
           updateCta={updateSecondaryCta}
           defaultCta={DEFAULT_SECONDARY_CTA}
           onValidationChange={onValidationChange}

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -106,6 +106,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
     allowVariantHighlightedText,
     allowVariantImageUrl,
     allowVariantCustomPrimaryCta,
+    allowVariantSecondaryCta,
     allowVariantCustomSecondaryCta,
     allowVariantSeparateArticleCount,
     allowVariantTicker,
@@ -369,9 +370,10 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             secondaryCta={variant.secondaryCta}
             updatePrimaryCta={updatePrimaryCta}
             updateSecondaryCta={updateSecondaryCta}
+            allowVariantCustomSecondaryCta={allowVariantCustomSecondaryCta}
             isDisabled={!editMode}
             onValidationChange={onValidationChange}
-            supportSecondaryCta={allowVariantCustomSecondaryCta}
+            supportSecondaryCta={allowVariantSecondaryCta}
           />
         </div>
       )}

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditorCtasEditor.tsx
@@ -19,6 +19,7 @@ interface EpicTestVariantEditorButtonsEditorProps {
   secondaryCta?: SecondaryCta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
   updateSecondaryCta: (updatedCta?: SecondaryCta) => void;
+  allowVariantCustomSecondaryCta: boolean;
   onValidationChange: (isValid: boolean) => void;
   isDisabled: boolean;
   supportSecondaryCta: boolean;
@@ -29,6 +30,7 @@ const EpicTestVariantEditorButtonsEditor: React.FC<EpicTestVariantEditorButtonsE
   secondaryCta,
   updatePrimaryCta,
   updateSecondaryCta,
+  allowVariantCustomSecondaryCta,
   onValidationChange,
   isDisabled,
   supportSecondaryCta,
@@ -52,6 +54,7 @@ const EpicTestVariantEditorButtonsEditor: React.FC<EpicTestVariantEditorButtonsE
           isDisabled={isDisabled}
           cta={secondaryCta}
           updateCta={updateSecondaryCta}
+          allowVariantCustomSecondaryCta={allowVariantCustomSecondaryCta}
           defaultCta={DEFAULT_SECONDARY_CTA}
           onValidationChange={onValidationChange}
         />

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -49,6 +49,7 @@ export interface EpicEditorConfig {
   allowVariantHighlightedText: boolean;
   allowVariantImageUrl: boolean;
   allowVariantCustomPrimaryCta: boolean;
+  allowVariantSecondaryCta: boolean;
   allowVariantCustomSecondaryCta: boolean;
   allowVariantSeparateArticleCount: boolean;
   allowVariantTicker: boolean;
@@ -73,6 +74,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHighlightedText: true,
   allowVariantImageUrl: true,
   allowVariantCustomPrimaryCta: true,
+  allowVariantSecondaryCta: true,
   allowVariantCustomSecondaryCta: true,
   allowVariantSeparateArticleCount: true,
   allowVariantTicker: true,
@@ -98,6 +100,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHighlightedText: false,
   allowVariantImageUrl: false,
   allowVariantCustomPrimaryCta: true,
+  allowVariantSecondaryCta: true,
   allowVariantCustomSecondaryCta: true,
   allowVariantSeparateArticleCount: false,
   allowVariantTicker: false,
@@ -124,6 +127,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHighlightedText: true,
   allowVariantImageUrl: false,
   allowVariantCustomPrimaryCta: false,
+  allowVariantSecondaryCta: false,
   allowVariantCustomSecondaryCta: false,
   allowVariantSeparateArticleCount: false,
   allowVariantTicker: false,
@@ -149,6 +153,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantHighlightedText: true,
   allowVariantImageUrl: false,
   allowVariantCustomPrimaryCta: true,
+  allowVariantSecondaryCta: true,
   allowVariantCustomSecondaryCta: false,
   allowVariantSeparateArticleCount: false,
   allowVariantTicker: true,

--- a/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
+++ b/public/src/components/channelManagement/variantEditorSecondaryCtaEditor.tsx
@@ -22,6 +22,7 @@ interface VariantEditorSecondaryCtaEditorProps {
   label: string;
   cta?: SecondaryCta;
   updateCta: (updatedCta?: SecondaryCta) => void;
+  allowVariantCustomSecondaryCta: boolean;
   onValidationChange: (isValid: boolean) => void;
   isDisabled: boolean;
   defaultCta: Cta;
@@ -31,6 +32,7 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
   label,
   cta,
   updateCta,
+  allowVariantCustomSecondaryCta,
   onValidationChange,
   isDisabled,
   defaultCta,
@@ -67,7 +69,7 @@ const VariantEditorSecondaryCtaEditor: React.FC<VariantEditorSecondaryCtaEditorP
             disabled={isDisabled}
           >
             <MenuItem value={'None'}>None</MenuItem>
-            <MenuItem value={SecondaryCtaType.Custom}>Custom</MenuItem>
+            { allowVariantCustomSecondaryCta && <MenuItem value={SecondaryCtaType.Custom}>Custom</MenuItem> }
             <MenuItem value={SecondaryCtaType.ContributionsReminder}>
               Contributions reminder
             </MenuItem>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
