### PR TITLE
Mini directory refractor - Banner Tests

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -9,7 +9,7 @@ import {
 } from '../helpers/shared';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
 import { Typography } from '@mui/material';
-import BannerTestVariantEditor from './bannerTestVariantEditor';
+import VariantEditor from './variantEditor';
 import CampaignSelector from '../CampaignSelector';
 import TestVariantsEditor from '../testVariantsEditor';
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
@@ -148,7 +148,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   };
 
   const renderVariantEditor = (variant: BannerVariant): React.ReactElement => (
-    <BannerTestVariantEditor
+    <VariantEditor
       key={`banner-${test.name}-${variant.name}`}
       variant={variant}
       onVariantChange={onVariantChange}

--- a/public/src/components/channelManagement/bannerTests/newVariantButton.tsx
+++ b/public/src/components/channelManagement/bannerTests/newVariantButton.tsx
@@ -72,7 +72,7 @@ interface BannerTestNewVariantButtonProps {
   isDisabled: boolean;
 }
 
-const BannerTestNewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
+const NewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
   existingNames,
   createVariant,
   isDisabled,
@@ -139,4 +139,4 @@ const BannerTestNewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
   );
 };
 
-export default BannerTestNewVariantButton;
+export default NewVariantButton;

--- a/public/src/components/channelManagement/bannerTests/variantCtasEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantCtasEditor.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import VariantEditorCtaEditor from '../variantEditorCtaEditor';
-import VariantEditorSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
+import VariantCtaEditor from '../variantEditorCtaEditor';
+import VariantSecondaryCtaEditor from '../variantEditorSecondaryCtaEditor';
 import { Cta, SecondaryCta } from '../helpers/shared';
 import { DEFAULT_PRIMARY_CTA, DEFAULT_SECONDARY_CTA } from './utils/defaults';
 
@@ -14,7 +14,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
 }));
 
-interface BannerTestVariantEditorCtasEditorProps {
+interface VariantCtasEditorProps {
   primaryCta?: Cta;
   secondaryCta?: SecondaryCta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
@@ -24,7 +24,7 @@ interface BannerTestVariantEditorCtasEditorProps {
   supportSecondaryCta: boolean;
 }
 
-const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEditorProps> = ({
+const VariantCtasEditor: React.FC<VariantCtasEditorProps> = ({
   primaryCta,
   secondaryCta,
   updatePrimaryCta,
@@ -32,12 +32,12 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
   onValidationChange,
   isDisabled,
   supportSecondaryCta,
-}: BannerTestVariantEditorCtasEditorProps) => {
+}: VariantCtasEditorProps) => {
   const classes = useStyles();
 
   return (
     <div className={classes.container}>
-      <VariantEditorCtaEditor
+      <VariantCtaEditor
         label="Primary button"
         isDisabled={isDisabled}
         cta={primaryCta}
@@ -47,7 +47,7 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
       />
 
       {supportSecondaryCta && (
-        <VariantEditorSecondaryCtaEditor
+        <VariantSecondaryCtaEditor
           label="Secondary button"
           isDisabled={isDisabled}
           cta={secondaryCta}
@@ -61,4 +61,4 @@ const BannerTestVariantEditorCtasEditor: React.FC<BannerTestVariantEditorCtasEdi
   );
 };
 
-export default BannerTestVariantEditorCtasEditor;
+export default VariantCtasEditor;

--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { FormControlLabel, Radio, RadioGroup, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import BannerTestVariantEditorCtasEditor from './bannerTestVariantEditorCtasEditor';
+import VariantCtasEditor from './variantCtasEditor';
 import {
   EMPTY_ERROR_HELPER_TEXT,
   getEmptyParagraphsError,
@@ -91,7 +91,7 @@ const getLabelSuffix = (deviceType: DeviceType): string => {
   }
 };
 
-interface BannerTestVariantContentEditorProps {
+interface VariantContentEditorProps {
   content: BannerContent;
   template: BannerUi;
   onChange: (updatedContent: BannerContent) => void;
@@ -121,13 +121,13 @@ const getParagraphsOrMessageText = (
   return bodyCopy;
 };
 
-const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorProps> = ({
+const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
   content,
   onChange,
   onValidationChange,
   editMode,
   deviceType,
-}: BannerTestVariantContentEditorProps) => {
+}: VariantContentEditorProps) => {
   const classes = useStyles();
 
   const templateValidator = templateValidatorForPlatform('DOTCOM');
@@ -314,7 +314,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
             {`Buttons${labelSuffix}`}
           </Typography>
 
-          <BannerTestVariantEditorCtasEditor
+          <VariantCtasEditor
             primaryCta={content.cta}
             secondaryCta={content.secondaryCta}
             updatePrimaryCta={updatePrimaryCta}
@@ -329,7 +329,7 @@ const BannerTestVariantContentEditor: React.FC<BannerTestVariantContentEditorPro
   );
 };
 
-interface BannerTestVariantEditorProps {
+interface VariantEditorProps {
   variant: BannerVariant;
   onVariantChange: (updatedVariant: BannerVariant) => void;
   editMode: boolean;
@@ -338,13 +338,13 @@ interface BannerTestVariantEditorProps {
   designs: BannerDesign[];
 }
 
-const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
+const VariantEditor: React.FC<VariantEditorProps> = ({
   variant,
   editMode,
   onValidationChange,
   onVariantChange,
   designs,
-}: BannerTestVariantEditorProps) => {
+}: VariantEditorProps) => {
   const classes = useStyles();
   const setValidationStatusForField = useValidation(onValidationChange);
 
@@ -393,7 +393,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
       </div>
 
       <div className={classes.sectionContainer}>
-        <BannerTestVariantContentEditor
+        <VariantContentEditor
           content={variant.bannerContent}
           template={variant.template}
           onChange={(updatedContent: BannerContent): void =>
@@ -426,7 +426,7 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
           />
         </RadioGroup>
         {variant.mobileBannerContent && (
-          <BannerTestVariantContentEditor
+          <VariantContentEditor
             content={variant.mobileBannerContent}
             template={variant.template}
             onChange={(updatedContent: BannerContent): void =>
@@ -473,4 +473,4 @@ const BannerTestVariantEditor: React.FC<BannerTestVariantEditorProps> = ({
   );
 };
 
-export default BannerTestVariantEditor;
+export default VariantEditor;


### PR DESCRIPTION
## What does this change?
The naming of some files has got a bit difficult to read. 

This PR renames the files under the banner tests directory to make them shorter and easier to understand. There is no actual code/functionality change within this PR.

## How to test
Check banner tests and variants still works as expected
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
