### PR TITLE
Support more than one google group for auth

### DIFF
--- a/app/controllers/AmountsController.scala
+++ b/app/controllers/AmountsController.scala
@@ -3,11 +3,11 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.AmountsTests
 import models.AmountsTests._
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class AmountsController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class AmountsController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[AmountsTests](authAction, components, stage, filename = "configured-amounts-v3.json", runtime) {
 }

--- a/app/controllers/AnalyticsController.scala
+++ b/app/controllers/AnalyticsController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.googleauth.AuthAction
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax.EncoderOps
-import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents, Result}
+import play.api.mvc.{AbstractController, Action, ActionBuilder, AnyContent, ControllerComponents, Result}
 import services.Athena
 import zio.{IO, ZEnv, ZIO}
 import models.GroupedVariantViews.encoder
@@ -11,7 +11,8 @@ import utils.Circe.noNulls
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AnalyticsController(authAction: AuthAction[AnyContent],
+class AnalyticsController(
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc._
 
-class Application(authAction: AuthAction[AnyContent],
+class Application(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
                   components: ControllerComponents,
                   stage: String,
                   sdcUrlOverride: Option[String])

--- a/app/controllers/AppsMeteringSwitchesController.scala
+++ b/app/controllers/AppsMeteringSwitchesController.scala
@@ -3,11 +3,11 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.AppsMeteringSwitches
 import models.AppsMeteringSwitches._
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class AppsMeteringSwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class AppsMeteringSwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[AppsMeteringSwitches](authAction, components, stage, filename = "apps-metering-switches.json", runtime) {
 }

--- a/app/controllers/BanditDataController.scala
+++ b/app/controllers/BanditDataController.scala
@@ -3,14 +3,15 @@ package controllers
 import com.gu.googleauth.AuthAction
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax.EncoderOps
-import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents, Result}
+import play.api.mvc.{AbstractController, Action, ActionBuilder, AnyContent, ControllerComponents, Result}
 import services.DynamoBanditData
 import utils.Circe.noNulls
 import zio.{IO, ZEnv, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BanditDataController(authAction: AuthAction[AnyContent],
+class BanditDataController(
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/CampaignsController.scala
+++ b/app/controllers/CampaignsController.scala
@@ -16,7 +16,7 @@ import zio.{IO, ZEnv, ZIO}
 import scala.concurrent.{ExecutionContext, Future}
 
 class CampaignsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/CapiController.scala
+++ b/app/controllers/CapiController.scala
@@ -1,13 +1,13 @@
 package controllers
 
 import com.gu.googleauth.AuthAction
-import play.api.mvc.AnyContent
+import play.api.mvc.{ActionBuilder, AnyContent}
 import play.api.mvc.Results.Ok
 import services.CapiService
 
 import scala.concurrent.ExecutionContext
 
-class CapiController(authAction: AuthAction[AnyContent], capiService: CapiService)(implicit ec: ExecutionContext) {
+class CapiController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], capiService: CapiService)(implicit ec: ExecutionContext) {
 
   def getTags() = authAction.async { request =>
     capiService

--- a/app/controllers/ChannelSwitchesController.scala
+++ b/app/controllers/ChannelSwitchesController.scala
@@ -2,11 +2,11 @@ package controllers
 
 import com.gu.googleauth.AuthAction
 import models.ChannelSwitches
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class ChannelSwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class ChannelSwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[ChannelSwitches](authAction, components, stage, filename = "channel-switches.json", runtime) {
 }

--- a/app/controllers/ChannelTestsController.scala
+++ b/app/controllers/ChannelTestsController.scala
@@ -31,7 +31,7 @@ object ChannelTestsController {
   * Uses an S3 file for lock protection to prevent concurrent editing.
   */
 abstract class ChannelTestsController[T <: ChannelTest[T] : Decoder : Encoder](
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   lockFileName: String,

--- a/app/controllers/DefaultPromosController.scala
+++ b/app/controllers/DefaultPromosController.scala
@@ -3,11 +3,11 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.{AppsMeteringSwitches, DefaultPromos}
 import models.AppsMeteringSwitches._
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class DefaultPromosController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class DefaultPromosController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[DefaultPromos](authAction, components, stage, filename = "default-promos.json", runtime) {
 }

--- a/app/controllers/HeaderTestsController.scala
+++ b/app/controllers/HeaderTestsController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.{Channel, HeaderTest}
 import models.HeaderTest._
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests}
 import zio.ZEnv
 
@@ -14,7 +14,7 @@ object HeaderTestsController {
 }
 
 class HeaderTestsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.googleauth.{GoogleAuthConfig, GoogleGroupChecker, LoginSupport}
+import com.gu.googleauth.{AuthAction, Filters, GoogleAuthConfig, GoogleGroupChecker, LoginSupport}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
@@ -34,7 +34,8 @@ class Login(
    * Looks up user's identity via Google
    */
   def oauth2Callback: Action[AnyContent] = Action.async { implicit request =>
-    processOauth2Callback(requiredGoogleGroups, googleGroupChecker)
+//    processOauth2Callback(requiredGoogleGroups, googleGroupChecker)
+    processOauth2Callback()
   }
 
   def logout: Action[AnyContent] = Action { implicit request =>

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.googleauth.{AuthAction, Filters, GoogleAuthConfig, GoogleGroupChecker, LoginSupport}
+import com.gu.googleauth.{GoogleAuthConfig, LoginSupport}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
@@ -10,7 +10,6 @@ class Login(
   val authConfig: GoogleAuthConfig,
   val wsClient: WSClient,
   requiredGoogleGroups: Set[String],
-  googleGroupChecker: GoogleGroupChecker,
   components: ControllerComponents
 )(implicit executionContext: ExecutionContext)
   extends AbstractController(components) with LoginSupport {
@@ -34,7 +33,6 @@ class Login(
    * Looks up user's identity via Google
    */
   def oauth2Callback: Action[AnyContent] = Action.async { implicit request =>
-//    processOauth2Callback(requiredGoogleGroups, googleGroupChecker)
     processOauth2Callback()
   }
 

--- a/app/controllers/S3ObjectController.scala
+++ b/app/controllers/S3ObjectController.scala
@@ -5,7 +5,7 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.auto._
 import io.circe.syntax._
 import play.api.libs.circe.Circe
-import play.api.mvc.{AbstractController, AnyContent, ControllerComponents, Result}
+import play.api.mvc.{AbstractController, ActionBuilder, AnyContent, ControllerComponents, Result}
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
 import utils.Circe.noNulls
@@ -21,7 +21,7 @@ case class VersionedS3DataWithEmail[T](value: T, version: String, email: String)
   * Controller for managing JSON data in a single object in S3
   */
 abstract class S3ObjectController[T : Decoder : Encoder](
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   filename: String,

--- a/app/controllers/SuperModeController.scala
+++ b/app/controllers/SuperModeController.scala
@@ -12,7 +12,7 @@ import zio.{IO, ZEnv, ZIO}
 import scala.concurrent.{ExecutionContext, Future}
 
 class SuperModeController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -1,12 +1,12 @@
 package controllers
 
 import com.gu.googleauth.AuthAction
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import models.SupportFrontendSwitches.{SupportFrontendSwitches, SupportFrontendSwitchesDecoder, SupportFrontendSwitchesEncoder}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class SwitchesController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class SwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[SupportFrontendSwitches](authAction, components, stage, filename = "switches_v2.json", runtime) {
 }

--- a/app/controllers/banner/BannerDeployController.scala
+++ b/app/controllers/banner/BannerDeployController.scala
@@ -4,11 +4,11 @@ import com.gu.googleauth.AuthAction
 import controllers.S3ObjectController
 import io.circe.generic.auto._
 import models.BannerDeploys
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class BannerDeployController(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class BannerDeployController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel1.json", runtime) {
 }

--- a/app/controllers/banner/BannerDeployController2.scala
+++ b/app/controllers/banner/BannerDeployController2.scala
@@ -4,11 +4,11 @@ import com.gu.googleauth.AuthAction
 import controllers.S3ObjectController
 import io.circe.generic.auto._
 import models.BannerDeploys
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class BannerDeployController2(authAction: AuthAction[AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class BannerDeployController2(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
   extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel2.json", runtime) {
 }

--- a/app/controllers/banner/BannerDesignsController.scala
+++ b/app/controllers/banner/BannerDesignsController.scala
@@ -4,8 +4,8 @@ import com.gu.googleauth.AuthAction
 import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoNoLockError}
 import models.{BannerDesign, BannerTest, Channel}
 import play.api.libs.circe.Circe
-import play.api.mvc.{AbstractController, AnyContent, ControllerComponents, Result}
-import services.{DynamoBannerDesigns, DynamoChannelTests, DynamoArchivedBannerDesigns}
+import play.api.mvc.{AbstractController, ActionBuilder, AnyContent, ControllerComponents, Result}
+import services.{DynamoArchivedBannerDesigns, DynamoBannerDesigns, DynamoChannelTests}
 import services.S3Client.S3ObjectSettings
 import utils.Circe.noNulls
 import zio.{IO, ZEnv, ZIO}
@@ -17,7 +17,7 @@ import models.BannerUI
 import scala.concurrent.{ExecutionContext, Future}
 
 class BannerDesignsController(
-    authAction: AuthAction[AnyContent],
+    authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
     components: ControllerComponents,
     stage: String,
     runtime: zio.Runtime[ZEnv],

--- a/app/controllers/banner/BannerTestsController.scala
+++ b/app/controllers/banner/BannerTestsController.scala
@@ -5,7 +5,7 @@ import controllers.ChannelTestsController
 import models.{BannerTest, Channel}
 import models.BannerTest._
 import play.api.libs.circe.Circe
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests}
 import zio.ZEnv
 
@@ -16,7 +16,7 @@ object BannerTestsController {
 }
 
 class BannerTestsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/banner/BannerTestsController2.scala
+++ b/app/controllers/banner/BannerTestsController2.scala
@@ -5,7 +5,7 @@ import controllers.ChannelTestsController
 import models.{BannerTest, Channel}
 import models.BannerTest._
 import play.api.libs.circe.Circe
-import play.api.mvc.{AnyContent, ControllerComponents}
+import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests}
 import zio.ZEnv
 
@@ -16,7 +16,7 @@ object BannerTestsController2 {
 }
 
 class BannerTestsController2(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/epic/AMPEpicTestsController.scala
+++ b/app/controllers/epic/AMPEpicTestsController.scala
@@ -16,7 +16,7 @@ object AMPEpicTestsController {
 }
 
 class AMPEpicTestsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/epic/AppleNewsEpicTestsController.scala
+++ b/app/controllers/epic/AppleNewsEpicTestsController.scala
@@ -16,7 +16,7 @@ object AppleNewsEpicTestsController {
 }
 
 class AppleNewsEpicTestsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/epic/EpicTestsController.scala
+++ b/app/controllers/epic/EpicTestsController.scala
@@ -16,7 +16,7 @@ object EpicTestsController {
 }
 
 class EpicTestsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/controllers/epic/LiveblogEpicTestsController.scala
+++ b/app/controllers/epic/LiveblogEpicTestsController.scala
@@ -16,7 +16,7 @@ object LiveblogEpicTestsController {
 }
 
 class LiveblogEpicTestsController(
-  authAction: AuthAction[AnyContent],
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
   runtime: zio.Runtime[ZEnv],

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -53,7 +53,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
 
   private val authAction =
     new AuthAction[AnyContent](authConfig, controllers.routes.Login.loginAction, controllerComponents.parsers.default)(executionContext) andThen
-      // All users must have 2fa enforced
+      // User must have 2fa enforced
       requireGroup[AuthAction.UserIdentityRequest](Set(twoFactorAuthEnforceGoogleGroup))
       // User must be in at least one of the required groups
       requireGroup[AuthAction.UserIdentityRequest](requiredGoogleGroups)

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -8,7 +8,7 @@ import controllers.banner._
 import controllers.epic._
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
-import play.api.mvc.{ActionBuilder, AnyContent}
+import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
 import services.{Athena, Aws, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoSuperMode, S3}
@@ -82,7 +82,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
   override lazy val router: Router = new Routes(
     httpErrorHandler,
     new Application(authAction, controllerComponents, stage, sdcUrlOverride),
-    new Login(authConfig, wsClient, requiredGoogleGroups, groupChecker, controllerComponents),
+    new Login(authConfig, wsClient, requiredGoogleGroups, controllerComponents),
     new SwitchesController(authAction, controllerComponents, stage, runtime),
     new AmountsController(authAction, controllerComponents, stage, runtime),
     new EpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
 class AppComponents(context: Context, stage: String) extends BuiltInComponentsFromContext(context) with AhcWSComponents with NoHttpFiltersComponents with AssetsComponents with Filters {
 
-  private val authConfig = {
+  override def authConfig = {
     val clientId = configuration.get[String]("googleAuth.clientId")
     val clientSecret = configuration.get[String]("googleAuth.clientSecret")
     val redirectUrl = configuration.get[String]("googleAuth.redirectUrl")

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -48,10 +48,14 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     )
   }
 
+  private val twoFactorAuthEnforceGoogleGroup = configuration.get[String]("googleAuth.2faEnforceGroup")
   private val requiredGoogleGroups: Set[String] = configuration.get[String]("googleAuth.requiredGroups").split(',').toSet
 
   private val authAction =
     new AuthAction[AnyContent](authConfig, controllers.routes.Login.loginAction, controllerComponents.parsers.default)(executionContext) andThen
+      // All users must have 2fa enforced
+      requireGroup[AuthAction.UserIdentityRequest](Set(twoFactorAuthEnforceGoogleGroup))
+      // User must be in at least one of the required groups
       requireGroup[AuthAction.UserIdentityRequest](requiredGoogleGroups)
 
   private val runtime = zio.Runtime.default

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -54,7 +54,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
   private val authAction =
     new AuthAction[AnyContent](authConfig, controllers.routes.Login.loginAction, controllerComponents.parsers.default)(executionContext) andThen
       // User must have 2fa enforced
-      requireGroup[AuthAction.UserIdentityRequest](Set(twoFactorAuthEnforceGoogleGroup))
+      requireGroup[AuthAction.UserIdentityRequest](Set(twoFactorAuthEnforceGoogleGroup)) andThen
       // User must be in at least one of the required groups
       requireGroup[AuthAction.UserIdentityRequest](requiredGoogleGroups)
 


### PR DESCRIPTION
We want to allow other groups (24/7 Support, Central Production) to access the RRCP. This is not currently possible - users have to be in the support.admin.console google group.

### Before the change:
The server fetches a list of google groups from config. When logging in, a user must be a member of _all_ the configured groups. This list includes a special group for enforcing 2fa, since users must also be in this group.

### After the change:
When making any authorised request, a user must be in _at least one_ of the configured groups.
Additionally, we also still need to check that the user is in the special 2fa group. So I have moved this into a separate config item, so that we can check membership of this group separately from the other list of groups.

### The change
Previously the group checking was done in `Login.scala` at the point that a user logs in, with the line:
`processOauth2Callback(requiredGoogleGroups, googleGroupChecker)`
The google auth library would then use the `googleGroupChecker` to do the check - but [this method](https://github.com/guardian/play-googleauth/blob/d77d3bb8d9842a84229df70ed1f8613c7113f3d4/play-v29/src/main/scala/com/gu/googleauth/actions.scala#L219) requires a user to be in all groups, which is not what we want.

Instead, we now do the group checking as part of the `authAction`, which is created in `AppComponents.scala`. This method of group checking[ only requires one group to match](https://github.com/guardian/play-googleauth/blob/d77d3bb8d9842a84229df70ed1f8613c7113f3d4/play-v29/src/main/scala/com/gu/googleauth/actions.scala#L243).

It's a bit confusing that the play google-auth library behaves in two different ways like this. But I can see examples of both methods in our repos.

### Testing
Deployed to CODE, and temporarily removed a user from the support.admin.console google group to confirm their access was lost.