### PR TITLE
Add Roulette  to RRCP Experiment Methodologies

### DIFF
--- a/app/models/Methodology.scala
+++ b/app/models/Methodology.scala
@@ -19,6 +19,11 @@ case class EpsilonGreedyBandit(
   testName: Option[String] = None
 ) extends Methodology
 
+case class Roulette(
+  name: String = "Roulette",
+  testName: Option[String] = None
+) extends Methodology
+
 case object Methodology {
   val defaultMethodologies = List(ABTest())
 

--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -87,6 +87,8 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
     const value = event.target.value as Methodology['name'];
     if (value === 'EpsilonGreedyBandit') {
       onChange(defaultEpsilonGreedyBandit);
+    } else if(value === 'Roulette'){
+      onChange({ name: 'Roulette' });
     } else {
       onChange({ name: 'ABTest' });
     }
@@ -104,6 +106,9 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
           </MenuItem>
           <MenuItem value={'EpsilonGreedyBandit'} key={'EpsilonGreedyBandit'}>
             Epsilon-greedy bandit
+          </MenuItem>
+          <MenuItem value={'Roulette'} key={'Roulette'}>
+            Roulette
           </MenuItem>
         </Select>
       </div>

--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -87,7 +87,7 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
     const value = event.target.value as Methodology['name'];
     if (value === 'EpsilonGreedyBandit') {
       onChange(defaultEpsilonGreedyBandit);
-    } else if(value === 'Roulette'){
+    } else if (value === 'Roulette') {
       onChange({ name: 'Roulette' });
     } else {
       onChange({ name: 'ABTest' });

--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -16,6 +16,9 @@ import AddIcon from '@mui/icons-material/Add';
 import Alert from '@mui/lab/Alert';
 import { addMethodologyToTestName } from './helpers/methodology';
 
+const isBandit = (methodology: Methodology): boolean =>
+  methodology.name === 'EpsilonGreedyBandit' || methodology.name === 'Roulette';
+
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
     '& > * + *': {
@@ -127,9 +130,9 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
               }}
             />
           </div>
-          <BanditAnalyticsButton testName={testName} channel={channel} />
         </>
       )}
+      {isBandit(methodology) && <BanditAnalyticsButton testName={testName} channel={channel} />}
       <div className={classes.testNameAndDeleteButton}>
         {methodology.testName && <div className={classes.testName}>{methodology.testName}</div>}
         <div className={classes.deleteButton}>

--- a/public/src/components/channelManagement/helpers/methodology.ts
+++ b/public/src/components/channelManagement/helpers/methodology.ts
@@ -8,8 +8,7 @@ export const addMethodologyToTestName = (testName: string, methodology: Methodol
     return `${firstPart}_EpsilonGreedyBandit-${methodology.epsilon}${suffix}`;
   } else if (methodology.name === 'Roulette') {
     return `${firstPart}_Roulette${suffix}`;
-  }
-  else {
+  } else {
     return `${firstPart}_ABTest${suffix}`;
   }
 };

--- a/public/src/components/channelManagement/helpers/methodology.ts
+++ b/public/src/components/channelManagement/helpers/methodology.ts
@@ -6,7 +6,10 @@ export const addMethodologyToTestName = (testName: string, methodology: Methodol
   const suffix = secondPart ? `__${secondPart}` : '';
   if (methodology.name === 'EpsilonGreedyBandit') {
     return `${firstPart}_EpsilonGreedyBandit-${methodology.epsilon}${suffix}`;
-  } else {
+  } else if (methodology.name === 'Roulette') {
+    return `${firstPart}_Roulette${suffix}`;
+  }
+  else {
     return `${firstPart}_ABTest${suffix}`;
   }
 };

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -20,10 +20,14 @@ interface EpsilonGreedyBanditMethodology {
   name: 'EpsilonGreedyBandit';
   epsilon: number;
 }
+interface RouletteMethodology {
+  name: 'Roulette';
+}
 // each methodology may have an optional testName, which should be used for tracking
 export type Methodology = { testName?: string } & (
   | ABTestMethodology
   | EpsilonGreedyBanditMethodology
+  | RouletteMethodology
 );
 
 export interface Test {

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -83,7 +83,9 @@ const TestListTest: React.FC<TestListTestProps> = ({
   const classes = useStyles();
 
   const hasArticleCount = test.articlesViewedSettings !== undefined;
-  const isBanditTest = test.methodologies.find(method => method.name === 'EpsilonGreedyBandit'|| method.name === 'Roulette');
+  const isBanditTest = test.methodologies.find(
+    method => method.name === 'EpsilonGreedyBandit' || method.name === 'Roulette',
+  );
 
   const [ref, isHovered] = useHover<HTMLDivElement>();
 

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -83,7 +83,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
   const classes = useStyles();
 
   const hasArticleCount = test.articlesViewedSettings !== undefined;
-  const isBanditTest = test.methodologies.find(method => method.name === 'EpsilonGreedyBandit');
+  const isBanditTest = test.methodologies.find(method => method.name === 'EpsilonGreedyBandit'|| method.name === 'Roulette');
 
   const [ref, isHovered] = useHover<HTMLDivElement>();
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds "Roulette" as the third experiment methodology in RRCP

## How to test

Tested in CODE

## Images

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/502d46db-265a-4713-8b0d-29989079abb7">

On saving the test, the Methodology will be saved in the DynamoDB table along with other test details
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/a09d07bf-4b73-49f8-b9d9-16a2bf4bb8cf">
