### PR TITLE
Remove default separateArticleCount on banners

### DIFF
--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -24,7 +24,6 @@ const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
     cta: DEFAULT_PRIMARY_CTA,
   },
-  separateArticleCount: true,
 };
 
 const PROD_DEFAULT_VARIANT: BannerVariant = {
@@ -35,7 +34,6 @@ const PROD_DEFAULT_VARIANT: BannerVariant = {
     highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
     cta: DEFAULT_PRIMARY_CTA,
   },
-  separateArticleCount: true,
 };
 
 export const getDefaultVariant = (): BannerVariant => {


### PR DESCRIPTION
We [recently changed banners](https://github.com/guardian/support-admin-console/pull/600/files#diff-7d9f5a15b5c7aca35bcce52adaef2ab0a6ac61652adafa4bbfdf6fe7e57f4174R47) to support a richer model for the "separate article count" feature, so that we can configure copy.

For backwards compatibility, the old boolean field was left in.

Currently the default banner config (used when creating a new variant) sets this legacy field to `true`.
This is a problem because the banner component still uses the legacy field as well as the new one. This PR removes it from the default config.

Note - we should still do the full cleanup and remove this old field everywhere, later.