### PR TITLE
Banner test deploySchedule

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -26,6 +26,8 @@ case class BannerVariant(
     tickerSettings: Option[TickerSettings] = None,
 )
 
+case class BannerTestDeploySchedule(daysBetween: Int)
+
 case class BannerTest(
     name: String,
     channel: Option[Channel],
@@ -44,6 +46,7 @@ case class BannerTest(
     signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
     isBanditTest: Option[Boolean] = None,
     consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
+    deploySchedule: Option[BannerTestDeploySchedule] = None,
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest =

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -323,7 +323,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
 
         <div className={classes.sectionContainer}>
           <Typography variant={'h3'} className={classes.sectionHeader}>
-            Deploy schedule
+            Deploy schedule override
           </Typography>
 
           <DeployScheduleEditor

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -16,7 +16,12 @@ import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelecto
 import TestEditorArticleCountEditor, {
   DEFAULT_ARTICLES_VIEWED_SETTINGS,
 } from '../testEditorArticleCountEditor';
-import { BannerContent, BannerTest, BannerVariant } from '../../../models/banner';
+import {
+  BannerContent,
+  BannerTest,
+  BannerTestDeploySchedule,
+  BannerVariant,
+} from '../../../models/banner';
 import { getDefaultVariant } from './utils/defaults';
 import VariantSummary from '../../tests/variants/variantSummary';
 import BannerVariantPreview from './bannerVariantPreview';
@@ -33,6 +38,7 @@ import {
 import TestEditorContextTargeting from '../testEditorContextTargeting';
 import { getDesignForVariant } from '../../../utils/bannerDesigns';
 import { BanditEditor } from '../banditEditor';
+import { DeployScheduleEditor } from './deployScheduleEditor';
 
 const copyHasTemplate = (content: BannerContent, template: string): boolean =>
   (content.heading && content.heading.includes(template)) ||
@@ -149,6 +155,13 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
     updateTest({
       ...test,
       articlesViewedSettings: updatedArticlesViewedSettings,
+    });
+  };
+
+  const onDeployScheduleChange = (updatedDeploySchedule?: BannerTestDeploySchedule): void => {
+    updateTest({
+      ...test,
+      deploySchedule: updatedDeploySchedule,
     });
   };
 
@@ -304,6 +317,19 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             articlesViewedSettings={test.articlesViewedSettings}
             onArticlesViewedSettingsChanged={onArticlesViewedSettingsChange}
             onValidationChange={onArticlesViewedSettingsValidationChanged}
+            isDisabled={!userHasTestLocked}
+          />
+        </div>
+
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Deploy schedule
+          </Typography>
+
+          <DeployScheduleEditor
+            deploySchedule={test.deploySchedule}
+            onDeployScheduleChange={onDeployScheduleChange}
+            onValidationChange={isValid => setValidationStatusForField('deploySchedule', isValid)}
             isDisabled={!userHasTestLocked}
           />
         </div>

--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -83,7 +83,7 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
             helperText={errors.daysBetween?.message || 'Must be a number'}
             onBlur={handleSubmit(onSubmit)}
             name="daysBetween"
-            label="CONTROL"
+            label="Days between deploys"
             InputLabelProps={{ shrink: true }}
             variant="outlined"
             fullWidth

--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from 'react';
+import { makeStyles } from '@mui/styles';
+import { FormControl, FormControlLabel, Radio, RadioGroup, TextField, Theme } from '@mui/material';
+import { BannerTestDeploySchedule } from '../../../models/banner';
+import { useForm } from 'react-hook-form';
+import { EMPTY_ERROR_HELPER_TEXT, notNumberValidator } from '../helpers/validation';
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(3),
+    },
+  },
+}));
+
+interface DeployScheduleEditorProps {
+  deploySchedule?: BannerTestDeploySchedule;
+  onDeployScheduleChange: (deploySchedule?: BannerTestDeploySchedule) => void;
+  onValidationChange: (isValid: boolean) => void;
+  isDisabled: boolean;
+}
+
+const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
+  deploySchedule,
+  onDeployScheduleChange,
+  onValidationChange,
+  isDisabled,
+}: DeployScheduleEditorProps) => {
+  const classes = useStyles();
+
+  const defaultValues: BannerTestDeploySchedule = {
+    daysBetween: 1,
+  };
+  const { register, errors, handleSubmit } = useForm<BannerTestDeploySchedule>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0 || !deploySchedule;
+    onValidationChange(isValid);
+  }, [errors.daysBetween]);
+
+  const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.value === 'enabled') {
+      onDeployScheduleChange(defaultValues);
+    } else {
+      onDeployScheduleChange(undefined);
+    }
+  };
+
+  const onSubmit = (data: BannerTestDeploySchedule): void => {
+    onDeployScheduleChange(data);
+  };
+
+  return (
+    <FormControl>
+      <div className={classes.container}>
+        <RadioGroup value={deploySchedule ? 'enabled' : 'disabled'} onChange={onRadioGroupChange}>
+          <FormControlLabel
+            value="disabled"
+            key="disabled"
+            control={<Radio />}
+            label="Disabled - use channel deploy schedule"
+            disabled={isDisabled}
+          />
+          <FormControlLabel
+            value="enabled"
+            key="enabled"
+            control={<Radio />}
+            label="Enabled - override channel deploy schedule"
+            disabled={isDisabled}
+          />
+        </RadioGroup>
+
+        {deploySchedule && (
+          <TextField
+            inputRef={register({
+              required: EMPTY_ERROR_HELPER_TEXT,
+              validate: notNumberValidator,
+            })}
+            error={errors.daysBetween !== undefined}
+            helperText={errors.daysBetween?.message || 'Must be a number'}
+            onBlur={handleSubmit(onSubmit)}
+            name="daysBetween"
+            label="CONTROL"
+            InputLabelProps={{ shrink: true }}
+            variant="outlined"
+            fullWidth
+            disabled={isDisabled}
+          />
+        )}
+      </div>
+    </FormControl>
+  );
+};
+
+export { DeployScheduleEditor };

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -35,6 +35,10 @@ export interface BannerVariant extends Variant {
   tickerSettings?: TickerSettings;
 }
 
+export interface BannerTestDeploySchedule {
+  daysBetween: number;
+}
+
 export interface BannerTest extends Test {
   name: string;
   nickname?: string;
@@ -47,4 +51,5 @@ export interface BannerTest extends Test {
   deviceType?: DeviceType;
   campaignName?: string;
   contextTargeting: PageContextTargeting;
+  deploySchedule?: BannerTestDeploySchedule;
 }


### PR DESCRIPTION
Associated SDC change: https://github.com/guardian/support-dotcom-components/pull/1235

Marketing want the ability to override the channel-wide deploy schedule.
For example: channel 2 deploys weekly, but they'd like to show an app install banner (for mobile users) every 24 hours.

The solution implemented here is to add a `deploySchedule` to the `BannerTest` model, to allow Marketing users to override the channel-wide deploy schedule. When set, it allows them to set the number of days between deploys per user. This uses the user's `lastClosedAt` timestamp to decide when to next deploy the banner.

![Screenshot 2024-10-11 at 15 29 50](https://github.com/user-attachments/assets/b907cff6-0c8b-4a0d-8564-5db581dcafd1)

