### PR TITLE
Only show signed-in status selector where available

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -302,6 +302,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             isDisabled={!userHasTestLocked}
             showSupporterStatusSelector={true}
             showDeviceTypeSelector={true}
+            showSignedInStatusSelector={true}
             selectedSignedInStatus={test.signedInStatus}
             onSignedInStatusChange={onSignedInStatusChange}
             selectedConsentStatus={test.consentStatus}

--- a/public/src/components/channelManagement/epicTests/testEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/testEditor.tsx
@@ -360,6 +360,7 @@ export const getEpicTestEditor = (
               isDisabled={!userHasTestLocked}
               showSupporterStatusSelector={epicEditorConfig.allowSupporterStatusTargeting}
               showDeviceTypeSelector={epicEditorConfig.allowDeviceTypeTargeting}
+              showSignedInStatusSelector={epicEditorConfig.showSignedInStatusSelector}
               selectedSignedInStatus={test.signedInStatus}
               onSignedInStatusChange={onSignedInStatusChange}
               selectedConsentStatus={test.consentStatus}

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -183,6 +183,7 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
           isDisabled={!userHasTestLocked}
           showSupporterStatusSelector={true}
           showDeviceTypeSelector={true}
+          showSignedInStatusSelector={true}
           selectedSignedInStatus={test.signedInStatus}
           onSignedInStatusChange={onSignedInStatusChange}
           selectedConsentStatus={test.consentStatus}

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -50,6 +50,7 @@ export interface EpicEditorConfig {
   supportedRegions?: Region[];
   allowSupporterStatusTargeting: boolean;
   allowDeviceTypeTargeting: boolean;
+  showSignedInStatusSelector: boolean;
   allowViewFrequencySettings: boolean;
   allowArticleCount: boolean;
   testNamePrefix?: string;
@@ -82,6 +83,7 @@ export const ARTICLE_EPIC_CONFIG: EpicEditorConfig = {
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
   allowDeviceTypeTargeting: true,
+  showSignedInStatusSelector: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: true,
@@ -111,6 +113,7 @@ export const LIVEBLOG_EPIC_CONFIG: EpicEditorConfig = {
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: true,
   allowDeviceTypeTargeting: true,
+  showSignedInStatusSelector: true,
   allowViewFrequencySettings: true,
   allowArticleCount: true,
   allowVariantHeader: true,
@@ -141,6 +144,7 @@ export const APPLE_NEWS_EPIC_CONFIG: EpicEditorConfig = {
   supportedRegions: ['UnitedStates', 'AUDCountries', 'GBPCountries'],
   allowSupporterStatusTargeting: false,
   allowDeviceTypeTargeting: false,
+  showSignedInStatusSelector: false,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,
@@ -170,6 +174,7 @@ export const AMP_EPIC_CONFIG: EpicEditorConfig = {
   allowLocationTargeting: true,
   allowSupporterStatusTargeting: false,
   allowDeviceTypeTargeting: false,
+  showSignedInStatusSelector: false,
   allowViewFrequencySettings: false,
   allowArticleCount: false,
   allowVariantHeader: true,

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -37,6 +37,7 @@ interface TestEditorTargetAudienceSelectorProps {
   isDisabled: boolean;
   showSupporterStatusSelector: boolean;
   showDeviceTypeSelector: boolean;
+  showSignedInStatusSelector: boolean;
   selectedSignedInStatus?: SignedInStatus;
   onSignedInStatusChange: (signedInStatus: SignedInStatus) => void;
   selectedConsentStatus?: ConsentStatus;
@@ -55,6 +56,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   isDisabled,
   showSupporterStatusSelector,
   showDeviceTypeSelector,
+  showSignedInStatusSelector,
   selectedSignedInStatus,
   onSignedInStatusChange,
   selectedConsentStatus,
@@ -109,19 +111,21 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
         </>
       )}
 
-      <>
-        <Typography className={classes.heading}>Signed In Status</Typography>
-        <TypedRadioGroup
-          selectedValue={selectedSignedInStatus ?? 'All'}
-          onChange={onSignedInStatusChange}
-          isDisabled={isDisabled}
-          labels={{
-            All: 'All',
-            SignedIn: 'Signed in',
-            SignedOut: 'Signed out',
-          }}
-        />
-      </>
+      {showSignedInStatusSelector && (
+        <>
+          <Typography className={classes.heading}>Signed In Status</Typography>
+          <TypedRadioGroup
+            selectedValue={selectedSignedInStatus ?? 'All'}
+            onChange={onSignedInStatusChange}
+            isDisabled={isDisabled}
+            labels={{
+              All: 'All',
+              SignedIn: 'Signed in',
+              SignedOut: 'Signed out',
+            }}
+          />
+        </>
+      )}
 
       {showConsentStatusSelector && (
         <>


### PR DESCRIPTION
we're currently showing this feature on the AMP + Apple News epic tools, where it's not available.