### PR TITLE
Tooltip on banner design archive button

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/StickyTopBar.tsx
@@ -8,6 +8,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
+  Tooltip,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import EditIcon from '@mui/icons-material/Edit';
@@ -104,39 +105,44 @@ const StickyTopBar: React.FC<Props> = ({
     const [isOpen, open, close] = useOpenable();
 
     return (
-      <>
-        <Button
-          variant="outlined"
-          startIcon={<ArchiveIcon style={{ color: grey[700] }} />}
-          size="medium"
-          onClick={open}
-        >
-          {/* eslint-disable-next-line react/prop-types */}
-          <Typography className={classes.buttonText}>Archive banner design</Typography>
-        </Button>
-        <Dialog
-          open={isOpen}
-          onClose={close}
-          aria-labelledby="archive-dialog-title"
-          aria-describedby="archive-dialog-description"
-        >
-          <DialogTitle id="archive-dialog-title">Are you sure?</DialogTitle>
-          <DialogContent>
-            <DialogContentText id="archive-dialog-description">
-              Archiving this design will remove it from the banner design tool - you can only
-              restore with an engineer&apos;s help.
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button color="primary" onClick={close}>
-              Cancel
-            </Button>
-            <Button color="primary" onClick={() => onArchive(name)}>
-              Archive design
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </>
+      <Tooltip
+        title={design.status !== 'Draft' ? 'Design must be in draft status before archiving' : ''}
+      >
+        <span>
+          <Button
+            variant="outlined"
+            startIcon={<ArchiveIcon style={{ color: grey[700] }} />}
+            size="medium"
+            onClick={open}
+            disabled={design.status !== 'Draft'}
+          >
+            {/* eslint-disable-next-line react/prop-types */}
+            <Typography className={classes.buttonText}>Archive banner design</Typography>
+          </Button>
+          <Dialog
+            open={isOpen}
+            onClose={close}
+            aria-labelledby="archive-dialog-title"
+            aria-describedby="archive-dialog-description"
+          >
+            <DialogTitle id="archive-dialog-title">Are you sure?</DialogTitle>
+            <DialogContent>
+              <DialogContentText id="archive-dialog-description">
+                Archiving this design will remove it from the banner design tool - you can only
+                restore with an engineer&apos;s help.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button color="primary" onClick={close}>
+                Cancel
+              </Button>
+              <Button color="primary" onClick={() => onArchive(name)}>
+                Archive design
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </span>
+      </Tooltip>
     );
   };
 
@@ -184,7 +190,7 @@ const StickyTopBar: React.FC<Props> = ({
           )}
           {userHasLock && (
             <>
-              {design.status === 'Draft' && <ArchiveButton />}
+              <ArchiveButton />
               <Button
                 variant="outlined"
                 size="medium"


### PR DESCRIPTION
You have to set a banner design to "draft" before you can archive it. Currently this isn't clear in the tool - it just hides the archive button.
This PR changes the tool to always show the archive button, and if the design is live then the button is disabled and a tooltip explains why.

Design is live:
![Screenshot 2024-10-07 at 09 07 02](https://github.com/user-attachments/assets/6426902a-fda6-4063-bfb5-18a8f3c1acde)

Design is in draft:
![Screenshot 2024-10-07 at 09 07 16](https://github.com/user-attachments/assets/5ba48f7a-5935-431f-a78d-d55b5946e038)
