### PR TITLE
Add ArticleCount by Tag to banner tests

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -44,6 +44,7 @@ case class BannerVariant(
     bannerContent: Option[BannerContent],
     mobileBannerContent: Option[BannerContent],
     separateArticleCount: Option[Boolean],
+    separateArticleCountSettings: Option[SeparateArticleCount],
     tickerSettings: Option[TickerSettings] = None,
 )
 

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -289,7 +289,6 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             onArticlesViewedSettingsChanged={onArticlesViewedSettingsChange}
             onValidationChange={onArticlesViewedSettingsValidationChanged}
             isDisabled={!userHasTestLocked}
-            isEpic={false}
           />
         </div>
       </div>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { FormControlLabel, Radio, RadioGroup, Switch, Theme, Typography } from '@mui/material';
+import { FormControlLabel, Radio, RadioGroup, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
 import {

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -26,8 +26,8 @@ import {
 } from '../richTextEditor/richTextEditor';
 import TickerEditor from '../tickerEditor';
 import { BannerDesign } from '../../../models/bannerDesign';
-import VariantEditorSeparateArticleCountEditor from "../variantEditorSeparateArticleCountEditor";
-import { SeparateArticleCount } from "../../../models/epic";
+import VariantEditorSeparateArticleCountEditor from '../variantEditorSeparateArticleCountEditor';
+import { SeparateArticleCount } from '../../../models/epic';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -380,8 +380,13 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
     }
   };
 
-  const updateSeparateArticleCountSettings = (updatedSeparateArticleCountSettings?: SeparateArticleCount): void => {
-    onVariantChange({ ...variant, separateArticleCountSettings: updatedSeparateArticleCountSettings });
+  const updateSeparateArticleCountSettings = (
+    updatedSeparateArticleCountSettings?: SeparateArticleCount,
+  ): void => {
+    onVariantChange({
+      ...variant,
+      separateArticleCountSettings: updatedSeparateArticleCountSettings,
+    });
   };
   return (
     <div className={classes.container}>
@@ -450,17 +455,17 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           />
         )}
       </div>
-        <div className={classes.sectionContainer}>
-          <Typography className={classes.sectionHeader} variant="h4">
-            Separate article count
-          </Typography>
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.sectionHeader} variant="h4">
+          Separate article count
+        </Typography>
 
-          <VariantEditorSeparateArticleCountEditor
-            separateArticleCount={variant.separateArticleCountSettings}
-            updateSeparateArticleCount={updateSeparateArticleCountSettings}
-            isDisabled={!editMode}
-          />
-        </div>
+        <VariantEditorSeparateArticleCountEditor
+          separateArticleCount={variant.separateArticleCountSettings}
+          updateSeparateArticleCount={updateSeparateArticleCountSettings}
+          isDisabled={!editMode}
+        />
+      </div>
 
       {allowVariantTicker && (
         <div className={classes.sectionContainer}>

--- a/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestVariantEditor.tsx
@@ -26,6 +26,8 @@ import {
 } from '../richTextEditor/richTextEditor';
 import TickerEditor from '../tickerEditor';
 import { BannerDesign } from '../../../models/bannerDesign';
+import VariantEditorSeparateArticleCountEditor from "../variantEditorSeparateArticleCountEditor";
+import { SeparateArticleCount } from "../../../models/epic";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -378,6 +380,9 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
     }
   };
 
+  const updateSeparateArticleCountSettings = (updatedSeparateArticleCountSettings?: SeparateArticleCount): void => {
+    onVariantChange({ ...variant, separateArticleCountSettings: updatedSeparateArticleCountSettings });
+  };
   return (
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
@@ -445,23 +450,18 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           />
         )}
       </div>
-      <div className={classes.sectionContainer}>
-        <Typography className={classes.sectionHeader} variant="h4">
-          Separate article count (displayed only for users with at least 5 article views)
-        </Typography>
+        <div className={classes.sectionContainer}>
+          <Typography className={classes.sectionHeader} variant="h4">
+            Separate article count
+          </Typography>
 
-        <div className={classes.switchContainer}>
-          <Typography className={classes.switchLabel}>Disabled</Typography>
-          <Switch
-            checked={!!variant.separateArticleCount}
-            onChange={(e): void =>
-              onVariantChange({ ...variant, separateArticleCount: e.target.checked })
-            }
-            disabled={!editMode}
+          <VariantEditorSeparateArticleCountEditor
+            separateArticleCount={variant.separateArticleCountSettings}
+            updateSeparateArticleCount={updateSeparateArticleCountSettings}
+            isDisabled={!editMode}
           />
-          <Typography className={classes.switchLabel}>Enabled</Typography>
         </div>
