### PR TITLE
Add heading size editor to banner design tool

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -23,6 +23,15 @@ case class HeaderImage(
   altText: String
 )
 
+// case class FontSize // is this needed?
+case class FontSize (
+  size: String
+)
+case class Font (
+  heading: FontSize
+)
+
+
 sealed trait BannerDesignVisual
 object BannerDesignVisual {
   case class Image(
@@ -124,4 +133,5 @@ case class BannerDesign(
   headerImage: Option[HeaderImage],
   colours: BannerDesignColours,
   lockStatus: Option[LockStatus],
+  fonts: Option[Font],
 )

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -23,7 +23,6 @@ case class HeaderImage(
   altText: String
 )
 
-// case class FontSize // is this needed?
 case class FontSize (
   size: String
 )

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -23,13 +23,17 @@ case class HeaderImage(
   altText: String
 )
 
-case class FontSize (
-  size: String
-)
-case class Font (
-  heading: FontSize
-)
+sealed trait FontSize
+object FontSize {
+  case object small extends FontSize
+  case object medium extends FontSize
+  case object large extends FontSize
 
+  implicit val decoder: Decoder[FontSize] = deriveEnumerationDecoder[FontSize]
+  implicit val encoder: Encoder[FontSize] = deriveEnumerationEncoder[FontSize]
+}
+case class Font(size: FontSize)
+case class Fonts(heading: Font)
 
 sealed trait BannerDesignVisual
 object BannerDesignVisual {
@@ -132,5 +136,5 @@ case class BannerDesign(
   headerImage: Option[HeaderImage],
   colours: BannerDesignColours,
   lockStatus: Option[LockStatus],
-  fonts: Option[Font],
+  fonts: Option[Fonts],
 )

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -6,7 +6,6 @@ import {
   BannerDesignVisual,
   BasicColours,
   CtaDesign,
-  Font,
   HighlightedTextColours,
   TickerDesign,
 } from '../../../models/bannerDesign';

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -205,7 +205,7 @@ const BannerDesignForm: React.FC<Props> = ({
           <HeadlineSizeEditor
             headerSize={design.fonts?.heading?.size}
             isDisabled={isDisabled}
-            // onValidationChange={onValidationChange} // TODO: needed?
+            onValidationChange={onValidationChange}
             onChange={onHeadlineSizeChange}
           />
         </AccordionDetails>

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -6,6 +6,7 @@ import {
   BannerDesignVisual,
   BasicColours,
   CtaDesign,
+  FontSize,
   HighlightedTextColours,
   TickerDesign,
 } from '../../../models/bannerDesign';
@@ -118,7 +119,7 @@ const BannerDesignForm: React.FC<Props> = ({
     });
   };
 
-  const onHeadlineSizeChange = (headerSize: 'small' | 'medium' | 'large' = 'medium'): void => {
+  const onHeadlineSizeChange = (headerSize: FontSize): void => {
     onChange({
       ...design,
       fonts: {

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -6,6 +6,7 @@ import {
   BannerDesignVisual,
   BasicColours,
   CtaDesign,
+  Font,
   HighlightedTextColours,
   TickerDesign,
 } from '../../../models/bannerDesign';
@@ -20,6 +21,7 @@ import { HeaderImageEditor } from './HeaderImageEditor';
 import { BannerVisualEditor } from './BannerVisualEditor';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { InfoOutlined } from '@mui/icons-material';
+import { HeadlineSizeEditor } from './HeadlineSizeEditor';
 
 type Props = {
   design: BannerDesign;
@@ -117,6 +119,17 @@ const BannerDesignForm: React.FC<Props> = ({
     });
   };
 
+  const onHeadlineSizeChange = (headerSize: 'small' | 'medium' | 'large' = 'medium'): void => {
+    onChange({
+      ...design,
+      fonts: {
+        heading: {
+          size: headerSize,
+        },
+      },
+    });
+  };
+
   const onCtaColoursChange = (name: 'primaryCta' | 'secondaryCta' | 'closeButton') => (
     cta: CtaDesign,
   ): void => {
@@ -181,6 +194,20 @@ const BannerDesignForm: React.FC<Props> = ({
             isDisabled={isDisabled}
             onValidationChange={onValidationChange}
             onChange={onHeaderImageChange}
+          />
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion className={classes.accordion}>
+        <AccordionSummary className={classes.sectionHeader} expandIcon={<ExpandMoreIcon />}>
+          Headline Size
+        </AccordionSummary>
+        <AccordionDetails>
+          <HeadlineSizeEditor
+            headerSize={design.fonts?.heading?.size}
+            isDisabled={isDisabled}
+            // onValidationChange={onValidationChange} // TODO: needed?
+            onChange={onHeadlineSizeChange}
           />
         </AccordionDetails>
       </Accordion>

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignForm.tsx
@@ -206,7 +206,6 @@ const BannerDesignForm: React.FC<Props> = ({
           <HeadlineSizeEditor
             headerSize={design.fonts?.heading?.size}
             isDisabled={isDisabled}
-            onValidationChange={onValidationChange}
             onChange={onHeadlineSizeChange}
           />
         </AccordionDetails>

--- a/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
@@ -5,20 +5,22 @@ import { FontSize } from '../../../models/bannerDesign';
 interface Props {
   headerSize?: FontSize;
   isDisabled: boolean;
-  // onValidationChange: (fieldName: string, isValid: boolean) => void;
+  onValidationChange: (fieldName: string, isValid: boolean) => void;
   onChange: (headerSize: FontSize) => void;
 }
 
 export const HeadlineSizeEditor: React.FC<Props> = ({
   headerSize,
   isDisabled,
-  // onValidationChange, // TODO: is this needed?
+  onValidationChange,
   onChange,
 }: Props) => {
   const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     if (event.target.value === 'small') {
+      onValidationChange('HeadlineSizeEditor', true);
       onChange('small');
     } else {
+      onValidationChange('HeadlineSizeEditor', true);
       onChange('medium');
     }
   };
@@ -27,6 +29,7 @@ export const HeadlineSizeEditor: React.FC<Props> = ({
     <div>
       <FormControl>
         <RadioGroup
+          defaultValue={'medium'}
           value={headerSize === 'small' ? 'small' : 'medium'}
           onChange={onRadioGroupChange}
         >

--- a/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
@@ -5,22 +5,18 @@ import { FontSize } from '../../../models/bannerDesign';
 interface Props {
   headerSize?: FontSize;
   isDisabled: boolean;
-  onValidationChange: (fieldName: string, isValid: boolean) => void;
   onChange: (headerSize: FontSize) => void;
 }
 
 export const HeadlineSizeEditor: React.FC<Props> = ({
   headerSize,
   isDisabled,
-  onValidationChange,
   onChange,
 }: Props) => {
   const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     if (event.target.value === 'small') {
-      onValidationChange('HeadlineSizeEditor', true);
       onChange('small');
     } else {
-      onValidationChange('HeadlineSizeEditor', true);
       onChange('medium');
     }
   };

--- a/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
@@ -1,12 +1,12 @@
 import { FormControl, FormControlLabel, RadioGroup, Radio } from '@mui/material';
 import React from 'react';
-import { Font } from '../../../models/bannerDesign';
+import { FontSize } from '../../../models/bannerDesign';
 
 interface Props {
-  headerSize?: Font['size'];
+  headerSize?: FontSize;
   isDisabled: boolean;
   // onValidationChange: (fieldName: string, isValid: boolean) => void;
-  onChange: (headerSize: Font['size']) => void;
+  onChange: (headerSize: FontSize) => void;
 }
 
 export const HeadlineSizeEditor: React.FC<Props> = ({
@@ -17,10 +17,8 @@ export const HeadlineSizeEditor: React.FC<Props> = ({
 }: Props) => {
   const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     if (event.target.value === 'small') {
-      console.log('selected small');
       onChange('small');
     } else {
-      console.log('selected medium');
       onChange('medium');
     }
   };
@@ -35,7 +33,7 @@ export const HeadlineSizeEditor: React.FC<Props> = ({
           <FormControlLabel
             name="small"
             value="small"
-            // key="disabled"
+            key="small"
             control={<Radio />}
             label="Small heading size - use for tiny banners without copy"
             disabled={isDisabled}
@@ -43,7 +41,7 @@ export const HeadlineSizeEditor: React.FC<Props> = ({
           <FormControlLabel
             name="medium"
             value="medium"
-            // key="enabled"
+            key="medium"
             control={<Radio />}
             label="Medium heading size (default)"
             disabled={isDisabled}

--- a/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
@@ -38,7 +38,7 @@ export const HeadlineSizeEditor: React.FC<Props> = ({
             value="small"
             key="small"
             control={<Radio />}
-            label="Small heading size - use for tiny banners without copy"
+            label="Small heading size - use for tiny banners without body copy"
             disabled={isDisabled}
           />
           <FormControlLabel

--- a/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeadlineSizeEditor.tsx
@@ -1,0 +1,55 @@
+import { FormControl, FormControlLabel, RadioGroup, Radio } from '@mui/material';
+import React from 'react';
+import { Font } from '../../../models/bannerDesign';
+
+interface Props {
+  headerSize?: Font['size'];
+  isDisabled: boolean;
+  // onValidationChange: (fieldName: string, isValid: boolean) => void;
+  onChange: (headerSize: Font['size']) => void;
+}
+
+export const HeadlineSizeEditor: React.FC<Props> = ({
+  headerSize,
+  isDisabled,
+  // onValidationChange, // TODO: is this needed?
+  onChange,
+}: Props) => {
+  const onRadioGroupChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.value === 'small') {
+      console.log('selected small');
+      onChange('small');
+    } else {
+      console.log('selected medium');
+      onChange('medium');
+    }
+  };
+
+  return (
+    <div>
+      <FormControl>
+        <RadioGroup
+          value={headerSize === 'small' ? 'small' : 'medium'}
+          onChange={onRadioGroupChange}
+        >
+          <FormControlLabel
+            name="small"
+            value="small"
+            // key="disabled"
+            control={<Radio />}
+            label="Small heading size - use for tiny banners without copy"
+            disabled={isDisabled}
+          />
+          <FormControlLabel
+            name="medium"
+            value="medium"
+            // key="enabled"
+            control={<Radio />}
+            label="Medium heading size (default)"
+            disabled={isDisabled}
+          />
+        </RadioGroup>
+      </FormControl>
+    </div>
+  );
+};

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -31,6 +31,11 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
   name,
   status: 'Draft',
   visual: defaultBannerChoiceCardsDesign,
+  fonts: {
+    heading: {
+      size: 'medium',
+    },
+  },
   colours: {
     basic: {
       background: stringToHexColour('F1F8FC'),

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -63,9 +63,18 @@ export interface ChoiceCardsDesign {
 }
 export type BannerDesignVisual = BannerDesignImage | ChoiceCardsDesign;
 
+export type FontSize = 'small' | 'medium' | 'large';
+
+export interface Font {
+  size?: FontSize;
+}
+
 export type BannerDesignProps = {
   visual?: BannerDesignVisual;
   headerImage?: BannerDesignHeaderImage;
+  fonts?: {
+    heading?: Font;
+  };
   colours: {
     basic: BasicColours;
     highlightedText: HighlightedTextColours;


### PR DESCRIPTION
## What does this change?

This adds the option to have a small headline size in a banner design.  It is intended to be used for mobile banners with no copy but it is difficult to add such a restriction since the design is created separately from (and before) the copy.

Changes to the model are reflected in the following PRs which need to be merged before this (in the following order): 
- support-dotcom-components [PR1245](https://github.com/guardian/support-dotcom-components/pull/1245)
- dotcom-rendering to bump the version of SDC [PR12834](https://github.com/guardian/dotcom-rendering/pull/12834)
- dotcom-rendering to use the new model [PR12835](https://github.com/guardian/dotcom-rendering/pull/12835)

## How can we measure success?

Tiny banners will have smaller headline font sizes which means less wrapping of longer headlines.

## Have we considered potential risks?

There are some risks of the small headline size being used on banners with copy - as this headline size is nearly the same size as the copy, it will be less obvious and may have a knock on effect on revenue.  MRR will, however, be able to review the banner before making it live which should help to reduce the risk.

## Images

Here is the new section in the banner design tool: 

<img width="1000" alt="Screenshot 2024-11-07 at 16 51 48" src="https://github.com/user-attachments/assets/f522fba8-ea48-40ee-8b2b-9dbfb369210a">

## Accessibility

This is using the same mechanism as other, similar, items in the page.
