### PR TITLE
Override jackson-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ libraryDependencies ++= Seq(
 )
 
 dependencyOverrides ++= List(
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2",
   // The version of netty-handler currently used by athena has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-handler" % "4.1.100.Final",
   "io.netty" % "netty-codec-http2" % "4.1.100.Final"

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ libraryDependencies ++= Seq(
 )
 
 dependencyOverrides ++= List(
+  // Play still uses an old version of jackson-core which has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
   "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2",
   // The version of netty-handler currently used by athena has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-handler" % "4.1.100.Final",


### PR DESCRIPTION
Snyk has flagged the current version of jackson-core as a high vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
This comes via Play:
![Screenshot 2024-08-08 at 13 51 33](https://github.com/user-attachments/assets/e19ca28e-f06e-4abf-9e92-899b5296d10e)


Although there are newer versions of jackson without that vulnerability, the latest version of Play still uses the old version of jackson. (There is [a PR](https://github.com/playframework/playframework/pull/12440) but things move slowly.)
So for now we have to override the jackson-core version, until Play is updated.

Tested in CODE