### PR TITLE
Remove image url restriction from banner design tool

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -4,11 +4,6 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { BannerDesignHeaderImage } from '../../../models/bannerDesign';
 
-const imageUrlValidation = {
-  value: /^https:\/\/i\.guim\.co\.uk\//,
-  message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
-};
-
 export const DEFAULT_HEADER_IMAGE_SETTINGS: BannerDesignHeaderImage = {
   mobileUrl: '',
   tabletUrl: '',
@@ -98,7 +93,6 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
             })}
             error={errors?.mobileUrl !== undefined}
             helperText={errors?.mobileUrl?.message}
@@ -113,7 +107,6 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
             })}
             error={errors?.tabletUrl !== undefined}
             helperText={errors?.tabletUrl?.message}
@@ -128,7 +121,6 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             inputRef={register({
               required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: imageUrlValidation,
             })}
             error={errors?.desktopUrl !== undefined}
             helperText={errors?.desktopUrl?.message}

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -4,11 +4,6 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { BannerDesignImage } from '../../../models/bannerDesign';
 
-const imageUrlValidation = {
-  value: /^https:\/\/i\.guim\.co\.uk\//,
-  message: 'Images must be valid URLs hosted on https://i.guim.co.uk/',
-};
-
 interface Props {
   image: BannerDesignImage;
   isDisabled: boolean;
@@ -44,7 +39,6 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         inputRef={register({
           required: EMPTY_ERROR_HELPER_TEXT,
-          pattern: imageUrlValidation,
         })}
         error={errors?.mobileUrl !== undefined}
         helperText={errors?.mobileUrl?.message}
@@ -59,7 +53,6 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         inputRef={register({
           required: EMPTY_ERROR_HELPER_TEXT,
-          pattern: imageUrlValidation,
         })}
         error={errors?.tabletUrl !== undefined}
         helperText={errors?.tabletUrl?.message}
@@ -74,7 +67,6 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         inputRef={register({
           required: EMPTY_ERROR_HELPER_TEXT,
-          pattern: imageUrlValidation,
         })}
         error={errors?.desktopUrl !== undefined}
         helperText={errors?.desktopUrl?.message}


### PR DESCRIPTION
We're planning on hosting svgs outside of the Grid, so this validation no longer applies