### PR TITLE
Epic impressions

### DIFF
--- a/app/controllers/AnalyticsController.scala
+++ b/app/controllers/AnalyticsController.scala
@@ -1,0 +1,45 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax.EncoderOps
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents, Result}
+import services.Athena
+import zio.{IO, ZEnv, ZIO}
+import models.GroupedVariantViews.encoder
+import utils.Circe.noNulls
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AnalyticsController(authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  stage: String,
+  runtime: zio.Runtime[ZEnv],
+  athena: Athena
+)(implicit ec: ExecutionContext) extends AbstractController(components) with LazyLogging {
+
+  private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
+    runtime.unsafeRunToFuture {
+      f.catchAll(error => {
+        logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
+        IO.succeed(InternalServerError(error.getMessage))
+      })
+    }
+
+  def getDataForVariants(channel: String, testName: String): Action[AnyContent] = authAction.async { request =>
+    run {
+      val result = for {
+        from <- request.getQueryString("from").toRight("missing parameter")
+        to <- request.getQueryString("to").toRight("missing parameter")
+      } yield {
+        athena
+          .getVariantViews(from, to, channel, testName)
+          .map(data => Ok(noNulls(data.asJson)))
+      }
+      result match {
+        case Right(result) => result
+        case Left(error) => IO.succeed(BadRequest(error))
+      }
+    }
+  }
+}

--- a/app/controllers/SuperModeController.scala
+++ b/app/controllers/SuperModeController.scala
@@ -45,7 +45,7 @@ class SuperModeController(
         url <- request.getQueryString("url")
       } yield {
         athena
-          .get(from, to, url)
+          .getArticleEpicData(from, to, url)
           .map(data => Ok(noNulls(data.asJson)))
       }
 

--- a/app/models/Analytics.scala
+++ b/app/models/Analytics.scala
@@ -1,0 +1,34 @@
+package models
+
+import io.circe.Encoder
+import models.GroupedVariantViews.VariantName
+
+case class VariantViews(dateHour: String, name: VariantName, views: Int)
+
+case class GroupedVariantViews(dateHour: String, views: Map[VariantName, Int])
+
+object VariantViews {
+  def parse(mapping: Map[String, String]): Option[VariantViews] = {
+    def parseInt(name: String): Option[Int] = mapping
+      .get(name)
+      .flatMap(Option(_)) // It could be null - wrap in Option
+      .flatMap(_.toIntOption)
+
+    for {
+      dateHour <- mapping.get("date_hour")
+      name <- mapping.get("variant")
+      views <- parseInt("views")
+    } yield new VariantViews(
+      dateHour = dateHour,
+      name = name,
+      views = views
+    )
+  }
+}
+
+object GroupedVariantViews {
+  type VariantName = String
+
+  import io.circe.generic.auto._
+  implicit val encoder = Encoder[GroupedVariantViews]
+}

