### PR TITLE
Mini directory refractor - Banner Deploy

### DIFF
--- a/public/src/components/channelManagement/bannerDeploy/bannerChannelDeployer.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerChannelDeployer.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Button, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { BannerChannel } from './bannerDeployDashboard';
-import BannerChannelDeployerTable from './bannerDeployChannelDeployerTable';
+import BannerChannelDeployerTable from './bannerChannelDeployerTable';
 
 import {
   fetchFrontendSettings,
@@ -47,13 +47,13 @@ interface DataFromServer {
   email: string;
 }
 
-interface BannerDeployChannelDeployerProps {
+interface BannerChannelDeployerProps {
   channel: BannerChannel;
 }
 
-const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = ({
+const BannerChannelDeployer: React.FC<BannerChannelDeployerProps> = ({
   channel,
-}: BannerDeployChannelDeployerProps) => {
+}: BannerChannelDeployerProps) => {
   const classes = useStyles();
 
   const isChannel1 = channel === 'CHANNEL1';
@@ -150,4 +150,4 @@ const BannerDeployChannelDeployer: React.FC<BannerDeployChannelDeployerProps> = 
   );
 };
 
-export default BannerDeployChannelDeployer;
+export default BannerChannelDeployer;

--- a/public/src/components/channelManagement/bannerDeploy/bannerChannelDeployerTable.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerChannelDeployerTable.tsx
@@ -15,8 +15,8 @@ import {
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { BannerChannel } from './bannerDeployDashboard';
-import { BannerDeploys, BannersToRedeploy } from './bannerDeployChannelDeployer';
-import BannerDeployChannelDeployerTableRow from './bannerDeployChannelDeployerTableRow';
+import { BannerDeploys, BannersToRedeploy } from './bannerChannelDeployer';
+import BannerChannelDeployerTableRow from './bannerChannelDeployerTableRow';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   schedule: {
@@ -24,7 +24,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
 }));
 
-interface BannerDeployChannelDeployerTableProps {
+interface BannerChannelDeployerTableProps {
   channel: BannerChannel;
   bannerDeploys?: BannerDeploys;
   bannersToRedeploy: BannersToRedeploy;
@@ -32,13 +32,13 @@ interface BannerDeployChannelDeployerTableProps {
   onRedeployClick: (region: string, shouldRedeploy: boolean) => void;
 }
 
-const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTableProps> = ({
+const BannerChannelDeployerTable: React.FC<BannerChannelDeployerTableProps> = ({
   channel,
   bannerDeploys,
   bannersToRedeploy,
   onRedeployAllClick,
   onRedeployClick,
-}: BannerDeployChannelDeployerTableProps) => {
+}: BannerChannelDeployerTableProps) => {
   const classes = useStyles();
 
   const isChannel1 = channel === 'CHANNEL1';
@@ -87,7 +87,7 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
         <TableBody>
           {bannerDeploys &&
             Object.keys(bannerDeploys).map(region => (
-              <BannerDeployChannelDeployerTableRow
+              <BannerChannelDeployerTableRow
                 key={region}
                 region={region}
                 timestamp={bannerDeploys[region as keyof BannerDeploys].timestamp}
@@ -104,4 +104,4 @@ const BannerDeployChannelDeployerTable: React.FC<BannerDeployChannelDeployerTabl
   );
 };
 
-export default BannerDeployChannelDeployerTable;
+export default BannerChannelDeployerTable;

--- a/public/src/components/channelManagement/bannerDeploy/bannerChannelDeployerTableRow.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerChannelDeployerTableRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Checkbox, TableRow, TableCell } from '@mui/material';
 
-type BannerDeployChannelDeployerTableRowProps = {
+type BannerChannelDeployerTableRowProps = {
   region: string;
   timestamp: number;
   email: string;
@@ -59,13 +59,13 @@ const prettifiedUser = (email: string): string => {
     : email;
 };
 
-const BannerDeployChannelDeployerTableRow: React.FC<BannerDeployChannelDeployerTableRowProps> = ({
+const BannerChannelDeployerTableRow: React.FC<BannerChannelDeployerTableRowProps> = ({
   region,
   timestamp,
   email,
   shouldRedeploy,
   onRedeployClick,
-}: BannerDeployChannelDeployerTableRowProps) => {
+}: BannerChannelDeployerTableRowProps) => {
   return (
     <TableRow key={region}>
       <TableCell padding="checkbox">
@@ -81,4 +81,4 @@ const BannerDeployChannelDeployerTableRow: React.FC<BannerDeployChannelDeployerT
   );
 };
 
-export default BannerDeployChannelDeployerTableRow;
+export default BannerChannelDeployerTableRow;

--- a/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
+++ b/public/src/components/channelManagement/bannerDeploy/bannerDeployDashboard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
-import BannerDeployeChannelDeployer from './bannerDeployChannelDeployer';
+import BannerChannelDeployer from './bannerChannelDeployer';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ spacing }: Theme) => ({
@@ -30,10 +30,10 @@ const BannerDeployDashboard: React.FC = () => {
     <div className={classes.scrollableContainer}>
       <div className={classes.container}>
         <div className={classes.tableContainer}>
-          <BannerDeployeChannelDeployer channel="CHANNEL1" />
+          <BannerChannelDeployer channel="CHANNEL1" />
         </div>
         <div className={classes.tableContainer}>
-          <BannerDeployeChannelDeployer channel="CHANNEL2" />
+          <BannerChannelDeployer channel="CHANNEL2" />
         </div>
       </div>
     </div>


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The naming of some files has got a bit difficult to read. This PR renames the files under the banner deploy directory to make them shorter and easier to understand. There is no actual code/functionality change within this PR.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Check banner deploy still works as expected
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
