### PR TITLE
Switch on BANDIT_FEATURE_SWITCH

### DIFF
--- a/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestEditor.tsx
@@ -37,7 +37,7 @@ import { TestEditorProps } from '../testsForm';
 import { EpicBanditEditor } from './epicBanditEditor';
 import { AnalyticsButton } from '../AnalyticsButton';
 
-const BANDIT_FEATURE_SWITCH = false;
+const BANDIT_FEATURE_SWITCH = true;
 
 const copyHasTemplate = (test: EpicTest, template: string): boolean =>
   test.variants.some(


### PR DESCRIPTION
## What does this change?

This is to switch the BANDIT_FEATURE_SWITCH to true , so that Experiment Methodology becomes available to select the Multi-Multi-Armed Bandit option. which in turn sets isBanditTest boolean in DB 



## Images
<img width="1359" alt="image" src="https://github.com/guardian/support-admin-console/assets/73653255/7f9b6b69-95cd-472c-b8ef-08a9c8dff8ec">


##NOTE

This change should be merged only when we are ready to create the MAB epic tests and need to be switched off (changed back to false)once we are done with the tests.
