### PR TITLE
Hide methodology editor if not supported

### DIFF
--- a/public/src/components/channelManagement/epicTests/testEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/testEditor.tsx
@@ -259,7 +259,7 @@ export const getEpicTestEditor = (
             </div>
           </div>
         )}
-        {epicEditorConfig.allowCustomVariantSplit && (
+        {epicEditorConfig.allowMethodologyEditor && (
           <div className={classes.sectionContainer}>
             <Typography variant={'h3'} className={classes.sectionHeader}>
               Experiment Methodology

--- a/public/src/components/channelManagement/epicTests/testEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/testEditor.tsx
@@ -259,16 +259,18 @@ export const getEpicTestEditor = (
             </div>
           </div>
         )}
-        <div className={classes.sectionContainer}>
-          <Typography variant={'h3'} className={classes.sectionHeader}>
-            Experiment Methodology
-          </Typography>
-          <TestMethodologyEditor
-            methodologies={test.methodologies}
-            isDisabled={!userHasTestLocked}
-            onChange={onMethodologyChange}
-          />
-        </div>
+        {epicEditorConfig.allowCustomVariantSplit && (
+          <div className={classes.sectionContainer}>
+            <Typography variant={'h3'} className={classes.sectionHeader}>
+              Experiment Methodology
+            </Typography>
+            <TestMethodologyEditor
+              methodologies={test.methodologies}
+              isDisabled={!userHasTestLocked}
+              onChange={onMethodologyChange}
+            />
+          </div>
+        )}
 
         {epicEditorConfig.allowCustomVariantSplit && canHaveCustomVariantSplit(test.variants) && (
           <div className={classes.sectionContainer}>

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -44,6 +44,7 @@ export interface EpicEditorConfig {
   // test level settings
   allowMultipleVariants: boolean;
   allowCustomVariantSplit: boolean;
+  allowMethodologyEditor: boolean;
   allowContentTargeting: boolean;
   allowLocationTargeting: boolean;
   supportedRegions?: Region[];
@@ -76,6 +77,7 @@ export interface EpicEditorConfig {
 export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: true,
   allowCustomVariantSplit: true,
+  allowMethodologyEditor: true,
   allowContentTargeting: true,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
@@ -104,6 +106,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
 export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: true,
   allowCustomVariantSplit: true,
+  allowMethodologyEditor: false,
   allowContentTargeting: true,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
@@ -132,6 +135,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
 export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: false,
   allowCustomVariantSplit: false,
+  allowMethodologyEditor: false,
   allowContentTargeting: true,
   allowLocationTargeting: true,
   supportedRegions: ['UnitedStates', 'AUDCountries', 'GBPCountries'],
@@ -161,6 +165,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
 export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowMultipleVariants: true,
   allowCustomVariantSplit: false,
+  allowMethodologyEditor: false,
   allowContentTargeting: false,
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: false,


### PR DESCRIPTION
this is because we only support Bandit testing for the standard epic, and banners.