-      </div>
+
       {allowVariantTicker && (
         <div className={classes.sectionContainer}>
           <Typography className={classes.sectionHeader} variant="h4">

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -15,6 +15,7 @@ import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 import { mockAmountsCardData, SelectedAmountsVariant } from '../../../utils/models';
 import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
 import { ArticleCounts } from '../epicTests/epicVariantPreview';
+import { SeparateArticleCount } from "../../../models/epic";
 
 // Mock prices data
 interface ProductPriceData {
@@ -75,6 +76,7 @@ interface BannerProps {
   mobileContent?: BannerContent;
   tickerSettings?: TickerSettingsWithData;
   separateArticleCount?: boolean;
+  separateArticleCountSettings?: SeparateArticleCount;
   choiceCardAmounts?: SelectedAmountsVariant;
   design?: BannerDesignProps;
 }
@@ -110,6 +112,7 @@ const buildProps = (
     },
     tickerSettings: tickerSettingsWithData,
     separateArticleCount: variant.separateArticleCount,
+    separateArticleCountSettings: variant.separateArticleCountSettings,
     prices: mockPricesData,
     choiceCardAmounts: mockAmountsCardData,
     design,

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -15,7 +15,7 @@ import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 import { mockAmountsCardData, SelectedAmountsVariant } from '../../../utils/models';
 import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
 import { ArticleCounts } from '../epicTests/epicVariantPreview';
-import { SeparateArticleCount } from "../../../models/epic";
+import { SeparateArticleCount } from '../../../models/epic';
 
 // Mock prices data
 interface ProductPriceData {

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -14,6 +14,7 @@ import { useModule } from '../../../hooks/useModule';
 import useTickerData, { TickerSettingsWithData } from '../hooks/useTickerData';
 import { mockAmountsCardData, SelectedAmountsVariant } from '../../../utils/models';
 import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
+import { ArticleCounts } from '../epicTests/epicVariantPreview';
 
 // Mock prices data
 interface ProductPriceData {
@@ -69,7 +70,7 @@ interface BannerProps {
   bannerChannel: string;
   countryCode?: string;
   prices?: Prices;
-  numArticles: number;
+  articleCounts: ArticleCounts;
   content: BannerContent;
   mobileContent?: BannerContent;
   tickerSettings?: TickerSettingsWithData;
@@ -103,7 +104,10 @@ const buildProps = (
     content: variant.bannerContent,
     mobileContent: variant.mobileBannerContent,
     countryCode: 'GB',
-    numArticles: 13,
+    articleCounts: {
+      for52Weeks: 13,
+      forTargetedWeeks: 13,
+    },
     tickerSettings: tickerSettingsWithData,
     separateArticleCount: variant.separateArticleCount,
     prices: mockPricesData,

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -402,7 +402,6 @@ export const getEpicTestEditor = (
               onArticlesViewedSettingsChanged={onArticlesViewedSettingsChange}
               onValidationChange={onArticlesViewedSettingsValidationChanged}
               isDisabled={!userHasTestLocked}
-              isEpic={true}
             />
           </div>
         )}

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -168,15 +168,15 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               />
             </div>
           </div>
-            <div>
-              <MultiselectAutocomplete
-                disabled={isDisabled}
-                tagIds={tagIds}
-                onUpdate={(newTagIds): void => {
-                  onArticlesViewedSettingsChanged({ ...articlesViewedSettings, tagIds: newTagIds });
-                }}
-              />
-            </div>
+          <div>
+            <MultiselectAutocomplete
+              disabled={isDisabled}
+              tagIds={tagIds}
+              onUpdate={(newTagIds): void => {
+                onArticlesViewedSettingsChanged({ ...articlesViewedSettings, tagIds: newTagIds });
+              }}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -41,7 +41,6 @@ interface TestEditorArticleCountEditorProps {
   onArticlesViewedSettingsChanged: (updatedArticlesViewedSettings?: ArticlesViewedSettings) => void;
   onValidationChange: (isValid: boolean) => void;
   isDisabled: boolean;
-  isEpic: boolean;
 }
 
 const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> = ({
@@ -49,7 +48,6 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
   onArticlesViewedSettingsChanged,
   onValidationChange,
   isDisabled,
-  isEpic,
 }: TestEditorArticleCountEditorProps) => {
   const classes = useStyles();
 
@@ -170,7 +168,6 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               />
             </div>
           </div>
-          {isEpic && (
             <div>
               <MultiselectAutocomplete
                 disabled={isDisabled}
@@ -180,7 +177,6 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
                 }}
               />
             </div>
-          )}
         </div>
       )}
     </div>

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -12,7 +12,7 @@ import {
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
-import { SeparateArticleCount } from "./epic";
+import { SeparateArticleCount } from './epic';
 
 export enum BannerTemplate {
   ContributionsBanner = 'ContributionsBanner',

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -12,6 +12,7 @@ import {
 } from '../components/channelManagement/helpers/shared';
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
+import { SeparateArticleCount } from "./epic";
 
 export enum BannerTemplate {
   ContributionsBanner = 'ContributionsBanner',
@@ -40,6 +41,7 @@ export interface BannerVariant extends Variant {
   bannerContent: BannerContent;
   mobileBannerContent?: BannerContent;
   separateArticleCount?: boolean;
+  separateArticleCountSettings?: SeparateArticleCount;
   tickerSettings?: TickerSettings;
 }
 


### PR DESCRIPTION
## What does this change?

This PR is to add ArticleCount by Tag to banner tests.

##After change

<img width="1728" alt="image" src="https://github.com/guardian/support-admin-console/assets/73653255/56b216c1-2711-449c-a864-959299926bd9">


It also replaces the SeparateArticleCount from a boolean to an Object.This will make it possible to customise the Subheading 

<img width="1728" alt="Screenshot 2024-06-14 at 08 25 12" src="https://github.com/guardian/support-admin-console/assets/73653255/082076a9-be58-4794-883f-ab8bdfd65196">

