### PR TITLE
Require minViews

### DIFF
--- a/app/models/ArticlesViewedSettings.scala
+++ b/app/models/ArticlesViewedSettings.scala
@@ -7,7 +7,7 @@ case class MaxViews(
 )
 
 case class ArticlesViewedSettings(
- minViews: Option[Int],
+ minViews: Int,
  maxViews: Option[Int],
  periodInWeeks: Int,
  tagIds: List[String]=Nil

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -221,7 +221,7 @@ export type ModifiedTests = {
 };
 
 export interface ArticlesViewedSettings {
-  minViews: number | null;
+  minViews: number;
   maxViews: number | null;
   periodInWeeks: number;
   tagIds: string[] | null;

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -77,7 +77,7 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
 
   const onSubmit = ({ minViews, maxViews, periodInWeeks }: FormData): void => {
     onArticlesViewedSettingsChanged({
-      minViews: parseInt(minViews) || null,
+      minViews: parseInt(minViews),
       maxViews: parseInt(maxViews) || null,
       periodInWeeks: parseInt(periodInWeeks),
       tagIds: articlesViewedSettings?.tagIds || null,
@@ -126,7 +126,10 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
           <div className={classes.formContainer}>
             <div>
               <TextField
-                inputRef={register({ validate: notNumberValidator })}
+                inputRef={register({
+                  required: EMPTY_ERROR_HELPER_TEXT,
+                  validate: notNumberValidator,
+                })}
                 error={errors.minViews !== undefined}
                 helperText={errors.minViews?.message}
                 onBlur={handleSubmit(onSubmit)}


### PR DESCRIPTION
In SDC the `minViews` field [is required](https://github.com/guardian/support-dotcom-components/blob/main/packages/shared/src/types/abTests/shared.ts#L78) if the `articlesViewedSettings` field is defined.

But this is not the case in the RRCP, which lets you set it to undefined.
This PR makes it mandatory. If Marketing want to target users below a `maxViews` count, they can set `minViews` to 0.

<img width="287" alt="Screenshot 2024-06-06 at 09 18 20" src="https://github.com/guardian/support-admin-console/assets/1513454/87e3014e-b358-4a0c-8481-068c130d4ba4">

