### PR TITLE
Enable ticker on liveblog epic

### DIFF
--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -108,7 +108,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowVariantSecondaryCta: true,
   allowVariantCustomSecondaryCta: true,
   allowVariantSeparateArticleCount: false,
-  allowVariantTicker: false,
+  allowVariantTicker: true,
   allowVariantChoiceCards: true,
   allowVariantSignInLink: false,
   allowBylineWithImage: false,


### PR DESCRIPTION
the liveblog epic component now supports the ticker - https://github.com/guardian/dotcom-rendering/pull/12522
![Screenshot 2024-10-10 at 08 57 18](https://github.com/user-attachments/assets/c77632a5-12f2-4756-a359-3291ec17bbe3)

