### PR TITLE
Add Apple News Epic Switch to RRCP

### DIFF
--- a/app/models/ChannelSwitches.scala
+++ b/app/models/ChannelSwitches.scala
@@ -6,6 +6,7 @@ import io.circe.generic.extras.Configuration
 
 case class ChannelSwitches(
   enableEpics: Boolean,
+  enableAppleNewsEpics: Boolean = true,
   enableBanners: Boolean,
   enableHeaders: Boolean = true,
   enableSuperMode: Boolean,

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -49,6 +49,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       "GuCname",
       "GuStringParameter",
       "GuDynamoDBReadPolicy",
+      "GuGetS3ObjectsPolicy",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -2467,6 +2468,22 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
               "Version": "2012-10-17",
             },
             "PolicyName": "dynamoPolicyForCapi",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3:::support-admin-console/PROD/*",
+                    "arn:aws:s3:::support-admin-console/channel-switches.json",
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "s3ReadPolicyForCapi",
           },
         ],
         "RoleName": "support-admin-console-channel-tests-capi-role-PROD",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -338,12 +338,17 @@ export class AdminConsole extends GuStack {
     const dynamoPolicyForCapi = new GuDynamoDBReadPolicy(this, `DynamoRead-for-capi`, {
       tableName: channelTestsDynamoTable.tableName,
     });
+    const s3ReadPolicyForCapi = new GuGetS3ObjectsPolicy(this, 's3Get-for-capi', {
+        bucketName: 'support-admin-console',
+        paths: [`${this.stage}/*`, 'channel-switches.json'],
+      });
 
     new Role(this, 'capi-role', {
       roleName: `support-admin-console-channel-tests-capi-role-${this.stage}`,
       assumedBy: new AccountPrincipal(capiAccountId.valueAsString),
       inlinePolicies: {
         dynamoPolicyForCapi: dynamoPolicyForCapi.document,
+        s3ReadPolicyForCapi: s3ReadPolicyForCapi.document,
       },
     });
 

--- a/public/src/components/channelManagement/ChannelSwitches.tsx
+++ b/public/src/components/channelManagement/ChannelSwitches.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles(() => ({
 type SwitchName =
   | 'enableBanners'
   | 'enableEpics'
+  | 'enableAppleNewsEpics'
   | 'enableHeaders'
   | 'enableSuperMode'
   | 'enableHardcodedEpicTests'
@@ -84,6 +85,12 @@ const ChannelSwitches: React.FC<InnerProps<ChannelSwitches>> = ({
         name="enableEpics"
         label="Enable Epics (this does not include Apple News)"
         enabled={switches.enableEpics}
+        setSwitch={onSwitchChange}
+      />
+      <ChannelSwitch
+        name="enableAppleNewsEpics"
+        label="Enable Epics on Apple News"
+        enabled={switches.enableAppleNewsEpics}
         setSwitch={onSwitchChange}
       />
       <ChannelSwitch


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is to add a new " Enable Epics on Apple News" switch under Channel Switches in RRCP.This switch is to enable/disable  all epics on Apple News.

## How to test



## Images
<img width="1718" alt="image" src="https://github.com/user-attachments/assets/0693c139-f8db-4f08-9b6c-23469ca5663a">


This also updates the CAPI Role to access the s3 bucket to read channel-switches.json