### PR TITLE
Newsletter sign up changes

### DIFF
--- a/app/models/NewsletterSignup.scala
+++ b/app/models/NewsletterSignup.scala
@@ -1,3 +1,3 @@
 package models
 
-case class NewsletterSignup(url: String)
+case class NewsletterSignup(newsletterId: String, successDescription: String)

--- a/public/src/components/channelManagement/epicTests/epicNewsletterSignUp.tsx
+++ b/public/src/components/channelManagement/epicTests/epicNewsletterSignUp.tsx
@@ -5,8 +5,8 @@ import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { useForm } from 'react-hook-form';
 
 interface FormData {
-  url: string;
-}
+  newsletterId: string;
+  successDescription: string;}
 
 interface EpicTestNewsletterProps {
   newsletterSignup: NewsletterSignup;
@@ -22,37 +22,55 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
   isDisabled,
 }: EpicTestNewsletterProps) => {
   const defaultValues: FormData = {
-    url: newsletterSignup.url,
+    newsletterId: newsletterSignup.newsletterId,
+    successDescription: newsletterSignup.successDescription,
   };
-  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+  const {register, handleSubmit, errors} = useForm<FormData>({mode: 'onChange', defaultValues});
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.url]);
+  }, [errors.newsletterId, errors.successDescription]);
 
-  const onSubmit = ({ url }: FormData): void => {
-    updateNewsletterSignup({ url });
+  const onSubmit = ({newsletterId, successDescription}: FormData): void => {
+    updateNewsletterSignup({newsletterId, successDescription});
   };
 
   return (
-    <div>
-      <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
-        error={errors.url !== undefined}
-        helperText={errors.url?.message}
-        onBlur={handleSubmit(onSubmit)}
-        name="url"
-        label="Newsletter URL"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth
-      />
-    </div>
-  );
+    <>
+      <div>
+        <TextField
+          inputRef={register({
+            required: EMPTY_ERROR_HELPER_TEXT,
+          })}
+          error={errors.newsletterId !== undefined}
+          helperText={errors.newsletterId?.message}
+          onBlur={handleSubmit(onSubmit)}
+          name="newsletterId"
+          label="Newsletter Id"
+          margin="normal"
+          variant="outlined"
+          disabled={isDisabled}
+          fullWidth/>
+      </div>
+      <div>
+        <TextField
+          inputRef={register({
+            required: EMPTY_ERROR_HELPER_TEXT,
+          })}
+          error={errors.successDescription !== undefined}
+          helperText={errors.successDescription?.message}
+          onBlur={handleSubmit(onSubmit)}
+          name="signUpSuccessMessage"
+          label="Sign up success message"
+          margin="normal"
+          variant="outlined"
+          disabled={isDisabled}
+          fullWidth/>
+      </div>
+    </>
+)
+  ;
 };
 
 export default EpicTestNewsletter;

--- a/public/src/components/channelManagement/epicTests/epicNewsletterSignUp.tsx
+++ b/public/src/components/channelManagement/epicTests/epicNewsletterSignUp.tsx
@@ -6,7 +6,8 @@ import { useForm } from 'react-hook-form';
 
 interface FormData {
   newsletterId: string;
-  successDescription: string;}
+  successDescription: string;
+}
 
 interface EpicTestNewsletterProps {
   newsletterSignup: NewsletterSignup;
@@ -25,15 +26,15 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
     newsletterId: newsletterSignup.newsletterId,
     successDescription: newsletterSignup.successDescription,
   };
-  const {register, handleSubmit, errors} = useForm<FormData>({mode: 'onChange', defaultValues});
+  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
   }, [errors.newsletterId, errors.successDescription]);
 
-  const onSubmit = ({newsletterId, successDescription}: FormData): void => {
-    updateNewsletterSignup({newsletterId, successDescription});
+  const onSubmit = ({ newsletterId, successDescription }: FormData): void => {
+    updateNewsletterSignup({ newsletterId, successDescription });
   };
 
   return (
@@ -51,7 +52,8 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
           margin="normal"
           variant="outlined"
           disabled={isDisabled}
-          fullWidth/>
+          fullWidth
+        />
       </div>
       <div>
         <TextField
@@ -66,11 +68,11 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
           margin="normal"
           variant="outlined"
           disabled={isDisabled}
-          fullWidth/>
+          fullWidth
+        />
       </div>
     </>
-)
-  ;
+  );
 };
 
 export default EpicTestNewsletter;

--- a/public/src/components/channelManagement/epicTests/epicNewsletterSignUp.tsx
+++ b/public/src/components/channelManagement/epicTests/epicNewsletterSignUp.tsx
@@ -63,7 +63,7 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
           error={errors.successDescription !== undefined}
           helperText={errors.successDescription?.message}
           onBlur={handleSubmit(onSubmit)}
-          name="signUpSuccessMessage"
+          name="successDescription"
           label="Sign up success message"
           margin="normal"
           variant="outlined"

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -173,7 +173,10 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   const onCtasToggleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const value = event.target.value;
     if (value === 'newsletterSignup') {
-      onVariantChange({ ...variant, newsletterSignup: { newsletterId: '', successDescription: '' } });
+      onVariantChange({
+        ...variant,
+        newsletterSignup: { newsletterId: '', successDescription: '' },
+      });
     } else {
       onVariantChange({ ...variant, newsletterSignup: undefined });
     }

--- a/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/epicTestVariantEditor.tsx
@@ -173,7 +173,7 @@ const EpicTestVariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   const onCtasToggleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const value = event.target.value;
     if (value === 'newsletterSignup') {
-      onVariantChange({ ...variant, newsletterSignup: { url: '' } });
+      onVariantChange({ ...variant, newsletterSignup: { newsletterId: '', successDescription: '' } });
     } else {
       onVariantChange({ ...variant, newsletterSignup: undefined });
     }

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -185,7 +185,8 @@ export interface TestStatus {
 }
 
 export interface NewsletterSignup {
-  url: string;
+  newsletterId: string;
+  successDescription: string;
 }
 
 export interface Cta {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are going to use the newer newsletter sign up component meaning that there is a need to change what we pass through to SDC/DCR. There are two fields on the newer component which are:
- newsletterId 
- successDescripton after the user has inputted their email

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1104" alt="image" src="https://github.com/guardian/support-admin-console/assets/115992455/75e23f06-0552-4cde-9eb7-817567856514">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
