### PR TITLE
Block unknown http methods

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -144,6 +144,38 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SSM::Parameter",
     },
+    "AllowKnownMethods07D772B3": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupAdminconsole160A1621",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "http-request-method",
+            "HttpRequestMethodConfig": {
+              "Values": [
+                "GET",
+                "PATCH",
+                "POST",
+                "PUT",
+                "DELETE",
+                "HEAD",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerAdminconsole3E633904",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "ArchivedBannerDesignsDynamoTable": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -383,6 +415,35 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
+    },
+    "BlockUnknownMethods281EDB58": {
+      "Properties": {
+        "Actions": [
+          {
+            "FixedResponseConfig": {
+              "ContentType": "application/json",
+              "MessageBody": "Unsupported http method",
+              "StatusCode": "400",
+            },
+            "Type": "fixed-response",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerAdminconsole3E633904",
+        },
+        "Priority": 2,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "CampaignsDynamoTable": {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -160,7 +160,6 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
             "HttpRequestMethodConfig": {
               "Values": [
                 "GET",
-                "PATCH",
                 "POST",
                 "PUT",
                 "DELETE",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -305,7 +305,7 @@ export class AdminConsole extends GuStack {
     new ApplicationListenerRule(this, 'AllowKnownMethods', {
       listener: ec2App.listener,
       priority: 1,
-      conditions: [ListenerCondition.httpRequestMethods(['GET', 'PATCH', 'POST', 'PUT', 'DELETE', 'HEAD'])],
+      conditions: [ListenerCondition.httpRequestMethods(['GET', 'POST', 'PUT', 'DELETE', 'HEAD'])],
       targetGroups: [ec2App.targetGroup],
     });
     // Default rule to block requests which don't match the above rule


### PR DESCRIPTION
Bots regularly hit the loadbalancer probing for vulnerabilities. Most result in a 4XX from the server.
But Play handles unknown http methods by returning a 501. This is a problem because it triggers our 5XX alarm. We don't want to change the threshold for that alarm as in general we _do_ want to know when the server returns errors.

E.g. from the logs:
`Illegal request, responding with status '501 Not Implemented': Unsupported HTTP method: IOLFJZ`

This PR adds a loadbalancer target rule to only route requests with supported http methods to the server. Anything else will receive a 400.

With invalid methods we now get a 400, not 501:
<img width="550" alt="Screenshot 2024-07-19 at 13 01 15" src="https://github.com/user-attachments/assets/699438e2-5c5f-4dda-91f5-35f83bff5d34">

Valid methods still go through to the server:
<img width="465" alt="Screenshot 2024-07-19 at 13 02 54" src="https://github.com/user-attachments/assets/852d35f5-81e7-43ce-8503-1811537735c2">
