### PR TITLE
Fix athena errors

### DIFF
--- a/app/services/Athena.scala
+++ b/app/services/Athena.scala
@@ -203,7 +203,7 @@ class Athena() extends StrictLogging {
           .flatMap(row => {
             val data = ArticleEpicData(row)
             if (data.isEmpty) {
-              logger.error(s"Failed to parse row from athena: $row")
+              logger.info(s"Failed to parse row from athena: $row")
             }
             data
           })
@@ -221,7 +221,7 @@ class Athena() extends StrictLogging {
           .flatMap(row => {
             val variantViews = VariantViews.parse(row)
             if (variantViews.isEmpty) {
-              logger.error(s"Failed to parse row from athena: $variantViews")
+              logger.info(s"Failed to parse row from athena: $row")
             }
             variantViews
           })

--- a/app/services/Athena.scala
+++ b/app/services/Athena.scala
@@ -187,6 +187,7 @@ class Athena() extends StrictLogging {
           .resultSet()
           .rows()
           .asScala.toList
+          .drop(1)  // first row is always the column names, so we discard this
           .map(row => {
             val values = row.data().asScala.toList.map(d => d.varCharValue())
             columnNames.zip(values).toMap // Map columnNames to values
@@ -203,7 +204,7 @@ class Athena() extends StrictLogging {
           .flatMap(row => {
             val data = ArticleEpicData(row)
             if (data.isEmpty) {
-              logger.info(s"Failed to parse row from athena: $row")
+              logger.error(s"Failed to parse row from athena: $row")
             }
             data
           })
@@ -221,7 +222,7 @@ class Athena() extends StrictLogging {
           .flatMap(row => {
             val variantViews = VariantViews.parse(row)
             if (variantViews.isEmpty) {
-              logger.info(s"Failed to parse row from athena: $row")
+              logger.error(s"Failed to parse row from athena: $row")
             }
             variantViews
           })


### PR DESCRIPTION
We're seeing this error and it's triggering an alarm:
`Failed to parse row from athena: None.`
This happens because the first row in the result is always the column names -
`Map(date_hour -> date_hour, variant -> variant, views -> views)`

So we can just drop the first row