### PR TITLE
Use setup-sbt action

### DIFF
--- a/.github/workflows/admin-console.yml
+++ b/.github/workflows/admin-console.yml
@@ -49,17 +49,14 @@ jobs:
           aws-region: eu-west-1
 
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: "corretto"
-          java-version: "11"
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.coursier
-          key: sbt
+          distribution: 'corretto'
+          java-version: '11'
+          cache: 'sbt'
+
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
 
       - name: riffraff
         run: |


### PR DESCRIPTION
SBT isn't available in the latest ubuntu image: https://github.com/actions/setup-java/issues/694 so we've had failures: `sbt: command not found`.

Also updates to newer version of `setup-java`