--- a/app/services/Athena.scala
+++ b/app/services/Athena.scala
@@ -133,8 +133,8 @@ class Athena() extends StrictLogging {
       s"""
          |SELECT date_hour, ab.variant, COUNT(*) AS views
          |FROM acquisition.epic_views_prod, UNNEST(abtests) t(ab)
-         |WHERE date_hour >= timestamp '$from' AND date_hour < timestamp '$to'
-         |AND ab.name = '$testName'
+         |WHERE date_hour >= TIMESTAMP '$from' AND date_hour < TIMESTAMP '$to'
+         |AND ab.name = ?
          |GROUP BY 1,2 ORDER BY 1,2
     """
 
@@ -143,6 +143,7 @@ class Athena() extends StrictLogging {
       .queryString(
         query.stripMargin
       )
+      .executionParameters(testName)
       .queryExecutionContext(queryExecutionContext)
       .resultConfiguration(resultConfiguration)
       .build()

--- a/app/services/Athena.scala
+++ b/app/services/Athena.scala
@@ -2,6 +2,8 @@ package services
 
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.{Decoder, Encoder}
+import models.GroupedVariantViews.VariantName
+import models.{Channel, GroupedVariantViews, VariantViews}
 import services.AthenaError.{AthenaError, AthenaQueryFailed, AthenaResultPending}
 import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
@@ -70,7 +72,7 @@ class Athena() extends StrictLogging {
 
   type QueryExecutionId = String
 
-  private def startQuery(from: String, to: String, url: String): ZIO[ZEnv, AthenaError, QueryExecutionId] = {
+  private def startArticleEpicQuery(from: String, to: String, url: String): ZIO[ZEnv, AthenaError, QueryExecutionId] = {
     val fromDate = from.take(10)
     val toDate = to.take(10)
     logger.info(s"Querying athena")
@@ -124,6 +126,33 @@ class Athena() extends StrictLogging {
       .map(_.queryExecutionId())
   }
 
+  private def startVariantViewsQuery(from: String, to: String, channel: String, testName: String): ZIO[ZEnv, AthenaError, QueryExecutionId] = {
+    logger.info(s"Querying athena")
+
+    val request = StartQueryExecutionRequest
+      .builder()
+      .queryString(
+        s"""
+           |SELECT date_hour, ab.variant, COUNT(*) AS views
+           |FROM acquisition.epic_views_prod, UNNEST(abtests) t(ab)
+           |WHERE date_hour >= timestamp '$from' AND date_hour < timestamp '$to'
+           |AND ab.name = '2024-05-24_STICKY_VARIANTS__UK'
+           |GROUP BY 1,2 ORDER BY 1,2
+        """
+          .stripMargin
+      )
+      .queryExecutionContext(queryExecutionContext)
+      .resultConfiguration(resultConfiguration)
+      .build()
+
+    effectBlocking(client.startQueryExecution(request))
+      .mapError(err => {
+        logger.error(s"Query failed with: ${err.getMessage}")
+        AthenaQueryFailed(err)
+      })
+      .map(_.queryExecutionId())
+  }
+
   // Repeatedly checks the status of the query execution until it either succeeds or fails
   private def pollQueryResult(queryExecutionId: String): ZIO[ZEnv, AthenaError, QueryExecutionId] =
     effectBlocking {
@@ -144,7 +173,7 @@ class Athena() extends StrictLogging {
       .retryWhileEquals(AthenaResultPending)
 
   // Get resultSet of the completed query and parse each row
-  private def getQueryResult(queryExecutionId: QueryExecutionId): ZIO[ZEnv, AthenaError, List[ArticleEpicData]] = {
+  private def getQueryResult(queryExecutionId: QueryExecutionId): ZIO[ZEnv, AthenaError, List[Map[String, String]]] = {
     val request = GetQueryResultsRequest.builder().queryExecutionId(queryExecutionId).build()
 
     effectBlocking(client.getQueryResults(request))
@@ -155,24 +184,53 @@ class Athena() extends StrictLogging {
           .resultSet()
           .rows()
           .asScala.toList
-          .flatMap(row => {
+          .map(row => {
             val values = row.data().asScala.toList.map(d => d.varCharValue())
-            val data = ArticleEpicData(
-              columnNames.zip(values).toMap // Map columnNames to values
-            )
+            columnNames.zip(values).toMap // Map columnNames to values
+          })
+      }
+  }
+
+  def getArticleEpicData(from: String, to: String, url: String): ZIO[ZEnv, Throwable, List[ArticleEpicData]] =
+    startArticleEpicQuery(from, to, url)
+      .flatMap(pollQueryResult)
+      .flatMap(getQueryResult)
+      .map(rows => {
+        rows
+          .flatMap(row => {
+            val data = ArticleEpicData(row)
             if (data.isEmpty) {
-              logger.error(s"Failed to parse row from athena: $values")
+              logger.error(s"Failed to parse row from athena: $row")
             }
             data
           })
           .sortBy(_.timestamp)
-      }
-  }
-
-  def get(from: String, to: String, url: String): ZIO[ZEnv, Throwable, List[ArticleEpicData]] =
-    startQuery(from, to, url)
-      .flatMap(pollQueryResult)
-      .flatMap(getQueryResult)
+      })
       .tapError(error => ZIO.succeed(logger.error(s"Athena error: ${error.getMessage}")))
       .tap(result => ZIO.succeed(logger.info(s"Athena result: ${result.length}")))
+
+  def getVariantViews(from: String, to: String, channel: String, testName: String): ZIO[ZEnv, Throwable, List[GroupedVariantViews]] = {
+    startVariantViewsQuery(from, to, channel, testName)
+      .flatMap(pollQueryResult)
+      .flatMap(getQueryResult)
+      .map(rows => {
+        rows
+          .flatMap(row => {
+            val variantViews = VariantViews.parse(row)
+            if (variantViews.isEmpty) {
+              logger.error(s"Failed to parse row from athena: $variantViews")
+            }
+            variantViews
+          })
+          .groupBy(variantViews => variantViews.dateHour)
+          .map { case (dateHour, variantViewsList) => dateHour -> {
+            val viewCounts = variantViewsList.foldLeft(Map.empty[VariantName,Int])((acc, variantViews) => acc + (variantViews.name -> variantViews.views))
+            GroupedVariantViews(dateHour, viewCounts)
+          }}
+          .values.toList
+          .sortBy(_.dateHour)
+      })
+      .tapError(error => ZIO.succeed(logger.error(s"Athena error: ${error.getMessage}")))
+      .tap(result => ZIO.succeed(logger.info(s"Athena result: $result")))
+  }
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -97,6 +97,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new AppsMeteringSwitchesController(authAction, controllerComponents, stage, runtime),
     new DefaultPromosController(authAction,controllerComponents, stage, runtime),
     new SuperModeController(authAction, controllerComponents, stage, runtime, dynamoSuperModeService, athena),
+    new AnalyticsController(authAction, controllerComponents, stage, runtime, athena),
     assets
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -226,5 +226,8 @@ POST  /support-frontend/default-promos/update              controllers.DefaultPr
 GET   /frontend/super-mode                             controllers.SuperModeController.getSuperModeRows()
 GET   /frontend/epic-article-data                      controllers.SuperModeController.getArticleData()
 
+# ----- analytics ----- #
+GET   /frontend/analytics/:channel/:testName           controllers.AnalyticsController.getDataForVariants(channel: String, testName: String)
+
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)

--- a/public/src/components/channelManagement/AnalyticsButton.tsx
+++ b/public/src/components/channelManagement/AnalyticsButton.tsx
@@ -2,17 +2,20 @@ import { makeStyles } from '@mui/styles';
 import {Button, Dialog, Theme, Typography} from "@mui/material";
 import React, {useEffect} from 'react';
 import useOpenable from '../../hooks/useOpenable';
-import {addHours, formatISO9075, subHours} from "date-fns";
-import { LineChart, CartesianGrid, Line, XAxis, YAxis } from 'recharts';
+import { formatISO9075, subHours} from "date-fns";
+import {LineChart, CartesianGrid, Line, XAxis, YAxis, Legend} from 'recharts';
 import {Test} from "./helpers/shared";
 
 const useStyles = makeStyles(({}: Theme) => ({
   dialog: {
     padding: '10px',
   },
+  heading: {
+    margin: '12px',
+    fontSize: 16,
+  },
   variantName: {
-    marginBottom: '10px',
-    fontSize: 26,
+    fontSize: 18,
     fontWeight: 500,
   },
 }));
@@ -38,23 +41,23 @@ interface ChartProps {
   variantNames: string[];
 }
 
-type FlattenedGroupVariantViews = {
-  dateHour: string;
-} & { [variantName: string]: number };
+
+const Colours = ['red', 'blue', 'green', 'orange', 'yellow'];
 
 const Chart = ({ data, variantNames }: ChartProps) => {
   const flattenedData = data.map(({ dateHour, views }) => ({
     dateHour: dateHour,
     ...views,
   }));
-  console.log({ flattenedData })
+
   return (
-    <LineChart width={500} height={300} data={flattenedData}>
+    <LineChart width={800} height={500} data={flattenedData}>
       <XAxis dataKey="dateHour" />
       <YAxis />
       <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
-      {variantNames.map(name => (
-        <Line key={name} type="monotone" dataKey={name} stroke="#8884d8" />
+      <Legend />
+      {variantNames.map((name, idx) => (
+        <Line key={name} type="monotone" dataKey={name} stroke={Colours[idx]} />
       ))}
     </LineChart>
   );
@@ -88,8 +91,6 @@ export const AnalyticsButton: React.FC<AnalyticsButtonProps> = ({
       .then(setData);
   }, [testName, channel]);
 
-  console.log(data);
-
   return (
     <>
       <Button variant="outlined" onClick={open}>
@@ -97,9 +98,13 @@ export const AnalyticsButton: React.FC<AnalyticsButtonProps> = ({
       </Button>
 
       <Dialog open={isOpen} onClose={close} fullWidth maxWidth="xl" className={classes.dialog}>
-        <h1>{testName}</h1>
+        <div className={classes.heading}>
+          <h3 className={classes.variantName}>{testName}</h3>
+          <h3>Impressions per hour:</h3>
+        </div>
 
         {data && <Chart data={data} variantNames={variants.map(v => v.name)} />}
+        {!data && <Typography>Loading...</Typography>}
       </Dialog>
     </>
   );

--- a/public/src/components/channelManagement/AnalyticsButton.tsx
+++ b/public/src/components/channelManagement/AnalyticsButton.tsx
@@ -1,22 +1,30 @@
 import { makeStyles } from '@mui/styles';
-import {Button, Dialog, Theme, Typography} from "@mui/material";
-import React, {useEffect} from 'react';
+import {
+  Button,
+  Dialog,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Theme,
+  Typography,
+} from '@mui/material';
+import React, { useEffect } from 'react';
 import useOpenable from '../../hooks/useOpenable';
-import { formatISO9075, subHours} from "date-fns";
-import {LineChart, CartesianGrid, Line, XAxis, YAxis, Legend} from 'recharts';
-import {Test} from "./helpers/shared";
+import { formatISO9075, subDays, subHours } from 'date-fns';
+import { LineChart, CartesianGrid, Line, XAxis, YAxis, Legend } from 'recharts';
+import { Test } from './helpers/shared';
 
 const useStyles = makeStyles(({}: Theme) => ({
   dialog: {
     padding: '10px',
   },
   heading: {
-    margin: '12px',
-    fontSize: 16,
-  },
-  variantName: {
+    margin: '6px 12px 0 12px',
     fontSize: 18,
     fontWeight: 500,
+  },
+  chartContainer: {
+    margin: '12px',
   },
 }));
 
@@ -41,7 +49,6 @@ interface ChartProps {
   variantNames: string[];
 }
 
-
 const Colours = ['red', 'blue', 'green', 'orange', 'yellow'];
 
 const Chart = ({ data, variantNames }: ChartProps) => {
@@ -63,6 +70,18 @@ const Chart = ({ data, variantNames }: ChartProps) => {
   );
 };
 
+const buildTotals = (data: GroupedVariantViews[]): { [variantName: string]: number } => {
+  const totals: { [variantName: string]: number } = {};
+  data.forEach((viewsForHour: GroupedVariantViews) => {
+    Object.entries(viewsForHour.views).forEach(([variantName, count]) => {
+      totals[variantName] = (totals[variantName] || 0) + count;
+    });
+  });
+  return totals;
+};
+
+type Range = '24Hours' | 'week';
+
 interface AnalyticsButtonProps {
   test: Test;
   channel: Channel;
@@ -75,12 +94,15 @@ export const AnalyticsButton: React.FC<AnalyticsButtonProps> = ({
   const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
   const [data, setData] = React.useState<GroupedVariantViews[]>();
+  const [range, setRange] = React.useState<Range>('24Hours');
+  const [loading, setLoading] = React.useState<boolean>(false);
 
   const { name: testName, variants } = test;
 
   useEffect(() => {
+    setLoading(true);
     const now = new Date();
-    const from = subHours(now, 24);
+    const from = range === '24Hours' ? subHours(now, 24) : subDays(now, 7);
 
     fetch(
       `/frontend/analytics/${channel}/${testName}?from=${formatISO9075(from)}&to=${formatISO9075(
@@ -88,8 +110,11 @@ export const AnalyticsButton: React.FC<AnalyticsButtonProps> = ({
       )}`,
     )
       .then(resp => resp.json())
-      .then(setData);
-  }, [testName, channel]);
+      .then(data => {
+        setData(data);
+        setLoading(false);
+      });
+  }, [testName, channel, range]);
 
   return (
     <>
@@ -97,14 +122,38 @@ export const AnalyticsButton: React.FC<AnalyticsButtonProps> = ({
         Analytics
       </Button>
 
-      <Dialog open={isOpen} onClose={close} fullWidth maxWidth="xl" className={classes.dialog}>
+      <Dialog open={isOpen} onClose={close} fullWidth maxWidth="lg" className={classes.dialog}>
         <div className={classes.heading}>
-          <h3 className={classes.variantName}>{testName}</h3>
-          <h3>Impressions per hour:</h3>
+          <h3>Impressions for: {testName}</h3>
         </div>
 
-        {data && <Chart data={data} variantNames={variants.map(v => v.name)} />}
-        {!data && <Typography>Loading...</Typography>}
+        <div className={classes.chartContainer}>
+          <RadioGroup value={range} onChange={event => setRange(event.target.value as Range)}>
+            <FormControlLabel
+              value="24Hours"
+              key="24Hours"
+              control={<Radio />}
+              label="Last 24 hours"
+            />
+            <FormControlLabel value="week" key="week" control={<Radio />} label="Last week" />
+          </RadioGroup>
+          {loading && <Typography>Loading...</Typography>}
+          {data && (
+            <div>
+              <Chart data={data} variantNames={variants.map(v => v.name)} />
+              <div>
+                <h2>Total impressions:</h2>
+                {Object.entries(buildTotals(data)).map(([variantName, count]) => (
+                  <div key={variantName}>
+                    <Typography>
+                      {variantName}: {count}
+                    </Typography>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </Dialog>
     </>
   );

--- a/public/src/components/channelManagement/AnalyticsButton.tsx
+++ b/public/src/components/channelManagement/AnalyticsButton.tsx
@@ -1,0 +1,106 @@
+import { makeStyles } from '@mui/styles';
+import {Button, Dialog, Theme, Typography} from "@mui/material";
+import React, {useEffect} from 'react';
+import useOpenable from '../../hooks/useOpenable';
+import {addHours, formatISO9075, subHours} from "date-fns";
+import { LineChart, CartesianGrid, Line, XAxis, YAxis } from 'recharts';
+import {Test} from "./helpers/shared";
+
+const useStyles = makeStyles(({}: Theme) => ({
+  dialog: {
+    padding: '10px',
+  },
+  variantName: {
+    marginBottom: '10px',
+    fontSize: 26,
+    fontWeight: 500,
+  },
+}));
+
+type Channel =
+  | 'Epic'
+  | 'EpicAMP'
+  | 'EpicAppleNews'
+  | 'EpicLiveblog'
+  | 'Banner1'
+  | 'Banner2'
+  | 'Header';
+
+interface GroupedVariantViews {
+  dateHour: string;
+  views: {
+    [variantName: string]: number;
+  };
+}
+
+interface ChartProps {
+  data: GroupedVariantViews[];
+  variantNames: string[];
+}
+
+type FlattenedGroupVariantViews = {
+  dateHour: string;
+} & { [variantName: string]: number };
+
+const Chart = ({ data, variantNames }: ChartProps) => {
+  const flattenedData = data.map(({ dateHour, views }) => ({
+    dateHour: dateHour,
+    ...views,
+  }));
+  console.log({ flattenedData })
+  return (
+    <LineChart width={500} height={300} data={flattenedData}>
+      <XAxis dataKey="dateHour" />
+      <YAxis />
+      <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
+      {variantNames.map(name => (
+        <Line key={name} type="monotone" dataKey={name} stroke="#8884d8" />
+      ))}
+    </LineChart>
+  );
+};
+
+interface AnalyticsButtonProps {
+  test: Test;
+  channel: Channel;
+}
+
+export const AnalyticsButton: React.FC<AnalyticsButtonProps> = ({
+  test,
+  channel,
+}: AnalyticsButtonProps) => {
+  const classes = useStyles();
+  const [isOpen, open, close] = useOpenable();
+  const [data, setData] = React.useState<GroupedVariantViews[]>();
+
+  const { name: testName, variants } = test;
+
+  useEffect(() => {
+    const now = new Date();
+    const from = subHours(now, 24);
+
+    fetch(
+      `/frontend/analytics/${channel}/${testName}?from=${formatISO9075(from)}&to=${formatISO9075(
+        now,
+      )}`,
+    )
+      .then(resp => resp.json())
+      .then(setData);
+  }, [testName, channel]);
+
+  console.log(data);
+
+  return (
+    <>
+      <Button variant="outlined" onClick={open}>
+        Analytics
+      </Button>
+
+      <Dialog open={isOpen} onClose={close} fullWidth maxWidth="xl" className={classes.dialog}>
+        <h1>{testName}</h1>
+
+        {data && <Chart data={data} variantNames={variants.map(v => v.name)} />}
+      </Dialog>
+    </>
+  );
+};

--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -35,6 +35,7 @@ import { EpicTestPreviewButton } from './epicTestPreview';
 import { ValidatedTestEditor, ValidatedTestEditorProps } from '../validatedTestEditor';
 import { TestEditorProps } from '../testsForm';
 import { EpicBanditEditor } from './epicBanditEditor';
+import { AnalyticsButton } from '../AnalyticsButton';
 
 const BANDIT_FEATURE_SWITCH = false;
 
@@ -237,7 +238,10 @@ export const getEpicTestEditor = (
               <Typography variant={'h3'} className={classes.sectionHeader}>
                 Variants
               </Typography>
-              <EpicTestPreviewButton test={test} moduleName={epicEditorConfig.moduleName} />
+              <div className={classes.variantsHeaderButtonsContainer}>
+                <EpicTestPreviewButton test={test} moduleName={epicEditorConfig.moduleName} />
+                <AnalyticsButton test={test} channel={'Epic'} />
+              </div>
             </div>
             <div>
               <TestVariantsEditor<EpicVariant>

--- a/public/src/components/channelManagement/helpers/testEditorStyles.ts
+++ b/public/src/components/channelManagement/helpers/testEditorStyles.ts
@@ -32,4 +32,10 @@ export const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     paddingTop: spacing(4),
     paddingBottom: spacing(12),
   },
+  variantsHeaderButtonsContainer: {
+    display: 'flex',
+    '& > * + *': {
+      marginLeft: spacing(2),
+    },
+  },
 }));


### PR DESCRIPTION
Adds an "Analytics" button in the epic tool.
![Screenshot 2024-06-19 at 12 57 19](https://github.com/guardian/support-admin-console/assets/1513454/fff2c908-ff27-4f2c-877d-2d01c8ab886a)

It opens a model which makes a request to the backend for impressions data for the current epic test. The backend then queries athena.
A chart shows impressions over time per variant (uses the recharts library).
![Screenshot 2024-06-19 at 12 25 39](https://github.com/guardian/support-admin-console/assets/1513454/0282f53f-d240-4a28-9989-acfdc1fc3ee4)


Currently we only have impressions data for the epic in athena.