### PR TITLE
rename requiredGroups to allowedGroups

### DIFF
--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -9,7 +9,6 @@ import scala.concurrent.ExecutionContext
 class Login(
   val authConfig: GoogleAuthConfig,
   val wsClient: WSClient,
-  requiredGoogleGroups: Set[String],
   components: ControllerComponents
 )(implicit executionContext: ExecutionContext)
   extends AbstractController(components) with LoginSupport {


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/support-admin-console/pull/652) reused the `googleAuth.requiredGroups` config item but changed its meaning.
Now, a user must be in at least one of the configured groups