### PR TITLE
Show icon in tests list for bandit tests

### DIFF
--- a/public/src/components/channelManagement/testListBanditIcon.tsx
+++ b/public/src/components/channelManagement/testListBanditIcon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { makeStyles } from '@mui/styles';
+import SmartToyIcon from '@mui/icons-material/SmartToy';
+
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: '1px',
+    background: '#FFC107',
+    borderRadius: '2px',
+    lineHeight: 0,
+  },
+}));
+
+const TestListBanditIcon = (): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <div className={classes.container}>
+      <SmartToyIcon sx={{ fontSize: 16 }} />
+    </div>
+  );
+};
+
+export default TestListBanditIcon;

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -8,6 +8,7 @@ import TestListTestName from './testListTestName';
 import TestListTestArticleCountLabel from './testListTestArticleCountLabel';
 import useHover from '../../hooks/useHover';
 import EditIcon from '@mui/icons-material/Edit';
+import TestListBanditIcon from './testListBanditIcon';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
   test: {
@@ -20,6 +21,12 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
     background: 'white',
     borderRadius: '4px',
     padding: '0 12px',
+  },
+  icons: {
+    display: 'flex',
+    '& > * + *': {
+      marginLeft: '2px',
+    },
   },
   live: {
     border: `1px solid ${red[500]}`,
@@ -53,6 +60,7 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
     '& > * + *': {
       marginLeft: '4px',
     },
+    overflow: 'hidden',
   },
   whitePencil: {
     color: 'white',
@@ -75,6 +83,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
   const classes = useStyles();
 
   const hasArticleCount = test.articlesViewedSettings !== undefined;
+  const isBanditTest = test.methodologies.find(method => method.name === 'EpsilonGreedyBandit');
 
   const [ref, isHovered] = useHover<HTMLDivElement>();
 
@@ -101,7 +110,10 @@ const TestListTest: React.FC<TestListTestProps> = ({
         />
       </div>
 
-      {hasArticleCount && <TestListTestArticleCountLabel />}
+      <div className={classes.icons}>
+        {hasArticleCount && <TestListTestArticleCountLabel />}
+        {isBanditTest && <TestListBanditIcon />}
+      </div>
     </ListItem>
   );
 };


### PR DESCRIPTION
Displays a little robot icon in the tests list, to make it easier to see which tests are using multi-armed bandit testing.
This appears next to the article count ("AC") icon.
![Screenshot 2024-12-09 at 13 17 58](https://github.com/user-attachments/assets/9758fff3-be3f-4df6-a584-abf9b76f55f8)
