### PR TITLE
Upgrade Remirror to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6871,9 +6871,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -6895,7 +6895,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -6910,6 +6910,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/array-flatten": {
@@ -7704,9 +7708,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -9706,12 +9710,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -10020,9 +10024,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -10512,9 +10516,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -14124,11 +14128,10 @@
       "dev": true
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19446,9 +19449,9 @@
       }
     },
     "express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
@@ -19470,7 +19473,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -20040,9 +20043,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "requires": {
         "@types/http-proxy": "^1.17.8",
@@ -21477,12 +21480,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -21715,9 +21718,9 @@
       "integrity": "sha512-JFAeG9fp0QZnRoESHjkbVFbZ9BkOXkkagUVwZVo/pkSX+Fq1VKlY+5og/8X9CYc6C7vje/CV+bwJ5M2X0+IY9Q=="
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true
     },
     "natural-compare": {
@@ -22050,9 +22053,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "path-type": {
@@ -24639,9 +24642,9 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mui/material": "^5.15.10",
         "@mui/styles": "^5.15.10",
         "@mui/x-data-grid": "^5.17.12",
-        "@remirror/pm": "^1.0.11",
+        "@remirror/pm": "^2.0.9",
         "@remirror/react": "^1.0.21",
         "@types/lodash": "^4.14.176",
         "@types/react-beautiful-dnd": "^13.0.0",
@@ -28,7 +28,7 @@
         "react-qr-code": "^2.0.7",
         "react-router-dom": "^6.2.1",
         "recharts": "2.12.6",
-        "remirror": "^1.0.60"
+        "remirror": "^2.0.4"
       },
       "devDependencies": {
         "@types/jest": "24.0.18",
@@ -58,12 +58,25 @@
         "webpack-dev-server": "^4.13.3"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -71,30 +84,33 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.13.15",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
+      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/core": {
-      "version": "7.13.16",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.16",
-        "@babel/helper-compilation-targets": "^7.13.16",
-        "@babel/helper-module-transforms": "^7.13.14",
-        "@babel/helpers": "^7.13.16",
-        "@babel/parser": "^7.13.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.15",
-        "@babel/types": "^7.13.16",
-        "convert-source-map": "^1.7.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -104,12 +120,17 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
     "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.3.1",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -121,295 +142,176 @@
       }
     },
     "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "devOptional": true,
-      "license": "ISC",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/core/node_modules/source-map": {
-      "version": "0.5.7",
-      "devOptional": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@babel/generator": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
-      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
-      "devOptional": true,
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
       "dependencies": {
-        "@babel/types": "^7.24.5",
+        "@babel/parser": "^7.26.2",
+        "@babel/types": "^7.26.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.16",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.13.15",
-        "@babel/helper-validator-option": "^7.12.17",
-        "browserslist": "^4.14.5",
-        "semver": "^6.3.0"
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "devOptional": true,
-      "license": "ISC",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "devOptional": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "devOptional": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.13.12",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.13.12"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "license": "MIT",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.13.14",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-replace-supers": "^7.13.12",
-        "@babel/helper-simple-access": "^7.13.12",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.13",
-        "@babel/types": "^7.13.14"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-      "dev": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.13.12",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
-      }
-    },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.13.12",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
+      "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
       "dependencies": {
-        "@babel/types": "^7.13.12"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
-      "devOptional": true,
-      "dependencies": {
-        "@babel/types": "^7.24.5"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.12.17",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.13.17",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.17",
-        "@babel/types": "^7.13.17"
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+    "node_modules/@babel/helpers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/parser": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-      "devOptional": true,
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
+      "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.9",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -443,6 +345,28 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -589,6 +513,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
+      "integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-simple-access": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
@@ -601,33 +541,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
-      "devOptional": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
-      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
-      "devOptional": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.5",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.24.5",
-        "@babel/parser": "^7.24.5",
-        "@babel/types": "^7.24.5",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -636,11 +571,11 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.1",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -652,20 +587,17 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -703,11 +635,6 @@
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
       }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -761,6 +688,11 @@
         }
       }
     },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
@@ -809,14 +741,10 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@emotion/serialize/node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-    },
     "node_modules/@emotion/serialize/node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@emotion/sheet": {
       "version": "1.2.2",
@@ -1140,9 +1068,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -1228,12 +1156,12 @@
       "dev": true
     },
     "node_modules/@jest/types": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1248,7 +1176,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "devOptional": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1262,7 +1189,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1271,7 +1197,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1289,14 +1214,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "devOptional": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1314,24 +1237,198 @@
       "integrity": "sha512-3zEi5plBCOsEzUneRVuQb+2SAx3qaC1dj0FfFAI6zIJQoDWu0dlSwKijMRack7oO9tUWrchfj3OkKQAd1LBdVg==",
       "license": "MIT"
     },
-    "node_modules/@lingui/core": {
-      "version": "3.13.0",
-      "license": "MIT",
+    "node_modules/@linaria/logger": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@linaria/logger/-/logger-4.5.0.tgz",
+      "integrity": "sha512-XdQLk242Cpcsc9a3Cz1ktOE5ysTo2TpxdeFQEPwMm8Z/+F/S6ZxBDdHYJL09srXWz3hkJr3oS2FPuMZNH1HIxw==",
       "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "make-plural": "^6.2.2",
-        "messageformat-parser": "^4.1.3"
+        "debug": "^4.1.1",
+        "picocolors": "^1.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@linaria/logger/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@linaria/logger/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/@linaria/tags": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@linaria/tags/-/tags-4.5.4.tgz",
+      "integrity": "sha512-HPxLB6HlJWLi6o8+8lTLegOmDnbMbuzEE+zzunaPZEGSoIIYx8HAv5VbY/sG/zNyxDElk6laiAwEVWN8h5/zxg==",
+      "dependencies": {
+        "@babel/generator": "^7.22.9",
+        "@linaria/logger": "^4.5.0",
+        "@linaria/utils": "^4.5.3"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@linaria/utils": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@linaria/utils/-/utils-4.5.3.tgz",
+      "integrity": "sha512-tSpxA3Zn0DKJ2n/YBnYAgiDY+MNvkmzAHrD8R9PKrpGaZ+wz1jQEmE1vGn1cqh8dJyWK0NzPAA8sf1cqa+RmAg==",
+      "dependencies": {
+        "@babel/core": "^7.22.9",
+        "@babel/generator": "^7.22.9",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.22.5",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "@linaria/logger": "^4.5.0",
+        "babel-merge": "^3.0.0",
+        "find-up": "^5.0.0",
+        "minimatch": "^9.0.3"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@linaria/utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@linaria/utils/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@linaria/utils/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@linaria/utils/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@linaria/utils/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@linaria/utils/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lingui/core": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.17.2.tgz",
+      "integrity": "sha512-YOd068NanznN8lLQqOKPlAY0ill3rrgmiAvPRKuYkrxzJMIHqlIFO/2Kcc/RH5vClOmLfg+wgR4rsHK/kLKelQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@messageformat/parser": "^5.0.0",
+        "make-plural": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@lingui/detect-locale": {
-      "version": "3.13.0",
-      "license": "MIT",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-3.17.2.tgz",
+      "integrity": "sha512-rqyO16lj05WRfBuppo++mPzB1fQBFDhGqEFz5X97CbWXYp6AadOIkrm+pbn114Y2Yumy9QI7Cm4Ptbfk7CXO3Q==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/@lingui/message-utils": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-4.14.1.tgz",
+      "integrity": "sha512-J6MzyTLNCzEnyR1Da188G81cRcQMbk/lyYnLWMzQjIELDX8bBBwNea91Sf5Zm+BB+ADWmmGTdUqRPAjDqT9Y5w==",
+      "dependencies": {
+        "@messageformat/parser": "^5.0.0",
+        "js-sha256": "^0.10.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@messageformat/parser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.0.tgz",
+      "integrity": "sha512-jKlkls3Gewgw6qMjKZ9SFfHUpdzEVdovKFtW1qRhJ3WI4FW5R/NnGDqr8SDGz+krWDO3ki94boMmQvGke1HwUQ==",
+      "dependencies": {
+        "moo": "^0.5.1"
+      }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
     },
     "node_modules/@mui/base": {
       "version": "5.0.0-beta.36",
@@ -1488,10 +1585,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@mui/material/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT"
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@mui/private-theming": {
       "version": "5.15.9",
@@ -1595,11 +1691,6 @@
         }
       }
     },
-    "node_modules/@mui/styles/node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-    },
     "node_modules/@mui/styles/node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1690,10 +1781,9 @@
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT"
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@mui/x-data-grid": {
       "version": "5.17.12",
@@ -1766,6 +1856,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@ocavue/svgmoji-cjs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@ocavue/svgmoji-cjs/-/svgmoji-cjs-0.1.1.tgz",
+      "integrity": "sha512-tCP6ggbtgIL4hPM5goVFSjL51jH/BLl/yBLy98wAV9a2L/Sn9iS3abfprPeQw6/nan5lLaz4Vz8ZP37LKh+xfQ==",
+      "dependencies": {
+        "svgmoji": "^3.2.0"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1776,23 +1874,24 @@
       }
     },
     "node_modules/@remirror/core": {
-      "version": "1.3.3",
-      "license": "MIT",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/core/-/core-2.0.19.tgz",
+      "integrity": "sha512-TGvDPUdKYqOiDQmt3+58GNBi4PX6QhBhII1qk9btZ/uFvG2/LLHEe+KN/BfBdvykGAu8CK9codLzg8NZd2fDEg==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/core-utils": "^1.1.4",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/icons": "^1.0.7",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.5",
+        "@remirror/core-utils": "^2.0.13",
+        "@remirror/i18n": "^2.0.5",
+        "@remirror/icons": "^2.0.3",
+        "@remirror/messages": "^2.0.6",
         "nanoevents": "^5.1.13",
         "tiny-warning": "^1.0.3"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.7"
       }
     },
     "node_modules/@remirror/core-constants": {
@@ -1805,8 +1904,9 @@
       }
     },
     "node_modules/@remirror/core-helpers": {
-      "version": "1.0.5",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-1.0.6.tgz",
+      "integrity": "sha512-4n5eii/3L85B4SSY8/9Rerpcgl+4/Zl7gMojIm43AkDqyCJNejRkqNW7jtflbkugEBjJP+sb6hEVMsW4jKCOHw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@linaria/core": "3.0.0-beta.13",
@@ -1826,918 +1926,837 @@
       }
     },
     "node_modules/@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-      "license": "MIT",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-2.0.6.tgz",
+      "integrity": "sha512-baoSrVd0ECjiCqx8MZ/vEBxVsFmbRlM/hpKUyhkiWlL3vxFr7s+LNb7Rjl+l6IYmm65A7CU+pBa2W4846cMoAg==",
       "dependencies": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/core-types/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/core-types/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/core-types/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/core-utils": {
-      "version": "1.1.4",
-      "license": "MIT",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-2.0.13.tgz",
+      "integrity": "sha512-5UggNc6Z2d7M8SVkstsVitID8DAHSKPrqet7Hfn4/dY+p4iMCOdwf9cLqcHMg3467k5/5/RvJPMTr9GQOEx7Hg==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.5",
+        "@remirror/messages": "^2.0.6",
         "@types/min-document": "^2.19.0",
         "css-in-js-utils": "^3.1.0",
-        "min-document": "^2.19.0"
+        "get-dom-document": "^0.1.3",
+        "min-document": "^2.19.0",
+        "parenthesis": "^3.1.8"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/node": "*",
-        "domino": "*",
-        "jsdom": "*"
+        "@remirror/pm": "^2.0.7",
+        "@types/node": "*"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
-        },
-        "domino": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
         }
       }
     },
-    "node_modules/@remirror/dom": {
-      "version": "1.0.17",
-      "license": "MIT",
+    "node_modules/@remirror/core-utils/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/preset-core": "^1.0.17"
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/core-utils/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/core-utils/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/core-utils/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/core-utils/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/core-utils/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/core-utils/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@lingui/detect-locale": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
+      "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/core/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@remirror/i18n": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
+      "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@lingui/detect-locale": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0",
+        "make-plural": "^6.2.2"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@remirror/icons": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
+      "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/core/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/dom": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/dom/-/dom-2.0.16.tgz",
+      "integrity": "sha512-DxjEFgQc24O93WN/YL7nHUanER/a1FIGQGRgsFoN9Px2t+Op39i2PZ0hm1ZE7ivp9/gE7obaMbgsXnjEJ8RX+A==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/preset-core": "^2.0.16"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.5"
       }
     },
     "node_modules/@remirror/extension-annotation": {
-      "version": "1.1.10",
-      "license": "MIT",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-annotation/-/extension-annotation-2.0.16.tgz",
+      "integrity": "sha512-jtLfWaNWQFfsE3lguQbYds4W3HJGLM0Ezrsc1q1w17EQxr5aJnjA2tNMjZL+6IdFzqEjuxd7Y9aRln3rU4WbnA==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/messages": "^2.0.3"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-annotation/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-bidi": {
-      "version": "1.0.13",
-      "license": "MIT",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-bidi/-/extension-bidi-2.0.16.tgz",
+      "integrity": "sha512-Dk3JMNPZwsU+ClcBbaD4k52vw7+tInUMMVN7RHIx4TFSVPeLq6vskvLaisbpfegt+lSq/4K8jSsYhjMoLjLWTw==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
         "@types/direction": "^1.0.0",
         "direction": "^1.0.4"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-bidi/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-blockquote": {
-      "version": "1.0.15",
-      "license": "MIT",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-blockquote/-/extension-blockquote-2.0.14.tgz",
+      "integrity": "sha512-jWko6/spZ49OvZVZVFUSPhOIZR8VY9aUFiMKJQfclkL3fESJPSPshkm6rANrnY24sk7VKfpXgpwCSqmJVJ8EiA==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "@remirror/theme": "^2.0.7"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-blockquote/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-bold": {
-      "version": "1.0.13",
-      "license": "MIT",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-bold/-/extension-bold-2.0.13.tgz",
+      "integrity": "sha512-b4yaQcU0m/tXxUVAlDSHcm3Z4dVnWKXfUmlpP8QDjISQ0F0vloRWSK2U9yvcldhmnTNJ/il0kn9PmJeoRbqkeA==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-bold/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-bold/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-bold/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-bold/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-bold/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-bold/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-bold/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-callout": {
-      "version": "1.0.15",
-      "license": "MIT",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-callout/-/extension-callout-2.0.17.tgz",
+      "integrity": "sha512-HBXQHasZrRgaRCqAXEleaHEwI2eGHe4a54KwFiId88rLwJRS6aQd1AI9KwGnnyHSTwnNIEMXX3vtMHH1ej1Sfw==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-callout/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-callout/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-callout/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-code": {
-      "version": "1.0.14",
-      "license": "MIT",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-code/-/extension-code-2.0.13.tgz",
+      "integrity": "sha512-uf4mkIHcw5RIscw1YcOMwikMMu+x5cqUkFdo5jjA3cssirh/87xDQJAeXLB4weN/ZNexbaJ2tSslWpMFrNBW8A==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-codemirror5": {
-      "version": "1.0.13",
-      "license": "MIT",
+    "node_modules/@remirror/extension-code-block": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-code-block/-/extension-code-block-2.0.20.tgz",
+      "integrity": "sha512-d1c/WHUw76Oq9aL/gQ3ihBwfAGyDi/XinN7oOd8ODdaK4zbDonGOCjB1Q5zZDJCZRDt5I6RYP/Z/Xzm/PgTsmQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/codemirror": "*",
-        "codemirror": "^5"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-columns": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-diff": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-doc": {
-      "version": "1.0.14",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-embed": {
-      "version": "1.1.18",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@types/querystringify": "^2.0.0",
-        "prosemirror-resizable-view": "^1.1.8",
-        "querystringify": "^2.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.11"
-      }
-    },
-    "node_modules/@remirror/extension-emoji": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "emojibase": "^6.0.0",
-        "emojibase-data": "^6.1.0",
-        "emojibase-regex": "^6.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "svgmoji": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-epic-mode": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-events": {
-      "version": "1.0.14",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-font-family": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-font-size": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "round": "^2.0.1"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-gap-cursor": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-heading": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-history": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-image": {
-      "version": "1.0.23",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "prosemirror-resizable-view": "^1.1.8"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.11"
-      }
-    },
-    "node_modules/@remirror/extension-italic": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-link": {
-      "version": "1.1.12",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-list": {
-      "version": "1.2.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-markdown": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@types/marked": "^3.0.0",
-        "@types/turndown": "^5.0.1",
-        "marked": "^3.0.0",
-        "turndown": "^7.1.1",
-        "turndown-plugin-gfm": "^1.0.2"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-mention": {
-      "version": "1.0.14",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom": {
-      "version": "1.0.16",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-node-formatting": {
-      "version": "1.0.16",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-positioner": {
-      "version": "1.1.14",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "nanoevents": "^5.1.13"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-react-ssr": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-react-component": "^1.1.4",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/react-utils": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/extension-react-ssr/node_modules/@remirror/extension-react-component": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "nanoevents": "^5.1.13"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/extension-search": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-search/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-shortcuts": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-strike": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-sub": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-sup": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-tables": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-text": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-text-case": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-text-color": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "color2k": "^1.2.4"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-trailing-node": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-underline": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace": {
-      "version": "1.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/extension-yjs": {
-      "version": "1.0.19",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-annotation": "^1.1.10",
-        "@remirror/messages": "^1.0.6",
-        "y-prosemirror": "^1.0.14",
-        "y-protocols": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "yjs": "^13.4.0"
-      }
-    },
-    "node_modules/@remirror/i18n": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@lingui/detect-locale": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.5",
-        "make-plural": "^6.2.1"
-      }
-    },
-    "node_modules/@remirror/icons": {
-      "version": "1.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-helpers": "^1.0.5"
-      }
-    },
-    "node_modules/@remirror/messages": {
-      "version": "1.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.5"
-      }
-    },
-    "node_modules/@remirror/pm": {
-      "version": "1.0.11",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.0",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.2.8",
-        "@types/prosemirror-transform": "^1.1.5",
-        "@types/prosemirror-view": "^1.23.1",
-        "prosemirror-collab": "^1.2.2",
-        "prosemirror-commands": "^1.2.0",
-        "prosemirror-dropcursor": "^1.4.0",
-        "prosemirror-gapcursor": "^1.2.1",
-        "prosemirror-history": "^1.2.0",
-        "prosemirror-inputrules": "^1.1.3",
-        "prosemirror-keymap": "^1.1.5",
-        "prosemirror-model": "^1.16.1",
-        "prosemirror-paste-rules": "^1.0.7",
-        "prosemirror-schema-list": "^1.1.6",
-        "prosemirror-state": "^1.3.4",
-        "prosemirror-suggest": "^1.0.7",
-        "prosemirror-tables": "^1.1.1",
-        "prosemirror-trailing-node": "^1.0.7",
-        "prosemirror-transform": "^1.3.3",
-        "prosemirror-view": "^1.23.6"
-      }
-    },
-    "node_modules/@remirror/preset-core": {
-      "version": "1.0.17",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-doc": "^1.0.14",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/extension-gap-cursor": "^1.0.13",
-        "@remirror/extension-history": "^1.0.13",
-        "@remirror/extension-paragraph": "^1.0.13",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-text": "^1.0.13"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/preset-formatting": {
-      "version": "1.0.19",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-bold": "^1.0.13",
-        "@remirror/extension-columns": "^1.0.13",
-        "@remirror/extension-font-size": "^1.0.15",
-        "@remirror/extension-heading": "^1.0.13",
-        "@remirror/extension-italic": "^1.0.13",
-        "@remirror/extension-node-formatting": "^1.0.16",
-        "@remirror/extension-strike": "^1.0.13",
-        "@remirror/extension-sub": "^1.0.13",
-        "@remirror/extension-sup": "^1.0.13",
-        "@remirror/extension-text-case": "^1.0.13",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/extension-text-highlight": "^1.0.15",
-        "@remirror/extension-underline": "^1.0.13",
-        "@remirror/extension-whitespace": "^1.0.13"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/preset-wysiwyg": {
-      "version": "1.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-bidi": "^1.0.13",
-        "@remirror/extension-blockquote": "^1.0.15",
-        "@remirror/extension-bold": "^1.0.13",
-        "@remirror/extension-code": "^1.0.14",
-        "@remirror/extension-code-block": "^1.0.18",
-        "@remirror/extension-drop-cursor": "^1.0.13",
-        "@remirror/extension-embed": "^1.1.18",
-        "@remirror/extension-gap-cursor": "^1.0.13",
-        "@remirror/extension-hard-break": "^1.0.13",
-        "@remirror/extension-heading": "^1.0.13",
-        "@remirror/extension-horizontal-rule": "^1.0.13",
-        "@remirror/extension-image": "^1.0.23",
-        "@remirror/extension-italic": "^1.0.13",
-        "@remirror/extension-link": "^1.1.12",
-        "@remirror/extension-list": "^1.2.13",
-        "@remirror/extension-search": "^1.0.13",
-        "@remirror/extension-shortcuts": "^1.1.2",
-        "@remirror/extension-strike": "^1.0.13",
-        "@remirror/extension-trailing-node": "^1.0.13",
-        "@remirror/extension-underline": "^1.0.13",
-        "@remirror/preset-core": "^1.0.17"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.11"
-      }
-    },
-    "node_modules/@remirror/preset-wysiwyg/node_modules/@remirror/extension-code-block": {
-      "version": "1.0.18",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
         "@types/refractor": "^3.0.2",
-        "refractor": "^3.3.1"
+        "refractor": "^3.6.0"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/prettier": "^2",
-        "prettier": "^2"
+        "@remirror/pm": "^2.0.9",
+        "@types/prettier": "^2.7.2",
+        "prettier": "^2.8.8"
       },
       "peerDependenciesMeta": {
         "@types/prettier": {
@@ -2749,6 +2768,4523 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-code-block/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-code/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-code/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-code/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-code/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-code/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-code/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-code/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-codemirror5/-/extension-codemirror5-2.0.15.tgz",
+      "integrity": "sha512-PUZRkuoCVJB+A1JZSWuSTckree3A/ibR7nbhqNCMMSDI88aTCCovFV3/yaQahoIkmjDfUWIacFrlHnZ+A4OmIQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9",
+        "@types/codemirror": "*",
+        "codemirror": "^5.65.13"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-codemirror5/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-collaboration/-/extension-collaboration-2.0.13.tgz",
+      "integrity": "sha512-sqkUjsPYQnuBIbyMW/FsSkQSyQ9GbQcawrigcCOxwlQp3f1snzKzfEcGRMPrUAG06UfDRedoGv/HVb+K4uIiIw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-collaboration/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-columns": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-columns/-/extension-columns-2.0.16.tgz",
+      "integrity": "sha512-WkeIAcHPStu5+k/us46rSsXthctCip+IrY7fESwewbFsSaAleSvgkna5ig7eyST7cDYVb4ILnbGImsSYY32TRQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-columns/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-columns/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-columns/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-columns/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-columns/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-columns/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-columns/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-diff": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-diff/-/extension-diff-2.0.13.tgz",
+      "integrity": "sha512-6IxewTYkiFTOqEB7W3uZHBCS6pTw76qJVceWziFnSzwlf0JPqs80C4y6BLOdC6rIa3nB9USSlDkf8y1HDubVZw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-diff/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-diff/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-diff/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-diff/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-diff/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-diff/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-diff/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-doc": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-doc/-/extension-doc-2.1.7.tgz",
+      "integrity": "sha512-HeIUpg+TmcPw7m4OrRtMbiSWPYS8vEcbv24/GqWYECPS6rWkBpqIlYz/sjQuV16nT/YjkKdmmNMn4eDtJZw2cw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-doc/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-doc/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-doc/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-doc/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-doc/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-doc/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-doc/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-drop-cursor/-/extension-drop-cursor-2.0.13.tgz",
+      "integrity": "sha512-To6YtaBZ4v4XWaoD1oMd/EGsKMw2plLizZHrH70q7voP5rJjjzQ1O0Z8N/qgeM6Ai7ZM1O8PAozUW1OpqQQJJA==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-drop-cursor/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-embed": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-embed/-/extension-embed-2.0.16.tgz",
+      "integrity": "sha512-1yzRWu+IVeILk01qR7mft0qrvIOQbKKkCnFSC09NT9LomUqXmbDGALL2DX9nVujG2TJrkT8aUZEcvV+cOWnOIw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@types/querystringify": "^2.0.0",
+        "prosemirror-resizable-view": "^2.0.15",
+        "querystringify": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-embed/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-embed/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-embed/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-embed/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-embed/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-embed/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-embed/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-emoji": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-emoji/-/extension-emoji-2.0.19.tgz",
+      "integrity": "sha512-EfS9z6VBQIvpy0bOU1GnF8o2xO8TXMC30iOnUmseu6rmj93rkQrKTmsIVQ3HEWoaDX2AKLNwAM2P/Zm9KtdSyg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@ocavue/svgmoji-cjs": "^0.1.1",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "emojibase": "^6.1.0",
+        "emojibase-data": "^6.2.0",
+        "emojibase-regex": "^6.0.1",
+        "escape-string-regexp": "^4.0.0",
+        "svgmoji": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-emoji/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-entity-reference": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-entity-reference/-/extension-entity-reference-2.2.8.tgz",
+      "integrity": "sha512-I9zjDws9En6GdUGfhrnoAAPRXJjsdrGetj5Sbsl1Xm/XpES6Jm/iDoZYr1/tJrgyys3USi96iwHCpV5p9FEnXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/extension-positioner": "^2.1.8"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-epic-mode/-/extension-epic-mode-2.0.13.tgz",
+      "integrity": "sha512-KDHF0Uyr0RevWtp1ca4VOL+4iD6SXlPpEbRKz7Mlg5Fnl9IGTEsraHwg9OthoTN1Kc8fzYMzOxv6qwyTsvMuVw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-epic-mode/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-events": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-2.1.17.tgz",
+      "integrity": "sha512-vIBV5tQYgQ8hkYXWPrgQwjmBxTe55FynKS4aDSpde1pfSf6MUUaTWNlMGQzmTWBukhw1tGppNiJkKuYpOL/YxQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.7"
+      }
+    },
+    "node_modules/@remirror/extension-events/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-events/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-events/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-events/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-events/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-events/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-events/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-font-family": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-font-family/-/extension-font-family-2.0.15.tgz",
+      "integrity": "sha512-hKr2CsyfdxtDMRDtpRgjKyxAwiuTM/BilVncs38jCDr8//GayK3XNU3hK287XKxfLXpr7ug7EHQXAx7wV94W+w==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-font-family/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-font-size": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-font-size/-/extension-font-size-2.0.15.tgz",
+      "integrity": "sha512-+5Kpq9Q/gQ+Z5dSbJq8Q10Jq6YmbjsuH0kL8qyJvhQbvsjiiMt3jEJrF3rHLHRUOnvpKVINaWRJ2EpsP5NOzTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "round": "^2.0.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-font-size/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-gap-cursor/-/extension-gap-cursor-2.0.13.tgz",
+      "integrity": "sha512-oaLrh/6cRhAdEksDNmrEcqnVixRjzARDr+cq2jJfPdVG0316xgNi7CkTnWJJCWSqQ4D6lrriMY5pQO3Qwlv5Kg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-gap-cursor/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-hard-break/-/extension-hard-break-2.0.13.tgz",
+      "integrity": "sha512-86T5bWl7O6feaXYIUylAuzq6lbpWhF6cM7CY7IW5c9+l8qpUMSktylfgAVAajjAtIfIB+g83m0D2AjL5VXksvg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-hard-break/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-heading": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-heading/-/extension-heading-2.0.16.tgz",
+      "integrity": "sha512-rK44ASoDpJcjnSBiafm2pQ5CMYtSimPkBAc/OBmiS5obgt4uGSx74FeoVOPi0+2fae2awZT9NscsoAZz1bGfyg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-heading/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-heading/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-heading/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-heading/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-heading/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-heading/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-heading/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-history": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-2.0.13.tgz",
+      "integrity": "sha512-LjW60KVpniRawttyhrWxM6ieE8sTYprqpCdMRbc7RuxBhdHaxlcQJGAjJvnBM7078qV/55S616P620YGYaBU4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-history/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-history/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-history/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-history/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-history/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-history/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-history/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-horizontal-rule/-/extension-horizontal-rule-2.0.13.tgz",
+      "integrity": "sha512-CV1lIWZ0n8btANKIP4xiUzTFbWRhOiBfdncePZvoRSYTa4UwfAQ6KapUVkcUHEL20UtDkDX8fGpF6kjtEGRCCQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-horizontal-rule/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-image": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-image/-/extension-image-2.1.12.tgz",
+      "integrity": "sha512-2nbywHOM4fXOFNxRdFFKaEUUtup57YAvpet5g7VBFwHamw6JWfWJwS6Bl8Baa6Vq6vEG51kU4TiCEInoGqOFKQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "prosemirror-resizable-view": "^2.0.15"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-image/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-image/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-image/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-image/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-italic": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-italic/-/extension-italic-2.0.13.tgz",
+      "integrity": "sha512-DZ7BoIxQqwTWoTYgc7GpK+SCBKfDoJjh4xKQIrC/45tcK+WdPaaxNRhdtGUzwOhHL2psYT6HtDOyN/DpO5hjWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-italic/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-italic/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-italic/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-italic/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-italic/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-italic/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-italic/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-link": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-link/-/extension-link-2.0.19.tgz",
+      "integrity": "sha512-V2buYAbfPK3CSzCmwkHUE+30qpd/c++m/vfjhLagZHCbUJMbtQE8D41+OTUjiCvuCYhB94nrxWyyPYpXA7sOfQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "extract-domain": "2.2.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-link/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-link/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-link/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-link/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-link/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-link/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-link/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-list": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-list/-/extension-list-2.0.18.tgz",
+      "integrity": "sha512-+F8i4Ax1Ii9Rig5ORV8XEpZG/cqn/BgCmsxZy7yjEiPLEM+zSnEKCrldixkbb47NiTDEbDfrFcWeR/taqJ3kFQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-list/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-list/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-list/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-list/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-markdown": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-markdown/-/extension-markdown-2.0.14.tgz",
+      "integrity": "sha512-tv8h2KyAF6dvawqslW8FG/qftpfNzseQujaVc0o/KmV9iE8kQnIdTcDPClL0GWwk9fOqlLL8C2zkKnvLMKk4Cw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@types/marked": "^4.3.1",
+        "@types/turndown": "^5.0.1",
+        "marked": "^4.3.0",
+        "turndown": "^7.1.2",
+        "turndown-plugin-gfm": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-markdown/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-mention": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-mention/-/extension-mention-2.0.17.tgz",
+      "integrity": "sha512-QyJo8CtxWVC/WliaEVREMYLb+xD9qWVqtF/3dSa3A+3FQSzasutDrUlcmR0soo/Nc3YmlsRMVi+njVgpta/Dww==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-mention-atom/-/extension-mention-atom-2.0.19.tgz",
+      "integrity": "sha512-/ElJi0zafw4ErGSfmIMQteYNErH31SRi7usHAQkT3oFAZDbvPE1QPfNE3bdSqJgVt3+IqC7E7jr+QTCqHhOi5A==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-mention-atom/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-mention/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-mention/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-node-formatting/-/extension-node-formatting-2.0.15.tgz",
+      "integrity": "sha512-s7WfiNlGdb1EOAepvLIKx/E1fyPtpr3HoTGrySCONfvwG6DJN4T3HMWAhMz30mts8leK2wlsItjRfgWVlf3Leg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-node-formatting/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-2.0.13.tgz",
+      "integrity": "sha512-/iEYz6Sn/RLqTefa/vjjyfhMQAGcpNQY7hdW0rSox+IiwDKeeY+uR2TCi3hs/D9IMzNERZXMKD5Wk8ver1kYCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-paragraph/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-placeholder/-/extension-placeholder-2.0.14.tgz",
+      "integrity": "sha512-YyrDs1Plyrpy5N6ehG3QOZNxpsQpDdI34yFQst+g2t/amnY6ScCnAJJ4GE666P4xnPF2V9gY0478Re09JmJ1KQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "@remirror/theme": "^2.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-placeholder/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-positioner": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-positioner/-/extension-positioner-2.1.8.tgz",
+      "integrity": "sha512-7svqCFayauNSFCXejvitFqkTUhxk74FCCoWNI2S4p8m0y80TzJDVrASjc2m8/kZALjVeIE4Byg1gE58zj3r9SA==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-events": "^2.1.14",
+        "@remirror/messages": "^2.0.3",
+        "@remirror/theme": "^2.0.7",
+        "nanoevents": "^5.1.13"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-positioner/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-search": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-search/-/extension-search-2.0.14.tgz",
+      "integrity": "sha512-PZrf20bqr8n+E1kgeb6uQJG5ZeD8nHTzzICZRe01ltwmO4vqnWMXr7Tm5Z6Byh+ZqwLbMWkIeUzoaV7RdBQ94Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-search/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-search/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-shortcuts": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-shortcuts/-/extension-shortcuts-2.0.13.tgz",
+      "integrity": "sha512-LHHn7lnbicL9CQet9w9Aayw25SqsA5s9ysGWO9R9DbrYKJWWL1EijvZ3rz+N6nlb9/ItFWA6eNSSUSausnv+iA==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-strike": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-strike/-/extension-strike-2.0.13.tgz",
+      "integrity": "sha512-42aEM12xux3RoxTZHJ6OBPpHux96btiMC7btPz7lJ/mqcAtVvIP3RHb8D01esU7KEpqIaI6H6n2WKc/JmvCdMQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-strike/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-strike/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-strike/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-strike/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-strike/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-strike/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-strike/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-sub": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-sub/-/extension-sub-2.0.13.tgz",
+      "integrity": "sha512-eeEdHBWynyoU6YXc6Xt+n93nK2JJ0ry2TGqr8nzomssm2gddASPJKXFoPELuwME/iqzz64SxU/RcI7BRc/lbdw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-sub/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-sub/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-sub/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-sub/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-sub/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-sub/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-sub/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-sup": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-sup/-/extension-sup-2.0.13.tgz",
+      "integrity": "sha512-8Pz+K8aSlxVCeqk9ZSX+JiSBNeCau8EbGkfTg1wAatq1jCrNhFHOHoazYOqA+nJjYP7/c5hiCoPYLpyXweIX3w==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-sup/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-sup/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-sup/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-sup/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-sup/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-sup/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-sup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-tables": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-tables/-/extension-tables-2.4.3.tgz",
+      "integrity": "sha512-Mo7eGYc2h/rJW4uUYluh529Lv6Lwjyy10M2SJ52Yxnr0kZDU0bTJZsXRF+SxPgS0V8qQkqhwSSCDoys/x9IqLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-tables/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-tables/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-tables/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-text": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text/-/extension-text-2.0.13.tgz",
+      "integrity": "sha512-0lGw8zz3OZzRY5zGrI1gXJIfuv23Yf3IdK3507oqE0oVAnP61vPB5WMaYv3EtGez9g3RoXO8S0bIJJ3syzdILg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-text-case": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-case/-/extension-text-case-2.0.15.tgz",
+      "integrity": "sha512-EFkEW2JvgyiNJch0wINYY801ATjXW8X+zbMSeJAE0mP0CV/1FY7svcJ2Fn7/4Czy8RVryKLgfN+xqjjLg/HNwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-text-case/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-text-color": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-2.0.17.tgz",
+      "integrity": "sha512-KoZ//Lgts6shVeGzK0CKdHmfq7vp0HuB9Upk1Sd6igKuJVMpmwM2UPUYtO/ig2N+KT4r+EUYPOiLrSzoCr3zog==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/i18n": "^2.0.5",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "color2k": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@lingui/detect-locale": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
+      "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@remirror/i18n": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
+      "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@lingui/detect-locale": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0",
+        "make-plural": "^6.2.2"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/extension-text-color/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-highlight/-/extension-text-highlight-2.0.16.tgz",
+      "integrity": "sha512-WrTftw/0tpPxjcCFhZekkXa1A/eHedgNyL88B+8Np04W7YHWiuALlIVdG+yZ+NZPxR0SWypFpsA8Yu12kGGRiA==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-text-color": "^2.0.17",
+        "@remirror/messages": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-text-highlight/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-text/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-text/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-text/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-text/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-text/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-text/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-trailing-node/-/extension-trailing-node-2.0.13.tgz",
+      "integrity": "sha512-DCeovi8yJ8HzTHZ/8bIxalm7aSjngN2B+DazGb5b6iLPFiEi00zucsw81bnVkHMa8DKDeH7WVbe13wZI+tn+KA==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-trailing-node/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-underline": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-underline/-/extension-underline-2.0.13.tgz",
+      "integrity": "sha512-wrNDSqNvwqtZBiz0nOEQaWOEthxOtBVwkuTku83Sh7ftK6rNWJXtHKNKGUAFW6A9FXxvvqrnr8+n0DSgYdIAMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-underline/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-underline/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-underline/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-underline/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-underline/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-underline/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-underline/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-whitespace/-/extension-whitespace-2.0.13.tgz",
+      "integrity": "sha512-daRoiH2/xZWrz8tzV14rfG8Catd0ThPJdWgoQ0en3QxcwYsTOP1+DXE1ZwUdP/uukuHg6DMAvgMvsWwJMtVx9A==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-whitespace/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/extension-yjs": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-yjs/-/extension-yjs-3.0.16.tgz",
+      "integrity": "sha512-7JnK76M/7kwOQVmX79mOGKFpQg2UyMvslF1sadEKAAQIcX7bocoo09MmCnrg5tBuSI6Jb4mS+PG/QBH/7WKykQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.33.8",
+        "y-prosemirror": "^1.0.19",
+        "y-protocols": "^1.0.5"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9",
+        "yjs": "^13.6.1"
+      }
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/@lingui/core": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/@remirror/messages": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/extension-yjs/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/i18n": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-1.0.9.tgz",
+      "integrity": "sha512-uWYuFTuD5+4WEdHIvkrkimhAa3jIL89Z2KMRi2aj0pA8PDwD+svDNz8E1B1SUP2Th8JmGd0XfHRtg+OsiDTjTA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@lingui/core": "^3.10.4",
+        "@lingui/detect-locale": "^3.10.4",
+        "@remirror/core-helpers": "^1.0.6",
+        "make-plural": "^6.2.1"
+      }
+    },
+    "node_modules/@remirror/icons": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-1.0.8.tgz",
+      "integrity": "sha512-aS8wssUaH5yfJoeEPOPLKCsK7OSmXZlmSxxQ10j5REaw9UlyEWrFAb+GjGpFqeM8o7xS9T7W0M6yWyVSaKIeng==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-helpers": "^1.0.6"
+      }
+    },
+    "node_modules/@remirror/messages": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-1.0.7.tgz",
+      "integrity": "sha512-cnN5UxQGMW2rCJFqjzYzHG0qvCugraKc0r4b3atDE8HokVIJO1DHoVYux5A7UkfYVe5Enow/UUy/nj5zf3MhgA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@lingui/core": "^3.10.4",
+        "@remirror/core-helpers": "^1.0.6"
+      }
+    },
+    "node_modules/@remirror/pm": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-2.0.9.tgz",
+      "integrity": "sha512-B2/FpFMtNS6sEIKKsxzM6uLW/Zp+1PDfVxNmA7DRTg691v9Yhh5wYXwcg2mtcMTEiRELiPwjCR5kDHSIrzb6Ag==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-paste-rules": "^2.0.8",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-suggest": "^2.0.7",
+        "prosemirror-tables": "^1.3.7",
+        "prosemirror-trailing-node": "^2.0.9",
+        "prosemirror-transform": "^1.9.0",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/@remirror/pm/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/@remirror/pm/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@remirror/pm/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@remirror/pm/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/@remirror/pm/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/preset-core": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-core/-/preset-core-2.0.16.tgz",
+      "integrity": "sha512-Qg5kDJIoSqSCtqwuT/+xq1pXf5XHonnqE4oRL5Z7Tu9RRmQ6evMhdc6CqehP5xwI+52g7q9CCRQYyNAtAhS3LQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-doc": "^2.1.5",
+        "@remirror/extension-events": "^2.1.14",
+        "@remirror/extension-gap-cursor": "^2.0.13",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-paragraph": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-text": "^2.0.13"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/preset-formatting": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-formatting/-/preset-formatting-2.0.14.tgz",
+      "integrity": "sha512-Dn8AITrTycEsO3kmR3kiWE8tCjWQUmK4vvyE/aGTyvHQHsDt1KhK6X42os7D+ePxeRf4OkhaZJhdpVmujmCCUw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-columns": "^2.0.13",
+        "@remirror/extension-font-size": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.13",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-node-formatting": "^2.0.13",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-sub": "^2.0.13",
+        "@remirror/extension-sup": "^2.0.13",
+        "@remirror/extension-text-case": "^2.0.13",
+        "@remirror/extension-text-color": "^2.0.14",
+        "@remirror/extension-text-highlight": "^2.0.14",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/extension-whitespace": "^2.0.13"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/preset-wysiwyg": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-wysiwyg/-/preset-wysiwyg-2.0.19.tgz",
+      "integrity": "sha512-yYDfHy3WJzBmYkTd1R8WgY0xND4ZhSOQSmWWxYcCb9QJOWqeX/LREk6Ac+FV2Ygc+aoRGx5HI2R6POehe1fb5g==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-bidi": "^2.0.13",
+        "@remirror/extension-blockquote": "^2.0.14",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-code": "^2.0.13",
+        "@remirror/extension-code-block": "^2.0.14",
+        "@remirror/extension-drop-cursor": "^2.0.13",
+        "@remirror/extension-embed": "^2.0.13",
+        "@remirror/extension-gap-cursor": "^2.0.13",
+        "@remirror/extension-hard-break": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.13",
+        "@remirror/extension-horizontal-rule": "^2.0.13",
+        "@remirror/extension-image": "^2.1.9",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-link": "^2.0.15",
+        "@remirror/extension-list": "^2.0.16",
+        "@remirror/extension-search": "^2.0.14",
+        "@remirror/extension-shortcuts": "^2.0.13",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-trailing-node": "^2.0.13",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/preset-core": "^2.0.16"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
       }
     },
     "node_modules/@remirror/react": {
@@ -2801,13 +7337,367 @@
         }
       }
     },
-    "node_modules/@remirror/react-utils": {
-      "version": "1.0.6",
-      "license": "MIT",
+    "node_modules/@remirror/react-renderer/node_modules/@remirror/core": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
+      "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@linaria/core": "3.0.0-beta.13",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/core-types": "^1.0.4",
+        "@remirror/core-utils": "^1.1.11",
+        "@remirror/i18n": "^1.0.9",
+        "@remirror/icons": "^1.0.8",
+        "@remirror/messages": "^1.0.7",
+        "nanoevents": "^5.1.13",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/@remirror/core-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "dependencies": {
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/types": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.10"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/@remirror/core-utils": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
+      "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/core-types": "^1.0.4",
+        "@remirror/messages": "^1.0.7",
+        "@types/min-document": "^2.19.0",
+        "css-in-js-utils": "^3.1.0",
+        "min-document": "^2.19.0",
+        "parenthesis": "^3.1.8"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22",
+        "@types/node": "*",
+        "domino": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "domino": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/@remirror/pm": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@types/prosemirror-collab": "^1.1.2",
+        "@types/prosemirror-commands": "^1.0.4",
+        "@types/prosemirror-dropcursor": "^1.0.3",
+        "@types/prosemirror-gapcursor": "^1.0.4",
+        "@types/prosemirror-history": "^1.0.3",
+        "@types/prosemirror-inputrules": "^1.0.4",
+        "@types/prosemirror-keymap": "^1.0.4",
+        "@types/prosemirror-model": "^1.16.2",
+        "@types/prosemirror-schema-list": "^1.0.3",
+        "@types/prosemirror-state": "^1.3.0",
+        "@types/prosemirror-transform": "^1.4.0",
+        "@types/prosemirror-view": "^1.23.2",
+        "prosemirror-collab": "<1.3.0",
+        "prosemirror-commands": "<1.3.0",
+        "prosemirror-dropcursor": "<1.5.0",
+        "prosemirror-gapcursor": "<1.3.0",
+        "prosemirror-history": "<1.3.0",
+        "prosemirror-inputrules": "<1.2.0",
+        "prosemirror-keymap": "<1.2.0",
+        "prosemirror-model": "<1.17.0",
+        "prosemirror-paste-rules": "^1.1.3",
+        "prosemirror-schema-list": "<1.2.0",
+        "prosemirror-state": "<1.4.0",
+        "prosemirror-suggest": "^1.1.4",
+        "prosemirror-tables": "<1.2.0",
+        "prosemirror-trailing-node": "^1.0.11",
+        "prosemirror-transform": "<1.5.0",
+        "prosemirror-view": "<1.24.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/orderedmap": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+      "peer": true
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-collab": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-commands": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-dropcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-gapcursor": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-history": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "peer": true,
+      "dependencies": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-paste-rules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-schema-list": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-suggest": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/types": "^0.1.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-tables": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-trailing-node": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-transform": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-renderer/node_modules/prosemirror-view": {
+      "version": "1.23.13",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react-utils": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@remirror/react-utils/-/react-utils-1.0.7.tgz",
+      "integrity": "sha512-Pth2OppgT7jtpzZkZPYaKKXpiXmGKjrin08KuRuPRywL4ra3q75lpVFs4Yf+lYu/IvUda61yXew2oHfWsM9ktg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
         "@remirror/core-types": "^1.0.4"
       },
       "peerDependencies": {
@@ -2820,17 +7710,527 @@
         }
       }
     },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-react-component": {
-      "version": "1.1.4",
-      "license": "MIT",
+    "node_modules/@remirror/react-utils/node_modules/@remirror/core-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "dependencies": {
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/types": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.10"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/@remirror/pm": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@types/prosemirror-collab": "^1.1.2",
+        "@types/prosemirror-commands": "^1.0.4",
+        "@types/prosemirror-dropcursor": "^1.0.3",
+        "@types/prosemirror-gapcursor": "^1.0.4",
+        "@types/prosemirror-history": "^1.0.3",
+        "@types/prosemirror-inputrules": "^1.0.4",
+        "@types/prosemirror-keymap": "^1.0.4",
+        "@types/prosemirror-model": "^1.16.2",
+        "@types/prosemirror-schema-list": "^1.0.3",
+        "@types/prosemirror-state": "^1.3.0",
+        "@types/prosemirror-transform": "^1.4.0",
+        "@types/prosemirror-view": "^1.23.2",
+        "prosemirror-collab": "<1.3.0",
+        "prosemirror-commands": "<1.3.0",
+        "prosemirror-dropcursor": "<1.5.0",
+        "prosemirror-gapcursor": "<1.3.0",
+        "prosemirror-history": "<1.3.0",
+        "prosemirror-inputrules": "<1.2.0",
+        "prosemirror-keymap": "<1.2.0",
+        "prosemirror-model": "<1.17.0",
+        "prosemirror-paste-rules": "^1.1.3",
+        "prosemirror-schema-list": "<1.2.0",
+        "prosemirror-state": "<1.4.0",
+        "prosemirror-suggest": "^1.1.4",
+        "prosemirror-tables": "<1.2.0",
+        "prosemirror-trailing-node": "^1.0.11",
+        "prosemirror-transform": "<1.5.0",
+        "prosemirror-view": "<1.24.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/orderedmap": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+      "peer": true
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-collab": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-commands": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-dropcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-gapcursor": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-history": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "peer": true,
+      "dependencies": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-paste-rules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-schema-list": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-suggest": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/types": "^0.1.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-tables": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-trailing-node": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-transform": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react-utils/node_modules/prosemirror-view": {
+      "version": "1.23.13",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/core": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
+      "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@linaria/core": "3.0.0-beta.13",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/core-types": "^1.0.4",
+        "@remirror/core-utils": "^1.1.11",
+        "@remirror/i18n": "^1.0.9",
+        "@remirror/icons": "^1.0.8",
+        "@remirror/messages": "^1.0.7",
+        "nanoevents": "^5.1.13",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/core-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "dependencies": {
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/types": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.10"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/core-utils": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
+      "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/core-types": "^1.0.4",
+        "@remirror/messages": "^1.0.7",
+        "@types/min-document": "^2.19.0",
+        "css-in-js-utils": "^3.1.0",
+        "min-document": "^2.19.0",
+        "parenthesis": "^3.1.8"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22",
+        "@types/node": "*",
+        "domino": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "domino": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-doc": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-doc/-/extension-doc-1.0.25.tgz",
+      "integrity": "sha512-bC6YTkldMQ6/YT2HbN4AM2UtpoBDAmglj06UI6YspsUzJLhH+z+O6n5sgWQ89j9r3jKx9768YK9CPmtk6EIfLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-emoji": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-emoji/-/extension-emoji-1.0.29.tgz",
+      "integrity": "sha512-kegqTYJORylKGCcefj5c9S/+vZ9aUGtECpreF2fo0P8Njs7EOxzJxwoc/DRogLNLDjWVJxoQpS4nllNw/XA3lA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/theme": "^1.2.2",
+        "emojibase": "^6.0.0",
+        "emojibase-data": "^6.1.0",
+        "emojibase-regex": "^6.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "svgmoji": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-events": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-1.1.5.tgz",
+      "integrity": "sha512-l8+r6TMphdJ1khnKYy+PlqjhlEDvLTyHZ89BJRJmPaDfpsw7IhgcDbtvklYPtaJC9TkWRbxc9hfz/NOY8qwHHA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-gap-cursor": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-gap-cursor/-/extension-gap-cursor-1.0.24.tgz",
+      "integrity": "sha512-WiiBzcDRwwfbFbCUaR+lUFmjvNaZidJrOdfVswcUXe/LoxKqaQEZ7l7x3WIpuEXMIO/RCP6f+tb4ppzuJ9Erhg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-history": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-1.0.24.tgz",
+      "integrity": "sha512-f7OMtCAuzVis/fPOiZvkQ3Ay8My032HhRHcDNX1d0yqiYNN6XWsD93sAYbC7c6ymLZ9GP1YNiorJ4GmXd8mBsQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-mention": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-mention/-/extension-mention-1.0.25.tgz",
+      "integrity": "sha512-tlzdpb4XEt+9v5408M/SPtRZlX+0DOE+2iycvu7H0mrc8TYWEG23YDznu7w86wr3PGEg9+LzofVUDK+rpfmbDg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/extension-events": "^1.1.5",
+        "@remirror/messages": "^1.0.7",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-mention-atom": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-mention-atom/-/extension-mention-atom-1.0.29.tgz",
+      "integrity": "sha512-5JE6EVVFP2HPa9Drzfxuas1ehhQgt2fNnVtTCusk5eznoMAsRiMzM6XrtsKXw5ZUqbfZ0MoDZjRniQYwnhUdXA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/extension-events": "^1.1.5",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/theme": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-paragraph": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-1.0.24.tgz",
+      "integrity": "sha512-sfsir4HSUKX6Dags+6KHFywHhwx+C6SUqKgp+MakrqEw9rKFOZs4yNDY25MsTxBZTVQ3dq/2vi1nCdt6Q6trAA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-placeholder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-placeholder/-/extension-placeholder-1.0.28.tgz",
+      "integrity": "sha512-siAI6ugWEBu7uu3zMlpizf3bXGpy9tHNtc9558XRpRyOQu6DaKyAZq/A9h4Vf2xqN8VYit8zJ8KckaBuAp2a5A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/theme": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-positioner": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-positioner/-/extension-positioner-1.2.9.tgz",
+      "integrity": "sha512-2LThtxAeDBJNzZlYAB7gI5H3dULKvt5NH5UVHKzhXXxkO2q3OCCs9oz5sNOxphrS1K31Oh54gCEoiKUta6fppA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/extension-events": "^1.1.5",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/theme": "^1.2.2",
         "nanoevents": "^5.1.13"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-react-component": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-react-component/-/extension-react-component-1.1.16.tgz",
+      "integrity": "sha512-X4x8STuDcz5Pz68YLMOb9ps1STFl3ZqdjhrILolLxXjfkJmLeCLRNwMUFTs9KrIJX842HAKwLevOTrA0vjlxkA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7",
+        "nanoevents": "^5.1.13"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22",
         "@types/react": "^16.14.0 || ^17 || ^18",
         "@types/react-dom": "^16.9.0 || ^17 || ^18",
         "react": "^16.14.0 || ^17 || ^18",
@@ -2841,6 +8241,28 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-react-ssr": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-react-ssr/-/extension-react-ssr-1.0.28.tgz",
+      "integrity": "sha512-X7TV3FkMc/NGLnEBDaFUAckNXuPe1sjcoG2XkSuoOYG0DfiBTfv5SD11/QJT2a2lRNqxlB9QpXS2Ngz4sRHaYw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/extension-react-component": "^1.1.16",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/react-utils": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22",
+        "@types/react": "^16.14.0 || ^17 || ^18",
+        "react": "^16.14.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2877,6 +8299,107 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-tables": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-tables/-/extension-tables-1.0.28.tgz",
+      "integrity": "sha512-erG70aN6WoyV6i/5n2hVgcGRq28Ahz8XBYWKF/GpVuReO0nA3FvBUIa2jKYrAVYnnYVfv/lMyTs9fJL4HRQOrA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/theme": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-text": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text/-/extension-text-1.0.24.tgz",
+      "integrity": "sha512-+WpPwJnZNWrWNNH4lX8yMFvSjQ6/ueRXCjqmtC5KulfMxjIce6PEJOBsBLIgGVwLXqJDdXxBEnTmj7BqtoqolQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/messages": "^1.0.7"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/extension-text-color": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-1.0.28.tgz",
+      "integrity": "sha512-blau7PEy/53T8cJ2fpKIa76krsQ1KllCLUc7yXL1/cw3zHACV4up9lUTqD5jTQnPxSKUacI6ZykJekC+9fjq5Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/i18n": "^1.0.9",
+        "@remirror/messages": "^1.0.7",
+        "@remirror/theme": "^1.2.2",
+        "color2k": "^1.2.4"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/pm": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@types/prosemirror-collab": "^1.1.2",
+        "@types/prosemirror-commands": "^1.0.4",
+        "@types/prosemirror-dropcursor": "^1.0.3",
+        "@types/prosemirror-gapcursor": "^1.0.4",
+        "@types/prosemirror-history": "^1.0.3",
+        "@types/prosemirror-inputrules": "^1.0.4",
+        "@types/prosemirror-keymap": "^1.0.4",
+        "@types/prosemirror-model": "^1.16.2",
+        "@types/prosemirror-schema-list": "^1.0.3",
+        "@types/prosemirror-state": "^1.3.0",
+        "@types/prosemirror-transform": "^1.4.0",
+        "@types/prosemirror-view": "^1.23.2",
+        "prosemirror-collab": "<1.3.0",
+        "prosemirror-commands": "<1.3.0",
+        "prosemirror-dropcursor": "<1.5.0",
+        "prosemirror-gapcursor": "<1.3.0",
+        "prosemirror-history": "<1.3.0",
+        "prosemirror-inputrules": "<1.2.0",
+        "prosemirror-keymap": "<1.2.0",
+        "prosemirror-model": "<1.17.0",
+        "prosemirror-paste-rules": "^1.1.3",
+        "prosemirror-schema-list": "<1.2.0",
+        "prosemirror-state": "<1.4.0",
+        "prosemirror-suggest": "^1.1.4",
+        "prosemirror-tables": "<1.2.0",
+        "prosemirror-trailing-node": "^1.0.11",
+        "prosemirror-transform": "<1.5.0",
+        "prosemirror-view": "<1.24.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/@remirror/preset-core": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-core/-/preset-core-1.0.31.tgz",
+      "integrity": "sha512-mPW9dm1ynrRTezMrzf+6a0N10MVyoJTBsWRN8tG2o68XXR4c8NnUfbAZeQzv1OTUuOdL86ea+JUR6PWD4jhhAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core": "^1.4.7",
+        "@remirror/extension-doc": "^1.0.25",
+        "@remirror/extension-events": "^1.1.5",
+        "@remirror/extension-gap-cursor": "^1.0.24",
+        "@remirror/extension-history": "^1.0.24",
+        "@remirror/extension-paragraph": "^1.0.24",
+        "@remirror/extension-positioner": "^1.2.9",
+        "@remirror/extension-text": "^1.0.24"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.22"
       }
     },
     "node_modules/@remirror/react/node_modules/@remirror/preset-react": {
@@ -2984,42 +8507,6 @@
         "reakit": "^1.0.0"
       }
     },
-    "node_modules/@remirror/react/node_modules/@remirror/react-components/node_modules/reakit-system-palette/node_modules/reakit-system": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-      "license": "MIT",
-      "dependencies": {
-        "reakit-utils": "^0.15.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-components/node_modules/reakit-utils": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-components/node_modules/reakit/node_modules/reakit-system": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-      "license": "MIT",
-      "dependencies": {
-        "reakit-utils": "^0.15.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/@remirror/react/node_modules/@remirror/react-core": {
       "version": "1.0.19",
       "license": "MIT",
@@ -3122,9 +8609,257 @@
         }
       }
     },
-    "node_modules/@remirror/theme": {
+    "node_modules/@remirror/react/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/orderedmap": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+      "peer": true
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-collab": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-commands": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-dropcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-gapcursor": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-history": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "peer": true,
+      "dependencies": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-paste-rules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-schema-list": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-suggest": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/types": "^0.1.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-tables": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-trailing-node": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-transform": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/react/node_modules/prosemirror-view": {
+      "version": "1.23.13",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/theme": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-1.2.2.tgz",
+      "integrity": "sha512-tT171xQWEneqq4kesRUfRB29CgT2VoG5NtCTD69ZuiKK+j481f6tXcyquQG15PSxwEr5AVC8aB75qKiZJBlHWQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@linaria/core": "3.0.0-beta.13",
@@ -3134,9 +8869,309 @@
         "csstype": "^3.0.7"
       }
     },
+    "node_modules/@remirror/theme/node_modules/@remirror/core-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "dependencies": {
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/types": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.10"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/@remirror/pm": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@types/prosemirror-collab": "^1.1.2",
+        "@types/prosemirror-commands": "^1.0.4",
+        "@types/prosemirror-dropcursor": "^1.0.3",
+        "@types/prosemirror-gapcursor": "^1.0.4",
+        "@types/prosemirror-history": "^1.0.3",
+        "@types/prosemirror-inputrules": "^1.0.4",
+        "@types/prosemirror-keymap": "^1.0.4",
+        "@types/prosemirror-model": "^1.16.2",
+        "@types/prosemirror-schema-list": "^1.0.3",
+        "@types/prosemirror-state": "^1.3.0",
+        "@types/prosemirror-transform": "^1.4.0",
+        "@types/prosemirror-view": "^1.23.2",
+        "prosemirror-collab": "<1.3.0",
+        "prosemirror-commands": "<1.3.0",
+        "prosemirror-dropcursor": "<1.5.0",
+        "prosemirror-gapcursor": "<1.3.0",
+        "prosemirror-history": "<1.3.0",
+        "prosemirror-inputrules": "<1.2.0",
+        "prosemirror-keymap": "<1.2.0",
+        "prosemirror-model": "<1.17.0",
+        "prosemirror-paste-rules": "^1.1.3",
+        "prosemirror-schema-list": "<1.2.0",
+        "prosemirror-state": "<1.4.0",
+        "prosemirror-suggest": "^1.1.4",
+        "prosemirror-tables": "<1.2.0",
+        "prosemirror-trailing-node": "^1.0.11",
+        "prosemirror-transform": "<1.5.0",
+        "prosemirror-view": "<1.24.0"
+      }
+    },
     "node_modules/@remirror/theme/node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/@remirror/theme/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/orderedmap": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+      "peer": true
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-collab": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-commands": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-dropcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-gapcursor": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-history": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "peer": true,
+      "dependencies": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-paste-rules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-schema-list": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-suggest": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/types": "^0.1.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-tables": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-trailing-node": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-transform": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/@remirror/theme/node_modules/prosemirror-view": {
+      "version": "1.23.13",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
     },
     "node_modules/@remirror/types": {
       "version": "0.1.1",
@@ -3201,7 +9236,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@svgmoji/blob/-/blob-3.2.0.tgz",
       "integrity": "sha512-N96WOrH9GxPSPZ/FuvZl6T9Rh54stAEuUcBppIRFh9/WwkU7Hczrjabw4uunwxFLX5TgR+rHlKJl3/jaTnXJrQ==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@svgmoji/core": "^3.2.0"
@@ -3211,7 +9245,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@svgmoji/core/-/core-3.2.0.tgz",
       "integrity": "sha512-QsD78Op3S/5kUVsa5ierr4Wu/xwAdYuMI3Zmc/Y2ekYBEMGEUY8QxilXQRSAQ4ku4PnNV4xlB9e7xhD5hy113A==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "emojibase": "^5.1.0",
@@ -3225,7 +9258,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-5.2.0.tgz",
       "integrity": "sha512-5T02oTJaWpScAtYbukKVc8vQ1367MyfVtFHUMoOVZ9/r1kFcbYqjSktD56TICBAeyW9uc1t+7qQuXEtntM6p5A==",
-      "license": "MIT",
       "funding": {
         "type": "ko-fi",
         "url": "https://ko-fi.com/milesjohnson"
@@ -3235,7 +9267,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/emojibase-regex/-/emojibase-regex-5.1.3.tgz",
       "integrity": "sha512-gT8T9LxLA8VJdI+8KQtyykB9qKzd7WuUL3M2yw6y9tplFeufOUANg3UKVaKUvkMcRNvZsSElWhxcJrx8WPE12g==",
-      "license": "MIT",
       "funding": {
         "type": "ko-fi",
         "url": "https://ko-fi.com/milesjohnson"
@@ -3245,7 +9276,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -3257,7 +9287,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@svgmoji/noto/-/noto-3.2.0.tgz",
       "integrity": "sha512-JgtNciB06hMDI1Pb1N2IgLh44XRMZUUNwBANzjY5jXTPqOCu1A1VA35ENvUsRhEUZOm8I+hbdAEHkwMVqxLeIQ==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@svgmoji/core": "^3.2.0"
@@ -3267,7 +9296,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@svgmoji/openmoji/-/openmoji-3.2.0.tgz",
       "integrity": "sha512-USHbG+O80HfmdoNAHbOnlO+2gppXJfHFWKSRFj53Th4aimWEx4/9MB3cFbC3KZ1NOqXaLBq9jDaw4vFuGDVTUQ==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@svgmoji/core": "^3.2.0"
@@ -3277,20 +9305,9 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@svgmoji/twemoji/-/twemoji-3.2.0.tgz",
       "integrity": "sha512-6xqZgh9viFDKf5wvrxw56ImCR3Ni84IqwK45lxojOe1Gc1Mni1GpPfr4gb7WHDKjumfx+K7BHSvX0KXt3Nr3CQ==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@svgmoji/core": "^3.2.0"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3359,11 +9376,6 @@
       "dependencies": {
         "@types/tern": "*"
       }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
@@ -3450,8 +9462,7 @@
     "node_modules/@types/direction": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/direction/-/direction-1.0.0.tgz",
-      "integrity": "sha512-et1wmqXm/5smJ8lTJfBnwD12/2Y7eVJLKbuaRT0h2xaKAoo1h8Dz2Io22GObDLFwxY1ddXRTLH3Gq5v44Fl/2w==",
-      "license": "MIT"
+      "integrity": "sha512-et1wmqXm/5smJ8lTJfBnwD12/2Y7eVJLKbuaRT0h2xaKAoo1h8Dz2Io22GObDLFwxY1ddXRTLH3Gq5v44Fl/2w=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -3491,12 +9502,11 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
-      "license": "MIT",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
       "dependencies": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/history": {
@@ -3581,8 +9591,9 @@
       "license": "MIT"
     },
     "node_modules/@types/marked": {
-      "version": "3.0.3",
-      "license": "MIT"
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w=="
     },
     "node_modules/@types/material-ui": {
       "version": "0.21.16",
@@ -3601,10 +9612,9 @@
       "dev": true
     },
     "node_modules/@types/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@types/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-lsYeSW1zfNqHTL1RuaOgfAhoiOWV1RAQDKT0BZ26z4Faz8llVIj1r1ablUo5QY6yzHMketuvu4+N0sv0eZpXTg==",
-      "license": "MIT"
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@types/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-nsNPWMSTapqOMR6/fSka9W77q5JdxaWkx3bSmzvQv2dvEI/VIWYrVmcoFY3j1YTPQK7buYdY6LqsUrQlsAGmaw=="
     },
     "node_modules/@types/node": {
       "version": "14.6.1",
@@ -3618,12 +9628,9 @@
       "license": "MIT"
     },
     "node_modules/@types/object.pick": {
-      "version": "1.3.1",
-      "license": "MIT"
-    },
-    "node_modules/@types/orderedmap": {
-      "version": "1.0.0",
-      "license": "MIT"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/object.pick/-/object.pick-1.3.4.tgz",
+      "integrity": "sha512-5PjwB0uP2XDp3nt5u5NJAG2DORHIRClPzWT/TTZhJ2Ekwe8M5bA9tvPdi9NO/n2uvu2/ictat8kgqvLfcIE1SA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3631,13 +9638,15 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.2.3",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "devOptional": true
     },
     "node_modules/@types/prismjs": {
-      "version": "1.16.6",
-      "license": "MIT"
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
@@ -3645,103 +9654,123 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/prosemirror-collab": {
-      "version": "1.1.2",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-collab/-/prosemirror-collab-1.3.0.tgz",
+      "integrity": "sha512-3jdIU0Du8qrdm8K8DuP2I9gg8j5LQLwiZiuovQmAWnuyMbqoheXwyJlF3wtGZAAnBmwb6JAJvDUXx1ffHBjMDw==",
+      "deprecated": "This is a stub types definition. prosemirror-collab provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-transform": "*"
+        "prosemirror-collab": "*"
       }
     },
     "node_modules/@types/prosemirror-commands": {
-      "version": "1.0.4",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-commands/-/prosemirror-commands-1.3.0.tgz",
+      "integrity": "sha512-3UV4Pk4WRhrU7sGI5q/DAFS0DDIWYdaJwFqgrCblYRSOrJDLU8GIaZK5GmUaZtYF07E29XMKo9D2cDDh5pZBGg==",
+      "deprecated": "This is a stub types definition. prosemirror-commands provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-view": "*"
+        "prosemirror-commands": "*"
       }
     },
     "node_modules/@types/prosemirror-dropcursor": {
-      "version": "1.0.3",
-      "license": "MIT",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-dropcursor/-/prosemirror-dropcursor-1.5.0.tgz",
+      "integrity": "sha512-Xa13THoY0YkvYP/peH995ahT79w3ErdsmFUIaTY21nshxxnn5mdSgG+RTpkqXwZ85v+n28MvNfLF2gm+c8RZ1A==",
+      "deprecated": "This is a stub types definition. prosemirror-dropcursor provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-state": "*"
+        "prosemirror-dropcursor": "*"
       }
     },
     "node_modules/@types/prosemirror-gapcursor": {
-      "version": "1.0.4",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.0.tgz",
+      "integrity": "sha512-KbZbwrr2i6+AAOtTTQhbgXlAL1ZTY+FE8PsGz4vqRLeS4ow7sppdI3oHGMn0xmCgqXI+ajEDYENKHUQ2WZkXew==",
+      "deprecated": "This is a stub types definition. prosemirror-gapcursor provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-gapcursor": "*"
       }
     },
     "node_modules/@types/prosemirror-history": {
-      "version": "1.0.3",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-history/-/prosemirror-history-1.3.0.tgz",
+      "integrity": "sha512-Cs3jtZvk+9N5ygsry2gEwkgMq11YwSFaChoxIRq75nGbDp8ZVAiYEqF6iAunsrExQC3zh0ojmf+XxP5X3j2Ztw==",
+      "deprecated": "This is a stub types definition. prosemirror-history provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-history": "*"
       }
     },
     "node_modules/@types/prosemirror-inputrules": {
-      "version": "1.0.4",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz",
+      "integrity": "sha512-N30wadmd6uVnGR97JvX2mEOEoqsLr/nv96SkTb3JKfTLqtdLW6UHjDf3fiOPPQkj2hMqhS9ENnsIbDKfsYrSdw==",
+      "deprecated": "This is a stub types definition. prosemirror-inputrules provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-inputrules": "*"
       }
     },
     "node_modules/@types/prosemirror-keymap": {
-      "version": "1.0.4",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-keymap/-/prosemirror-keymap-1.2.0.tgz",
+      "integrity": "sha512-Vv/hOlNsDBOkqmxWUjgK7Ch5mFNRnvG88mfl2WhLFp4awdg3oQiZeTPN0wosWSO4mpK9aAWtZEhvJ/639HTLTQ==",
+      "deprecated": "This is a stub types definition. prosemirror-keymap provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-commands": "*",
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-view": "*"
+        "prosemirror-keymap": "*"
       }
     },
     "node_modules/@types/prosemirror-model": {
-      "version": "1.16.0",
-      "license": "MIT",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.17.0.tgz",
+      "integrity": "sha512-lG5xEMkE8r8Soa80KdWPTbCLUaSHBHVHpTIEsQiebfONpvmS5061IMGzHUdb1oWjgrwh8EJq0GgMNwXHUx5mVg==",
+      "deprecated": "This is a stub types definition. prosemirror-model provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/orderedmap": "*"
+        "prosemirror-model": "*"
       }
     },
     "node_modules/@types/prosemirror-schema-list": {
-      "version": "1.0.3",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-schema-list/-/prosemirror-schema-list-1.2.0.tgz",
+      "integrity": "sha512-njvba73mgBanQOt2/piYMeP+nsu8lzomA350Lh7/sdr6NPsRvYPggwJDIZEG0Cb/MB0fnv4PdRaTi93PoLHArw==",
+      "deprecated": "This is a stub types definition. prosemirror-schema-list provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/orderedmap": "*",
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-schema-list": "*"
       }
     },
     "node_modules/@types/prosemirror-state": {
-      "version": "1.2.8",
-      "license": "MIT",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-state/-/prosemirror-state-1.4.0.tgz",
+      "integrity": "sha512-71epLy1HD2H7Qn6iOoQrFdbdFP32Cg5U7OvlCXMuYO8ygUdz07dfqA1lNj1y+KLf3HkRCXVkfvi3OnNa/tFZ3A==",
+      "deprecated": "This is a stub types definition. prosemirror-state provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-transform": "*",
-        "@types/prosemirror-view": "*"
+        "prosemirror-state": "*"
       }
     },
     "node_modules/@types/prosemirror-transform": {
-      "version": "1.1.5",
-      "license": "MIT",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-transform/-/prosemirror-transform-1.5.0.tgz",
+      "integrity": "sha512-++krMS5bt3SxNOqjrftispPLRkvfXXw2BtVq4VPJ8Vpf+Sne1MhxVoj0EFCM+14MFlX0EHYQvX3k9AaQzob9ZQ==",
+      "deprecated": "This is a stub types definition. prosemirror-transform provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*"
+        "prosemirror-transform": "*"
       }
     },
     "node_modules/@types/prosemirror-view": {
-      "version": "1.23.1",
-      "license": "MIT",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.24.0.tgz",
+      "integrity": "sha512-Swn08/O+QIOKOSfFFa+KKF19eeHetwA+pBMAHZ7wbF0wPrMS3zJ+G9wbOGqSkUv6JOVpuhlOP8Xg5nA3MyIXgQ==",
+      "deprecated": "This is a stub types definition. prosemirror-view provides its own type definitions, so you do not need this installed.",
+      "peer": true,
       "dependencies": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-transform": "*"
+        "prosemirror-view": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -3751,10 +9780,9 @@
       "dev": true
     },
     "node_modules/@types/querystringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/querystringify/-/querystringify-2.0.0.tgz",
-      "integrity": "sha512-9WgEGTevECrXJC2LSWPqiPYWq8BRmeaOyZn47js/3V6UF0PWtcVfvvR43YjeO8BzBsthTz98jMczujOwTw+WYg==",
-      "license": "MIT"
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/querystringify/-/querystringify-2.0.2.tgz",
+      "integrity": "sha512-7d6OQK6pJ//zE32XLK3vI6GHYhBDcYooaRco9cKFGNu59GVatL5+u7rkiAViq44DxDTd/7QQNBWSDHfJGBz/Pw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
@@ -3835,8 +9863,9 @@
       }
     },
     "node_modules/@types/react/node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@types/reactcss": {
       "version": "1.2.6",
@@ -3848,10 +9877,9 @@
       }
     },
     "node_modules/@types/refractor": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/refractor/-/refractor-3.0.2.tgz",
-      "integrity": "sha512-2HMXuwGuOqzUG+KUTm9GDJCHl0LCBKsB5cg28ujEmVi/0qgTb6jOmkVSO5K48qXksyl2Fr3C0Q2VrgD4zbwyXg==",
-      "license": "MIT",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/refractor/-/refractor-3.4.1.tgz",
+      "integrity": "sha512-wYuorIiCTSuvRT9srwt+taF6mH/ww+SyN2psM0sjef2qW+sS8GmshgDGTEDgWB1sTVGgYVE6EK7dBA2MxQxibg==",
       "dependencies": {
         "@types/prismjs": "*"
       }
@@ -3918,16 +9946,14 @@
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.1.tgz",
-      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==",
-      "license": "MIT"
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
+      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w=="
     },
     "node_modules/@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "license": "MIT"
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -4011,12 +10037,28 @@
         "eslint": "*"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -4030,22 +10072,6 @@
         "eslint": ">=5"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
@@ -4057,27 +10083,25 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.5",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4114,11 +10138,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/debug": {
-      "version": "4.3.3",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4130,11 +10155,10 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "4.33.0",
@@ -4207,11 +10231,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.3.3",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4244,27 +10269,25 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4519,13 +10542,6 @@
         "throttle-debounce": "^3.0.1"
       }
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4558,44 +10574,6 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0"
       }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -4631,15 +10609,15 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -4711,11 +10689,11 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.2.1",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
       },
       "engines": {
@@ -4796,13 +10774,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/babel-jest": {
       "version": "29.6.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
@@ -4822,6 +10793,27 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-merge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-merge/-/babel-merge-3.0.0.tgz",
+      "integrity": "sha512-eBOBtHnzt9xvnjpYNI5HmaPp/b2vMveE5XggzqHnQeHJ8mFIBrBv6WZEVIj5jJ2uwTItkqKo9gWzEEcBxEq0yw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "deepmerge": "^2.2.1",
+        "object.omit": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-merge/node_modules/deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -4910,7 +10902,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/batch": {
@@ -5022,10 +11013,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
-      "devOptional": true,
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5041,10 +11031,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5128,10 +11118,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001655",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
-      "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
-      "devOptional": true,
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5154,9 +11143,10 @@
       "license": "MIT"
     },
     "node_modules/chalk": {
-      "version": "4.1.0",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5181,7 +11171,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5191,7 +11180,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5201,7 +11189,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5384,8 +11371,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.65.0",
-      "license": "MIT"
+      "version": "5.65.18",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.18.tgz",
+      "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
@@ -5451,24 +11439,16 @@
       "integrity": "sha512-G39qNMGyM/fhl8hcy1YqpfXzQ810zSGyiJAgdMFlreCI7Hpwu3Jpu4tuBM/Oxu1Bek1FwyaBbtrtdkTr4HDhLA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "node_modules/comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5574,11 +11554,9 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
       "version": "0.7.1",
@@ -5641,11 +11619,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -5670,7 +11647,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
       "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
-      "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
       }
@@ -5701,20 +11677,11 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/css-loader/node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
-    },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5756,23 +11723,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
-      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/csstype": {
-      "version": "2.6.18",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "dev": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -5890,21 +11845,6 @@
       "integrity": "sha512-4FbVrHDwfOASx7uQVxeiCTo7ggSdYZbqs8lH+WU6ViypPlDbe9y6IP5VVUDQBv9DcnyaiPT5XT0UWHgJ64zLeQ==",
       "license": "MIT"
     },
-    "node_modules/data-urls": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -5928,13 +11868,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -5952,10 +11885,9 @@
       "license": "MIT"
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "license": "MIT",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6007,16 +11939,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -6079,7 +12001,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
       "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
-      "license": "MIT",
       "bin": {
         "direction": "cli.js"
       },
@@ -6130,32 +12051,14 @@
       }
     },
     "node_modules/dom-helpers/node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/domino": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
-      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6164,10 +12067,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
-      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
-      "devOptional": true
+      "version": "1.5.67",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.67.tgz",
+      "integrity": "sha512-nz88NNBsD7kQSAGGJyp8hS6xSPtWwqNogA0mjtc2nUYeEf3nURK9qpV18TuBdDmEDgVWotS8Wkzf+V52dSQ/LQ=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6192,7 +12094,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-6.1.0.tgz",
       "integrity": "sha512-1GkKJPXP6tVkYJHOBSJHoGOr/6uaDxZ9xJ6H7m6PfdGXTmQgbALHLWaVRY4Gi/qf5x/gT/NUXLPuSHYLqtLtrQ==",
-      "license": "MIT",
       "funding": {
         "type": "ko-fi",
         "url": "https://ko-fi.com/milesjohnson"
@@ -6202,7 +12103,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/emojibase-data/-/emojibase-data-6.2.0.tgz",
       "integrity": "sha512-SWKaXD2QeQs06IE7qfJftsI5924Dqzp+V9xaa5RzZIEWhmlrG6Jt2iKwfgOPHu+5S8MEtOI7GdpKsXj46chXOw==",
-      "license": "MIT",
       "funding": {
         "type": "ko-fi",
         "url": "https://ko-fi.com/milesjohnson"
@@ -6215,7 +12115,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/emojibase-regex/-/emojibase-regex-6.0.1.tgz",
       "integrity": "sha512-Mj1UT6IIk4j91yMFE0QetpUYcmsr5ZDkkOIMSGafhIgC086mBMaCh2Keaykx8YEllmV7hmx5zdANDzCYBYAVDw==",
-      "license": "MIT",
       "funding": {
         "type": "ko-fi",
         "url": "https://ko-fi.com/milesjohnson"
@@ -6241,7 +12140,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "4.3.0",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -6250,19 +12151,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -6377,7 +12265,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -6393,6 +12280,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -6532,6 +12420,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -6588,24 +12488,20 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/debug": {
-      "version": "4.1.1",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
+        "ms": "^2.1.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint/node_modules/globals": {
@@ -6635,9 +12531,10 @@
       }
     },
     "node_modules/eslint/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/regexpp": {
       "version": "2.0.1",
@@ -6650,11 +12547,10 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -6713,9 +12609,10 @@
       }
     },
     "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.2.0",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -6811,9 +12708,9 @@
       }
     },
     "node_modules/execa/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6996,6 +12893,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/extract-domain": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/extract-domain/-/extract-domain-2.2.1.tgz",
+      "integrity": "sha512-lOq1adCJha0tFFBci4quxC4XLa6+Rs2WgAwTo9qbO9OsElvJmGgCvOzmHo/yg5CiqeP4+sHjkXYGkrCcIEprMg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7050,6 +12952,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "dev": true
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -7237,21 +13145,6 @@
         }
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7316,7 +13209,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7329,6 +13221,22 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-dom-document": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/get-dom-document/-/get-dom-document-0.1.3.tgz",
+      "integrity": "sha512-bZ0O00gSQgMo+wz7gU6kbbWCPh4dfDsL9ZOmVhA8TOXszl5GV56TpTuW1/Qq/QctgpjK56yyvB1vBO+wzz8Szw==",
+      "funding": {
+        "url": "https://github.com/sponsors/ocavue"
+      },
+      "peerDependencies": {
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/get-intrinsic": {
@@ -7423,7 +13331,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7528,7 +13435,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
       "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -7538,7 +13444,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
       "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -7571,19 +13476,6 @@
         "obuf": "^1.0.0",
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
-      }
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/html-entities": {
@@ -7659,46 +13551,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/http-proxy-middleware": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -7722,45 +13574,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -7806,7 +13619,6 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
       "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "safari-14-idb-fix": "^1.0.6"
       }
@@ -7952,24 +13764,26 @@
       }
     },
     "node_modules/inquirer/node_modules/string-width": {
-      "version": "4.2.0",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "6.0.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -8006,9 +13820,9 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
       "dev": true,
       "engines": {
         "node": ">= 10"
@@ -8018,7 +13832,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8028,7 +13841,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -8094,7 +13906,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8130,7 +13941,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha512-e+gU0KGrlbqjEcV80SAqg4g7PQYOm3/IrdwAJ+kPwHqGhLKhtuTJGGxGtrsc8RXlHt2A8Vlnv+79Vq2B1GQasg==",
-      "license": "MIT",
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -8172,7 +13982,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8187,7 +13996,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
       "integrity": "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==",
-      "license": "WTFPL OR ISC",
       "dependencies": {
         "is-finite": "^1.0.0"
       }
@@ -8224,12 +14032,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.1.1",
@@ -8311,8 +14113,9 @@
       }
     },
     "node_modules/isomorphic.js": {
-      "version": "0.2.4",
-      "license": "MIT",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -8381,12 +14184,12 @@
       }
     },
     "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -8398,9 +14201,9 @@
       }
     },
     "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/istanbul-reports": {
@@ -8942,13 +14745,10 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8957,12 +14757,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -9022,13 +14822,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -9057,6 +14857,11 @@
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
       "license": "MIT"
     },
+    "node_modules/js-sha256": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
+      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9075,60 +14880,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsdom": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
-      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "cssstyle": "^3.0.0",
-        "data-urls": "^4.0.0",
-        "decimal.js": "^10.4.3",
-        "domexception": "^4.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.4",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.1",
-        "ws": "^8.13.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -9155,7 +14915,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -9246,9 +15005,9 @@
       }
     },
     "node_modules/jss/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/jsx-ast-utils": {
       "version": "2.4.1",
@@ -9272,8 +15031,9 @@
       }
     },
     "node_modules/jsx-dom/node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -9336,13 +15096,19 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.43",
-      "license": "MIT",
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -9430,18 +15196,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -9496,10 +15250,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "license": "MIT",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -9592,10 +15347,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/messageformat-parser": {
-      "version": "4.1.3",
-      "license": "MIT"
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9634,7 +15385,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9643,7 +15394,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9677,9 +15428,10 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9706,6 +15458,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -9780,9 +15537,73 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
+    "node_modules/multishift/node_modules/@remirror/core-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "dependencies": {
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/types": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^1.0.10"
+      }
+    },
+    "node_modules/multishift/node_modules/@remirror/pm": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@types/prosemirror-collab": "^1.1.2",
+        "@types/prosemirror-commands": "^1.0.4",
+        "@types/prosemirror-dropcursor": "^1.0.3",
+        "@types/prosemirror-gapcursor": "^1.0.4",
+        "@types/prosemirror-history": "^1.0.3",
+        "@types/prosemirror-inputrules": "^1.0.4",
+        "@types/prosemirror-keymap": "^1.0.4",
+        "@types/prosemirror-model": "^1.16.2",
+        "@types/prosemirror-schema-list": "^1.0.3",
+        "@types/prosemirror-state": "^1.3.0",
+        "@types/prosemirror-transform": "^1.4.0",
+        "@types/prosemirror-view": "^1.23.2",
+        "prosemirror-collab": "<1.3.0",
+        "prosemirror-commands": "<1.3.0",
+        "prosemirror-dropcursor": "<1.5.0",
+        "prosemirror-gapcursor": "<1.3.0",
+        "prosemirror-history": "<1.3.0",
+        "prosemirror-inputrules": "<1.2.0",
+        "prosemirror-keymap": "<1.2.0",
+        "prosemirror-model": "<1.17.0",
+        "prosemirror-paste-rules": "^1.1.3",
+        "prosemirror-schema-list": "<1.2.0",
+        "prosemirror-state": "<1.4.0",
+        "prosemirror-suggest": "^1.1.4",
+        "prosemirror-tables": "<1.2.0",
+        "prosemirror-trailing-node": "^1.0.11",
+        "prosemirror-transform": "<1.5.0",
+        "prosemirror-view": "<1.24.0"
+      }
+    },
     "node_modules/multishift/node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/multishift/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/multishift/node_modules/nano-css": {
       "version": "5.3.4",
@@ -9800,6 +15621,242 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/multishift/node_modules/orderedmap": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+      "peer": true
+    },
+    "node_modules/multishift/node_modules/prosemirror-collab": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-commands": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-dropcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-gapcursor": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-history": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "peer": true,
+      "dependencies": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-paste-rules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-schema-list": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-suggest": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/types": "^0.1.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-tables": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.1.2",
+        "prosemirror-model": "^1.8.1",
+        "prosemirror-state": "^1.3.1",
+        "prosemirror-transform": "^1.2.1",
+        "prosemirror-view": "^1.13.3"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-trailing-node": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@remirror/core-constants": "^1.0.2",
+        "@remirror/core-helpers": "^1.0.6",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/prosemirror-model": "^1",
+        "@types/prosemirror-state": "^1",
+        "@types/prosemirror-view": "^1",
+        "prosemirror-model": "^1",
+        "prosemirror-state": "^1",
+        "prosemirror-view": "^1"
+      },
+      "peerDependenciesMeta": {
+        "@types/prosemirror-model": {
+          "optional": true
+        },
+        "@types/prosemirror-state": {
+          "optional": true
+        },
+        "@types/prosemirror-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-transform": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/multishift/node_modules/prosemirror-view": {
+      "version": "1.23.13",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/multishift/node_modules/react-use": {
@@ -9827,8 +15884,9 @@
       }
     },
     "node_modules/multishift/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -9912,8 +15970,7 @@
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "devOptional": true
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -9949,17 +16006,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10180,8 +16229,9 @@
       }
     },
     "node_modules/orderedmap": {
-      "version": "1.1.1",
-      "license": "MIT"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -10254,11 +16304,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parenthesis": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+    },
     "node_modules/parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -10276,7 +16330,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-exponential/-/parse-exponential-1.0.1.tgz",
       "integrity": "sha512-QUa7PaOc7O6ei3hb0NmADJGrDYLbPBdcSKFUBGfwlMdHsrg8LOsliPEkpP0qHSKQOyzyyxCB00fxJKcP75Gl7w==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10299,19 +16352,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10326,7 +16366,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10372,9 +16411,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10467,12 +16506,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/postcss-modules-local-by-default/node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
-    },
     "node_modules/postcss-modules-scope": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
@@ -10516,11 +16549,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
     "node_modules/precision": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/precision/-/precision-1.0.1.tgz",
       "integrity": "sha512-cBMxnM2nzEF1xx75NhhOaKjsDNt92WUZv17t/p3wrvCfA+2RL0twbgfvXvgDbxxsfUUb5C5he5tla8Xa2ny1Ew==",
-      "license": "MIT",
       "dependencies": {
         "is-finite": "~1.0.1",
         "parse-exponential": "~1.0.1"
@@ -10590,9 +16628,9 @@
       }
     },
     "node_modules/pretty-format/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
     "node_modules/prismjs": {
@@ -10647,7 +16685,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -10657,24 +16694,27 @@
       }
     },
     "node_modules/prosemirror-collab": {
-      "version": "1.2.2",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
     },
     "node_modules/prosemirror-commands": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.6.2.tgz",
+      "integrity": "sha512-0nDHH++qcf/BuPLYvmqZTUUsPJUCPBUXt0J1ErTcDIS369CTp773itzLGIgIXG4LJXOlwYCr44+Mh4ii6MP1QA==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-transform": "^1.10.2"
       }
     },
     "node_modules/prosemirror-dropcursor": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.1.tgz",
+      "integrity": "sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -10682,8 +16722,9 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.2.1",
-      "license": "MIT",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
+      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -10692,140 +16733,276 @@
       }
     },
     "node_modules/prosemirror-history": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
         "rope-sequence": "^1.3.0"
       }
     },
     "node_modules/prosemirror-inputrules": {
-      "version": "1.1.3",
-      "license": "MIT",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
+      "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
       }
     },
     "node_modules/prosemirror-keymap": {
-      "version": "1.1.5",
-      "license": "MIT",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
+      "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.16.1",
-      "license": "MIT",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.24.0.tgz",
+      "integrity": "sha512-Ft7epNnycoQSM+2ObF35SBbBX+5WY39v8amVlrtlAcpglhlHs2tCTnWl7RX5tbp/PsMKcRcWV9cXPuoBWq0AIQ==",
       "dependencies": {
-        "orderedmap": "^1.1.0"
+        "orderedmap": "^2.0.0"
       }
     },
     "node_modules/prosemirror-paste-rules": {
-      "version": "1.0.7",
-      "license": "MIT",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-2.0.8.tgz",
+      "integrity": "sha512-k3wBSc4fwtrx/UbCaf8LzMugB+P/R/TvACRfPiLruHtOP0a6FJWsZ/GTV2DJX5mQ/xyuS/vDX+q7jIsSV1D5AQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-paste-rules/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/prosemirror-paste-rules/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/prosemirror-paste-rules/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/prosemirror-paste-rules/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
       },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/prosemirror-paste-rules/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prosemirror-paste-rules/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prosemirror-resizable-view": {
-      "version": "1.1.8",
-      "license": "MIT",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/prosemirror-resizable-view/-/prosemirror-resizable-view-2.0.15.tgz",
+      "integrity": "sha512-xd/TEJD5D0XmiUUFQOMWV8ZCZjvZRiDiFmGMEXxaB5NtCZK2DqCPVZ2wxsEj1upE1ri4+6/EhHLAdV65GD2oBQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-utils": "^1.1.4",
-        "prosemirror-model": "^1.16.1",
-        "prosemirror-view": "^1.23.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-utils": "^2.0.13",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-resizable-view/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/prosemirror-resizable-view/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/prosemirror-resizable-view/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/prosemirror-resizable-view/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/prosemirror-resizable-view/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prosemirror-schema-list": {
-      "version": "1.1.6",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.4.1.tgz",
+      "integrity": "sha512-jbDyaP/6AFfDfu70VzySsD75Om2t3sXTOdl5+31Wlxlg62td1haUpty/ybajSfJ1pkGadlOfwQq9kgW5IMo1Rg==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
       }
     },
     "node_modules/prosemirror-state": {
-      "version": "1.3.4",
-      "license": "MIT",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
       }
     },
     "node_modules/prosemirror-suggest": {
-      "version": "1.0.7",
-      "license": "MIT",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-2.0.7.tgz",
+      "integrity": "sha512-Jww17dk2z1z3P90G0LXAlZtpgOHgtMa/l39G1Fzw2RWrS+1ki2L4X5tppbhKQkHSCtBe5u++udkxQ6tRDKN21A==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/types": "^0.1.1",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/types": "^1.0.1",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-suggest/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/prosemirror-suggest/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/prosemirror-suggest/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/prosemirror-suggest/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
       },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/prosemirror-suggest/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10833,9 +17010,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prosemirror-suggest/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prosemirror-tables": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.1.tgz",
+      "integrity": "sha512-p8WRJNA96jaNQjhJolmbxTzd6M4huRE5xQ8OxjvMhQUP0Nzpo4zz6TztEiwk6aoqGBhz9lxRWR1yRZLlpQN98w==",
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -10845,39 +17034,28 @@
       }
     },
     "node_modules/prosemirror-trailing-node": {
-      "version": "1.0.7",
-      "license": "MIT",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.9.tgz",
+      "integrity": "sha512-YvyIn3/UaLFlFKrlJB6cObvUhmwFNZVhy1Q8OpW/avoTbD/Y7H5EcjK4AZFKhmuS6/N6WkGgt7gWtBWDnmFvHg==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
+        "@remirror/core-constants": "^2.0.2",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
       }
+    },
+    "node_modules/prosemirror-trailing-node/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
     },
     "node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10886,17 +17064,19 @@
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.3.3",
-      "license": "MIT",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.2.tgz",
+      "integrity": "sha512-2iUq0wv2iRoJO/zj5mv8uDUriOHWzXRnOTVgCzSXnktS/2iQRa3UUQwVlkBlYZFtygw6Nh1+X4mGqoYBINn5KQ==",
       "dependencies": {
-        "prosemirror-model": "^1.0.0"
+        "prosemirror-model": "^1.21.0"
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.23.6",
-      "license": "MIT",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.37.0.tgz",
+      "integrity": "sha512-z2nkKI1sJzyi7T47Ji/ewBPuIma1RNvQCCYVdV+MqWBV7o4Sa1n94UJCJJ1aQRF/xRkFfyqLGlGFWitIcCOtbg==",
       "dependencies": {
-        "prosemirror-model": "^1.16.0",
+        "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -10930,18 +17110,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11273,11 +17446,10 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11307,6 +17479,27 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/reakit-system": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+      "dependencies": {
+        "reakit-utils": "^0.15.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/reakit-utils": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/reakit-warning": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
@@ -11317,16 +17510,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/reakit-warning/node_modules/reakit-utils": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/recharts": {
@@ -11414,9 +17597,10 @@
       }
     },
     "node_modules/regexpp": {
-      "version": "3.1.0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -11425,70 +17609,72 @@
       }
     },
     "node_modules/remirror": {
-      "version": "1.0.60",
-      "license": "MIT",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/remirror/-/remirror-2.0.4.tgz",
+      "integrity": "sha512-zsOH7wm/yLk7FSC8BjCNH8zq4JdkHFid4HwJg05elqPMx8GQ91vPcIqupZxa6kyOTM1ZbYiRtXPMFecCCRh5jg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/core-utils": "^1.1.4",
-        "@remirror/dom": "^1.0.17",
-        "@remirror/extension-annotation": "^1.1.10",
-        "@remirror/extension-bidi": "^1.0.13",
-        "@remirror/extension-blockquote": "^1.0.15",
-        "@remirror/extension-bold": "^1.0.13",
-        "@remirror/extension-callout": "^1.0.15",
-        "@remirror/extension-code": "^1.0.14",
-        "@remirror/extension-code-block": "^1.0.18",
-        "@remirror/extension-codemirror5": "^1.0.13",
-        "@remirror/extension-collaboration": "^1.0.13",
-        "@remirror/extension-columns": "^1.0.13",
-        "@remirror/extension-diff": "^1.0.13",
-        "@remirror/extension-doc": "^1.0.14",
-        "@remirror/extension-drop-cursor": "^1.0.13",
-        "@remirror/extension-embed": "^1.1.18",
-        "@remirror/extension-emoji": "^1.0.15",
-        "@remirror/extension-epic-mode": "^1.0.13",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/extension-font-family": "^1.0.13",
-        "@remirror/extension-font-size": "^1.0.15",
-        "@remirror/extension-gap-cursor": "^1.0.13",
-        "@remirror/extension-hard-break": "^1.0.13",
-        "@remirror/extension-heading": "^1.0.13",
-        "@remirror/extension-history": "^1.0.13",
-        "@remirror/extension-horizontal-rule": "^1.0.13",
-        "@remirror/extension-image": "^1.0.23",
-        "@remirror/extension-italic": "^1.0.13",
-        "@remirror/extension-link": "^1.1.12",
-        "@remirror/extension-list": "^1.2.13",
-        "@remirror/extension-markdown": "^1.0.13",
-        "@remirror/extension-mention": "^1.0.14",
-        "@remirror/extension-mention-atom": "^1.0.16",
-        "@remirror/extension-node-formatting": "^1.0.16",
-        "@remirror/extension-paragraph": "^1.0.13",
-        "@remirror/extension-placeholder": "^1.0.15",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-search": "^1.0.13",
-        "@remirror/extension-shortcuts": "^1.1.2",
-        "@remirror/extension-strike": "^1.0.13",
-        "@remirror/extension-sub": "^1.0.13",
-        "@remirror/extension-sup": "^1.0.13",
-        "@remirror/extension-tables": "^1.0.15",
-        "@remirror/extension-text": "^1.0.13",
-        "@remirror/extension-text-case": "^1.0.13",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/extension-text-highlight": "^1.0.15",
-        "@remirror/extension-trailing-node": "^1.0.13",
-        "@remirror/extension-underline": "^1.0.13",
-        "@remirror/extension-whitespace": "^1.0.13",
-        "@remirror/extension-yjs": "^1.0.19",
-        "@remirror/icons": "^1.0.7",
-        "@remirror/preset-core": "^1.0.17",
-        "@remirror/preset-formatting": "^1.0.19",
-        "@remirror/preset-wysiwyg": "^1.1.35",
-        "@remirror/theme": "^1.2.0",
+        "@remirror/core": "^2.0.3",
+        "@remirror/core-constants": "^2.0.0",
+        "@remirror/core-helpers": "^2.0.0",
+        "@remirror/core-types": "^2.0.0",
+        "@remirror/core-utils": "^2.0.3",
+        "@remirror/dom": "^2.0.4",
+        "@remirror/extension-annotation": "^2.0.4",
+        "@remirror/extension-bidi": "^2.0.3",
+        "@remirror/extension-blockquote": "^2.0.3",
+        "@remirror/extension-bold": "^2.0.3",
+        "@remirror/extension-callout": "^2.0.3",
+        "@remirror/extension-code": "^2.0.3",
+        "@remirror/extension-code-block": "^2.0.3",
+        "@remirror/extension-codemirror5": "^2.0.3",
+        "@remirror/extension-collaboration": "^2.0.3",
+        "@remirror/extension-columns": "^2.0.3",
+        "@remirror/extension-diff": "^2.0.3",
+        "@remirror/extension-doc": "^2.0.3",
+        "@remirror/extension-drop-cursor": "^2.0.3",
+        "@remirror/extension-embed": "^2.0.3",
+        "@remirror/extension-emoji": "^2.0.3",
+        "@remirror/extension-entity-reference": "^2.0.4",
+        "@remirror/extension-epic-mode": "^2.0.3",
+        "@remirror/extension-events": "^2.1.3",
+        "@remirror/extension-font-family": "^2.0.3",
+        "@remirror/extension-font-size": "^2.0.3",
+        "@remirror/extension-gap-cursor": "^2.0.3",
+        "@remirror/extension-hard-break": "^2.0.3",
+        "@remirror/extension-heading": "^2.0.3",
+        "@remirror/extension-history": "^2.0.3",
+        "@remirror/extension-horizontal-rule": "^2.0.3",
+        "@remirror/extension-image": "^2.0.3",
+        "@remirror/extension-italic": "^2.0.3",
+        "@remirror/extension-link": "^2.0.4",
+        "@remirror/extension-list": "^2.0.4",
+        "@remirror/extension-markdown": "^2.0.3",
+        "@remirror/extension-mention": "^2.0.4",
+        "@remirror/extension-mention-atom": "^2.0.4",
+        "@remirror/extension-node-formatting": "^2.0.3",
+        "@remirror/extension-paragraph": "^2.0.3",
+        "@remirror/extension-placeholder": "^2.0.3",
+        "@remirror/extension-positioner": "^2.0.4",
+        "@remirror/extension-search": "^2.0.3",
+        "@remirror/extension-shortcuts": "^2.0.3",
+        "@remirror/extension-strike": "^2.0.3",
+        "@remirror/extension-sub": "^2.0.3",
+        "@remirror/extension-sup": "^2.0.3",
+        "@remirror/extension-tables": "^2.0.3",
+        "@remirror/extension-text": "^2.0.3",
+        "@remirror/extension-text-case": "^2.0.3",
+        "@remirror/extension-text-color": "^2.0.3",
+        "@remirror/extension-text-highlight": "^2.0.3",
+        "@remirror/extension-trailing-node": "^2.0.3",
+        "@remirror/extension-underline": "^2.0.3",
+        "@remirror/extension-whitespace": "^2.0.3",
+        "@remirror/extension-yjs": "^3.0.3",
+        "@remirror/icons": "^2.0.0",
+        "@remirror/preset-core": "^2.0.4",
+        "@remirror/preset-formatting": "^2.0.3",
+        "@remirror/preset-wysiwyg": "^2.0.4",
+        "@remirror/theme": "^2.0.0",
         "@types/codemirror": "^5.60.2",
         "@types/refractor": "^3.0.2",
         "codemirror": "^5.62.0",
@@ -11496,7 +17682,7 @@
         "yjs": "^13.5.23"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.11",
+        "@remirror/pm": "^2.0.0",
         "@types/prettier": "^2.1.5",
         "prettier": "^2.2.0"
       },
@@ -11509,32 +17695,124 @@
         }
       }
     },
-    "node_modules/remirror/node_modules/@remirror/extension-code-block": {
-      "version": "1.0.18",
-      "license": "MIT",
+    "node_modules/remirror/node_modules/@linaria/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "@types/refractor": "^3.0.2",
-        "refractor": "^3.3.1"
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
       },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/prettier": "^2",
-        "prettier": "^2"
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
+    },
+    "node_modules/remirror/node_modules/@remirror/core-constants": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+    },
+    "node_modules/remirror/node_modules/@remirror/core-helpers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-2.0.4.tgz",
+      "integrity": "sha512-aYoiJ8x/Sxc4OIZCcZI2tSa92rOufzpDkVTHtwh8+HEsGj0PumUrXbwVd3jHZRSoOUNYNG8fPnOmzuVOsO9CMQ==",
+      "dependencies": {
+        "@linaria/core": "4.2.10",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/remirror/node_modules/@remirror/icons": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
+      "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "^3.0.0"
+      }
+    },
+    "node_modules/remirror/node_modules/@remirror/icons/node_modules/@remirror/core-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+      "dependencies": {
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/remirror/node_modules/@remirror/theme": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/remirror/node_modules/@remirror/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/remirror/node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
       },
-      "peerDependenciesMeta": {
-        "@types/prettier": {
-          "optional": true
-        },
-        "@types/refractor": {
-          "optional": true
-        },
-        "prettier": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/remirror/node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+    },
+    "node_modules/remirror/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/remirror/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/remove-accents": {
@@ -11565,7 +17843,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/reselect": {
       "version": "4.1.7",
@@ -11675,14 +17953,14 @@
       }
     },
     "node_modules/rope-sequence": {
-      "version": "1.3.2",
-      "license": "MIT"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="
     },
     "node_modules/round": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/round/-/round-2.0.1.tgz",
       "integrity": "sha512-wzT6PF3wNEd2PCLTBQxteheeSwViBrD89E1XZjl4sj505C4LwTpqOQSNXLEROHDQw35NoylYbMxoUhgf2hb4qw==",
-      "license": "MIT",
       "dependencies": {
         "precision": "~1.0.0",
         "round-precision": "~1.0.0"
@@ -11692,7 +17970,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/round-precision/-/round-precision-1.0.0.tgz",
       "integrity": "sha512-L2a0XDSNeaaBTEGmzuENMK4T8c0HqKYeS3pCDurW4MRPo8O6LeCLqVPWUt5+xW9rrEcG9QaYrAFcApEFXKziyw==",
-      "license": "MIT",
       "dependencies": {
         "is-finite": "~1.0.1",
         "is-integer": "~1.0.4"
@@ -11700,13 +17977,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/rtl-css-js": {
       "version": "1.15.0",
@@ -11763,20 +18033,20 @@
     "node_modules/safari-14-idb-fix": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
-      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -11846,11 +18116,10 @@
       }
     },
     "node_modules/sass-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -11865,30 +18134,15 @@
       }
     },
     "node_modules/sass-loader/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11900,9 +18154,9 @@
       }
     },
     "node_modules/schema-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-      "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -11919,15 +18173,15 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -11984,11 +18238,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -12357,7 +18610,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12396,24 +18648,33 @@
       }
     },
     "node_modules/spdy-transport/node_modules/debug": {
-      "version": "4.1.1",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/spdy-transport/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/spdy-transport/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -12424,17 +18685,27 @@
       }
     },
     "node_modules/spdy/node_modules/debug": {
-      "version": "4.1.1",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/spdy/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -12718,9 +18989,10 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/supports-color": {
-      "version": "7.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12743,7 +19015,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svgmoji/-/svgmoji-3.2.0.tgz",
       "integrity": "sha512-tjmdQhIju2ZQ81FLBlPngg1aWMOhQjP9ErXb2ROikM0aBGA/hqI0/DN/5J0sDsXzJPHmODpSFhWfiSsUieU3bA==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@svgmoji/blob": "^3.2.0",
@@ -12759,14 +19030,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/table": {
       "version": "5.4.6",
@@ -12894,9 +19157,9 @@
       }
     },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -12985,15 +19248,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13019,35 +19273,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "punycode": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/ts-easing": {
@@ -13100,13 +19325,10 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13190,11 +19412,10 @@
       }
     },
     "node_modules/ts-loader/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -13314,8 +19535,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.13.0",
-      "license": "0BSD"
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -13334,19 +19556,17 @@
       }
     },
     "node_modules/turndown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
-      "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
-      "license": "MIT",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
       "dependencies": {
-        "domino": "^2.1.6"
+        "@mixmark-io/domino": "^2.2.0"
       }
     },
     "node_modules/turndown-plugin-gfm": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
-      "license": "MIT"
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -13405,16 +19625,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -13424,11 +19634,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unraw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
-      "devOptional": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -13444,8 +19658,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -13460,17 +19674,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
@@ -13574,19 +19777,6 @@
       "version": "2.2.4",
       "license": "MIT"
     },
-    "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -13626,16 +19816,6 @@
       "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/webpack": {
@@ -13729,12 +19909,6 @@
         }
       }
     },
-    "node_modules/webpack-cli/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
-    },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -13745,9 +19919,9 @@
       }
     },
     "node_modules/webpack-cli/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -13826,12 +20000,6 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/webpack-dev-middleware/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
-    },
     "node_modules/webpack-dev-server": {
       "version": "4.13.3",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.3.tgz",
@@ -13891,12 +20059,6 @@
         }
       }
     },
-    "node_modules/webpack-dev-server/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
-    },
     "node_modules/webpack-merge": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
@@ -13920,9 +20082,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -14001,56 +20163,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/which": {
@@ -14177,7 +20289,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14194,37 +20306,24 @@
         }
       }
     },
-    "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/y-prosemirror": {
-      "version": "1.0.14",
-      "license": "MIT",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.13.tgz",
+      "integrity": "sha512-eW5/rJcYhqlrqyPLTaGIaPSt7YS6f2wwbV5wXlUkY8rERY0tSJPoumsPD7UWwtXk9C5TdTsvwaIrdOoD1QLbYA==",
       "dependencies": {
         "lib0": "^0.2.42"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -14235,20 +20334,26 @@
         "prosemirror-state": "^1.2.3",
         "prosemirror-view": "^1.9.10",
         "y-protocols": "^1.0.1",
-        "yjs": "^13.3.2"
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/y-protocols": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
       "dependencies": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
       }
     },
     "node_modules/y18n": {
@@ -14261,10 +20366,9 @@
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -14343,11 +20447,15 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.5.24",
-      "hasInstallScript": true,
-      "license": "MIT",
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
       "dependencies": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.98"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -14358,7 +20466,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -14368,271 +20475,189 @@
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+    "@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "requires": {
-        "@babel/highlight": "^7.24.2",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.15",
-      "devOptional": true
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
+      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg=="
     },
     "@babel/core": {
-      "version": "7.13.16",
-      "devOptional": true,
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.16",
-        "@babel/helper-compilation-targets": "^7.13.16",
-        "@babel/helper-module-transforms": "^7.13.14",
-        "@babel/helpers": "^7.13.16",
-        "@babel/parser": "^7.13.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.15",
-        "@babel/types": "^7.13.16",
-        "convert-source-map": "^1.7.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+        },
         "debug": {
-          "version": "4.3.1",
-          "devOptional": true,
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "devOptional": true
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "devOptional": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "devOptional": true
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
     "@babel/generator": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
-      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
-      "devOptional": true,
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
       "requires": {
-        "@babel/types": "^7.24.5",
+        "@babel/parser": "^7.26.2",
+        "@babel/types": "^7.26.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.16",
-      "devOptional": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
       "requires": {
-        "@babel/compat-data": "^7.13.15",
-        "@babel/helper-validator-option": "^7.12.17",
-        "browserslist": "^4.14.5",
-        "semver": "^6.3.0"
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "devOptional": true
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
-      }
-    },
-    "@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "devOptional": true
-    },
-    "@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "devOptional": true,
-      "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "devOptional": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.13.12",
-      "devOptional": true,
-      "requires": {
-        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.7",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.14",
-      "devOptional": true,
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "requires": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-replace-supers": "^7.13.12",
-        "@babel/helper-simple-access": "^7.13.12",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.13",
-        "@babel/types": "^7.13.14"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "devOptional": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-      "dev": true
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "devOptional": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.13.12",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
-      }
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw=="
     },
     "@babel/helper-simple-access": {
-      "version": "7.13.12",
-      "devOptional": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
+      "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
       "requires": {
-        "@babel/types": "^7.13.12"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
-      "devOptional": true,
-      "requires": {
-        "@babel/types": "^7.24.5"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ=="
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA=="
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.17",
-      "devOptional": true
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw=="
     },
     "@babel/helpers": {
-      "version": "7.13.17",
-      "devOptional": true,
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.17",
-        "@babel/types": "^7.13.17"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
       }
     },
     "@babel/parser": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-      "devOptional": true
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "requires": {
+        "@babel/types": "^7.26.0"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
+      "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.9",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -14659,6 +20684,22 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-import-meta": {
@@ -14760,6 +20801,16 @@
         "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
+      "integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-simple-access": "^7.25.9"
+      }
+    },
     "@babel/runtime": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
@@ -14769,57 +20820,51 @@
       }
     },
     "@babel/template": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
-      "devOptional": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "requires": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       }
     },
     "@babel/traverse": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
-      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
-      "devOptional": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
       "requires": {
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.5",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.24.5",
-        "@babel/parser": "^7.24.5",
-        "@babel/types": "^7.24.5",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "devOptional": true,
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "devOptional": true
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
     "@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "requires": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       }
     },
     "@bcoe/v8-coverage": {
@@ -14852,11 +20897,6 @@
         "stylis": "4.2.0"
       },
       "dependencies": {
-        "@emotion/hash": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-          "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -14890,6 +20930,11 @@
         "@emotion/sheet": "^1.0.3",
         "@emotion/utils": "^1.0.0"
       }
+    },
+    "@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
     },
     "@emotion/is-prop-valid": {
       "version": "1.2.1",
@@ -14931,13 +20976,10 @@
         "csstype": "^3.0.2"
       },
       "dependencies": {
-        "@emotion/hash": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-          "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-        },
         "csstype": {
-          "version": "3.0.10"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
@@ -15197,9 +21239,9 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.27.8"
@@ -15272,12 +21314,12 @@
       }
     },
     "@jest/types": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -15289,7 +21331,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "devOptional": true,
       "requires": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -15299,14 +21340,12 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "devOptional": true
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "devOptional": true
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
     },
     "@jridgewell/source-map": {
       "version": "0.3.6",
@@ -15321,14 +21360,12 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "devOptional": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "devOptional": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -15345,16 +21382,146 @@
       "resolved": "https://registry.npmjs.org/@linaria/core/-/core-3.0.0-beta.13.tgz",
       "integrity": "sha512-3zEi5plBCOsEzUneRVuQb+2SAx3qaC1dj0FfFAI6zIJQoDWu0dlSwKijMRack7oO9tUWrchfj3OkKQAd1LBdVg=="
     },
-    "@lingui/core": {
-      "version": "3.13.0",
+    "@linaria/logger": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@linaria/logger/-/logger-4.5.0.tgz",
+      "integrity": "sha512-XdQLk242Cpcsc9a3Cz1ktOE5ysTo2TpxdeFQEPwMm8Z/+F/S6ZxBDdHYJL09srXWz3hkJr3oS2FPuMZNH1HIxw==",
       "requires": {
-        "@babel/runtime": "^7.11.2",
-        "make-plural": "^6.2.2",
-        "messageformat-parser": "^4.1.3"
+        "debug": "^4.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "@linaria/tags": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@linaria/tags/-/tags-4.5.4.tgz",
+      "integrity": "sha512-HPxLB6HlJWLi6o8+8lTLegOmDnbMbuzEE+zzunaPZEGSoIIYx8HAv5VbY/sG/zNyxDElk6laiAwEVWN8h5/zxg==",
+      "requires": {
+        "@babel/generator": "^7.22.9",
+        "@linaria/logger": "^4.5.0",
+        "@linaria/utils": "^4.5.3"
+      }
+    },
+    "@linaria/utils": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@linaria/utils/-/utils-4.5.3.tgz",
+      "integrity": "sha512-tSpxA3Zn0DKJ2n/YBnYAgiDY+MNvkmzAHrD8R9PKrpGaZ+wz1jQEmE1vGn1cqh8dJyWK0NzPAA8sf1cqa+RmAg==",
+      "requires": {
+        "@babel/core": "^7.22.9",
+        "@babel/generator": "^7.22.9",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.22.5",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "@linaria/logger": "^4.5.0",
+        "babel-merge": "^3.0.0",
+        "find-up": "^5.0.0",
+        "minimatch": "^9.0.3"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "@lingui/core": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.17.2.tgz",
+      "integrity": "sha512-YOd068NanznN8lLQqOKPlAY0ill3rrgmiAvPRKuYkrxzJMIHqlIFO/2Kcc/RH5vClOmLfg+wgR4rsHK/kLKelQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "@messageformat/parser": "^5.0.0",
+        "make-plural": "^6.2.2"
       }
     },
     "@lingui/detect-locale": {
-      "version": "3.13.0"
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-3.17.2.tgz",
+      "integrity": "sha512-rqyO16lj05WRfBuppo++mPzB1fQBFDhGqEFz5X97CbWXYp6AadOIkrm+pbn114Y2Yumy9QI7Cm4Ptbfk7CXO3Q=="
+    },
+    "@lingui/message-utils": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-4.14.1.tgz",
+      "integrity": "sha512-J6MzyTLNCzEnyR1Da188G81cRcQMbk/lyYnLWMzQjIELDX8bBBwNea91Sf5Zm+BB+ADWmmGTdUqRPAjDqT9Y5w==",
+      "requires": {
+        "@messageformat/parser": "^5.0.0",
+        "js-sha256": "^0.10.1"
+      }
+    },
+    "@messageformat/parser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.0.tgz",
+      "integrity": "sha512-jKlkls3Gewgw6qMjKZ9SFfHUpdzEVdovKFtW1qRhJ3WI4FW5R/NnGDqr8SDGz+krWDO3ki94boMmQvGke1HwUQ==",
+      "requires": {
+        "moo": "^0.5.1"
+      }
+    },
+    "@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
     },
     "@mui/base": {
       "version": "5.0.0-beta.36",
@@ -15422,9 +21589,9 @@
           "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
@@ -15480,11 +21647,6 @@
         "prop-types": "^15.8.1"
       },
       "dependencies": {
-        "@emotion/hash": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-          "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-        },
         "csstype": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -15532,9 +21694,9 @@
       },
       "dependencies": {
         "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
@@ -15581,25 +21743,136 @@
         "fastq": "^1.6.0"
       }
     },
+    "@ocavue/svgmoji-cjs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@ocavue/svgmoji-cjs/-/svgmoji-cjs-0.1.1.tgz",
+      "integrity": "sha512-tCP6ggbtgIL4hPM5goVFSjL51jH/BLl/yBLy98wAV9a2L/Sn9iS3abfprPeQw6/nan5lLaz4Vz8ZP37LKh+xfQ==",
+      "requires": {
+        "svgmoji": "^3.2.0"
+      }
+    },
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@remirror/core": {
-      "version": "1.3.3",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/core/-/core-2.0.19.tgz",
+      "integrity": "sha512-TGvDPUdKYqOiDQmt3+58GNBi4PX6QhBhII1qk9btZ/uFvG2/LLHEe+KN/BfBdvykGAu8CK9codLzg8NZd2fDEg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/core-utils": "^1.1.4",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/icons": "^1.0.7",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.5",
+        "@remirror/core-utils": "^2.0.13",
+        "@remirror/i18n": "^2.0.5",
+        "@remirror/icons": "^2.0.3",
+        "@remirror/messages": "^2.0.6",
         "nanoevents": "^5.1.13",
         "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@lingui/detect-locale": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
+          "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w=="
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/i18n": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
+          "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@lingui/detect-locale": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0",
+            "make-plural": "^6.2.2"
+          }
+        },
+        "@remirror/icons": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
+          "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/core-constants": {
@@ -15611,7 +21884,9 @@
       }
     },
     "@remirror/core-helpers": {
-      "version": "1.0.5",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-1.0.6.tgz",
+      "integrity": "sha512-4n5eii/3L85B4SSY8/9Rerpcgl+4/Zl7gMojIm43AkDqyCJNejRkqNW7jtflbkugEBjJP+sb6hEVMsW4jKCOHw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@linaria/core": "3.0.0-beta.13",
@@ -15631,637 +21906,4350 @@
       }
     },
     "@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-2.0.6.tgz",
+      "integrity": "sha512-baoSrVd0ECjiCqx8MZ/vEBxVsFmbRlM/hpKUyhkiWlL3vxFr7s+LNb7Rjl+l6IYmm65A7CU+pBa2W4846cMoAg==",
       "requires": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1"
+      },
+      "dependencies": {
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/core-utils": {
-      "version": "1.1.4",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-2.0.13.tgz",
+      "integrity": "sha512-5UggNc6Z2d7M8SVkstsVitID8DAHSKPrqet7Hfn4/dY+p4iMCOdwf9cLqcHMg3467k5/5/RvJPMTr9GQOEx7Hg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.5",
+        "@remirror/messages": "^2.0.6",
         "@types/min-document": "^2.19.0",
         "css-in-js-utils": "^3.1.0",
-        "min-document": "^2.19.0"
+        "get-dom-document": "^0.1.3",
+        "min-document": "^2.19.0",
+        "parenthesis": "^3.1.8"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/dom": {
-      "version": "1.0.17",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/dom/-/dom-2.0.16.tgz",
+      "integrity": "sha512-DxjEFgQc24O93WN/YL7nHUanER/a1FIGQGRgsFoN9Px2t+Op39i2PZ0hm1ZE7ivp9/gE7obaMbgsXnjEJ8RX+A==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/preset-core": "^1.0.17"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/preset-core": "^2.0.16"
       }
     },
     "@remirror/extension-annotation": {
-      "version": "1.1.10",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-annotation/-/extension-annotation-2.0.16.tgz",
+      "integrity": "sha512-jtLfWaNWQFfsE3lguQbYds4W3HJGLM0Ezrsc1q1w17EQxr5aJnjA2tNMjZL+6IdFzqEjuxd7Y9aRln3rU4WbnA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-bidi": {
-      "version": "1.0.13",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-bidi/-/extension-bidi-2.0.16.tgz",
+      "integrity": "sha512-Dk3JMNPZwsU+ClcBbaD4k52vw7+tInUMMVN7RHIx4TFSVPeLq6vskvLaisbpfegt+lSq/4K8jSsYhjMoLjLWTw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
         "@types/direction": "^1.0.0",
         "direction": "^1.0.4"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-blockquote": {
-      "version": "1.0.15",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-blockquote/-/extension-blockquote-2.0.14.tgz",
+      "integrity": "sha512-jWko6/spZ49OvZVZVFUSPhOIZR8VY9aUFiMKJQfclkL3fESJPSPshkm6rANrnY24sk7VKfpXgpwCSqmJVJ8EiA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "@remirror/theme": "^2.0.7"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-bold": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-bold/-/extension-bold-2.0.13.tgz",
+      "integrity": "sha512-b4yaQcU0m/tXxUVAlDSHcm3Z4dVnWKXfUmlpP8QDjISQ0F0vloRWSK2U9yvcldhmnTNJ/il0kn9PmJeoRbqkeA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-callout": {
-      "version": "1.0.15",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-callout/-/extension-callout-2.0.17.tgz",
+      "integrity": "sha512-HBXQHasZrRgaRCqAXEleaHEwI2eGHe4a54KwFiId88rLwJRS6aQd1AI9KwGnnyHSTwnNIEMXX3vtMHH1ej1Sfw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-code": {
-      "version": "1.0.14",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-code/-/extension-code-2.0.13.tgz",
+      "integrity": "sha512-uf4mkIHcw5RIscw1YcOMwikMMu+x5cqUkFdo5jjA3cssirh/87xDQJAeXLB4weN/ZNexbaJ2tSslWpMFrNBW8A==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
+    "@remirror/extension-code-block": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-code-block/-/extension-code-block-2.0.20.tgz",
+      "integrity": "sha512-d1c/WHUw76Oq9aL/gQ3ihBwfAGyDi/XinN7oOd8ODdaK4zbDonGOCjB1Q5zZDJCZRDt5I6RYP/Z/Xzm/PgTsmQ==",
+      "requires": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "@types/refractor": "^3.0.2",
+        "refractor": "^3.6.0"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-codemirror5": {
-      "version": "1.0.13",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-codemirror5/-/extension-codemirror5-2.0.15.tgz",
+      "integrity": "sha512-PUZRkuoCVJB+A1JZSWuSTckree3A/ibR7nbhqNCMMSDI88aTCCovFV3/yaQahoIkmjDfUWIacFrlHnZ+A4OmIQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-collaboration": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-collaboration/-/extension-collaboration-2.0.13.tgz",
+      "integrity": "sha512-sqkUjsPYQnuBIbyMW/FsSkQSyQ9GbQcawrigcCOxwlQp3f1snzKzfEcGRMPrUAG06UfDRedoGv/HVb+K4uIiIw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-columns": {
-      "version": "1.0.13",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-columns/-/extension-columns-2.0.16.tgz",
+      "integrity": "sha512-WkeIAcHPStu5+k/us46rSsXthctCip+IrY7fESwewbFsSaAleSvgkna5ig7eyST7cDYVb4ILnbGImsSYY32TRQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-diff": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-diff/-/extension-diff-2.0.13.tgz",
+      "integrity": "sha512-6IxewTYkiFTOqEB7W3uZHBCS6pTw76qJVceWziFnSzwlf0JPqs80C4y6BLOdC6rIa3nB9USSlDkf8y1HDubVZw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-doc": {
-      "version": "1.0.14",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-doc/-/extension-doc-2.1.7.tgz",
+      "integrity": "sha512-HeIUpg+TmcPw7m4OrRtMbiSWPYS8vEcbv24/GqWYECPS6rWkBpqIlYz/sjQuV16nT/YjkKdmmNMn4eDtJZw2cw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-drop-cursor": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-drop-cursor/-/extension-drop-cursor-2.0.13.tgz",
+      "integrity": "sha512-To6YtaBZ4v4XWaoD1oMd/EGsKMw2plLizZHrH70q7voP5rJjjzQ1O0Z8N/qgeM6Ai7ZM1O8PAozUW1OpqQQJJA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-embed": {
-      "version": "1.1.18",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-embed/-/extension-embed-2.0.16.tgz",
+      "integrity": "sha512-1yzRWu+IVeILk01qR7mft0qrvIOQbKKkCnFSC09NT9LomUqXmbDGALL2DX9nVujG2TJrkT8aUZEcvV+cOWnOIw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
         "@types/querystringify": "^2.0.0",
-        "prosemirror-resizable-view": "^1.1.8",
+        "prosemirror-resizable-view": "^2.0.15",
         "querystringify": "^2.2.0"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-emoji": {
-      "version": "1.0.15",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-emoji/-/extension-emoji-2.0.19.tgz",
+      "integrity": "sha512-EfS9z6VBQIvpy0bOU1GnF8o2xO8TXMC30iOnUmseu6rmj93rkQrKTmsIVQ3HEWoaDX2AKLNwAM2P/Zm9KtdSyg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "emojibase": "^6.0.0",
-        "emojibase-data": "^6.1.0",
-        "emojibase-regex": "^6.0.0",
+        "@babel/runtime": "^7.22.3",
+        "@ocavue/svgmoji-cjs": "^0.1.1",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "emojibase": "^6.1.0",
+        "emojibase-data": "^6.2.0",
+        "emojibase-regex": "^6.0.1",
         "escape-string-regexp": "^4.0.0",
         "svgmoji": "^3.2.0"
       },
       "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
-    "@remirror/extension-epic-mode": {
-      "version": "1.0.13",
+    "@remirror/extension-entity-reference": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-entity-reference/-/extension-entity-reference-2.2.8.tgz",
+      "integrity": "sha512-I9zjDws9En6GdUGfhrnoAAPRXJjsdrGetj5Sbsl1Xm/XpES6Jm/iDoZYr1/tJrgyys3USi96iwHCpV5p9FEnXg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/extension-positioner": "^2.1.8"
+      }
+    },
+    "@remirror/extension-epic-mode": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-epic-mode/-/extension-epic-mode-2.0.13.tgz",
+      "integrity": "sha512-KDHF0Uyr0RevWtp1ca4VOL+4iD6SXlPpEbRKz7Mlg5Fnl9IGTEsraHwg9OthoTN1Kc8fzYMzOxv6qwyTsvMuVw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-events": {
-      "version": "1.0.14",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-2.1.17.tgz",
+      "integrity": "sha512-vIBV5tQYgQ8hkYXWPrgQwjmBxTe55FynKS4aDSpde1pfSf6MUUaTWNlMGQzmTWBukhw1tGppNiJkKuYpOL/YxQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-font-family": {
-      "version": "1.0.13",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-font-family/-/extension-font-family-2.0.15.tgz",
+      "integrity": "sha512-hKr2CsyfdxtDMRDtpRgjKyxAwiuTM/BilVncs38jCDr8//GayK3XNU3hK287XKxfLXpr7ug7EHQXAx7wV94W+w==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-font-size": {
-      "version": "1.0.15",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-font-size/-/extension-font-size-2.0.15.tgz",
+      "integrity": "sha512-+5Kpq9Q/gQ+Z5dSbJq8Q10Jq6YmbjsuH0kL8qyJvhQbvsjiiMt3jEJrF3rHLHRUOnvpKVINaWRJ2EpsP5NOzTg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
         "round": "^2.0.1"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-gap-cursor": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-gap-cursor/-/extension-gap-cursor-2.0.13.tgz",
+      "integrity": "sha512-oaLrh/6cRhAdEksDNmrEcqnVixRjzARDr+cq2jJfPdVG0316xgNi7CkTnWJJCWSqQ4D6lrriMY5pQO3Qwlv5Kg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-hard-break": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-hard-break/-/extension-hard-break-2.0.13.tgz",
+      "integrity": "sha512-86T5bWl7O6feaXYIUylAuzq6lbpWhF6cM7CY7IW5c9+l8qpUMSktylfgAVAajjAtIfIB+g83m0D2AjL5VXksvg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-heading": {
-      "version": "1.0.13",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-heading/-/extension-heading-2.0.16.tgz",
+      "integrity": "sha512-rK44ASoDpJcjnSBiafm2pQ5CMYtSimPkBAc/OBmiS5obgt4uGSx74FeoVOPi0+2fae2awZT9NscsoAZz1bGfyg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-history": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-2.0.13.tgz",
+      "integrity": "sha512-LjW60KVpniRawttyhrWxM6ieE8sTYprqpCdMRbc7RuxBhdHaxlcQJGAjJvnBM7078qV/55S616P620YGYaBU4w==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-horizontal-rule": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-horizontal-rule/-/extension-horizontal-rule-2.0.13.tgz",
+      "integrity": "sha512-CV1lIWZ0n8btANKIP4xiUzTFbWRhOiBfdncePZvoRSYTa4UwfAQ6KapUVkcUHEL20UtDkDX8fGpF6kjtEGRCCQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-image": {
-      "version": "1.0.23",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-image/-/extension-image-2.1.12.tgz",
+      "integrity": "sha512-2nbywHOM4fXOFNxRdFFKaEUUtup57YAvpet5g7VBFwHamw6JWfWJwS6Bl8Baa6Vq6vEG51kU4TiCEInoGqOFKQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "prosemirror-resizable-view": "^1.1.8"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "prosemirror-resizable-view": "^2.0.15"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-italic": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-italic/-/extension-italic-2.0.13.tgz",
+      "integrity": "sha512-DZ7BoIxQqwTWoTYgc7GpK+SCBKfDoJjh4xKQIrC/45tcK+WdPaaxNRhdtGUzwOhHL2psYT6HtDOyN/DpO5hjWQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-link": {
-      "version": "1.1.12",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-link/-/extension-link-2.0.19.tgz",
+      "integrity": "sha512-V2buYAbfPK3CSzCmwkHUE+30qpd/c++m/vfjhLagZHCbUJMbtQE8D41+OTUjiCvuCYhB94nrxWyyPYpXA7sOfQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "extract-domain": "2.2.1"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-list": {
-      "version": "1.2.13",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-list/-/extension-list-2.0.18.tgz",
+      "integrity": "sha512-+F8i4Ax1Ii9Rig5ORV8XEpZG/cqn/BgCmsxZy7yjEiPLEM+zSnEKCrldixkbb47NiTDEbDfrFcWeR/taqJ3kFQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-markdown": {
-      "version": "1.0.13",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-markdown/-/extension-markdown-2.0.14.tgz",
+      "integrity": "sha512-tv8h2KyAF6dvawqslW8FG/qftpfNzseQujaVc0o/KmV9iE8kQnIdTcDPClL0GWwk9fOqlLL8C2zkKnvLMKk4Cw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@types/marked": "^3.0.0",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "@types/marked": "^4.3.1",
         "@types/turndown": "^5.0.1",
-        "marked": "^3.0.0",
-        "turndown": "^7.1.1",
+        "marked": "^4.3.0",
+        "turndown": "^7.1.2",
         "turndown-plugin-gfm": "^1.0.2"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-mention": {
-      "version": "1.0.14",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-mention/-/extension-mention-2.0.17.tgz",
+      "integrity": "sha512-QyJo8CtxWVC/WliaEVREMYLb+xD9qWVqtF/3dSa3A+3FQSzasutDrUlcmR0soo/Nc3YmlsRMVi+njVgpta/Dww==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
     "@remirror/extension-mention-atom": {
-      "version": "1.0.16",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-mention-atom/-/extension-mention-atom-2.0.19.tgz",
+      "integrity": "sha512-/ElJi0zafw4ErGSfmIMQteYNErH31SRi7usHAQkT3oFAZDbvPE1QPfNE3bdSqJgVt3+IqC7E7jr+QTCqHhOi5A==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-node-formatting": {
-      "version": "1.0.16",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-node-formatting/-/extension-node-formatting-2.0.15.tgz",
+      "integrity": "sha512-s7WfiNlGdb1EOAepvLIKx/E1fyPtpr3HoTGrySCONfvwG6DJN4T3HMWAhMz30mts8leK2wlsItjRfgWVlf3Leg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-paragraph": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-2.0.13.tgz",
+      "integrity": "sha512-/iEYz6Sn/RLqTefa/vjjyfhMQAGcpNQY7hdW0rSox+IiwDKeeY+uR2TCi3hs/D9IMzNERZXMKD5Wk8ver1kYCg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-placeholder": {
-      "version": "1.0.15",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-placeholder/-/extension-placeholder-2.0.14.tgz",
+      "integrity": "sha512-YyrDs1Plyrpy5N6ehG3QOZNxpsQpDdI34yFQst+g2t/amnY6ScCnAJJ4GE666P4xnPF2V9gY0478Re09JmJ1KQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "@remirror/theme": "^2.0.7"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-positioner": {
-      "version": "1.1.14",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-positioner/-/extension-positioner-2.1.8.tgz",
+      "integrity": "sha512-7svqCFayauNSFCXejvitFqkTUhxk74FCCoWNI2S4p8m0y80TzJDVrASjc2m8/kZALjVeIE4Byg1gE58zj3r9SA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-events": "^2.1.14",
+        "@remirror/messages": "^2.0.3",
+        "@remirror/theme": "^2.0.7",
         "nanoevents": "^5.1.13"
-      }
-    },
-    "@remirror/extension-react-ssr": {
-      "version": "1.0.15",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-react-component": "^1.1.4",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/react-utils": "^1.0.6"
       },
       "dependencies": {
-        "@remirror/extension-react-component": {
-          "version": "1.1.4",
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/messages": "^1.0.6",
-            "nanoevents": "^5.1.13"
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
           }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
     "@remirror/extension-search": {
-      "version": "1.0.13",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-search/-/extension-search-2.0.14.tgz",
+      "integrity": "sha512-PZrf20bqr8n+E1kgeb6uQJG5ZeD8nHTzzICZRe01ltwmO4vqnWMXr7Tm5Z6Byh+ZqwLbMWkIeUzoaV7RdBQ94Q==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
     "@remirror/extension-shortcuts": {
-      "version": "1.1.2",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-shortcuts/-/extension-shortcuts-2.0.13.tgz",
+      "integrity": "sha512-LHHn7lnbicL9CQet9w9Aayw25SqsA5s9ysGWO9R9DbrYKJWWL1EijvZ3rz+N6nlb9/ItFWA6eNSSUSausnv+iA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13"
       }
     },
     "@remirror/extension-strike": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-strike/-/extension-strike-2.0.13.tgz",
+      "integrity": "sha512-42aEM12xux3RoxTZHJ6OBPpHux96btiMC7btPz7lJ/mqcAtVvIP3RHb8D01esU7KEpqIaI6H6n2WKc/JmvCdMQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-sub": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-sub/-/extension-sub-2.0.13.tgz",
+      "integrity": "sha512-eeEdHBWynyoU6YXc6Xt+n93nK2JJ0ry2TGqr8nzomssm2gddASPJKXFoPELuwME/iqzz64SxU/RcI7BRc/lbdw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-sup": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-sup/-/extension-sup-2.0.13.tgz",
+      "integrity": "sha512-8Pz+K8aSlxVCeqk9ZSX+JiSBNeCau8EbGkfTg1wAatq1jCrNhFHOHoazYOqA+nJjYP7/c5hiCoPYLpyXweIX3w==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-tables": {
-      "version": "1.0.15",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-tables/-/extension-tables-2.4.3.tgz",
+      "integrity": "sha512-Mo7eGYc2h/rJW4uUYluh529Lv6Lwjyy10M2SJ52Yxnr0kZDU0bTJZsXRF+SxPgS0V8qQkqhwSSCDoys/x9IqLQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-text": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text/-/extension-text-2.0.13.tgz",
+      "integrity": "sha512-0lGw8zz3OZzRY5zGrI1gXJIfuv23Yf3IdK3507oqE0oVAnP61vPB5WMaYv3EtGez9g3RoXO8S0bIJJ3syzdILg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-text-case": {
-      "version": "1.0.13",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-case/-/extension-text-case-2.0.15.tgz",
+      "integrity": "sha512-EFkEW2JvgyiNJch0wINYY801ATjXW8X+zbMSeJAE0mP0CV/1FY7svcJ2Fn7/4Czy8RVryKLgfN+xqjjLg/HNwQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-text-color": {
-      "version": "1.0.15",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-2.0.17.tgz",
+      "integrity": "sha512-KoZ//Lgts6shVeGzK0CKdHmfq7vp0HuB9Upk1Sd6igKuJVMpmwM2UPUYtO/ig2N+KT4r+EUYPOiLrSzoCr3zog==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "color2k": "^1.2.4"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/i18n": "^2.0.5",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/theme": "^2.0.9",
+        "color2k": "^2.0.2"
+      },
+      "dependencies": {
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+          "requires": {
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
+          }
+        },
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@lingui/detect-locale": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
+          "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w=="
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/i18n": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
+          "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@lingui/detect-locale": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0",
+            "make-plural": "^6.2.2"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-text-highlight": {
-      "version": "1.0.15",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-text-highlight/-/extension-text-highlight-2.0.16.tgz",
+      "integrity": "sha512-WrTftw/0tpPxjcCFhZekkXa1A/eHedgNyL88B+8Np04W7YHWiuALlIVdG+yZ+NZPxR0SWypFpsA8Yu12kGGRiA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/extension-text-color": "^2.0.17",
+        "@remirror/messages": "^2.0.6"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-trailing-node": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-trailing-node/-/extension-trailing-node-2.0.13.tgz",
+      "integrity": "sha512-DCeovi8yJ8HzTHZ/8bIxalm7aSjngN2B+DazGb5b6iLPFiEi00zucsw81bnVkHMa8DKDeH7WVbe13wZI+tn+KA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-underline": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-underline/-/extension-underline-2.0.13.tgz",
+      "integrity": "sha512-wrNDSqNvwqtZBiz0nOEQaWOEthxOtBVwkuTku83Sh7ftK6rNWJXtHKNKGUAFW6A9FXxvvqrnr8+n0DSgYdIAMA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-whitespace": {
-      "version": "1.0.13",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-whitespace/-/extension-whitespace-2.0.13.tgz",
+      "integrity": "sha512-daRoiH2/xZWrz8tzV14rfG8Catd0ThPJdWgoQ0en3QxcwYsTOP1+DXE1ZwUdP/uukuHg6DMAvgMvsWwJMtVx9A==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/messages": "^1.0.6"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/extension-yjs": {
-      "version": "1.0.19",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-yjs/-/extension-yjs-3.0.16.tgz",
+      "integrity": "sha512-7JnK76M/7kwOQVmX79mOGKFpQg2UyMvslF1sadEKAAQIcX7bocoo09MmCnrg5tBuSI6Jb4mS+PG/QBH/7WKykQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-annotation": "^1.1.10",
-        "@remirror/messages": "^1.0.6",
-        "y-prosemirror": "^1.0.14",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/messages": "^2.0.6",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.33.8",
+        "y-prosemirror": "^1.0.19",
         "y-protocols": "^1.0.5"
+      },
+      "dependencies": {
+        "@lingui/core": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "@lingui/message-utils": "4.14.1",
+            "unraw": "^3.0.0"
+          }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/messages": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@lingui/core": "^4.2.0",
+            "@remirror/core-helpers": "^3.0.0"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/i18n": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-1.0.9.tgz",
+      "integrity": "sha512-uWYuFTuD5+4WEdHIvkrkimhAa3jIL89Z2KMRi2aj0pA8PDwD+svDNz8E1B1SUP2Th8JmGd0XfHRtg+OsiDTjTA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@lingui/core": "^3.10.4",
         "@lingui/detect-locale": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.5",
+        "@remirror/core-helpers": "^1.0.6",
         "make-plural": "^6.2.1"
       }
     },
     "@remirror/icons": {
-      "version": "1.0.7",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-1.0.8.tgz",
+      "integrity": "sha512-aS8wssUaH5yfJoeEPOPLKCsK7OSmXZlmSxxQ10j5REaw9UlyEWrFAb+GjGpFqeM8o7xS9T7W0M6yWyVSaKIeng==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@remirror/core-helpers": "^1.0.5"
+        "@remirror/core-helpers": "^1.0.6"
       }
     },
     "@remirror/messages": {
-      "version": "1.0.6",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-1.0.7.tgz",
+      "integrity": "sha512-cnN5UxQGMW2rCJFqjzYzHG0qvCugraKc0r4b3atDE8HokVIJO1DHoVYux5A7UkfYVe5Enow/UUy/nj5zf3MhgA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@lingui/core": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.5"
+        "@remirror/core-helpers": "^1.0.6"
       }
     },
     "@remirror/pm": {
-      "version": "1.0.11",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-2.0.9.tgz",
+      "integrity": "sha512-B2/FpFMtNS6sEIKKsxzM6uLW/Zp+1PDfVxNmA7DRTg691v9Yhh5wYXwcg2mtcMTEiRELiPwjCR5kDHSIrzb6Ag==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.0",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.2.8",
-        "@types/prosemirror-transform": "^1.1.5",
-        "@types/prosemirror-view": "^1.23.1",
-        "prosemirror-collab": "^1.2.2",
-        "prosemirror-commands": "^1.2.0",
-        "prosemirror-dropcursor": "^1.4.0",
-        "prosemirror-gapcursor": "^1.2.1",
-        "prosemirror-history": "^1.2.0",
-        "prosemirror-inputrules": "^1.1.3",
-        "prosemirror-keymap": "^1.1.5",
-        "prosemirror-model": "^1.16.1",
-        "prosemirror-paste-rules": "^1.0.7",
-        "prosemirror-schema-list": "^1.1.6",
-        "prosemirror-state": "^1.3.4",
-        "prosemirror-suggest": "^1.0.7",
-        "prosemirror-tables": "^1.1.1",
-        "prosemirror-trailing-node": "^1.0.7",
-        "prosemirror-transform": "^1.3.3",
-        "prosemirror-view": "^1.23.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-paste-rules": "^2.0.8",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-suggest": "^2.0.7",
+        "prosemirror-tables": "^1.3.7",
+        "prosemirror-trailing-node": "^2.0.9",
+        "prosemirror-transform": "^1.9.0",
+        "prosemirror-view": "^1.33.8"
+      },
+      "dependencies": {
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "@remirror/preset-core": {
-      "version": "1.0.17",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-core/-/preset-core-2.0.16.tgz",
+      "integrity": "sha512-Qg5kDJIoSqSCtqwuT/+xq1pXf5XHonnqE4oRL5Z7Tu9RRmQ6evMhdc6CqehP5xwI+52g7q9CCRQYyNAtAhS3LQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-doc": "^1.0.14",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/extension-gap-cursor": "^1.0.13",
-        "@remirror/extension-history": "^1.0.13",
-        "@remirror/extension-paragraph": "^1.0.13",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-text": "^1.0.13"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-doc": "^2.1.5",
+        "@remirror/extension-events": "^2.1.14",
+        "@remirror/extension-gap-cursor": "^2.0.13",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-paragraph": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-text": "^2.0.13"
       }
     },
     "@remirror/preset-formatting": {
-      "version": "1.0.19",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-formatting/-/preset-formatting-2.0.14.tgz",
+      "integrity": "sha512-Dn8AITrTycEsO3kmR3kiWE8tCjWQUmK4vvyE/aGTyvHQHsDt1KhK6X42os7D+ePxeRf4OkhaZJhdpVmujmCCUw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-bold": "^1.0.13",
-        "@remirror/extension-columns": "^1.0.13",
-        "@remirror/extension-font-size": "^1.0.15",
-        "@remirror/extension-heading": "^1.0.13",
-        "@remirror/extension-italic": "^1.0.13",
-        "@remirror/extension-node-formatting": "^1.0.16",
-        "@remirror/extension-strike": "^1.0.13",
-        "@remirror/extension-sub": "^1.0.13",
-        "@remirror/extension-sup": "^1.0.13",
-        "@remirror/extension-text-case": "^1.0.13",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/extension-text-highlight": "^1.0.15",
-        "@remirror/extension-underline": "^1.0.13",
-        "@remirror/extension-whitespace": "^1.0.13"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-columns": "^2.0.13",
+        "@remirror/extension-font-size": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.13",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-node-formatting": "^2.0.13",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-sub": "^2.0.13",
+        "@remirror/extension-sup": "^2.0.13",
+        "@remirror/extension-text-case": "^2.0.13",
+        "@remirror/extension-text-color": "^2.0.14",
+        "@remirror/extension-text-highlight": "^2.0.14",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/extension-whitespace": "^2.0.13"
       }
     },
     "@remirror/preset-wysiwyg": {
-      "version": "1.1.35",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-wysiwyg/-/preset-wysiwyg-2.0.19.tgz",
+      "integrity": "sha512-yYDfHy3WJzBmYkTd1R8WgY0xND4ZhSOQSmWWxYcCb9QJOWqeX/LREk6Ac+FV2Ygc+aoRGx5HI2R6POehe1fb5g==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-bidi": "^1.0.13",
-        "@remirror/extension-blockquote": "^1.0.15",
-        "@remirror/extension-bold": "^1.0.13",
-        "@remirror/extension-code": "^1.0.14",
-        "@remirror/extension-code-block": "^1.0.18",
-        "@remirror/extension-drop-cursor": "^1.0.13",
-        "@remirror/extension-embed": "^1.1.18",
-        "@remirror/extension-gap-cursor": "^1.0.13",
-        "@remirror/extension-hard-break": "^1.0.13",
-        "@remirror/extension-heading": "^1.0.13",
-        "@remirror/extension-horizontal-rule": "^1.0.13",
-        "@remirror/extension-image": "^1.0.23",
-        "@remirror/extension-italic": "^1.0.13",
-        "@remirror/extension-link": "^1.1.12",
-        "@remirror/extension-list": "^1.2.13",
-        "@remirror/extension-search": "^1.0.13",
-        "@remirror/extension-shortcuts": "^1.1.2",
-        "@remirror/extension-strike": "^1.0.13",
-        "@remirror/extension-trailing-node": "^1.0.13",
-        "@remirror/extension-underline": "^1.0.13",
-        "@remirror/preset-core": "^1.0.17"
-      },
-      "dependencies": {
-        "@remirror/extension-code-block": {
-          "version": "1.0.18",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/messages": "^1.0.6",
-            "@remirror/theme": "^1.2.0",
-            "@types/refractor": "^3.0.2",
-            "refractor": "^3.3.1"
-          }
-        }
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-bidi": "^2.0.13",
+        "@remirror/extension-blockquote": "^2.0.14",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-code": "^2.0.13",
+        "@remirror/extension-code-block": "^2.0.14",
+        "@remirror/extension-drop-cursor": "^2.0.13",
+        "@remirror/extension-embed": "^2.0.13",
+        "@remirror/extension-gap-cursor": "^2.0.13",
+        "@remirror/extension-hard-break": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.13",
+        "@remirror/extension-horizontal-rule": "^2.0.13",
+        "@remirror/extension-image": "^2.1.9",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-link": "^2.0.15",
+        "@remirror/extension-list": "^2.0.16",
+        "@remirror/extension-search": "^2.0.14",
+        "@remirror/extension-shortcuts": "^2.0.13",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-trailing-node": "^2.0.13",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/preset-core": "^2.0.16"
       }
     },
     "@remirror/react": {
@@ -16282,13 +26270,184 @@
         "@remirror/react-utils": "^1.0.6"
       },
       "dependencies": {
-        "@remirror/extension-react-component": {
-          "version": "1.1.4",
+        "@remirror/core": {
+          "version": "1.4.7",
+          "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
+          "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
           "requires": {
             "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/messages": "^1.0.6",
+            "@linaria/core": "3.0.0-beta.13",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/core-types": "^1.0.4",
+            "@remirror/core-utils": "^1.1.11",
+            "@remirror/i18n": "^1.0.9",
+            "@remirror/icons": "^1.0.8",
+            "@remirror/messages": "^1.0.7",
+            "nanoevents": "^5.1.13",
+            "tiny-warning": "^1.0.3"
+          }
+        },
+        "@remirror/core-types": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+          "requires": {
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/types": "^0.1.1"
+          }
+        },
+        "@remirror/core-utils": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
+          "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/core-types": "^1.0.4",
+            "@remirror/messages": "^1.0.7",
+            "@types/min-document": "^2.19.0",
+            "css-in-js-utils": "^3.1.0",
+            "min-document": "^2.19.0",
+            "parenthesis": "^3.1.8"
+          }
+        },
+        "@remirror/extension-doc": {
+          "version": "1.0.25",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-doc/-/extension-doc-1.0.25.tgz",
+          "integrity": "sha512-bC6YTkldMQ6/YT2HbN4AM2UtpoBDAmglj06UI6YspsUzJLhH+z+O6n5sgWQ89j9r3jKx9768YK9CPmtk6EIfLg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7"
+          }
+        },
+        "@remirror/extension-emoji": {
+          "version": "1.0.29",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-emoji/-/extension-emoji-1.0.29.tgz",
+          "integrity": "sha512-kegqTYJORylKGCcefj5c9S/+vZ9aUGtECpreF2fo0P8Njs7EOxzJxwoc/DRogLNLDjWVJxoQpS4nllNw/XA3lA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/theme": "^1.2.2",
+            "emojibase": "^6.0.0",
+            "emojibase-data": "^6.1.0",
+            "emojibase-regex": "^6.0.0",
+            "escape-string-regexp": "^4.0.0",
+            "svgmoji": "^3.2.0"
+          }
+        },
+        "@remirror/extension-events": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-1.1.5.tgz",
+          "integrity": "sha512-l8+r6TMphdJ1khnKYy+PlqjhlEDvLTyHZ89BJRJmPaDfpsw7IhgcDbtvklYPtaJC9TkWRbxc9hfz/NOY8qwHHA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7"
+          }
+        },
+        "@remirror/extension-gap-cursor": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-gap-cursor/-/extension-gap-cursor-1.0.24.tgz",
+          "integrity": "sha512-WiiBzcDRwwfbFbCUaR+lUFmjvNaZidJrOdfVswcUXe/LoxKqaQEZ7l7x3WIpuEXMIO/RCP6f+tb4ppzuJ9Erhg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7"
+          }
+        },
+        "@remirror/extension-history": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-1.0.24.tgz",
+          "integrity": "sha512-f7OMtCAuzVis/fPOiZvkQ3Ay8My032HhRHcDNX1d0yqiYNN6XWsD93sAYbC7c6ymLZ9GP1YNiorJ4GmXd8mBsQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7"
+          }
+        },
+        "@remirror/extension-mention": {
+          "version": "1.0.25",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-mention/-/extension-mention-1.0.25.tgz",
+          "integrity": "sha512-tlzdpb4XEt+9v5408M/SPtRZlX+0DOE+2iycvu7H0mrc8TYWEG23YDznu7w86wr3PGEg9+LzofVUDK+rpfmbDg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/extension-events": "^1.1.5",
+            "@remirror/messages": "^1.0.7",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "@remirror/extension-mention-atom": {
+          "version": "1.0.29",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-mention-atom/-/extension-mention-atom-1.0.29.tgz",
+          "integrity": "sha512-5JE6EVVFP2HPa9Drzfxuas1ehhQgt2fNnVtTCusk5eznoMAsRiMzM6XrtsKXw5ZUqbfZ0MoDZjRniQYwnhUdXA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/extension-events": "^1.1.5",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/theme": "^1.2.2"
+          }
+        },
+        "@remirror/extension-paragraph": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-1.0.24.tgz",
+          "integrity": "sha512-sfsir4HSUKX6Dags+6KHFywHhwx+C6SUqKgp+MakrqEw9rKFOZs4yNDY25MsTxBZTVQ3dq/2vi1nCdt6Q6trAA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7"
+          }
+        },
+        "@remirror/extension-placeholder": {
+          "version": "1.0.28",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-placeholder/-/extension-placeholder-1.0.28.tgz",
+          "integrity": "sha512-siAI6ugWEBu7uu3zMlpizf3bXGpy9tHNtc9558XRpRyOQu6DaKyAZq/A9h4Vf2xqN8VYit8zJ8KckaBuAp2a5A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/theme": "^1.2.2"
+          }
+        },
+        "@remirror/extension-positioner": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-positioner/-/extension-positioner-1.2.9.tgz",
+          "integrity": "sha512-2LThtxAeDBJNzZlYAB7gI5H3dULKvt5NH5UVHKzhXXxkO2q3OCCs9oz5sNOxphrS1K31Oh54gCEoiKUta6fppA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/extension-events": "^1.1.5",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/theme": "^1.2.2",
             "nanoevents": "^5.1.13"
+          }
+        },
+        "@remirror/extension-react-component": {
+          "version": "1.1.16",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-react-component/-/extension-react-component-1.1.16.tgz",
+          "integrity": "sha512-X4x8STuDcz5Pz68YLMOb9ps1STFl3ZqdjhrILolLxXjfkJmLeCLRNwMUFTs9KrIJX842HAKwLevOTrA0vjlxkA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7",
+            "nanoevents": "^5.1.13"
+          }
+        },
+        "@remirror/extension-react-ssr": {
+          "version": "1.0.28",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-react-ssr/-/extension-react-ssr-1.0.28.tgz",
+          "integrity": "sha512-X7TV3FkMc/NGLnEBDaFUAckNXuPe1sjcoG2XkSuoOYG0DfiBTfv5SD11/QJT2a2lRNqxlB9QpXS2Ngz4sRHaYw==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/extension-react-component": "^1.1.16",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/react-utils": "^1.0.7"
           }
         },
         "@remirror/extension-react-tables": {
@@ -16309,6 +26468,95 @@
             "@remirror/react-hooks": "^1.0.20",
             "@remirror/theme": "^1.2.0",
             "jsx-dom": "^6.4.23"
+          }
+        },
+        "@remirror/extension-tables": {
+          "version": "1.0.28",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-tables/-/extension-tables-1.0.28.tgz",
+          "integrity": "sha512-erG70aN6WoyV6i/5n2hVgcGRq28Ahz8XBYWKF/GpVuReO0nA3FvBUIa2jKYrAVYnnYVfv/lMyTs9fJL4HRQOrA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/theme": "^1.2.2"
+          }
+        },
+        "@remirror/extension-text": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-text/-/extension-text-1.0.24.tgz",
+          "integrity": "sha512-+WpPwJnZNWrWNNH4lX8yMFvSjQ6/ueRXCjqmtC5KulfMxjIce6PEJOBsBLIgGVwLXqJDdXxBEnTmj7BqtoqolQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/messages": "^1.0.7"
+          }
+        },
+        "@remirror/extension-text-color": {
+          "version": "1.0.28",
+          "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-1.0.28.tgz",
+          "integrity": "sha512-blau7PEy/53T8cJ2fpKIa76krsQ1KllCLUc7yXL1/cw3zHACV4up9lUTqD5jTQnPxSKUacI6ZykJekC+9fjq5Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/i18n": "^1.0.9",
+            "@remirror/messages": "^1.0.7",
+            "@remirror/theme": "^1.2.2",
+            "color2k": "^1.2.4"
+          }
+        },
+        "@remirror/pm": {
+          "version": "1.0.22",
+          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@types/prosemirror-collab": "^1.1.2",
+            "@types/prosemirror-commands": "^1.0.4",
+            "@types/prosemirror-dropcursor": "^1.0.3",
+            "@types/prosemirror-gapcursor": "^1.0.4",
+            "@types/prosemirror-history": "^1.0.3",
+            "@types/prosemirror-inputrules": "^1.0.4",
+            "@types/prosemirror-keymap": "^1.0.4",
+            "@types/prosemirror-model": "^1.16.2",
+            "@types/prosemirror-schema-list": "^1.0.3",
+            "@types/prosemirror-state": "^1.3.0",
+            "@types/prosemirror-transform": "^1.4.0",
+            "@types/prosemirror-view": "^1.23.2",
+            "prosemirror-collab": "<1.3.0",
+            "prosemirror-commands": "<1.3.0",
+            "prosemirror-dropcursor": "<1.5.0",
+            "prosemirror-gapcursor": "<1.3.0",
+            "prosemirror-history": "<1.3.0",
+            "prosemirror-inputrules": "<1.2.0",
+            "prosemirror-keymap": "<1.2.0",
+            "prosemirror-model": "<1.17.0",
+            "prosemirror-paste-rules": "^1.1.3",
+            "prosemirror-schema-list": "<1.2.0",
+            "prosemirror-state": "<1.4.0",
+            "prosemirror-suggest": "^1.1.4",
+            "prosemirror-tables": "<1.2.0",
+            "prosemirror-trailing-node": "^1.0.11",
+            "prosemirror-transform": "<1.5.0",
+            "prosemirror-view": "<1.24.0"
+          }
+        },
+        "@remirror/preset-core": {
+          "version": "1.0.31",
+          "resolved": "https://registry.npmjs.org/@remirror/preset-core/-/preset-core-1.0.31.tgz",
+          "integrity": "sha512-mPW9dm1ynrRTezMrzf+6a0N10MVyoJTBsWRN8tG2o68XXR4c8NnUfbAZeQzv1OTUuOdL86ea+JUR6PWD4jhhAw==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core": "^1.4.7",
+            "@remirror/extension-doc": "^1.0.25",
+            "@remirror/extension-events": "^1.1.5",
+            "@remirror/extension-gap-cursor": "^1.0.24",
+            "@remirror/extension-history": "^1.0.24",
+            "@remirror/extension-paragraph": "^1.0.24",
+            "@remirror/extension-positioner": "^1.2.9",
+            "@remirror/extension-text": "^1.0.24"
           }
         },
         "@remirror/preset-react": {
@@ -16360,16 +26608,6 @@
                 "reakit-system": "^0.15.2",
                 "reakit-utils": "^0.15.2",
                 "reakit-warning": "^0.6.2"
-              },
-              "dependencies": {
-                "reakit-system": {
-                  "version": "0.15.2",
-                  "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-                  "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-                  "requires": {
-                    "reakit-utils": "^0.15.2"
-                  }
-                }
               }
             },
             "reakit-system-palette": {
@@ -16377,23 +26615,7 @@
               "requires": {
                 "color": "3.1.3",
                 "reakit-system": "^0.15.2"
-              },
-              "dependencies": {
-                "reakit-system": {
-                  "version": "0.15.2",
-                  "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-                  "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-                  "requires": {
-                    "reakit-utils": "^0.15.2"
-                  }
-                }
               }
-            },
-            "reakit-utils": {
-              "version": "0.15.2",
-              "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-              "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-              "requires": {}
             }
           }
         },
@@ -16447,6 +26669,190 @@
             "@remirror/core": "^1.3.3",
             "@remirror/extension-react-ssr": "^1.0.15"
           }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "orderedmap": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+          "peer": true
+        },
+        "prosemirror-collab": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0"
+          }
+        },
+        "prosemirror-commands": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-dropcursor": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0",
+            "prosemirror-view": "^1.1.0"
+          }
+        },
+        "prosemirror-gapcursor": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.0.0",
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-view": "^1.0.0"
+          }
+        },
+        "prosemirror-history": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.2.2",
+            "prosemirror-transform": "^1.0.0",
+            "rope-sequence": "^1.3.0"
+          }
+        },
+        "prosemirror-inputrules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-keymap": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "w3c-keyname": "^2.2.0"
+          }
+        },
+        "prosemirror-model": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+          "peer": true,
+          "requires": {
+            "orderedmap": "^1.1.0"
+          }
+        },
+        "prosemirror-paste-rules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-schema-list": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-state": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-suggest": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/types": "^0.1.1",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-tables": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.1.2",
+            "prosemirror-model": "^1.8.1",
+            "prosemirror-state": "^1.3.1",
+            "prosemirror-transform": "^1.2.1",
+            "prosemirror-view": "^1.13.3"
+          }
+        },
+        "prosemirror-trailing-node": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-transform": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0"
+          }
+        },
+        "prosemirror-view": {
+          "version": "1.23.13",
+          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.16.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0"
+          }
         }
       }
     },
@@ -16455,19 +26861,527 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@remirror/core": "^1.3.3"
+      },
+      "dependencies": {
+        "@remirror/core": {
+          "version": "1.4.7",
+          "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
+          "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@linaria/core": "3.0.0-beta.13",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/core-types": "^1.0.4",
+            "@remirror/core-utils": "^1.1.11",
+            "@remirror/i18n": "^1.0.9",
+            "@remirror/icons": "^1.0.8",
+            "@remirror/messages": "^1.0.7",
+            "nanoevents": "^5.1.13",
+            "tiny-warning": "^1.0.3"
+          }
+        },
+        "@remirror/core-types": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+          "requires": {
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/types": "^0.1.1"
+          }
+        },
+        "@remirror/core-utils": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
+          "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/core-types": "^1.0.4",
+            "@remirror/messages": "^1.0.7",
+            "@types/min-document": "^2.19.0",
+            "css-in-js-utils": "^3.1.0",
+            "min-document": "^2.19.0",
+            "parenthesis": "^3.1.8"
+          }
+        },
+        "@remirror/pm": {
+          "version": "1.0.22",
+          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@types/prosemirror-collab": "^1.1.2",
+            "@types/prosemirror-commands": "^1.0.4",
+            "@types/prosemirror-dropcursor": "^1.0.3",
+            "@types/prosemirror-gapcursor": "^1.0.4",
+            "@types/prosemirror-history": "^1.0.3",
+            "@types/prosemirror-inputrules": "^1.0.4",
+            "@types/prosemirror-keymap": "^1.0.4",
+            "@types/prosemirror-model": "^1.16.2",
+            "@types/prosemirror-schema-list": "^1.0.3",
+            "@types/prosemirror-state": "^1.3.0",
+            "@types/prosemirror-transform": "^1.4.0",
+            "@types/prosemirror-view": "^1.23.2",
+            "prosemirror-collab": "<1.3.0",
+            "prosemirror-commands": "<1.3.0",
+            "prosemirror-dropcursor": "<1.5.0",
+            "prosemirror-gapcursor": "<1.3.0",
+            "prosemirror-history": "<1.3.0",
+            "prosemirror-inputrules": "<1.2.0",
+            "prosemirror-keymap": "<1.2.0",
+            "prosemirror-model": "<1.17.0",
+            "prosemirror-paste-rules": "^1.1.3",
+            "prosemirror-schema-list": "<1.2.0",
+            "prosemirror-state": "<1.4.0",
+            "prosemirror-suggest": "^1.1.4",
+            "prosemirror-tables": "<1.2.0",
+            "prosemirror-trailing-node": "^1.0.11",
+            "prosemirror-transform": "<1.5.0",
+            "prosemirror-view": "<1.24.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "peer": true
+        },
+        "orderedmap": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+          "peer": true
+        },
+        "prosemirror-collab": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0"
+          }
+        },
+        "prosemirror-commands": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-dropcursor": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0",
+            "prosemirror-view": "^1.1.0"
+          }
+        },
+        "prosemirror-gapcursor": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.0.0",
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-view": "^1.0.0"
+          }
+        },
+        "prosemirror-history": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.2.2",
+            "prosemirror-transform": "^1.0.0",
+            "rope-sequence": "^1.3.0"
+          }
+        },
+        "prosemirror-inputrules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-keymap": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "w3c-keyname": "^2.2.0"
+          }
+        },
+        "prosemirror-model": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+          "peer": true,
+          "requires": {
+            "orderedmap": "^1.1.0"
+          }
+        },
+        "prosemirror-paste-rules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-schema-list": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-state": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-suggest": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/types": "^0.1.1",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-tables": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.1.2",
+            "prosemirror-model": "^1.8.1",
+            "prosemirror-state": "^1.3.1",
+            "prosemirror-transform": "^1.2.1",
+            "prosemirror-view": "^1.13.3"
+          }
+        },
+        "prosemirror-trailing-node": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-transform": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0"
+          }
+        },
+        "prosemirror-view": {
+          "version": "1.23.13",
+          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.16.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0"
+          }
+        }
       }
     },
     "@remirror/react-utils": {
-      "version": "1.0.6",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@remirror/react-utils/-/react-utils-1.0.7.tgz",
+      "integrity": "sha512-Pth2OppgT7jtpzZkZPYaKKXpiXmGKjrin08KuRuPRywL4ra3q75lpVFs4Yf+lYu/IvUda61yXew2oHfWsM9ktg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
+        "@remirror/core-helpers": "^1.0.6",
         "@remirror/core-types": "^1.0.4"
+      },
+      "dependencies": {
+        "@remirror/core-types": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+          "requires": {
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/types": "^0.1.1"
+          }
+        },
+        "@remirror/pm": {
+          "version": "1.0.22",
+          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@types/prosemirror-collab": "^1.1.2",
+            "@types/prosemirror-commands": "^1.0.4",
+            "@types/prosemirror-dropcursor": "^1.0.3",
+            "@types/prosemirror-gapcursor": "^1.0.4",
+            "@types/prosemirror-history": "^1.0.3",
+            "@types/prosemirror-inputrules": "^1.0.4",
+            "@types/prosemirror-keymap": "^1.0.4",
+            "@types/prosemirror-model": "^1.16.2",
+            "@types/prosemirror-schema-list": "^1.0.3",
+            "@types/prosemirror-state": "^1.3.0",
+            "@types/prosemirror-transform": "^1.4.0",
+            "@types/prosemirror-view": "^1.23.2",
+            "prosemirror-collab": "<1.3.0",
+            "prosemirror-commands": "<1.3.0",
+            "prosemirror-dropcursor": "<1.5.0",
+            "prosemirror-gapcursor": "<1.3.0",
+            "prosemirror-history": "<1.3.0",
+            "prosemirror-inputrules": "<1.2.0",
+            "prosemirror-keymap": "<1.2.0",
+            "prosemirror-model": "<1.17.0",
+            "prosemirror-paste-rules": "^1.1.3",
+            "prosemirror-schema-list": "<1.2.0",
+            "prosemirror-state": "<1.4.0",
+            "prosemirror-suggest": "^1.1.4",
+            "prosemirror-tables": "<1.2.0",
+            "prosemirror-trailing-node": "^1.0.11",
+            "prosemirror-transform": "<1.5.0",
+            "prosemirror-view": "<1.24.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "peer": true
+        },
+        "orderedmap": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+          "peer": true
+        },
+        "prosemirror-collab": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0"
+          }
+        },
+        "prosemirror-commands": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-dropcursor": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0",
+            "prosemirror-view": "^1.1.0"
+          }
+        },
+        "prosemirror-gapcursor": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.0.0",
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-view": "^1.0.0"
+          }
+        },
+        "prosemirror-history": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.2.2",
+            "prosemirror-transform": "^1.0.0",
+            "rope-sequence": "^1.3.0"
+          }
+        },
+        "prosemirror-inputrules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-keymap": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "w3c-keyname": "^2.2.0"
+          }
+        },
+        "prosemirror-model": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+          "peer": true,
+          "requires": {
+            "orderedmap": "^1.1.0"
+          }
+        },
+        "prosemirror-paste-rules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-schema-list": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-state": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-suggest": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/types": "^0.1.1",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-tables": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.1.2",
+            "prosemirror-model": "^1.8.1",
+            "prosemirror-state": "^1.3.1",
+            "prosemirror-transform": "^1.2.1",
+            "prosemirror-view": "^1.13.3"
+          }
+        },
+        "prosemirror-trailing-node": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-transform": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0"
+          }
+        },
+        "prosemirror-view": {
+          "version": "1.23.13",
+          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.16.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0"
+          }
+        }
       }
     },
     "@remirror/theme": {
-      "version": "1.2.0",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-1.2.2.tgz",
+      "integrity": "sha512-tT171xQWEneqq4kesRUfRB29CgT2VoG5NtCTD69ZuiKK+j481f6tXcyquQG15PSxwEr5AVC8aB75qKiZJBlHWQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@linaria/core": "3.0.0-beta.13",
@@ -16477,8 +27391,243 @@
         "csstype": "^3.0.7"
       },
       "dependencies": {
+        "@remirror/core-types": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+          "requires": {
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/types": "^0.1.1"
+          }
+        },
+        "@remirror/pm": {
+          "version": "1.0.22",
+          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@types/prosemirror-collab": "^1.1.2",
+            "@types/prosemirror-commands": "^1.0.4",
+            "@types/prosemirror-dropcursor": "^1.0.3",
+            "@types/prosemirror-gapcursor": "^1.0.4",
+            "@types/prosemirror-history": "^1.0.3",
+            "@types/prosemirror-inputrules": "^1.0.4",
+            "@types/prosemirror-keymap": "^1.0.4",
+            "@types/prosemirror-model": "^1.16.2",
+            "@types/prosemirror-schema-list": "^1.0.3",
+            "@types/prosemirror-state": "^1.3.0",
+            "@types/prosemirror-transform": "^1.4.0",
+            "@types/prosemirror-view": "^1.23.2",
+            "prosemirror-collab": "<1.3.0",
+            "prosemirror-commands": "<1.3.0",
+            "prosemirror-dropcursor": "<1.5.0",
+            "prosemirror-gapcursor": "<1.3.0",
+            "prosemirror-history": "<1.3.0",
+            "prosemirror-inputrules": "<1.2.0",
+            "prosemirror-keymap": "<1.2.0",
+            "prosemirror-model": "<1.17.0",
+            "prosemirror-paste-rules": "^1.1.3",
+            "prosemirror-schema-list": "<1.2.0",
+            "prosemirror-state": "<1.4.0",
+            "prosemirror-suggest": "^1.1.4",
+            "prosemirror-tables": "<1.2.0",
+            "prosemirror-trailing-node": "^1.0.11",
+            "prosemirror-transform": "<1.5.0",
+            "prosemirror-view": "<1.24.0"
+          }
+        },
         "csstype": {
-          "version": "3.0.10"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "peer": true
+        },
+        "orderedmap": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+          "peer": true
+        },
+        "prosemirror-collab": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0"
+          }
+        },
+        "prosemirror-commands": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-dropcursor": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0",
+            "prosemirror-view": "^1.1.0"
+          }
+        },
+        "prosemirror-gapcursor": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.0.0",
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-view": "^1.0.0"
+          }
+        },
+        "prosemirror-history": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.2.2",
+            "prosemirror-transform": "^1.0.0",
+            "rope-sequence": "^1.3.0"
+          }
+        },
+        "prosemirror-inputrules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-keymap": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "w3c-keyname": "^2.2.0"
+          }
+        },
+        "prosemirror-model": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+          "peer": true,
+          "requires": {
+            "orderedmap": "^1.1.0"
+          }
+        },
+        "prosemirror-paste-rules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-schema-list": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-state": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-suggest": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/types": "^0.1.1",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-tables": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.1.2",
+            "prosemirror-model": "^1.8.1",
+            "prosemirror-state": "^1.3.1",
+            "prosemirror-transform": "^1.2.1",
+            "prosemirror-view": "^1.13.3"
+          }
+        },
+        "prosemirror-trailing-node": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-transform": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0"
+          }
+        },
+        "prosemirror-view": {
+          "version": "1.23.13",
+          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.16.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0"
+          }
         }
       }
     },
@@ -16597,13 +27746,6 @@
         "@svgmoji/core": "^3.2.0"
       }
     },
-    "@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "optional": true,
-      "peer": true
-    },
     "@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -16669,10 +27811,6 @@
       "requires": {
         "@types/tern": "*"
       }
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "dev": true
     },
     "@types/connect": {
       "version": "3.4.35",
@@ -16799,11 +27937,11 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
-      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
       "requires": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "@types/history": {
@@ -16878,7 +28016,9 @@
       "version": "4.14.177"
     },
     "@types/marked": {
-      "version": "3.0.3"
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w=="
     },
     "@types/material-ui": {
       "version": "0.21.16",
@@ -16897,9 +28037,9 @@
       "dev": true
     },
     "@types/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@types/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-lsYeSW1zfNqHTL1RuaOgfAhoiOWV1RAQDKT0BZ26z4Faz8llVIj1r1ablUo5QY6yzHMketuvu4+N0sv0eZpXTg=="
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@types/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-nsNPWMSTapqOMR6/fSka9W77q5JdxaWkx3bSmzvQv2dvEI/VIWYrVmcoFY3j1YTPQK7buYdY6LqsUrQlsAGmaw=="
     },
     "@types/node": {
       "version": "14.6.1",
@@ -16911,10 +28051,9 @@
       "integrity": "sha512-I27IoPpH250TUzc9FzXd0P1BV/BMJuzqD3jOz98ehf9dQqGkxlq+hO1bIqZGWqCg5bVOy0g4AUVJtnxe0klDmw=="
     },
     "@types/object.pick": {
-      "version": "1.3.1"
-    },
-    "@types/orderedmap": {
-      "version": "1.0.0"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/object.pick/-/object.pick-1.3.4.tgz",
+      "integrity": "sha512-5PjwB0uP2XDp3nt5u5NJAG2DORHIRClPzWT/TTZhJ2Ekwe8M5bA9tvPdi9NO/n2uvu2/ictat8kgqvLfcIE1SA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -16922,11 +28061,15 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
-      "version": "2.2.3",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "devOptional": true
     },
     "@types/prismjs": {
-      "version": "1.16.6"
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ=="
     },
     "@types/prop-types": {
       "version": "15.7.11",
@@ -16934,91 +28077,111 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "@types/prosemirror-collab": {
-      "version": "1.1.2",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-collab/-/prosemirror-collab-1.3.0.tgz",
+      "integrity": "sha512-3jdIU0Du8qrdm8K8DuP2I9gg8j5LQLwiZiuovQmAWnuyMbqoheXwyJlF3wtGZAAnBmwb6JAJvDUXx1ffHBjMDw==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-transform": "*"
+        "prosemirror-collab": "*"
       }
     },
     "@types/prosemirror-commands": {
-      "version": "1.0.4",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-commands/-/prosemirror-commands-1.3.0.tgz",
+      "integrity": "sha512-3UV4Pk4WRhrU7sGI5q/DAFS0DDIWYdaJwFqgrCblYRSOrJDLU8GIaZK5GmUaZtYF07E29XMKo9D2cDDh5pZBGg==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-view": "*"
+        "prosemirror-commands": "*"
       }
     },
     "@types/prosemirror-dropcursor": {
-      "version": "1.0.3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-dropcursor/-/prosemirror-dropcursor-1.5.0.tgz",
+      "integrity": "sha512-Xa13THoY0YkvYP/peH995ahT79w3ErdsmFUIaTY21nshxxnn5mdSgG+RTpkqXwZ85v+n28MvNfLF2gm+c8RZ1A==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-state": "*"
+        "prosemirror-dropcursor": "*"
       }
     },
     "@types/prosemirror-gapcursor": {
-      "version": "1.0.4",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.0.tgz",
+      "integrity": "sha512-KbZbwrr2i6+AAOtTTQhbgXlAL1ZTY+FE8PsGz4vqRLeS4ow7sppdI3oHGMn0xmCgqXI+ajEDYENKHUQ2WZkXew==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-gapcursor": "*"
       }
     },
     "@types/prosemirror-history": {
-      "version": "1.0.3",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-history/-/prosemirror-history-1.3.0.tgz",
+      "integrity": "sha512-Cs3jtZvk+9N5ygsry2gEwkgMq11YwSFaChoxIRq75nGbDp8ZVAiYEqF6iAunsrExQC3zh0ojmf+XxP5X3j2Ztw==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-history": "*"
       }
     },
     "@types/prosemirror-inputrules": {
-      "version": "1.0.4",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz",
+      "integrity": "sha512-N30wadmd6uVnGR97JvX2mEOEoqsLr/nv96SkTb3JKfTLqtdLW6UHjDf3fiOPPQkj2hMqhS9ENnsIbDKfsYrSdw==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-inputrules": "*"
       }
     },
     "@types/prosemirror-keymap": {
-      "version": "1.0.4",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-keymap/-/prosemirror-keymap-1.2.0.tgz",
+      "integrity": "sha512-Vv/hOlNsDBOkqmxWUjgK7Ch5mFNRnvG88mfl2WhLFp4awdg3oQiZeTPN0wosWSO4mpK9aAWtZEhvJ/639HTLTQ==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-commands": "*",
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-view": "*"
+        "prosemirror-keymap": "*"
       }
     },
     "@types/prosemirror-model": {
-      "version": "1.16.0",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.17.0.tgz",
+      "integrity": "sha512-lG5xEMkE8r8Soa80KdWPTbCLUaSHBHVHpTIEsQiebfONpvmS5061IMGzHUdb1oWjgrwh8EJq0GgMNwXHUx5mVg==",
+      "peer": true,
       "requires": {
-        "@types/orderedmap": "*"
+        "prosemirror-model": "*"
       }
     },
     "@types/prosemirror-schema-list": {
-      "version": "1.0.3",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-schema-list/-/prosemirror-schema-list-1.2.0.tgz",
+      "integrity": "sha512-njvba73mgBanQOt2/piYMeP+nsu8lzomA350Lh7/sdr6NPsRvYPggwJDIZEG0Cb/MB0fnv4PdRaTi93PoLHArw==",
+      "peer": true,
       "requires": {
-        "@types/orderedmap": "*",
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*"
+        "prosemirror-schema-list": "*"
       }
     },
     "@types/prosemirror-state": {
-      "version": "1.2.8",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-state/-/prosemirror-state-1.4.0.tgz",
+      "integrity": "sha512-71epLy1HD2H7Qn6iOoQrFdbdFP32Cg5U7OvlCXMuYO8ygUdz07dfqA1lNj1y+KLf3HkRCXVkfvi3OnNa/tFZ3A==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-transform": "*",
-        "@types/prosemirror-view": "*"
+        "prosemirror-state": "*"
       }
     },
     "@types/prosemirror-transform": {
-      "version": "1.1.5",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-transform/-/prosemirror-transform-1.5.0.tgz",
+      "integrity": "sha512-++krMS5bt3SxNOqjrftispPLRkvfXXw2BtVq4VPJ8Vpf+Sne1MhxVoj0EFCM+14MFlX0EHYQvX3k9AaQzob9ZQ==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*"
+        "prosemirror-transform": "*"
       }
     },
     "@types/prosemirror-view": {
-      "version": "1.23.1",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.24.0.tgz",
+      "integrity": "sha512-Swn08/O+QIOKOSfFFa+KKF19eeHetwA+pBMAHZ7wbF0wPrMS3zJ+G9wbOGqSkUv6JOVpuhlOP8Xg5nA3MyIXgQ==",
+      "peer": true,
       "requires": {
-        "@types/prosemirror-model": "*",
-        "@types/prosemirror-state": "*",
-        "@types/prosemirror-transform": "*"
+        "prosemirror-view": "*"
       }
     },
     "@types/qs": {
@@ -17028,9 +28191,9 @@
       "dev": true
     },
     "@types/querystringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/querystringify/-/querystringify-2.0.0.tgz",
-      "integrity": "sha512-9WgEGTevECrXJC2LSWPqiPYWq8BRmeaOyZn47js/3V6UF0PWtcVfvvR43YjeO8BzBsthTz98jMczujOwTw+WYg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/querystringify/-/querystringify-2.0.2.tgz",
+      "integrity": "sha512-7d6OQK6pJ//zE32XLK3vI6GHYhBDcYooaRco9cKFGNu59GVatL5+u7rkiAViq44DxDTd/7QQNBWSDHfJGBz/Pw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
@@ -17049,7 +28212,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.10"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
@@ -17120,9 +28285,9 @@
       }
     },
     "@types/refractor": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/refractor/-/refractor-3.0.2.tgz",
-      "integrity": "sha512-2HMXuwGuOqzUG+KUTm9GDJCHl0LCBKsB5cg28ujEmVi/0qgTb6jOmkVSO5K48qXksyl2Fr3C0Q2VrgD4zbwyXg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/refractor/-/refractor-3.4.1.tgz",
+      "integrity": "sha512-wYuorIiCTSuvRT9srwt+taF6mH/ww+SyN2psM0sjef2qW+sS8GmshgDGTEDgWB1sTVGgYVE6EK7dBA2MxQxibg==",
       "requires": {
         "@types/prismjs": "*"
       }
@@ -17186,14 +28351,14 @@
       "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ=="
     },
     "@types/turndown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.1.tgz",
-      "integrity": "sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
+      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w=="
     },
     "@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
     "@types/ws": {
       "version": "8.5.4",
@@ -17247,24 +28412,24 @@
             "@typescript-eslint/typescript-estree": "4.33.0",
             "eslint-scope": "^5.1.1",
             "eslint-utils": "^3.0.0"
-          },
-          "dependencies": {
-            "eslint-utils": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-              "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-              "dev": true,
-              "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-              }
-            }
           }
         },
         "debug": {
-          "version": "4.3.3",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
           }
         },
         "eslint-visitor-keys": {
@@ -17274,21 +28439,22 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+          "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -17305,16 +28471,18 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -17357,10 +28525,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.3",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "globby": {
@@ -17378,21 +28548,22 @@
           }
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+          "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -17608,13 +28779,6 @@
         "throttle-debounce": "^3.0.1"
       }
     },
-    "abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "optional": true,
-      "peer": true
-    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -17635,35 +28799,6 @@
       "version": "5.2.0",
       "dev": true,
       "requires": {}
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -17687,15 +28822,15 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "require-from-string": "^2.0.2"
           }
         },
         "json-schema-traverse": {
@@ -17743,10 +28878,11 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "4.2.1",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
-        "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
       }
     },
@@ -17799,13 +28935,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "optional": true,
-      "peer": true
-    },
     "babel-jest": {
       "version": "29.6.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
@@ -17819,6 +28948,22 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
+      }
+    },
+    "babel-merge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-merge/-/babel-merge-3.0.0.tgz",
+      "integrity": "sha512-eBOBtHnzt9xvnjpYNI5HmaPp/b2vMveE5XggzqHnQeHJ8mFIBrBv6WZEVIj5jJ2uwTItkqKo9gWzEEcBxEq0yw==",
+      "requires": {
+        "deepmerge": "^2.2.1",
+        "object.omit": "^3.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+        }
       }
     },
     "babel-plugin-istanbul": {
@@ -17887,8 +29032,7 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "batch": {
       "version": "0.6.1",
@@ -17977,15 +29121,14 @@
       }
     },
     "browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
-      "devOptional": true,
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       }
     },
     "bs-logger": {
@@ -18041,10 +29184,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001655",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
-      "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
-      "devOptional": true
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ=="
     },
     "case-anything": {
       "version": "1.1.5",
@@ -18052,7 +29194,9 @@
       "integrity": "sha512-UsoMDAMnOaD3mkNmbRg7WoCi6tViuqCihsUCVvHojgsVYJ6kcDjhrvzNwv8nZqjqatYTeQbfoDlJ+2xJVWwp4A=="
     },
     "chalk": {
-      "version": "4.1.0",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -18204,7 +29348,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.65.0"
+      "version": "5.65.18",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.18.tgz",
+      "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA=="
     },
     "collect-v8-coverage": {
       "version": "1.0.2",
@@ -18262,15 +29408,11 @@
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-1.2.5.tgz",
       "integrity": "sha512-G39qNMGyM/fhl8hcy1YqpfXzQ810zSGyiJAgdMFlreCI7Hpwu3Jpu4tuBM/Oxu1Bek1FwyaBbtrtdkTr4HDhLA=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
+    "colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "comma-separated-tokens": {
       "version": "1.0.8",
@@ -18346,10 +29488,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "cookie": {
       "version": "0.7.1",
@@ -18394,9 +29535,9 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -18438,20 +29579,11 @@
         "semver": "^7.3.8"
       },
       "dependencies": {
-        "postcss-value-parser": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-          "dev": true
-        },
         "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -18479,18 +29611,10 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
-    "cssstyle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
-      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "rrweb-cssom": "^0.6.0"
-      }
-    },
     "csstype": {
-      "version": "2.6.18",
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
       "dev": true
     },
     "d3-array": {
@@ -18575,18 +29699,6 @@
       "resolved": "https://registry.npmjs.org/dash-get/-/dash-get-1.0.2.tgz",
       "integrity": "sha512-4FbVrHDwfOASx7uQVxeiCTo7ggSdYZbqs8lH+WU6ViypPlDbe9y6IP5VVUDQBv9DcnyaiPT5XT0UWHgJ64zLeQ=="
     },
-    "data-urls": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.0"
-      }
-    },
     "date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -18600,13 +29712,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "optional": true,
-      "peer": true
     },
     "decimal.js-light": {
       "version": "2.5.1",
@@ -18624,9 +29729,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
     "default-gateway": {
       "version": "6.0.3",
@@ -18660,13 +29765,6 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "optional": true,
-      "peer": true
     },
     "depd": {
       "version": "1.1.2",
@@ -18744,7 +29842,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.10"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
@@ -18753,21 +29853,6 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
-    "domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "webidl-conversions": "^7.0.0"
-      }
-    },
-    "domino": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
-      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -18775,10 +29860,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
-      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
-      "devOptional": true
+      "version": "1.5.67",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.67.tgz",
+      "integrity": "sha512-nz88NNBsD7kQSAGGJyp8hS6xSPtWwqNogA0mjtc2nUYeEf3nURK9qpV18TuBdDmEDgVWotS8Wkzf+V52dSQ/LQ=="
     },
     "emittery": {
       "version": "0.13.1",
@@ -18821,20 +29905,15 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "4.3.0",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
       }
-    },
-    "entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "optional": true,
-      "peer": true
     },
     "envinfo": {
       "version": "7.8.1",
@@ -18915,8 +29994,7 @@
     "escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "devOptional": true
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -18927,7 +30005,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
     },
     "eslint": {
       "version": "6.8.0",
@@ -19010,19 +30089,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "eslint-utils": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "ms": "^2.1.3"
           }
         },
         "globals": {
@@ -19041,7 +30113,9 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "regexpp": {
@@ -19051,9 +30125,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         },
         "supports-color": {
@@ -19119,6 +30193,15 @@
         "estraverse": "^4.1.1"
       }
     },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -19150,7 +30233,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -19219,9 +30304,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+          "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -19357,6 +30442,11 @@
         "tmp": "^0.0.33"
       }
     },
+    "extract-domain": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/extract-domain/-/extract-domain-2.2.1.tgz",
+      "integrity": "sha512-lOq1adCJha0tFFBci4quxC4XLa6+Rs2WgAwTo9qbO9OsElvJmGgCvOzmHo/yg5CiqeP4+sHjkXYGkrCcIEprMg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -19400,6 +30490,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "dev": true
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -19536,18 +30632,6 @@
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -19593,14 +30677,19 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "devOptional": true
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-dom-document": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/get-dom-document/-/get-dom-document-0.1.3.tgz",
+      "integrity": "sha512-bZ0O00gSQgMo+wz7gU6kbbWCPh4dfDsL9ZOmVhA8TOXszl5GV56TpTuW1/Qq/QctgpjK56yyvB1vBO+wzz8Szw==",
+      "requires": {}
     },
     "get-intrinsic": {
       "version": "1.2.4",
@@ -19663,8 +30752,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "devOptional": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "gopd": {
       "version": "1.0.1",
@@ -19768,16 +30856,6 @@
         "wbuf": "^1.1.0"
       }
     },
-    "html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "whatwg-encoding": "^2.0.0"
-      }
-    },
     "html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -19840,37 +30918,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "http-proxy-middleware": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -19882,36 +30929,6 @@
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
         "micromatch": "^4.0.2"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true,
-          "peer": true
-        }
       }
     },
     "human-signals": {
@@ -20055,19 +31072,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -20093,9 +31114,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
       "dev": true
     },
     "is-alphabetical": {
@@ -20224,11 +31245,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "optional": true,
-      "peer": true
-    },
     "is-regex": {
       "version": "1.1.1",
       "dev": true,
@@ -20274,7 +31290,9 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
     "isomorphic.js": {
-      "version": "0.2.4"
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -20326,18 +31344,18 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -20756,23 +31774,20 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
     "jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -20819,13 +31834,13 @@
       }
     },
     "jest-worker": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -20846,6 +31861,11 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
+    "js-sha256": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
+      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -20859,43 +31879,10 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsdom": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
-      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "abab": "^2.0.6",
-        "cssstyle": "^3.0.0",
-        "data-urls": "^4.0.0",
-        "decimal.js": "^10.4.3",
-        "domexception": "^4.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.4",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.1",
-        "ws": "^8.13.0",
-        "xml-name-validator": "^4.0.0"
-      }
-    },
     "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "devOptional": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -20917,8 +31904,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jss": {
       "version": "10.10.0",
@@ -20932,9 +31918,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
@@ -21022,7 +32008,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.10"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
@@ -21069,7 +32057,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.43",
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -21138,15 +32128,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -21189,7 +32170,9 @@
       }
     },
     "marked": {
-      "version": "3.0.8"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "match-sorter": {
       "version": "6.3.1",
@@ -21256,9 +32239,6 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
-    "messageformat-parser": {
-      "version": "4.1.3"
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -21285,13 +32265,13 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "devOptional": true
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -21317,7 +32297,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -21335,6 +32317,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
     },
     "ms": {
       "version": "2.0.0",
@@ -21385,8 +32372,64 @@
             "tslib": "^2.3.0"
           }
         },
+        "@remirror/core-types": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
+          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+          "requires": {
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/types": "^0.1.1"
+          }
+        },
+        "@remirror/pm": {
+          "version": "1.0.22",
+          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
+          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@types/prosemirror-collab": "^1.1.2",
+            "@types/prosemirror-commands": "^1.0.4",
+            "@types/prosemirror-dropcursor": "^1.0.3",
+            "@types/prosemirror-gapcursor": "^1.0.4",
+            "@types/prosemirror-history": "^1.0.3",
+            "@types/prosemirror-inputrules": "^1.0.4",
+            "@types/prosemirror-keymap": "^1.0.4",
+            "@types/prosemirror-model": "^1.16.2",
+            "@types/prosemirror-schema-list": "^1.0.3",
+            "@types/prosemirror-state": "^1.3.0",
+            "@types/prosemirror-transform": "^1.4.0",
+            "@types/prosemirror-view": "^1.23.2",
+            "prosemirror-collab": "<1.3.0",
+            "prosemirror-commands": "<1.3.0",
+            "prosemirror-dropcursor": "<1.5.0",
+            "prosemirror-gapcursor": "<1.3.0",
+            "prosemirror-history": "<1.3.0",
+            "prosemirror-inputrules": "<1.2.0",
+            "prosemirror-keymap": "<1.2.0",
+            "prosemirror-model": "<1.17.0",
+            "prosemirror-paste-rules": "^1.1.3",
+            "prosemirror-schema-list": "<1.2.0",
+            "prosemirror-state": "<1.4.0",
+            "prosemirror-suggest": "^1.1.4",
+            "prosemirror-tables": "<1.2.0",
+            "prosemirror-trailing-node": "^1.0.11",
+            "prosemirror-transform": "<1.5.0",
+            "prosemirror-view": "<1.24.0"
+          }
+        },
         "csstype": {
-          "version": "3.0.10"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "peer": true
         },
         "nano-css": {
           "version": "5.3.4",
@@ -21399,6 +32442,185 @@
             "sourcemap-codec": "^1.4.8",
             "stacktrace-js": "^2.0.2",
             "stylis": "^4.0.6"
+          }
+        },
+        "orderedmap": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
+          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
+          "peer": true
+        },
+        "prosemirror-collab": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
+          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0"
+          }
+        },
+        "prosemirror-commands": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
+          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-dropcursor": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
+          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0",
+            "prosemirror-view": "^1.1.0"
+          }
+        },
+        "prosemirror-gapcursor": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
+          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.0.0",
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-view": "^1.0.0"
+          }
+        },
+        "prosemirror-history": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.2.2",
+            "prosemirror-transform": "^1.0.0",
+            "rope-sequence": "^1.3.0"
+          }
+        },
+        "prosemirror-inputrules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-keymap": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-state": "^1.0.0",
+            "w3c-keyname": "^2.2.0"
+          }
+        },
+        "prosemirror-model": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+          "peer": true,
+          "requires": {
+            "orderedmap": "^1.1.0"
+          }
+        },
+        "prosemirror-paste-rules": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
+          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-schema-list": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
+          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-state": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-suggest": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
+          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/types": "^0.1.1",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-tables": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
+          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
+          "peer": true,
+          "requires": {
+            "prosemirror-keymap": "^1.1.2",
+            "prosemirror-model": "^1.8.1",
+            "prosemirror-state": "^1.3.1",
+            "prosemirror-transform": "^1.2.1",
+            "prosemirror-view": "^1.13.3"
+          }
+        },
+        "prosemirror-trailing-node": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
+          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@remirror/core-constants": "^1.0.2",
+            "@remirror/core-helpers": "^1.0.6",
+            "escape-string-regexp": "^4.0.0"
+          }
+        },
+        "prosemirror-transform": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
+          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.0.0"
+          }
+        },
+        "prosemirror-view": {
+          "version": "1.23.13",
+          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
+          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
+          "peer": true,
+          "requires": {
+            "prosemirror-model": "^1.16.0",
+            "prosemirror-state": "^1.0.0",
+            "prosemirror-transform": "^1.1.0"
           }
         },
         "react-use": {
@@ -21421,7 +32643,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.1"
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -21481,8 +32705,7 @@
     "node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "devOptional": true
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -21511,13 +32734,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
-    },
-    "nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
-      "optional": true,
-      "peer": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -21666,7 +32882,9 @@
       }
     },
     "orderedmap": {
-      "version": "1.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -21716,6 +32934,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "parenthesis": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+    },
     "parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
@@ -21745,16 +32968,6 @@
         "lines-and-columns": "^1.1.6"
       }
     },
-    "parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "entities": "^4.4.0"
-      }
-    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -21764,8 +32977,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -21796,9 +33008,9 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -21848,14 +33060,6 @@
         "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-          "dev": true
-        }
       }
     },
     "postcss-modules-scope": {
@@ -21885,6 +33089,12 @@
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "precision": {
       "version": "1.0.1",
@@ -21934,9 +33144,9 @@
           "dev": true
         },
         "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
           "dev": true
         }
       }
@@ -21987,21 +33197,27 @@
       }
     },
     "prosemirror-collab": {
-      "version": "1.2.2",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "requires": {
         "prosemirror-state": "^1.0.0"
       }
     },
     "prosemirror-commands": {
-      "version": "1.2.0",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.6.2.tgz",
+      "integrity": "sha512-0nDHH++qcf/BuPLYvmqZTUUsPJUCPBUXt0J1ErTcDIS369CTp773itzLGIgIXG4LJXOlwYCr44+Mh4ii6MP1QA==",
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-transform": "^1.10.2"
       }
     },
     "prosemirror-dropcursor": {
-      "version": "1.4.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.1.tgz",
+      "integrity": "sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==",
       "requires": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -22009,7 +33225,9 @@
       }
     },
     "prosemirror-gapcursor": {
-      "version": "1.2.1",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
+      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
       "requires": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -22018,92 +33236,246 @@
       }
     },
     "prosemirror-history": {
-      "version": "1.2.0",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
       "requires": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
         "rope-sequence": "^1.3.0"
       }
     },
     "prosemirror-inputrules": {
-      "version": "1.1.3",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
+      "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
       "requires": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
       }
     },
     "prosemirror-keymap": {
-      "version": "1.1.5",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
+      "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
       "requires": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
       }
     },
     "prosemirror-model": {
-      "version": "1.16.1",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.24.0.tgz",
+      "integrity": "sha512-Ft7epNnycoQSM+2ObF35SBbBX+5WY39v8amVlrtlAcpglhlHs2tCTnWl7RX5tbp/PsMKcRcWV9cXPuoBWq0AIQ==",
       "requires": {
-        "orderedmap": "^1.1.0"
+        "orderedmap": "^2.0.0"
       }
     },
     "prosemirror-paste-rules": {
-      "version": "1.0.7",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-2.0.8.tgz",
+      "integrity": "sha512-k3wBSc4fwtrx/UbCaf8LzMugB+P/R/TvACRfPiLruHtOP0a6FJWsZ/GTV2DJX5mQ/xyuS/vDX+q7jIsSV1D5AQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
     "prosemirror-resizable-view": {
-      "version": "1.1.8",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/prosemirror-resizable-view/-/prosemirror-resizable-view-2.0.15.tgz",
+      "integrity": "sha512-xd/TEJD5D0XmiUUFQOMWV8ZCZjvZRiDiFmGMEXxaB5NtCZK2DqCPVZ2wxsEj1upE1ri4+6/EhHLAdV65GD2oBQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-utils": "^1.1.4",
-        "prosemirror-model": "^1.16.1",
-        "prosemirror-view": "^1.23.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-utils": "^2.0.13",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-view": "^1.33.8"
+      },
+      "dependencies": {
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "prosemirror-schema-list": {
-      "version": "1.1.6",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.4.1.tgz",
+      "integrity": "sha512-jbDyaP/6AFfDfu70VzySsD75Om2t3sXTOdl5+31Wlxlg62td1haUpty/ybajSfJ1pkGadlOfwQq9kgW5IMo1Rg==",
       "requires": {
         "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
       }
     },
     "prosemirror-state": {
-      "version": "1.3.4",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "requires": {
         "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
       }
     },
     "prosemirror-suggest": {
-      "version": "1.0.7",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-2.0.7.tgz",
+      "integrity": "sha512-Jww17dk2z1z3P90G0LXAlZtpgOHgtMa/l39G1Fzw2RWrS+1ki2L4X5tppbhKQkHSCtBe5u++udkxQ6tRDKN21A==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/types": "^0.1.1",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/types": "^1.0.1",
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+          "requires": {
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
     "prosemirror-tables": {
-      "version": "1.1.1",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.1.tgz",
+      "integrity": "sha512-p8WRJNA96jaNQjhJolmbxTzd6M4huRE5xQ8OxjvMhQUP0Nzpo4zz6TztEiwk6aoqGBhz9lxRWR1yRZLlpQN98w==",
       "requires": {
         "prosemirror-keymap": "^1.1.2",
         "prosemirror-model": "^1.8.1",
@@ -22113,14 +33485,19 @@
       }
     },
     "prosemirror-trailing-node": {
-      "version": "1.0.7",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.9.tgz",
+      "integrity": "sha512-YvyIn3/UaLFlFKrlJB6cObvUhmwFNZVhy1Q8OpW/avoTbD/Y7H5EcjK4AZFKhmuS6/N6WkGgt7gWtBWDnmFvHg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
+        "@remirror/core-constants": "^2.0.2",
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -22129,15 +33506,19 @@
       }
     },
     "prosemirror-transform": {
-      "version": "1.3.3",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.2.tgz",
+      "integrity": "sha512-2iUq0wv2iRoJO/zj5mv8uDUriOHWzXRnOTVgCzSXnktS/2iQRa3UUQwVlkBlYZFtygw6Nh1+X4mGqoYBINn5KQ==",
       "requires": {
-        "prosemirror-model": "^1.0.0"
+        "prosemirror-model": "^1.21.0"
       }
     },
     "prosemirror-view": {
-      "version": "1.23.6",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.37.0.tgz",
+      "integrity": "sha512-z2nkKI1sJzyi7T47Ji/ewBPuIma1RNvQCCYVdV+MqWBV7o4Sa1n94UJCJJ1aQRF/xRkFfyqLGlGFWitIcCOtbg==",
       "requires": {
-        "prosemirror-model": "^1.16.0",
+        "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -22166,18 +33547,11 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true
     },
-    "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "optional": true,
-      "peer": true
-    },
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "devOptional": true
+      "dev": true
     },
     "pure-rand": {
       "version": "6.0.2",
@@ -22390,9 +33764,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -22421,20 +33795,26 @@
         "picomatch": "^2.2.1"
       }
     },
+    "reakit-system": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+      "requires": {
+        "reakit-utils": "^0.15.2"
+      }
+    },
+    "reakit-utils": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
+      "requires": {}
+    },
     "reakit-warning": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
       "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
       "requires": {
         "reakit-utils": "^0.15.2"
-      },
-      "dependencies": {
-        "reakit-utils": {
-          "version": "0.15.2",
-          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-          "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-          "requires": {}
-        }
       }
     },
     "recharts": {
@@ -22500,73 +33880,78 @@
       }
     },
     "regexpp": {
-      "version": "3.1.0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "remirror": {
-      "version": "1.0.60",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/remirror/-/remirror-2.0.4.tgz",
+      "integrity": "sha512-zsOH7wm/yLk7FSC8BjCNH8zq4JdkHFid4HwJg05elqPMx8GQ91vPcIqupZxa6kyOTM1ZbYiRtXPMFecCCRh5jg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/core-utils": "^1.1.4",
-        "@remirror/dom": "^1.0.17",
-        "@remirror/extension-annotation": "^1.1.10",
-        "@remirror/extension-bidi": "^1.0.13",
-        "@remirror/extension-blockquote": "^1.0.15",
-        "@remirror/extension-bold": "^1.0.13",
-        "@remirror/extension-callout": "^1.0.15",
-        "@remirror/extension-code": "^1.0.14",
-        "@remirror/extension-code-block": "^1.0.18",
-        "@remirror/extension-codemirror5": "^1.0.13",
-        "@remirror/extension-collaboration": "^1.0.13",
-        "@remirror/extension-columns": "^1.0.13",
-        "@remirror/extension-diff": "^1.0.13",
-        "@remirror/extension-doc": "^1.0.14",
-        "@remirror/extension-drop-cursor": "^1.0.13",
-        "@remirror/extension-embed": "^1.1.18",
-        "@remirror/extension-emoji": "^1.0.15",
-        "@remirror/extension-epic-mode": "^1.0.13",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/extension-font-family": "^1.0.13",
-        "@remirror/extension-font-size": "^1.0.15",
-        "@remirror/extension-gap-cursor": "^1.0.13",
-        "@remirror/extension-hard-break": "^1.0.13",
-        "@remirror/extension-heading": "^1.0.13",
-        "@remirror/extension-history": "^1.0.13",
-        "@remirror/extension-horizontal-rule": "^1.0.13",
-        "@remirror/extension-image": "^1.0.23",
-        "@remirror/extension-italic": "^1.0.13",
-        "@remirror/extension-link": "^1.1.12",
-        "@remirror/extension-list": "^1.2.13",
-        "@remirror/extension-markdown": "^1.0.13",
-        "@remirror/extension-mention": "^1.0.14",
-        "@remirror/extension-mention-atom": "^1.0.16",
-        "@remirror/extension-node-formatting": "^1.0.16",
-        "@remirror/extension-paragraph": "^1.0.13",
-        "@remirror/extension-placeholder": "^1.0.15",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-search": "^1.0.13",
-        "@remirror/extension-shortcuts": "^1.1.2",
-        "@remirror/extension-strike": "^1.0.13",
-        "@remirror/extension-sub": "^1.0.13",
-        "@remirror/extension-sup": "^1.0.13",
-        "@remirror/extension-tables": "^1.0.15",
-        "@remirror/extension-text": "^1.0.13",
-        "@remirror/extension-text-case": "^1.0.13",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/extension-text-highlight": "^1.0.15",
-        "@remirror/extension-trailing-node": "^1.0.13",
-        "@remirror/extension-underline": "^1.0.13",
-        "@remirror/extension-whitespace": "^1.0.13",
-        "@remirror/extension-yjs": "^1.0.19",
-        "@remirror/icons": "^1.0.7",
-        "@remirror/preset-core": "^1.0.17",
-        "@remirror/preset-formatting": "^1.0.19",
-        "@remirror/preset-wysiwyg": "^1.1.35",
-        "@remirror/theme": "^1.2.0",
+        "@remirror/core": "^2.0.3",
+        "@remirror/core-constants": "^2.0.0",
+        "@remirror/core-helpers": "^2.0.0",
+        "@remirror/core-types": "^2.0.0",
+        "@remirror/core-utils": "^2.0.3",
+        "@remirror/dom": "^2.0.4",
+        "@remirror/extension-annotation": "^2.0.4",
+        "@remirror/extension-bidi": "^2.0.3",
+        "@remirror/extension-blockquote": "^2.0.3",
+        "@remirror/extension-bold": "^2.0.3",
+        "@remirror/extension-callout": "^2.0.3",
+        "@remirror/extension-code": "^2.0.3",
+        "@remirror/extension-code-block": "^2.0.3",
+        "@remirror/extension-codemirror5": "^2.0.3",
+        "@remirror/extension-collaboration": "^2.0.3",
+        "@remirror/extension-columns": "^2.0.3",
+        "@remirror/extension-diff": "^2.0.3",
+        "@remirror/extension-doc": "^2.0.3",
+        "@remirror/extension-drop-cursor": "^2.0.3",
+        "@remirror/extension-embed": "^2.0.3",
+        "@remirror/extension-emoji": "^2.0.3",
+        "@remirror/extension-entity-reference": "^2.0.4",
+        "@remirror/extension-epic-mode": "^2.0.3",
+        "@remirror/extension-events": "^2.1.3",
+        "@remirror/extension-font-family": "^2.0.3",
+        "@remirror/extension-font-size": "^2.0.3",
+        "@remirror/extension-gap-cursor": "^2.0.3",
+        "@remirror/extension-hard-break": "^2.0.3",
+        "@remirror/extension-heading": "^2.0.3",
+        "@remirror/extension-history": "^2.0.3",
+        "@remirror/extension-horizontal-rule": "^2.0.3",
+        "@remirror/extension-image": "^2.0.3",
+        "@remirror/extension-italic": "^2.0.3",
+        "@remirror/extension-link": "^2.0.4",
+        "@remirror/extension-list": "^2.0.4",
+        "@remirror/extension-markdown": "^2.0.3",
+        "@remirror/extension-mention": "^2.0.4",
+        "@remirror/extension-mention-atom": "^2.0.4",
+        "@remirror/extension-node-formatting": "^2.0.3",
+        "@remirror/extension-paragraph": "^2.0.3",
+        "@remirror/extension-placeholder": "^2.0.3",
+        "@remirror/extension-positioner": "^2.0.4",
+        "@remirror/extension-search": "^2.0.3",
+        "@remirror/extension-shortcuts": "^2.0.3",
+        "@remirror/extension-strike": "^2.0.3",
+        "@remirror/extension-sub": "^2.0.3",
+        "@remirror/extension-sup": "^2.0.3",
+        "@remirror/extension-tables": "^2.0.3",
+        "@remirror/extension-text": "^2.0.3",
+        "@remirror/extension-text-case": "^2.0.3",
+        "@remirror/extension-text-color": "^2.0.3",
+        "@remirror/extension-text-highlight": "^2.0.3",
+        "@remirror/extension-trailing-node": "^2.0.3",
+        "@remirror/extension-underline": "^2.0.3",
+        "@remirror/extension-whitespace": "^2.0.3",
+        "@remirror/extension-yjs": "^3.0.3",
+        "@remirror/icons": "^2.0.0",
+        "@remirror/preset-core": "^2.0.4",
+        "@remirror/preset-formatting": "^2.0.3",
+        "@remirror/preset-wysiwyg": "^2.0.4",
+        "@remirror/theme": "^2.0.0",
         "@types/codemirror": "^5.60.2",
         "@types/refractor": "^3.0.2",
         "codemirror": "^5.62.0",
@@ -22574,16 +33959,112 @@
         "yjs": "^13.5.23"
       },
       "dependencies": {
-        "@remirror/extension-code-block": {
-          "version": "1.0.18",
+        "@linaria/core": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/messages": "^1.0.6",
-            "@remirror/theme": "^1.2.0",
-            "@types/refractor": "^3.0.2",
-            "refractor": "^3.3.1"
+            "@linaria/logger": "^4.0.0",
+            "@linaria/tags": "^4.3.5",
+            "@linaria/utils": "^4.3.4"
           }
+        },
+        "@remirror/core-constants": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
+        },
+        "@remirror/core-helpers": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-2.0.4.tgz",
+          "integrity": "sha512-aYoiJ8x/Sxc4OIZCcZI2tSa92rOufzpDkVTHtwh8+HEsGj0PumUrXbwVd3jHZRSoOUNYNG8fPnOmzuVOsO9CMQ==",
+          "requires": {
+            "@linaria/core": "4.2.10",
+            "@remirror/core-constants": "^2.0.2",
+            "@remirror/types": "^1.0.1",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
+          }
+        },
+        "@remirror/icons": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
+          "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@remirror/core-helpers": "^3.0.0"
+          },
+          "dependencies": {
+            "@remirror/core-helpers": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+              "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+              "requires": {
+                "@remirror/core-constants": "^2.0.2",
+                "@remirror/types": "^1.0.1",
+                "@types/object.omit": "^3.0.0",
+                "@types/object.pick": "^1.3.2",
+                "@types/throttle-debounce": "^2.1.0",
+                "case-anything": "^2.1.13",
+                "dash-get": "^1.0.2",
+                "deepmerge": "^4.3.1",
+                "fast-deep-equal": "^3.1.3",
+                "make-error": "^1.3.6",
+                "object.omit": "^3.0.0",
+                "object.pick": "^1.3.0",
+                "throttle-debounce": "^3.0.1"
+              }
+            }
+          }
+        },
+        "@remirror/theme": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
+          "requires": {
+            "@babel/runtime": "^7.22.3",
+            "@linaria/core": "4.2.10",
+            "@remirror/core-types": "^2.0.5",
+            "color2k": "^2.0.2",
+            "csstype": "^3.1.2"
+          }
+        },
+        "@remirror/types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
+          "requires": {
+            "type-fest": "^2.19.0"
+          }
+        },
+        "case-anything": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
+        },
+        "color2k": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -22608,7 +34089,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "devOptional": true
+      "dev": true
     },
     "reselect": {
       "version": "4.1.7",
@@ -22683,7 +34164,9 @@
       }
     },
     "rope-sequence": {
-      "version": "1.3.2"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="
     },
     "round": {
       "version": "2.0.1",
@@ -22702,13 +34185,6 @@
         "is-finite": "~1.0.1",
         "is-integer": "~1.0.4"
       }
-    },
-    "rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-      "optional": true,
-      "peer": true
     },
     "rtl-css-js": {
       "version": "1.15.0",
@@ -22746,13 +34222,14 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "sass": {
       "version": "1.32.0",
@@ -22786,9 +34263,9 @@
           }
         },
         "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.8",
@@ -22797,22 +34274,11 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
-      }
-    },
-    "saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "xmlchars": "^2.2.0"
       }
     },
     "scheduler": {
@@ -22824,9 +34290,9 @@
       }
     },
     "schema-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-      "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
@@ -22836,15 +34302,15 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "require-from-string": "^2.0.2"
           }
         },
         "ajv-keywords": {
@@ -22885,9 +34351,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "send": {
@@ -23200,14 +34666,18 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -23227,20 +34697,24 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
-          "version": "2.1.2",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -23456,7 +34930,9 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "supports-color": {
-      "version": "7.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
@@ -23482,13 +34958,6 @@
     },
     "symbol-observable": {
       "version": "1.2.0"
-    },
-    "symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "optional": true,
-      "peer": true
     },
     "table": {
       "version": "5.4.6",
@@ -23521,9 +34990,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.12.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-          "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+          "version": "8.14.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+          "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
           "dev": true
         }
       }
@@ -23636,11 +35105,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -23660,29 +35124,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
-    },
-    "tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      }
-    },
-    "tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "punycode": "^2.3.0"
-      }
     },
     "ts-easing": {
       "version": "0.2.0",
@@ -23706,13 +35147,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -23771,9 +35209,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         },
         "supports-color": {
@@ -23870,7 +35308,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0"
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -23882,11 +35322,11 @@
       }
     },
     "turndown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
-      "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
       "requires": {
-        "domino": "^2.1.6"
+        "@mixmark-io/domino": "^2.2.0"
       }
     },
     "turndown-plugin-gfm": {
@@ -23929,27 +35369,24 @@
       "version": "4.5.5",
       "dev": true
     },
-    "universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "optional": true,
-      "peer": true
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
+    "unraw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+    },
     "update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
-      "devOptional": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "requires": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       }
     },
     "uri-js": {
@@ -23957,17 +35394,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "use-isomorphic-layout-effect": {
@@ -24043,16 +35469,6 @@
     "w3c-keyname": {
       "version": "2.2.4"
     },
-    "w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "xml-name-validator": "^4.0.0"
-      }
-    },
     "walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -24089,13 +35505,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "optional": true,
-      "peer": true
-    },
     "webpack": {
       "version": "5.94.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
@@ -24128,9 +35537,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.12.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-          "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+          "version": "8.14.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+          "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
           "dev": true
         },
         "acorn-import-attributes": {
@@ -24190,12 +35599,6 @@
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
-        "colorette": {
-          "version": "2.0.20",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-          "dev": true
-        },
         "commander": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -24203,9 +35606,9 @@
           "dev": true
         },
         "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+          "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -24256,14 +35659,6 @@
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"
-      },
-      "dependencies": {
-        "colorette": {
-          "version": "2.0.20",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-          "dev": true
-        }
       }
     },
     "webpack-dev-server": {
@@ -24302,14 +35697,6 @@
         "spdy": "^4.0.2",
         "webpack-dev-middleware": "^5.3.1",
         "ws": "^8.13.0"
-      },
-      "dependencies": {
-        "colorette": {
-          "version": "2.0.20",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-          "dev": true
-        }
       }
     },
     "webpack-merge": {
@@ -24344,46 +35731,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
-    },
-    "whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "iconv-lite": "0.6.3"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
-    "whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "optional": true,
-      "peer": true
-    },
-    "whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      }
     },
     "which": {
       "version": "1.3.1",
@@ -24480,22 +35827,8 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {}
-    },
-    "xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "optional": true,
-      "peer": true
-    },
-    "xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "optional": true,
-      "peer": true
     },
     "xtend": {
       "version": "4.0.2",
@@ -24503,17 +35836,19 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y-prosemirror": {
-      "version": "1.0.14",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.13.tgz",
+      "integrity": "sha512-eW5/rJcYhqlrqyPLTaGIaPSt7YS6f2wwbV5wXlUkY8rERY0tSJPoumsPD7UWwtXk9C5TdTsvwaIrdOoD1QLbYA==",
       "requires": {
         "lib0": "^0.2.42"
       }
     },
     "y-protocols": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
       "requires": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.85"
       }
     },
     "y18n": {
@@ -24523,10 +35858,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.10.2",
@@ -24589,16 +35923,17 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.5.24",
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
       "requires": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.98"
       }
     },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mui/styles": "^5.15.10",
         "@mui/x-data-grid": "^5.17.12",
         "@remirror/pm": "^2.0.9",
-        "@remirror/react": "^1.0.21",
+        "@remirror/react": "^2.0.35",
         "@types/lodash": "^4.14.176",
         "@types/react-beautiful-dnd": "^13.0.0",
         "date-fns": "^2.29.3",
@@ -28,7 +28,7 @@
         "react-qr-code": "^2.0.7",
         "react-router-dom": "^6.2.1",
         "recharts": "2.12.6",
-        "remirror": "^2.0.4"
+        "remirror": "^2.0.40"
       },
       "devDependencies": {
         "@types/jest": "24.0.18",
@@ -52,7 +52,7 @@
         "ts-jest": "^29.1.1",
         "ts-loader": "^6.1.2",
         "tsconfig-paths-webpack-plugin": "^3.2.0",
-        "typescript": "^4.5.5",
+        "typescript": "^5.7.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.0.2",
         "webpack-dev-server": "^4.13.3"
@@ -619,15 +619,15 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/serialize": "^1.1.2",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
@@ -635,6 +635,11 @@
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -658,34 +663,37 @@
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1",
-        "@emotion/weak-memoize": "^0.3.1",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
       }
     },
+    "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+    },
     "node_modules/@emotion/css": {
-      "version": "11.7.1",
-      "license": "MIT",
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
       "dependencies": {
-        "@emotion/babel-plugin": "^11.7.1",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/serialize": "^1.0.0",
-        "@emotion/sheet": "^1.0.3",
-        "@emotion/utils": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        }
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
       }
     },
     "node_modules/@emotion/hash": {
@@ -730,16 +738,21 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
-      "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "dependencies": {
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/unitless": "^0.8.1",
-        "@emotion/utils": "^1.2.1",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/serialize/node_modules/csstype": {
       "version": "3.1.3",
@@ -747,9 +760,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.11.0",
@@ -774,9 +787,9 @@
       }
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
@@ -787,9 +800,9 @@
       }
     },
     "node_modules/@emotion/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.3.1",
@@ -813,6 +826,20 @@
         "@floating-ui/utils": "^0.2.0"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
+      "integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.1",
+        "aria-hidden": "^1.2.3",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
@@ -834,7 +861,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }
@@ -1232,10 +1258,17 @@
       "dev": true
     },
     "node_modules/@linaria/core": {
-      "version": "3.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-3.0.0-beta.13.tgz",
-      "integrity": "sha512-3zEi5plBCOsEzUneRVuQb+2SAx3qaC1dj0FfFAI6zIJQoDWu0dlSwKijMRack7oO9tUWrchfj3OkKQAd1LBdVg==",
-      "license": "MIT"
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "dependencies": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.16.0 || >=13.7.0"
+      }
     },
     "node_modules/@linaria/logger": {
       "version": "4.5.0",
@@ -1385,24 +1418,24 @@
       }
     },
     "node_modules/@lingui/core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.17.2.tgz",
-      "integrity": "sha512-YOd068NanznN8lLQqOKPlAY0ill3rrgmiAvPRKuYkrxzJMIHqlIFO/2Kcc/RH5vClOmLfg+wgR4rsHK/kLKelQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@messageformat/parser": "^5.0.0",
-        "make-plural": "^6.2.2"
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@lingui/detect-locale": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-3.17.2.tgz",
-      "integrity": "sha512-rqyO16lj05WRfBuppo++mPzB1fQBFDhGqEFz5X97CbWXYp6AadOIkrm+pbn114Y2Yumy9QI7Cm4Ptbfk7CXO3Q==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
+      "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@lingui/message-utils": {
@@ -1895,29 +1928,23 @@
       }
     },
     "node_modules/@remirror/core-constants": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-1.0.2.tgz",
-      "integrity": "sha512-yiy+hqhjZwqR/pwLK4aXqzdR1helJytkz/xrfpgmSNh7Pj/HMl6gFxoGTI+5eS86mwsNecCcXQWKUhqVikWtiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
     },
     "node_modules/@remirror/core-helpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-1.0.6.tgz",
-      "integrity": "sha512-4n5eii/3L85B4SSY8/9Rerpcgl+4/Zl7gMojIm43AkDqyCJNejRkqNW7jtflbkugEBjJP+sb6hEVMsW4jKCOHw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
         "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.1",
+        "@types/object.pick": "^1.3.2",
         "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^1.1.3",
+        "case-anything": "^2.1.13",
         "dash-get": "^1.0.2",
-        "deepmerge": "^4.2.2",
+        "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
         "make-error": "^1.3.6",
         "object.omit": "^3.0.0",
@@ -1935,30 +1962,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/core-types/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/core-types/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/core-types/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/core-utils": {
@@ -1985,204 +1988,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remirror/core-utils/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/core-utils/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/core-utils/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/core-utils/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/core-utils/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/core-utils/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/core-utils/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@lingui/detect-locale": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
-      "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w==",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/core/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@remirror/i18n": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
-      "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@lingui/detect-locale": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0",
-        "make-plural": "^6.2.2"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@remirror/icons": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
-      "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/core/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/dom": {
@@ -2212,84 +2017,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-annotation/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-annotation/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-annotation/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-annotation/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-annotation/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-annotation/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-annotation/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-bidi": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@remirror/extension-bidi/-/extension-bidi-2.0.16.tgz",
@@ -2303,84 +2030,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-bidi/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-blockquote": {
@@ -2397,119 +2046,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-blockquote/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-blockquote/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-bold": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-bold/-/extension-bold-2.0.13.tgz",
@@ -2521,84 +2057,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-bold/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-bold/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-bold/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-bold/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-bold/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-bold/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-bold/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-callout": {
@@ -2613,119 +2071,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-callout/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-callout/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-callout/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-code": {
@@ -2770,197 +2115,6 @@
         }
       }
     },
-    "node_modules/@remirror/extension-code-block/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-code-block/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-code/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-code/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-code/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-code/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-code/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-code/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-code/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-codemirror5": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@remirror/extension-codemirror5/-/extension-codemirror5-2.0.15.tgz",
@@ -2976,84 +2130,6 @@
         "codemirror": "^5.65.13"
       }
     },
-    "node_modules/@remirror/extension-codemirror5/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-codemirror5/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-codemirror5/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-codemirror5/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-collaboration": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-collaboration/-/extension-collaboration-2.0.13.tgz",
@@ -3065,84 +2141,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-collaboration/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-columns": {
@@ -3158,84 +2156,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-columns/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-columns/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-columns/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-columns/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-columns/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-columns/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-columns/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-diff": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-diff/-/extension-diff-2.0.13.tgz",
@@ -3247,84 +2167,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-diff/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-diff/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-diff/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-diff/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-diff/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-diff/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-diff/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-doc": {
@@ -3340,84 +2182,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-doc/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-doc/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-doc/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-doc/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-doc/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-doc/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-doc/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-drop-cursor": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-drop-cursor/-/extension-drop-cursor-2.0.13.tgz",
@@ -3429,84 +2193,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-drop-cursor/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-embed": {
@@ -3523,84 +2209,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-embed/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-embed/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-embed/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-embed/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-embed/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-embed/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-embed/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-emoji": {
@@ -3623,125 +2231,12 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-emoji/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
     "node_modules/@remirror/extension-emoji/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-emoji/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3774,84 +2269,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-epic-mode/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-epic-mode/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-epic-mode/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-epic-mode/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-events": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-2.1.17.tgz",
@@ -3865,79 +2282,26 @@
         "@remirror/pm": "^2.0.7"
       }
     },
-    "node_modules/@remirror/extension-events/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+    "node_modules/@remirror/extension-find": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-find/-/extension-find-0.1.6.tgz",
+      "integrity": "sha512-WWcA6B4HXUU6kj4SP3OxKByFk07JQj99qQOw8nTFSTZ1AtUD4N2T/D5kSK2Uzmkreh/lCI5VJvTFwVEjft+3qg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
+        "@remirror/core": "^2.0.13",
+        "@types/string.prototype.matchall": "^4.0.1",
+        "escape-string-regexp": "^4.0.0",
+        "string.prototype.matchall": "^4.0.8"
       },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5"
+      }
+    },
+    "node_modules/@remirror/extension-find/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-events/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-events/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-events/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-events/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-events/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-events/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3956,84 +2320,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-font-family/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-font-family/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-font-family/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-font-family/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-font-family/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-font-family/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-font-family/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-font-size": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@remirror/extension-font-size/-/extension-font-size-2.0.15.tgz",
@@ -4046,84 +2332,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-font-size/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-gap-cursor": {
@@ -4139,84 +2347,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-gap-cursor/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-hard-break": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-hard-break/-/extension-hard-break-2.0.13.tgz",
@@ -4228,84 +2358,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-hard-break/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-heading": {
@@ -4321,84 +2373,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-heading/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-heading/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-heading/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-heading/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-heading/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-heading/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-heading/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-history": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-2.0.13.tgz",
@@ -4412,84 +2386,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-history/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-history/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-history/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-history/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-history/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-history/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-history/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-horizontal-rule": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-horizontal-rule/-/extension-horizontal-rule-2.0.13.tgz",
@@ -4501,84 +2397,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-horizontal-rule/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-image": {
@@ -4596,119 +2414,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-image/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-image/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-image/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-image/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-image/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-italic": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-italic/-/extension-italic-2.0.13.tgz",
@@ -4720,84 +2425,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-italic/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-italic/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-italic/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-italic/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-italic/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-italic/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-italic/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-link": {
@@ -4815,84 +2442,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-link/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-link/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-link/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-link/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-link/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-link/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-link/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-list": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/@remirror/extension-list/-/extension-list-2.0.18.tgz",
@@ -4906,119 +2455,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-list/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-list/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-list/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-list/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-markdown": {
@@ -5037,84 +2473,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-markdown/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-mention": {
@@ -5147,203 +2505,12 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-mention-atom/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-mention/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/@remirror/extension-mention/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-mention/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5362,84 +2529,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-node-formatting/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-node-formatting/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-node-formatting/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-node-formatting/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-paragraph": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-2.0.13.tgz",
@@ -5451,84 +2540,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-paragraph/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-placeholder": {
@@ -5543,119 +2554,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-placeholder/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-positioner": {
@@ -5674,117 +2572,64 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-positioner/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+    "node_modules/@remirror/extension-react-component": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-react-component/-/extension-react-component-2.0.13.tgz",
+      "integrity": "sha512-xKzfgrmhncUQXkTjGqlYUxjG/QmxWjtEzpXRpND3YYULTPcxlVK4dNXtPvk0aczD6cvZVZohOeRSl8ESSLSo6A==",
       "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "nanoevents": "^5.1.13"
       },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5",
+        "@types/react": "^16.14.0 || ^17 || ^18",
+        "@types/react-dom": "^16.9.0 || ^17 || ^18",
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
       },
-      "engines": {
-        "node": ">=16.0.0"
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@remirror/extension-positioner/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
+    "node_modules/@remirror/extension-react-tables": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-react-tables/-/extension-react-tables-2.2.21.tgz",
+      "integrity": "sha512-cPhWYXjyCGyGPAD/z1xcGQHnrowmw6EPT57qsRFPrEbGUJuRUKGgeP24dnE08T058Qja18ImrqFZEsCquLLs4A==",
       "dependencies": {
         "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
+        "@emotion/css": "^11.11.0",
         "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
+        "@remirror/core": "^2.0.19",
+        "@remirror/core-utils": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-tables": "^2.4.3",
+        "@remirror/icons": "^2.0.3",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/preset-core": "^2.0.16",
+        "@remirror/react-components": "^2.1.17",
+        "@remirror/react-core": "^2.0.21",
+        "@remirror/react-hooks": "^2.0.25",
+        "@remirror/theme": "^2.0.9"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-positioner/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.9",
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remirror/extension-search": {
@@ -5801,90 +2646,12 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-search/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-search/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-search/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-search/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-search/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-search/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/@remirror/extension-search/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-search/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5915,84 +2682,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-strike/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-strike/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-strike/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-strike/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-strike/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-strike/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-strike/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-sub": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-sub/-/extension-sub-2.0.13.tgz",
@@ -6006,84 +2695,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-sub/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-sub/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-sub/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-sub/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-sub/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-sub/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-sub/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-sup": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-sup/-/extension-sup-2.0.13.tgz",
@@ -6095,84 +2706,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-sup/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-sup/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-sup/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-sup/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-sup/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-sup/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-sup/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-tables": {
@@ -6189,119 +2722,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-tables/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-tables/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-tables/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-text": {
@@ -6330,84 +2750,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-text-case/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-case/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-text-case/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-text-case/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-case/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-case/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-text-case/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-text-color": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-2.0.17.tgz",
@@ -6424,139 +2766,6 @@
         "@remirror/pm": "^2.0.9"
       }
     },
-    "node_modules/@remirror/extension-text-color/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@lingui/detect-locale": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
-      "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w==",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@remirror/i18n": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
-      "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@lingui/detect-locale": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0",
-        "make-plural": "^6.2.2"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@remirror/extension-text-color/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-text-highlight": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@remirror/extension-text-highlight/-/extension-text-highlight-2.0.16.tgz",
@@ -6569,162 +2778,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.9"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-text-highlight/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/extension-text/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-text/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-text/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-text/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-text/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-text/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-trailing-node": {
@@ -6740,84 +2793,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-trailing-node/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-trailing-node/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-trailing-node/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-trailing-node/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-underline": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-underline/-/extension-underline-2.0.13.tgz",
@@ -6831,84 +2806,6 @@
         "@remirror/pm": "^2.0.5"
       }
     },
-    "node_modules/@remirror/extension-underline/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-underline/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-underline/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-underline/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-underline/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-underline/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-underline/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@remirror/extension-whitespace": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@remirror/extension-whitespace/-/extension-whitespace-2.0.13.tgz",
@@ -6920,84 +2817,6 @@
       },
       "peerDependencies": {
         "@remirror/pm": "^2.0.5"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/messages": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@lingui/core": "^4.2.0",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-whitespace/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/extension-yjs": {
@@ -7019,45 +2838,28 @@
         "yjs": "^13.6.1"
       }
     },
-    "node_modules/@remirror/extension-yjs/node_modules/@lingui/core": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
+    "node_modules/@remirror/i18n": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
+      "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "4.14.1",
-        "unraw": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@lingui/detect-locale": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0",
+        "make-plural": "^6.2.2"
       }
     },
-    "node_modules/@remirror/extension-yjs/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/extension-yjs/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
+    "node_modules/@remirror/icons": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
+      "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
       "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "^3.0.0"
       }
     },
-    "node_modules/@remirror/extension-yjs/node_modules/@remirror/messages": {
+    "node_modules/@remirror/messages": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
       "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
@@ -7065,67 +2867,6 @@
         "@babel/runtime": "^7.22.3",
         "@lingui/core": "^4.2.0",
         "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/@remirror/extension-yjs/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/extension-yjs/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/extension-yjs/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/i18n": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-1.0.9.tgz",
-      "integrity": "sha512-uWYuFTuD5+4WEdHIvkrkimhAa3jIL89Z2KMRi2aj0pA8PDwD+svDNz8E1B1SUP2Th8JmGd0XfHRtg+OsiDTjTA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@lingui/detect-locale": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.6",
-        "make-plural": "^6.2.1"
-      }
-    },
-    "node_modules/@remirror/icons": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-1.0.8.tgz",
-      "integrity": "sha512-aS8wssUaH5yfJoeEPOPLKCsK7OSmXZlmSxxQ10j5REaw9UlyEWrFAb+GjGpFqeM8o7xS9T7W0M6yWyVSaKIeng==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-helpers": "^1.0.6"
-      }
-    },
-    "node_modules/@remirror/messages": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-1.0.7.tgz",
-      "integrity": "sha512-cnN5UxQGMW2rCJFqjzYzHG0qvCugraKc0r4b3atDE8HokVIJO1DHoVYux5A7UkfYVe5Enow/UUy/nj5zf3MhgA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.6"
       }
     },
     "node_modules/@remirror/pm": {
@@ -7152,61 +2893,6 @@
         "prosemirror-trailing-node": "^2.0.9",
         "prosemirror-transform": "^1.9.0",
         "prosemirror-view": "^1.33.8"
-      }
-    },
-    "node_modules/@remirror/pm/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/@remirror/pm/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/pm/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/pm/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/@remirror/pm/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remirror/preset-core": {
@@ -7254,6 +2940,33 @@
         "@remirror/pm": "^2.0.5"
       }
     },
+    "node_modules/@remirror/preset-react": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-react/-/preset-react-2.0.14.tgz",
+      "integrity": "sha512-brsNceisHfXbBqmuCFEj8bBlc3Ggnz8uGynS5bHDzfFP7EZgsOjIaHu6BpkifX/3qaJlzPSj3p1keoUgeqt6Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-placeholder": "^2.0.14",
+        "@remirror/extension-react-component": "^2.0.13",
+        "@remirror/react-utils": "^2.0.5"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5",
+        "@types/react": "^16.14.0 || ^17 || ^18",
+        "@types/react-dom": "^16.9.0 || ^17 || ^18",
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remirror/preset-wysiwyg": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/@remirror/preset-wysiwyg/-/preset-wysiwyg-2.0.19.tgz",
@@ -7288,22 +3001,21 @@
       }
     },
     "node_modules/@remirror/react": {
-      "version": "1.0.21",
-      "license": "MIT",
+      "version": "2.0.35",
+      "resolved": "https://registry.npmjs.org/@remirror/react/-/react-2.0.35.tgz",
+      "integrity": "sha512-SFs64SiQoHUatR+guSo9G1EVwBLqZec+tUtxdun11zC/5iiye0qIk+gnvu2h5pl0zwdqpK+b0ZQ/lR7JKzwagA==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/extension-placeholder": "^1.0.15",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-react-component": "^1.1.4",
-        "@remirror/extension-react-ssr": "^1.0.15",
-        "@remirror/extension-react-tables": "^1.0.21",
-        "@remirror/preset-react": "^1.0.16",
-        "@remirror/react-components": "^1.0.20",
-        "@remirror/react-core": "^1.0.19",
-        "@remirror/react-hooks": "^1.0.20",
-        "@remirror/react-renderer": "^1.0.15",
-        "@remirror/react-ssr": "^1.0.15",
-        "@remirror/react-utils": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/extension-placeholder": "^2.0.14",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-react-component": "^2.0.13",
+        "@remirror/extension-react-tables": "^2.2.18",
+        "@remirror/preset-react": "^2.0.14",
+        "@remirror/react-components": "^2.1.17",
+        "@remirror/react-core": "^2.0.21",
+        "@remirror/react-hooks": "^2.0.25",
+        "@remirror/react-renderer": "^2.0.13",
+        "@remirror/react-utils": "^2.0.7"
       },
       "peerDependencies": {
         "@types/react": "^16.14.0 || ^17 || ^18",
@@ -7316,16 +3028,160 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-components": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@remirror/react-components/-/react-components-2.1.17.tgz",
+      "integrity": "sha512-25BIEfYJO10cxpChyA2fKdmQw5VSDD/Ltcjlxps9DuXTYtjPD1WQnwVdpUyW43W2r7UsvZ2OcVGtQLdJw+RBiw==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@emotion/react": "^11.11.0",
+        "@emotion/styled": "^11.11.0",
+        "@floating-ui/react": "^0.24.3",
+        "@lingui/core": "^4.2.0",
+        "@mui/material": "^5.13.2",
+        "@remirror/core": "^2.0.17",
+        "@remirror/extension-blockquote": "^2.0.14",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-callout": "^2.0.15",
+        "@remirror/extension-code": "^2.0.13",
+        "@remirror/extension-code-block": "^2.0.15",
+        "@remirror/extension-columns": "^2.0.14",
+        "@remirror/extension-find": "^0.1.6",
+        "@remirror/extension-font-size": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.14",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-horizontal-rule": "^2.0.13",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-list": "^2.0.16",
+        "@remirror/extension-node-formatting": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-sub": "^2.0.13",
+        "@remirror/extension-sup": "^2.0.13",
+        "@remirror/extension-tables": "^2.2.10",
+        "@remirror/extension-text-color": "^2.0.15",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/extension-whitespace": "^2.0.13",
+        "@remirror/i18n": "^2.0.4",
+        "@remirror/icons": "^2.0.2",
+        "@remirror/messages": "^2.0.5",
+        "@remirror/react-core": "^2.0.20",
+        "@remirror/react-hooks": "^2.0.25",
+        "@remirror/react-utils": "^2.0.5",
+        "@remirror/theme": "^2.0.8",
+        "@seznam/compose-react-refs": "^1.0.6",
+        "@types/react-color": "^3.0.6",
+        "create-context-state": "^2.0.2",
+        "match-sorter": "^6.3.1",
+        "multishift": "^2.0.8",
+        "react-color": "^2.19.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5",
+        "@types/react": "^16.14.0 || ^17 || ^18",
+        "@types/react-dom": "^16.9.0 || ^17 || ^18",
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-core": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@remirror/react-core/-/react-core-2.0.21.tgz",
+      "integrity": "sha512-8c7+e0Y0LmwErqR4nPdUs73WLFKGqVs/DuE9q0wxSfXWbArAFVAAZB4PWrpcbYMbb0jSvG7rKDgnFN8NM/1f5A==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.18",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-react-component": "^2.0.13",
+        "@remirror/i18n": "^2.0.4",
+        "@remirror/preset-core": "^2.0.16",
+        "@remirror/preset-react": "^2.0.14",
+        "@remirror/react-renderer": "^2.0.13",
+        "@remirror/react-utils": "^2.0.5",
+        "@remirror/theme": "^2.0.8",
+        "@seznam/compose-react-refs": "^1.0.6",
+        "create-context-state": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5",
+        "@types/react": "^16.14.0 || ^17 || ^18",
+        "@types/react-dom": "^16.9.0 || ^17 || ^18",
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remirror/react-hooks": {
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/@remirror/react-hooks/-/react-hooks-2.0.25.tgz",
+      "integrity": "sha512-/qByk9+OSDVBFD5N3CalsXNvbHF0GEfOEhNstsBGvg0xxf0NsuvPj1rYcXnVHk+9mgx2TMh+EiOhfURRR2A9vg==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.17",
+        "@remirror/extension-emoji": "^2.0.17",
+        "@remirror/extension-events": "^2.1.15",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-mention": "^2.0.15",
+        "@remirror/extension-mention-atom": "^2.0.17",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/i18n": "^2.0.4",
+        "@remirror/react-core": "^2.0.20",
+        "@remirror/react-utils": "^2.0.5",
+        "multishift": "^2.0.8",
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-previous": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@remirror/pm": "^2.0.5",
+        "@types/react": "^16.14.0 || ^17 || ^18",
+        "@types/react-dom": "^16.9.0 || ^17 || ^18",
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         }
       }
     },
     "node_modules/@remirror/react-renderer": {
-      "version": "1.0.15",
-      "license": "MIT",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/react-renderer/-/react-renderer-2.0.13.tgz",
+      "integrity": "sha512-72K/+j+6H1QPPXzQJT3DxY4I+Anc9W5XvqEyPE2GQST4Q6W1Lib10Rvdh/hxcC0TuPEa+Nam2DkRWBxSSsIATw==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3"
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13"
       },
       "peerDependencies": {
         "@types/react": "^16.14.0 || ^17 || ^18",
@@ -7335,370 +3191,17 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/@remirror/core": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
-      "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/core-utils": "^1.1.11",
-        "@remirror/i18n": "^1.0.9",
-        "@remirror/icons": "^1.0.8",
-        "@remirror/messages": "^1.0.7",
-        "nanoevents": "^5.1.13",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-      "dependencies": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/@remirror/core-utils": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
-      "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/messages": "^1.0.7",
-        "@types/min-document": "^2.19.0",
-        "css-in-js-utils": "^3.1.0",
-        "min-document": "^2.19.0",
-        "parenthesis": "^3.1.8"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22",
-        "@types/node": "*",
-        "domino": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "domino": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/@remirror/pm": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.2",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.3.0",
-        "@types/prosemirror-transform": "^1.4.0",
-        "@types/prosemirror-view": "^1.23.2",
-        "prosemirror-collab": "<1.3.0",
-        "prosemirror-commands": "<1.3.0",
-        "prosemirror-dropcursor": "<1.5.0",
-        "prosemirror-gapcursor": "<1.3.0",
-        "prosemirror-history": "<1.3.0",
-        "prosemirror-inputrules": "<1.2.0",
-        "prosemirror-keymap": "<1.2.0",
-        "prosemirror-model": "<1.17.0",
-        "prosemirror-paste-rules": "^1.1.3",
-        "prosemirror-schema-list": "<1.2.0",
-        "prosemirror-state": "<1.4.0",
-        "prosemirror-suggest": "^1.1.4",
-        "prosemirror-tables": "<1.2.0",
-        "prosemirror-trailing-node": "^1.0.11",
-        "prosemirror-transform": "<1.5.0",
-        "prosemirror-view": "<1.24.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/orderedmap": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-      "peer": true
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-collab": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-commands": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-dropcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0",
-        "prosemirror-view": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-gapcursor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-view": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-history": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.2.2",
-        "prosemirror-transform": "^1.0.0",
-        "rope-sequence": "^1.3.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-inputrules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-keymap": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "w3c-keyname": "^2.2.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-model": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-      "peer": true,
-      "dependencies": {
-        "orderedmap": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-paste-rules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-schema-list": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-state": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-suggest": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/types": "^0.1.1",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-tables": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-trailing-node": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-transform": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-renderer/node_modules/prosemirror-view": {
-      "version": "1.23.13",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.16.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/@remirror/react-utils": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@remirror/react-utils/-/react-utils-1.0.7.tgz",
-      "integrity": "sha512-Pth2OppgT7jtpzZkZPYaKKXpiXmGKjrin08KuRuPRywL4ra3q75lpVFs4Yf+lYu/IvUda61yXew2oHfWsM9ktg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@remirror/react-utils/-/react-utils-2.0.7.tgz",
+      "integrity": "sha512-FowQ47k0IV+8qVvQZu5OOS014FTPQ1x2BsXgfikvrMlggx5mRgsFkJ5Sf56iieyUUHqBwVXIWHtR2KVanQWbVQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/core-types": "^1.0.4"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.5"
       },
       "peerDependencies": {
         "@types/react": "^16.14.0 || ^17 || ^18",
@@ -7708,1216 +3211,18 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-      "dependencies": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/@remirror/pm": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.2",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.3.0",
-        "@types/prosemirror-transform": "^1.4.0",
-        "@types/prosemirror-view": "^1.23.2",
-        "prosemirror-collab": "<1.3.0",
-        "prosemirror-commands": "<1.3.0",
-        "prosemirror-dropcursor": "<1.5.0",
-        "prosemirror-gapcursor": "<1.3.0",
-        "prosemirror-history": "<1.3.0",
-        "prosemirror-inputrules": "<1.2.0",
-        "prosemirror-keymap": "<1.2.0",
-        "prosemirror-model": "<1.17.0",
-        "prosemirror-paste-rules": "^1.1.3",
-        "prosemirror-schema-list": "<1.2.0",
-        "prosemirror-state": "<1.4.0",
-        "prosemirror-suggest": "^1.1.4",
-        "prosemirror-tables": "<1.2.0",
-        "prosemirror-trailing-node": "^1.0.11",
-        "prosemirror-transform": "<1.5.0",
-        "prosemirror-view": "<1.24.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/orderedmap": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-      "peer": true
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-collab": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-commands": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-dropcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0",
-        "prosemirror-view": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-gapcursor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-view": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-history": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.2.2",
-        "prosemirror-transform": "^1.0.0",
-        "rope-sequence": "^1.3.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-inputrules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-keymap": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "w3c-keyname": "^2.2.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-model": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-      "peer": true,
-      "dependencies": {
-        "orderedmap": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-paste-rules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-schema-list": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-state": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-suggest": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/types": "^0.1.1",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-tables": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-trailing-node": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-transform": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react-utils/node_modules/prosemirror-view": {
-      "version": "1.23.13",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.16.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/core": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
-      "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/core-utils": "^1.1.11",
-        "@remirror/i18n": "^1.0.9",
-        "@remirror/icons": "^1.0.8",
-        "@remirror/messages": "^1.0.7",
-        "nanoevents": "^5.1.13",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-      "dependencies": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/core-utils": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
-      "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/core-types": "^1.0.4",
-        "@remirror/messages": "^1.0.7",
-        "@types/min-document": "^2.19.0",
-        "css-in-js-utils": "^3.1.0",
-        "min-document": "^2.19.0",
-        "parenthesis": "^3.1.8"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22",
-        "@types/node": "*",
-        "domino": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "domino": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-doc": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-doc/-/extension-doc-1.0.25.tgz",
-      "integrity": "sha512-bC6YTkldMQ6/YT2HbN4AM2UtpoBDAmglj06UI6YspsUzJLhH+z+O6n5sgWQ89j9r3jKx9768YK9CPmtk6EIfLg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-emoji": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-emoji/-/extension-emoji-1.0.29.tgz",
-      "integrity": "sha512-kegqTYJORylKGCcefj5c9S/+vZ9aUGtECpreF2fo0P8Njs7EOxzJxwoc/DRogLNLDjWVJxoQpS4nllNw/XA3lA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/theme": "^1.2.2",
-        "emojibase": "^6.0.0",
-        "emojibase-data": "^6.1.0",
-        "emojibase-regex": "^6.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "svgmoji": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-events": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-1.1.5.tgz",
-      "integrity": "sha512-l8+r6TMphdJ1khnKYy+PlqjhlEDvLTyHZ89BJRJmPaDfpsw7IhgcDbtvklYPtaJC9TkWRbxc9hfz/NOY8qwHHA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-gap-cursor": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-gap-cursor/-/extension-gap-cursor-1.0.24.tgz",
-      "integrity": "sha512-WiiBzcDRwwfbFbCUaR+lUFmjvNaZidJrOdfVswcUXe/LoxKqaQEZ7l7x3WIpuEXMIO/RCP6f+tb4ppzuJ9Erhg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-history": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-1.0.24.tgz",
-      "integrity": "sha512-f7OMtCAuzVis/fPOiZvkQ3Ay8My032HhRHcDNX1d0yqiYNN6XWsD93sAYbC7c6ymLZ9GP1YNiorJ4GmXd8mBsQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-mention": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-mention/-/extension-mention-1.0.25.tgz",
-      "integrity": "sha512-tlzdpb4XEt+9v5408M/SPtRZlX+0DOE+2iycvu7H0mrc8TYWEG23YDznu7w86wr3PGEg9+LzofVUDK+rpfmbDg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/extension-events": "^1.1.5",
-        "@remirror/messages": "^1.0.7",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-mention-atom": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-mention-atom/-/extension-mention-atom-1.0.29.tgz",
-      "integrity": "sha512-5JE6EVVFP2HPa9Drzfxuas1ehhQgt2fNnVtTCusk5eznoMAsRiMzM6XrtsKXw5ZUqbfZ0MoDZjRniQYwnhUdXA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/extension-events": "^1.1.5",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/theme": "^1.2.2"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-paragraph": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-1.0.24.tgz",
-      "integrity": "sha512-sfsir4HSUKX6Dags+6KHFywHhwx+C6SUqKgp+MakrqEw9rKFOZs4yNDY25MsTxBZTVQ3dq/2vi1nCdt6Q6trAA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-placeholder": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-placeholder/-/extension-placeholder-1.0.28.tgz",
-      "integrity": "sha512-siAI6ugWEBu7uu3zMlpizf3bXGpy9tHNtc9558XRpRyOQu6DaKyAZq/A9h4Vf2xqN8VYit8zJ8KckaBuAp2a5A==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/theme": "^1.2.2"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-positioner": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-positioner/-/extension-positioner-1.2.9.tgz",
-      "integrity": "sha512-2LThtxAeDBJNzZlYAB7gI5H3dULKvt5NH5UVHKzhXXxkO2q3OCCs9oz5sNOxphrS1K31Oh54gCEoiKUta6fppA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/extension-events": "^1.1.5",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/theme": "^1.2.2",
-        "nanoevents": "^5.1.13"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-react-component": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-react-component/-/extension-react-component-1.1.16.tgz",
-      "integrity": "sha512-X4x8STuDcz5Pz68YLMOb9ps1STFl3ZqdjhrILolLxXjfkJmLeCLRNwMUFTs9KrIJX842HAKwLevOTrA0vjlxkA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7",
-        "nanoevents": "^5.1.13"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-react-ssr": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-react-ssr/-/extension-react-ssr-1.0.28.tgz",
-      "integrity": "sha512-X7TV3FkMc/NGLnEBDaFUAckNXuPe1sjcoG2XkSuoOYG0DfiBTfv5SD11/QJT2a2lRNqxlB9QpXS2Ngz4sRHaYw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/extension-react-component": "^1.1.16",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/react-utils": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-react-tables": {
-      "version": "1.0.21",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@emotion/css": "^11.1.3",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core": "^1.3.3",
-        "@remirror/core-utils": "^1.1.4",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-tables": "^1.0.15",
-        "@remirror/icons": "^1.0.7",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/preset-core": "^1.0.17",
-        "@remirror/react-components": "^1.0.20",
-        "@remirror/react-core": "^1.0.19",
-        "@remirror/react-hooks": "^1.0.20",
-        "@remirror/theme": "^1.2.0",
-        "jsx-dom": "^6.4.23"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-tables": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-tables/-/extension-tables-1.0.28.tgz",
-      "integrity": "sha512-erG70aN6WoyV6i/5n2hVgcGRq28Ahz8XBYWKF/GpVuReO0nA3FvBUIa2jKYrAVYnnYVfv/lMyTs9fJL4HRQOrA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/theme": "^1.2.2"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-text": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-text/-/extension-text-1.0.24.tgz",
-      "integrity": "sha512-+WpPwJnZNWrWNNH4lX8yMFvSjQ6/ueRXCjqmtC5KulfMxjIce6PEJOBsBLIgGVwLXqJDdXxBEnTmj7BqtoqolQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/messages": "^1.0.7"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/extension-text-color": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-1.0.28.tgz",
-      "integrity": "sha512-blau7PEy/53T8cJ2fpKIa76krsQ1KllCLUc7yXL1/cw3zHACV4up9lUTqD5jTQnPxSKUacI6ZykJekC+9fjq5Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/i18n": "^1.0.9",
-        "@remirror/messages": "^1.0.7",
-        "@remirror/theme": "^1.2.2",
-        "color2k": "^1.2.4"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/pm": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.2",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.3.0",
-        "@types/prosemirror-transform": "^1.4.0",
-        "@types/prosemirror-view": "^1.23.2",
-        "prosemirror-collab": "<1.3.0",
-        "prosemirror-commands": "<1.3.0",
-        "prosemirror-dropcursor": "<1.5.0",
-        "prosemirror-gapcursor": "<1.3.0",
-        "prosemirror-history": "<1.3.0",
-        "prosemirror-inputrules": "<1.2.0",
-        "prosemirror-keymap": "<1.2.0",
-        "prosemirror-model": "<1.17.0",
-        "prosemirror-paste-rules": "^1.1.3",
-        "prosemirror-schema-list": "<1.2.0",
-        "prosemirror-state": "<1.4.0",
-        "prosemirror-suggest": "^1.1.4",
-        "prosemirror-tables": "<1.2.0",
-        "prosemirror-trailing-node": "^1.0.11",
-        "prosemirror-transform": "<1.5.0",
-        "prosemirror-view": "<1.24.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/preset-core": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@remirror/preset-core/-/preset-core-1.0.31.tgz",
-      "integrity": "sha512-mPW9dm1ynrRTezMrzf+6a0N10MVyoJTBsWRN8tG2o68XXR4c8NnUfbAZeQzv1OTUuOdL86ea+JUR6PWD4jhhAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.4.7",
-        "@remirror/extension-doc": "^1.0.25",
-        "@remirror/extension-events": "^1.1.5",
-        "@remirror/extension-gap-cursor": "^1.0.24",
-        "@remirror/extension-history": "^1.0.24",
-        "@remirror/extension-paragraph": "^1.0.24",
-        "@remirror/extension-positioner": "^1.2.9",
-        "@remirror/extension-text": "^1.0.24"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.22"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/preset-react": {
-      "version": "1.0.16",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-placeholder": "^1.0.15",
-        "@remirror/extension-react-component": "^1.1.4",
-        "@remirror/extension-react-ssr": "^1.0.15",
-        "@remirror/react-utils": "^1.0.6"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-components": {
-      "version": "1.0.20",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@popperjs/core": "^2.9.2",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-text-color": "^1.0.15",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/icons": "^1.0.7",
-        "@remirror/messages": "^1.0.6",
-        "@remirror/react-core": "^1.0.19",
-        "@remirror/react-hooks": "^1.0.20",
-        "@remirror/react-utils": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "@seznam/compose-react-refs": "^1.0.6",
-        "@types/react-color": "^3.0.5",
-        "create-context-state": "^1.0.1",
-        "match-sorter": "^6.3.0",
-        "multishift": "^1.0.6",
-        "react-color": "^2.19.3",
-        "react-popper": "^2.2.5",
-        "reakit": "^1.3.8",
-        "reakit-system-palette": "^0.14.1",
-        "reakit-utils": "^0.15.1",
-        "use-isomorphic-layout-effect": "^1.1.1",
-        "use-previous": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-components/node_modules/reakit": {
-      "version": "1.3.11",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.5.4",
-        "body-scroll-lock": "^3.1.5",
-        "reakit-system": "^0.15.2",
-        "reakit-utils": "^0.15.2",
-        "reakit-warning": "^0.6.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-components/node_modules/reakit-system-palette": {
-      "version": "0.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "color": "3.1.3",
-        "reakit-system": "^0.15.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0",
-        "reakit": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-core": {
-      "version": "1.0.19",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-react-component": "^1.1.4",
-        "@remirror/extension-react-ssr": "^1.0.15",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/preset-core": "^1.0.17",
-        "@remirror/preset-react": "^1.0.16",
-        "@remirror/react-renderer": "^1.0.15",
-        "@remirror/react-ssr": "^1.0.15",
-        "@remirror/react-utils": "^1.0.6",
-        "@remirror/theme": "^1.2.0",
-        "@seznam/compose-react-refs": "^1.0.6",
-        "create-context-state": "^1.0.1",
-        "fast-deep-equal": "^3.1.3",
-        "resize-observer-polyfill": "^1.5.1",
-        "tiny-warning": "^1.0.3",
-        "use-isomorphic-layout-effect": "^1.1.1",
-        "use-previous": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-hooks": {
-      "version": "1.0.20",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-emoji": "^1.0.15",
-        "@remirror/extension-events": "^1.0.14",
-        "@remirror/extension-history": "^1.0.13",
-        "@remirror/extension-mention": "^1.0.14",
-        "@remirror/extension-mention-atom": "^1.0.16",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/i18n": "^1.0.8",
-        "@remirror/react-core": "^1.0.19",
-        "@remirror/react-utils": "^1.0.6",
-        "multishift": "^1.0.6",
-        "use-isomorphic-layout-effect": "^1.1.1",
-        "use-previous": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/@remirror/react-ssr": {
-      "version": "1.0.15",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3",
-        "@remirror/extension-react-ssr": "^1.0.15"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10",
-        "@types/react": "^16.14.0 || ^17 || ^18",
-        "@types/react-dom": "^16.9.0 || ^17 || ^18",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/orderedmap": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-      "peer": true
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-collab": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-commands": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-dropcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0",
-        "prosemirror-view": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-gapcursor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-view": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-history": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.2.2",
-        "prosemirror-transform": "^1.0.0",
-        "rope-sequence": "^1.3.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-inputrules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-keymap": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "w3c-keyname": "^2.2.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-model": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-      "peer": true,
-      "dependencies": {
-        "orderedmap": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-paste-rules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-schema-list": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-state": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-suggest": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/types": "^0.1.1",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-tables": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-trailing-node": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-transform": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/react/node_modules/prosemirror-view": {
-      "version": "1.23.13",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.16.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/@remirror/theme": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-1.2.2.tgz",
-      "integrity": "sha512-tT171xQWEneqq4kesRUfRB29CgT2VoG5NtCTD69ZuiKK+j481f6tXcyquQG15PSxwEr5AVC8aB75qKiZJBlHWQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-types": "^1.0.4",
-        "case-anything": "^1.1.3",
-        "color2k": "^1.2.4",
-        "csstype": "^3.0.7"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-      "dependencies": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/@remirror/pm": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.2",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.3.0",
-        "@types/prosemirror-transform": "^1.4.0",
-        "@types/prosemirror-view": "^1.23.2",
-        "prosemirror-collab": "<1.3.0",
-        "prosemirror-commands": "<1.3.0",
-        "prosemirror-dropcursor": "<1.5.0",
-        "prosemirror-gapcursor": "<1.3.0",
-        "prosemirror-history": "<1.3.0",
-        "prosemirror-inputrules": "<1.2.0",
-        "prosemirror-keymap": "<1.2.0",
-        "prosemirror-model": "<1.17.0",
-        "prosemirror-paste-rules": "^1.1.3",
-        "prosemirror-schema-list": "<1.2.0",
-        "prosemirror-state": "<1.4.0",
-        "prosemirror-suggest": "^1.1.4",
-        "prosemirror-tables": "<1.2.0",
-        "prosemirror-trailing-node": "^1.0.11",
-        "prosemirror-transform": "<1.5.0",
-        "prosemirror-view": "<1.24.0"
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
       }
     },
     "node_modules/@remirror/theme/node_modules/csstype": {
@@ -8925,270 +3230,20 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "node_modules/@remirror/theme/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/orderedmap": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-      "peer": true
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-collab": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-commands": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-dropcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0",
-        "prosemirror-view": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-gapcursor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-view": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-history": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.2.2",
-        "prosemirror-transform": "^1.0.0",
-        "rope-sequence": "^1.3.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-inputrules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-keymap": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "w3c-keyname": "^2.2.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-model": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-      "peer": true,
-      "dependencies": {
-        "orderedmap": "^1.1.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-paste-rules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-schema-list": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-state": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-suggest": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/types": "^0.1.1",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-tables": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-trailing-node": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-transform": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0"
-      }
-    },
-    "node_modules/@remirror/theme/node_modules/prosemirror-view": {
-      "version": "1.23.13",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.16.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
-      }
-    },
     "node_modules/@remirror/types": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-0.1.1.tgz",
-      "integrity": "sha512-v0f6HF+hFyJs8VJuHRXEh7REKyuUi5rMHhxxTqwiKj/QxMMaVjKlPY0L1kFu+0dZ3gHmlKs8jmlSSIhgn4NpaA==",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
       "dependencies": {
-        "type-fest": "^1.2.2"
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@remirror/types/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "license": "(MIT OR CC0-1.0)",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9205,8 +3260,7 @@
     "node_modules/@seznam/compose-react-refs": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@seznam/compose-react-refs/-/compose-react-refs-1.0.6.tgz",
-      "integrity": "sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==",
-      "license": "ISC"
+      "integrity": "sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -9371,8 +3425,9 @@
       }
     },
     "node_modules/@types/codemirror": {
-      "version": "5.60.5",
-      "license": "MIT",
+      "version": "5.60.15",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
+      "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
       "dependencies": {
         "@types/tern": "*"
       }
@@ -9568,12 +3623,6 @@
         "jest-diff": "*"
       }
     },
-    "node_modules/@types/js-cookie": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "dev": true,
@@ -9653,126 +3702,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
-    "node_modules/@types/prosemirror-collab": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-collab/-/prosemirror-collab-1.3.0.tgz",
-      "integrity": "sha512-3jdIU0Du8qrdm8K8DuP2I9gg8j5LQLwiZiuovQmAWnuyMbqoheXwyJlF3wtGZAAnBmwb6JAJvDUXx1ffHBjMDw==",
-      "deprecated": "This is a stub types definition. prosemirror-collab provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-collab": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-commands": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-commands/-/prosemirror-commands-1.3.0.tgz",
-      "integrity": "sha512-3UV4Pk4WRhrU7sGI5q/DAFS0DDIWYdaJwFqgrCblYRSOrJDLU8GIaZK5GmUaZtYF07E29XMKo9D2cDDh5pZBGg==",
-      "deprecated": "This is a stub types definition. prosemirror-commands provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-commands": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-dropcursor": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-dropcursor/-/prosemirror-dropcursor-1.5.0.tgz",
-      "integrity": "sha512-Xa13THoY0YkvYP/peH995ahT79w3ErdsmFUIaTY21nshxxnn5mdSgG+RTpkqXwZ85v+n28MvNfLF2gm+c8RZ1A==",
-      "deprecated": "This is a stub types definition. prosemirror-dropcursor provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-dropcursor": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-gapcursor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.0.tgz",
-      "integrity": "sha512-KbZbwrr2i6+AAOtTTQhbgXlAL1ZTY+FE8PsGz4vqRLeS4ow7sppdI3oHGMn0xmCgqXI+ajEDYENKHUQ2WZkXew==",
-      "deprecated": "This is a stub types definition. prosemirror-gapcursor provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-gapcursor": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-history": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-history/-/prosemirror-history-1.3.0.tgz",
-      "integrity": "sha512-Cs3jtZvk+9N5ygsry2gEwkgMq11YwSFaChoxIRq75nGbDp8ZVAiYEqF6iAunsrExQC3zh0ojmf+XxP5X3j2Ztw==",
-      "deprecated": "This is a stub types definition. prosemirror-history provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-history": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-inputrules": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz",
-      "integrity": "sha512-N30wadmd6uVnGR97JvX2mEOEoqsLr/nv96SkTb3JKfTLqtdLW6UHjDf3fiOPPQkj2hMqhS9ENnsIbDKfsYrSdw==",
-      "deprecated": "This is a stub types definition. prosemirror-inputrules provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-inputrules": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-keymap": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-keymap/-/prosemirror-keymap-1.2.0.tgz",
-      "integrity": "sha512-Vv/hOlNsDBOkqmxWUjgK7Ch5mFNRnvG88mfl2WhLFp4awdg3oQiZeTPN0wosWSO4mpK9aAWtZEhvJ/639HTLTQ==",
-      "deprecated": "This is a stub types definition. prosemirror-keymap provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-model": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.17.0.tgz",
-      "integrity": "sha512-lG5xEMkE8r8Soa80KdWPTbCLUaSHBHVHpTIEsQiebfONpvmS5061IMGzHUdb1oWjgrwh8EJq0GgMNwXHUx5mVg==",
-      "deprecated": "This is a stub types definition. prosemirror-model provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-schema-list": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-schema-list/-/prosemirror-schema-list-1.2.0.tgz",
-      "integrity": "sha512-njvba73mgBanQOt2/piYMeP+nsu8lzomA350Lh7/sdr6NPsRvYPggwJDIZEG0Cb/MB0fnv4PdRaTi93PoLHArw==",
-      "deprecated": "This is a stub types definition. prosemirror-schema-list provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-schema-list": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-state": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-state/-/prosemirror-state-1.4.0.tgz",
-      "integrity": "sha512-71epLy1HD2H7Qn6iOoQrFdbdFP32Cg5U7OvlCXMuYO8ygUdz07dfqA1lNj1y+KLf3HkRCXVkfvi3OnNa/tFZ3A==",
-      "deprecated": "This is a stub types definition. prosemirror-state provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-transform": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-transform/-/prosemirror-transform-1.5.0.tgz",
-      "integrity": "sha512-++krMS5bt3SxNOqjrftispPLRkvfXXw2BtVq4VPJ8Vpf+Sne1MhxVoj0EFCM+14MFlX0EHYQvX3k9AaQzob9ZQ==",
-      "deprecated": "This is a stub types definition. prosemirror-transform provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-transform": "*"
-      }
-    },
-    "node_modules/@types/prosemirror-view": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.24.0.tgz",
-      "integrity": "sha512-Swn08/O+QIOKOSfFFa+KKF19eeHetwA+pBMAHZ7wbF0wPrMS3zJ+G9wbOGqSkUv6JOVpuhlOP8Xg5nA3MyIXgQ==",
-      "deprecated": "This is a stub types definition. prosemirror-view provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-view": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -9818,17 +3747,21 @@
       }
     },
     "node_modules/@types/react-color": {
-      "version": "3.0.6",
-      "license": "MIT",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.13.tgz",
+      "integrity": "sha512-2c/9FZ4ixC5T3JzN0LP5Cke2Mf0MKOP2Eh0NPDPWmuVH3NjPyhEjqNMQpN1Phr5m74egAy+p2lYNAFrX1z9Yrg==",
       "dependencies": {
-        "@types/react": "*",
         "@types/reactcss": "*"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
       "version": "18.2.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
       "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -9868,11 +3801,10 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@types/reactcss": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.6.tgz",
-      "integrity": "sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==",
-      "license": "MIT",
-      "dependencies": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.13.tgz",
+      "integrity": "sha512-gi3S+aUi6kpkF5vdhUsnkwbiSEIU/BEJyD7kBy2SudWBUuKmJk8AQKE0OVcQQeEy40Azh0lV6uynxlikYIJuwg==",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -9929,6 +3861,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/string.prototype.matchall": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
+      "integrity": "sha512-E0KMS5FrWafbfKTGsoTZgrPHxBVknPeBxUTNwJima3t5KLdOlY285sisQC0mkVPTNNBc4nxza5ldly/ct+ISrQ=="
     },
     "node_modules/@types/tern": {
       "version": "0.23.4",
@@ -10513,12 +4450,6 @@
         }
       }
     },
-    "node_modules/@xobotyi/scrollbar-width": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
-      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==",
-      "license": "MIT"
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -10532,12 +4463,11 @@
       "dev": true
     },
     "node_modules/a11y-status": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/a11y-status/-/a11y-status-1.0.0.tgz",
-      "integrity": "sha512-n+umejjHj6aQAxcmkeatE4eOMlvX5BcMvg75W9tAO1ZWksC2ZlM1+6pv1zLhVIGSSZEUAn395jsx4EZZe17+xg==",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/a11y-status/-/a11y-status-2.0.2.tgz",
+      "integrity": "sha512-aFT18wXwGG6QHe/HsFJeQqknZ+TVi7A/3xfYMIQI5EEHIJ9ak+fa7T9uuDSpFPzNCF/4oAZyG9d/nKJMOfKgPQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
+        "@babel/runtime": "^7.22.3",
         "@types/throttle-debounce": "^2.1.0",
         "throttle-debounce": "^3.0.1"
       }
@@ -10726,6 +4656,37 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aria-hidden/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -10764,6 +4725,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -10772,6 +4754,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-jest": {
@@ -10971,12 +4967,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/body-scroll-lock": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
-      "integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==",
-      "license": "MIT"
-    },
     "node_modules/bonjour-service": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -11081,16 +5071,41 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
+      "integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "get-intrinsic": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11137,10 +5152,15 @@
       ]
     },
     "node_modules/case-anything": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-1.1.5.tgz",
-      "integrity": "sha512-UsoMDAMnOaD3mkNmbRg7WoCi6tViuqCihsUCVvHojgsVYJ6kcDjhrvzNwv8nZqjqatYTeQbfoDlJ+2xJVWwp4A==",
-      "license": "MIT"
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -11381,16 +5401,6 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
-    "node_modules/color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11408,36 +5418,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color2k": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-1.2.5.tgz",
-      "integrity": "sha512-G39qNMGyM/fhl8hcy1YqpfXzQ810zSGyiJAgdMFlreCI7Hpwu3Jpu4tuBM/Oxu1Bek1FwyaBbtrtdkTr4HDhLA==",
-      "license": "MIT"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -11493,8 +5480,9 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.17",
-      "license": "MIT"
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -11573,13 +5561,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "dev": true,
@@ -11601,12 +5582,11 @@
       }
     },
     "node_modules/create-context-state": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/create-context-state/-/create-context-state-1.0.1.tgz",
-      "integrity": "sha512-51cEufc3OD4BjfLG6rKTu9d9HJPgYsJ4r/5rljf/LLB3IWc5cBp/VKCZ2BNseS8hy0lZu0OJNfZS1mEnnYywCQ==",
-      "license": "MIT",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/create-context-state/-/create-context-state-2.0.3.tgz",
+      "integrity": "sha512-txC1IX5nQcgT4OiPsZviciHXs5v7zTiqcymNQvUsRNSnvxi7cDSpQFTtdq8z1JE7JmmtVnwWzc6a8/PcpPwpXg==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10"
+        "@babel/runtime": "^7.22.3"
       },
       "peerDependencies": {
         "@types/react": "^16.14.0 || ^17 || ^18",
@@ -11687,19 +5667,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/css-vendor": {
@@ -11845,6 +5812,54 @@
       "integrity": "sha512-4FbVrHDwfOASx7uQVxeiCTo7ggSdYZbqs8lH+WU6ViypPlDbe9y6IP5VVUDQBv9DcnyaiPT5XT0UWHgJ64zLeQ==",
       "license": "MIT"
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -11908,7 +5923,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -11931,14 +5945,19 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -12059,6 +6078,19 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
+      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -12185,29 +6217,57 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/error-stack-parser": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "node_modules/es-abstract": {
-      "version": "1.17.6",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.3",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.13",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.15"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12217,13 +6277,9 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -12232,7 +6288,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -12243,11 +6298,34 @@
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true
     },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -12948,11 +7026,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
-    },
     "node_modules/fast-uri": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
@@ -12967,12 +7040,6 @@
       "engines": {
         "node": ">= 4.9.1"
       }
-    },
-    "node_modules/fastest-stable-stringify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
-      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -13145,6 +7212,14 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -13198,12 +7273,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -13240,16 +7340,20 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13287,6 +7391,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -13336,13 +7456,27 @@
         "node": ">=4"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dependencies": {
-        "get-intrinsic": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13373,6 +7507,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13387,7 +7529,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -13399,7 +7540,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -13408,10 +7548,23 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -13423,7 +7576,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -13706,21 +7858,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/inline-style-prefixer": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "css-in-js-utils": "^2.0.0"
-      }
-    },
-    "node_modules/inline-style-prefixer/node_modules/css-in-js-utils": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "node_modules/inquirer": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
@@ -13790,13 +7927,13 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
       "dependencies": {
-        "es-abstract": "^1.17.0-next.1",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13850,11 +7987,54 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -13869,10 +8049,25 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-callable": {
+    "node_modules/is-boolean-object": {
       "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
+      "integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -13891,10 +8086,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-date-object": {
+    "node_modules/is-data-view": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -13937,6 +8151,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
+      "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+      "dependencies": {
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -13965,6 +8193,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -14000,6 +8242,28 @@
         "is-finite": "^1.0.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -14007,6 +8271,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
+      "integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -14034,11 +8313,39 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dependencies": {
-        "has-symbols": "^1.0.1"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dependencies": {
+        "call-bind": "^1.0.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14060,9 +8367,13 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
+      "integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -14071,11 +8382,64 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
+      "integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
       "dependencies": {
-        "has-symbols": "^1.0.1"
+        "call-bind": "^1.0.7",
+        "has-symbols": "^1.0.3",
+        "safe-regex-test": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dependencies": {
+        "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14095,6 +8459,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -14851,12 +9220,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
-    },
     "node_modules/js-sha256": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
@@ -15021,20 +9384,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jsx-dom": {
-      "version": "6.4.23",
-      "resolved": "https://registry.npmjs.org/jsx-dom/-/jsx-dom-6.4.23.tgz",
-      "integrity": "sha512-Y0ax82xa4nzqFdbUXs3ma2haDZy4pB638kMZsGRzZqdmtyzY2nAKs7Bh3DrLn0vqMuxmvZQ3g9hq3NtnI5yXtQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "csstype": "^3.0.3"
-      }
-    },
-    "node_modules/jsx-dom/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -15175,8 +9524,7 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -15273,14 +9621,15 @@
     "node_modules/material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "license": "ISC"
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "license": "CC0-1.0"
+    "node_modules/math-intrinsics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
+      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -15485,19 +9834,18 @@
       }
     },
     "node_modules/multishift": {
-      "version": "1.0.6",
-      "license": "MIT",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/multishift/-/multishift-2.0.10.tgz",
+      "integrity": "sha512-zXNW/JXDHsl9VYc4ch/qQmA7XsbS1G77IjDCL1x1Q651S16DZBGw4Gus5XFwbPoD14TYKE/OfhtaW2W/74q+PA==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@reach/auto-id": "^0.16.0",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "4.0.0",
+        "@remirror/core-types": "3.0.0",
         "@seznam/compose-react-refs": "^1.0.6",
-        "a11y-status": "^1.0.0",
-        "compute-scroll-into-view": "^1.0.17",
-        "react-use": "^17.2.3",
+        "a11y-status": "2.0.2",
+        "compute-scroll-into-view": "^1.0.20",
         "tiny-warning": "^1.0.3",
-        "w3c-keyname": "^2.2.4"
+        "w3c-keyname": "^2.2.7"
       },
       "peerDependencies": {
         "@types/react": "^16.14.0 || ^17 || ^18",
@@ -15509,89 +9857,78 @@
         }
       }
     },
-    "node_modules/multishift/node_modules/@reach/auto-id": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
+    "node_modules/multishift/node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="
     },
-    "node_modules/multishift/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "license": "MIT",
+    "node_modules/multishift/node_modules/@remirror/core-helpers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-4.0.0.tgz",
+      "integrity": "sha512-w90bJ+SLim25DWLN0Y6KjBwDhSgyzWwPxazwHQj7s3Px9dF69sG4cq3nA8RP2TCq1CV4bZmtW4+hCV26pHvgeA==",
       "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
+        "@remirror/core-constants": "3.0.0",
+        "@remirror/types": "2.0.0",
+        "@types/object.omit": "^3.0.0",
+        "@types/object.pick": "^1.3.2",
+        "@types/throttle-debounce": "^2.1.0",
+        "case-anything": "^2.1.13",
+        "clsx": "^2.1.1",
+        "dash-get": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "make-error": "^1.3.6",
+        "object.omit": "^3.0.0",
+        "object.pick": "^1.3.0",
+        "throttle-debounce": "^3.0.1"
       }
     },
     "node_modules/multishift/node_modules/@remirror/core-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-      "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-3.0.0.tgz",
+      "integrity": "sha512-69Os/+iC5hqTEwix59ceX+FZ4T49f8Zqo477s0hdVCUcBmt5gxM/qxYwOv7PWUGt99TrkQ0gxWwvXT+ZMVOOtQ==",
       "dependencies": {
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1"
+        "@remirror/core-constants": "3.0.0",
+        "@remirror/types": "2.0.0"
       },
       "peerDependencies": {
-        "@remirror/pm": "^1.0.10"
+        "@remirror/pm": "^3.0.0"
       }
     },
     "node_modules/multishift/node_modules/@remirror/pm": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-      "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-3.0.0.tgz",
+      "integrity": "sha512-cVZK42NmmcdkrwM3fGXywOL67NTO9lXD3Hii/+8fldX88BRECuiBm/siUM9tHwnq4Y3hmIxxFrQ6DtS23c3FKA==",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@types/prosemirror-collab": "^1.1.2",
-        "@types/prosemirror-commands": "^1.0.4",
-        "@types/prosemirror-dropcursor": "^1.0.3",
-        "@types/prosemirror-gapcursor": "^1.0.4",
-        "@types/prosemirror-history": "^1.0.3",
-        "@types/prosemirror-inputrules": "^1.0.4",
-        "@types/prosemirror-keymap": "^1.0.4",
-        "@types/prosemirror-model": "^1.16.2",
-        "@types/prosemirror-schema-list": "^1.0.3",
-        "@types/prosemirror-state": "^1.3.0",
-        "@types/prosemirror-transform": "^1.4.0",
-        "@types/prosemirror-view": "^1.23.2",
-        "prosemirror-collab": "<1.3.0",
-        "prosemirror-commands": "<1.3.0",
-        "prosemirror-dropcursor": "<1.5.0",
-        "prosemirror-gapcursor": "<1.3.0",
-        "prosemirror-history": "<1.3.0",
-        "prosemirror-inputrules": "<1.2.0",
-        "prosemirror-keymap": "<1.2.0",
-        "prosemirror-model": "<1.17.0",
-        "prosemirror-paste-rules": "^1.1.3",
-        "prosemirror-schema-list": "<1.2.0",
-        "prosemirror-state": "<1.4.0",
-        "prosemirror-suggest": "^1.1.4",
-        "prosemirror-tables": "<1.2.0",
-        "prosemirror-trailing-node": "^1.0.11",
-        "prosemirror-transform": "<1.5.0",
-        "prosemirror-view": "<1.24.0"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "3.0.0",
+        "@remirror/core-helpers": "4.0.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-paste-rules": "3.0.0",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-suggest": "3.0.0",
+        "prosemirror-tables": "^1.3.7",
+        "prosemirror-trailing-node": "3.0.0",
+        "prosemirror-transform": "^1.9.0",
+        "prosemirror-view": "^1.33.8"
       }
     },
-    "node_modules/multishift/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    "node_modules/multishift/node_modules/@remirror/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-j7G+hpyJ3SsZts0RpANYrTkQSWyP1+uy3txZPWgDwXGv3R45wtqRfoDzGO45vFcE9aNno/ThGPvClORZjjbrpw==",
+      "dependencies": {
+        "type-fest": "^3.10.0"
+      }
     },
     "node_modules/multishift/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -15605,288 +9942,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/multishift/node_modules/nano-css": {
-      "version": "5.3.4",
-      "license": "Unlicense",
-      "dependencies": {
-        "css-tree": "^1.1.2",
-        "csstype": "^3.0.6",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^6.0.0",
-        "rtl-css-js": "^1.14.0",
-        "sourcemap-codec": "^1.4.8",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.0.6"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/multishift/node_modules/orderedmap": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-      "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-      "peer": true
-    },
-    "node_modules/multishift/node_modules/prosemirror-collab": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-      "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-commands": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-      "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-dropcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-      "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0",
-        "prosemirror-view": "^1.1.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-gapcursor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-      "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-view": "^1.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-history": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.2.2",
-        "prosemirror-transform": "^1.0.0",
-        "rope-sequence": "^1.3.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-inputrules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-keymap": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "w3c-keyname": "^2.2.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-model": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-      "peer": true,
-      "dependencies": {
-        "orderedmap": "^1.1.0"
-      }
-    },
     "node_modules/multishift/node_modules/prosemirror-paste-rules": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-      "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-3.0.0.tgz",
+      "integrity": "sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "3.0.0",
+        "@remirror/core-helpers": "4.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-schema-list": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-      "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-state": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
       }
     },
     "node_modules/multishift/node_modules/prosemirror-suggest": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-      "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-3.0.0.tgz",
+      "integrity": "sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/types": "^0.1.1",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "3.0.0",
+        "@remirror/core-helpers": "4.0.0",
+        "@remirror/types": "2.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
-      },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-tables": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-      "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-keymap": "^1.1.2",
-        "prosemirror-model": "^1.8.1",
-        "prosemirror-state": "^1.3.1",
-        "prosemirror-transform": "^1.2.1",
-        "prosemirror-view": "^1.13.3"
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
       }
     },
     "node_modules/multishift/node_modules/prosemirror-trailing-node": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-      "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
+        "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/prosemirror-model": "^1",
-        "@types/prosemirror-state": "^1",
-        "@types/prosemirror-view": "^1",
-        "prosemirror-model": "^1",
-        "prosemirror-state": "^1",
-        "prosemirror-view": "^1"
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/multishift/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "engines": {
+        "node": ">=14.16"
       },
-      "peerDependenciesMeta": {
-        "@types/prosemirror-model": {
-          "optional": true
-        },
-        "@types/prosemirror-state": {
-          "optional": true
-        },
-        "@types/prosemirror-view": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/multishift/node_modules/prosemirror-transform": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-      "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/prosemirror-view": {
-      "version": "1.23.13",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-      "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.16.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
-      }
-    },
-    "node_modules/multishift/node_modules/react-use": {
-      "version": "17.3.2",
-      "license": "Unlicense",
-      "dependencies": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0"
-      }
-    },
-    "node_modules/multishift/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -16020,10 +10135,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-      "dev": true,
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -16035,24 +10149,26 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "dependencies": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries": {
@@ -16449,6 +10565,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
@@ -16785,67 +10909,12 @@
         "prosemirror-view": "^1.33.8"
       }
     },
-    "node_modules/prosemirror-paste-rules/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/prosemirror-paste-rules/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/prosemirror-paste-rules/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/prosemirror-paste-rules/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/prosemirror-paste-rules/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/prosemirror-paste-rules/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16861,61 +10930,6 @@
         "@remirror/core-utils": "^2.0.13",
         "prosemirror-model": "^1.22.1",
         "prosemirror-view": "^1.33.8"
-      }
-    },
-    "node_modules/prosemirror-resizable-view/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/prosemirror-resizable-view/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/prosemirror-resizable-view/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/prosemirror-resizable-view/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/prosemirror-resizable-view/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -16955,67 +10969,12 @@
         "prosemirror-view": "^1.33.8"
       }
     },
-    "node_modules/prosemirror-suggest/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/prosemirror-suggest/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/prosemirror-suggest/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/prosemirror-suggest/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/prosemirror-suggest/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/prosemirror-suggest/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17046,11 +11005,6 @@
         "prosemirror-state": "^1.4.2",
         "prosemirror-view": "^1.33.8"
       }
-    },
-    "node_modules/prosemirror-trailing-node/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
     },
     "node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -17261,7 +11215,6 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
       "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "license": "MIT",
       "dependencies": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.15",
@@ -17296,12 +11249,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "license": "MIT"
-    },
     "node_modules/react-hook-form": {
       "version": "6.15.8",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
@@ -17315,18 +11262,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-popper": {
-      "version": "2.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17"
-      }
     },
     "node_modules/react-qr-code": {
       "version": "2.0.7",
@@ -17427,20 +11362,10 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/react-universal-interface": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-      "peerDependencies": {
-        "react": "*",
-        "tslib": "*"
-      }
-    },
     "node_modules/reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.0.1"
       }
@@ -17477,39 +11402,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/reakit-system": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-      "dependencies": {
-        "reakit-utils": "^0.15.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/reakit-utils": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/reakit-warning": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
-      "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
-      "license": "MIT",
-      "dependencies": {
-        "reakit-utils": "^0.15.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/recharts": {
@@ -17562,6 +11454,27 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.8.tgz",
+      "integrity": "sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "dunder-proto": "^1.0.0",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.2.0",
+        "which-builtin-type": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/refractor": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
@@ -17582,12 +11495,14 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17609,82 +11524,82 @@
       }
     },
     "node_modules/remirror": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/remirror/-/remirror-2.0.4.tgz",
-      "integrity": "sha512-zsOH7wm/yLk7FSC8BjCNH8zq4JdkHFid4HwJg05elqPMx8GQ91vPcIqupZxa6kyOTM1ZbYiRtXPMFecCCRh5jg==",
+      "version": "2.0.40",
+      "resolved": "https://registry.npmjs.org/remirror/-/remirror-2.0.40.tgz",
+      "integrity": "sha512-l60kVS9Ad+rlmLK7WxEaExcUXmNHX+jREH1ZhqGJ7Qv6Cr68He3rkbHeUQtJabGYYQ2ZfchJ/QfnEmQ3hHwaxQ==",
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^2.0.3",
-        "@remirror/core-constants": "^2.0.0",
-        "@remirror/core-helpers": "^2.0.0",
-        "@remirror/core-types": "^2.0.0",
-        "@remirror/core-utils": "^2.0.3",
-        "@remirror/dom": "^2.0.4",
-        "@remirror/extension-annotation": "^2.0.4",
-        "@remirror/extension-bidi": "^2.0.3",
-        "@remirror/extension-blockquote": "^2.0.3",
-        "@remirror/extension-bold": "^2.0.3",
-        "@remirror/extension-callout": "^2.0.3",
-        "@remirror/extension-code": "^2.0.3",
-        "@remirror/extension-code-block": "^2.0.3",
-        "@remirror/extension-codemirror5": "^2.0.3",
-        "@remirror/extension-collaboration": "^2.0.3",
-        "@remirror/extension-columns": "^2.0.3",
-        "@remirror/extension-diff": "^2.0.3",
-        "@remirror/extension-doc": "^2.0.3",
-        "@remirror/extension-drop-cursor": "^2.0.3",
-        "@remirror/extension-embed": "^2.0.3",
-        "@remirror/extension-emoji": "^2.0.3",
-        "@remirror/extension-entity-reference": "^2.0.4",
-        "@remirror/extension-epic-mode": "^2.0.3",
-        "@remirror/extension-events": "^2.1.3",
-        "@remirror/extension-font-family": "^2.0.3",
-        "@remirror/extension-font-size": "^2.0.3",
-        "@remirror/extension-gap-cursor": "^2.0.3",
-        "@remirror/extension-hard-break": "^2.0.3",
-        "@remirror/extension-heading": "^2.0.3",
-        "@remirror/extension-history": "^2.0.3",
-        "@remirror/extension-horizontal-rule": "^2.0.3",
-        "@remirror/extension-image": "^2.0.3",
-        "@remirror/extension-italic": "^2.0.3",
-        "@remirror/extension-link": "^2.0.4",
-        "@remirror/extension-list": "^2.0.4",
-        "@remirror/extension-markdown": "^2.0.3",
-        "@remirror/extension-mention": "^2.0.4",
-        "@remirror/extension-mention-atom": "^2.0.4",
-        "@remirror/extension-node-formatting": "^2.0.3",
-        "@remirror/extension-paragraph": "^2.0.3",
-        "@remirror/extension-placeholder": "^2.0.3",
-        "@remirror/extension-positioner": "^2.0.4",
-        "@remirror/extension-search": "^2.0.3",
-        "@remirror/extension-shortcuts": "^2.0.3",
-        "@remirror/extension-strike": "^2.0.3",
-        "@remirror/extension-sub": "^2.0.3",
-        "@remirror/extension-sup": "^2.0.3",
-        "@remirror/extension-tables": "^2.0.3",
-        "@remirror/extension-text": "^2.0.3",
-        "@remirror/extension-text-case": "^2.0.3",
-        "@remirror/extension-text-color": "^2.0.3",
-        "@remirror/extension-text-highlight": "^2.0.3",
-        "@remirror/extension-trailing-node": "^2.0.3",
-        "@remirror/extension-underline": "^2.0.3",
-        "@remirror/extension-whitespace": "^2.0.3",
-        "@remirror/extension-yjs": "^3.0.3",
-        "@remirror/icons": "^2.0.0",
-        "@remirror/preset-core": "^2.0.4",
-        "@remirror/preset-formatting": "^2.0.3",
-        "@remirror/preset-wysiwyg": "^2.0.4",
-        "@remirror/theme": "^2.0.0",
-        "@types/codemirror": "^5.60.2",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.6",
+        "@remirror/core-utils": "^2.0.13",
+        "@remirror/dom": "^2.0.16",
+        "@remirror/extension-annotation": "^2.0.16",
+        "@remirror/extension-bidi": "^2.0.15",
+        "@remirror/extension-blockquote": "^2.0.14",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-callout": "^2.0.16",
+        "@remirror/extension-code": "^2.0.13",
+        "@remirror/extension-code-block": "^2.0.19",
+        "@remirror/extension-codemirror5": "^2.0.14",
+        "@remirror/extension-collaboration": "^2.0.13",
+        "@remirror/extension-columns": "^2.0.15",
+        "@remirror/extension-diff": "^2.0.13",
+        "@remirror/extension-doc": "^2.1.6",
+        "@remirror/extension-drop-cursor": "^2.0.13",
+        "@remirror/extension-embed": "^2.0.15",
+        "@remirror/extension-emoji": "^2.0.18",
+        "@remirror/extension-entity-reference": "^2.2.7",
+        "@remirror/extension-epic-mode": "^2.0.13",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/extension-font-family": "^2.0.14",
+        "@remirror/extension-font-size": "^2.0.14",
+        "@remirror/extension-gap-cursor": "^2.0.13",
+        "@remirror/extension-hard-break": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.15",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-horizontal-rule": "^2.0.13",
+        "@remirror/extension-image": "^2.1.11",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-link": "^2.0.18",
+        "@remirror/extension-list": "^2.0.17",
+        "@remirror/extension-markdown": "^2.0.14",
+        "@remirror/extension-mention": "^2.0.16",
+        "@remirror/extension-mention-atom": "^2.0.18",
+        "@remirror/extension-node-formatting": "^2.0.14",
+        "@remirror/extension-paragraph": "^2.0.13",
+        "@remirror/extension-placeholder": "^2.0.14",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-search": "^2.0.14",
+        "@remirror/extension-shortcuts": "^2.0.13",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-sub": "^2.0.13",
+        "@remirror/extension-sup": "^2.0.13",
+        "@remirror/extension-tables": "^2.4.2",
+        "@remirror/extension-text": "^2.0.13",
+        "@remirror/extension-text-case": "^2.0.14",
+        "@remirror/extension-text-color": "^2.0.16",
+        "@remirror/extension-text-highlight": "^2.0.15",
+        "@remirror/extension-trailing-node": "^2.0.13",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/extension-whitespace": "^2.0.13",
+        "@remirror/extension-yjs": "^3.0.16",
+        "@remirror/icons": "^2.0.3",
+        "@remirror/preset-core": "^2.0.16",
+        "@remirror/preset-formatting": "^2.0.14",
+        "@remirror/preset-wysiwyg": "^2.0.19",
+        "@remirror/theme": "^2.0.9",
+        "@types/codemirror": "^5.60.7",
         "@types/refractor": "^3.0.2",
-        "codemirror": "^5.62.0",
-        "refractor": "^3.3.1",
-        "yjs": "^13.5.23"
+        "codemirror": "^5.65.13",
+        "refractor": "^3.6.0",
+        "yjs": "^13.6.1"
       },
       "peerDependencies": {
-        "@remirror/pm": "^2.0.0",
-        "@types/prettier": "^2.1.5",
-        "prettier": "^2.2.0"
+        "@remirror/pm": "^2.0.8",
+        "@types/prettier": "^2.7.2",
+        "prettier": "^2.8.8"
       },
       "peerDependenciesMeta": {
         "@types/prettier": {
@@ -17693,126 +11608,6 @@
         "prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/remirror/node_modules/@linaria/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-      "dependencies": {
-        "@linaria/logger": "^4.0.0",
-        "@linaria/tags": "^4.3.5",
-        "@linaria/utils": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.16.0 || >=13.7.0"
-      }
-    },
-    "node_modules/remirror/node_modules/@remirror/core-constants": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-    },
-    "node_modules/remirror/node_modules/@remirror/core-helpers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-2.0.4.tgz",
-      "integrity": "sha512-aYoiJ8x/Sxc4OIZCcZI2tSa92rOufzpDkVTHtwh8+HEsGj0PumUrXbwVd3jHZRSoOUNYNG8fPnOmzuVOsO9CMQ==",
-      "dependencies": {
-        "@linaria/core": "4.2.10",
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/remirror/node_modules/@remirror/icons": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
-      "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@remirror/core-helpers": "^3.0.0"
-      }
-    },
-    "node_modules/remirror/node_modules/@remirror/icons/node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/remirror/node_modules/@remirror/theme": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.3",
-        "@linaria/core": "4.2.10",
-        "@remirror/core-types": "^2.0.5",
-        "color2k": "^2.0.2",
-        "csstype": "^3.1.2"
-      }
-    },
-    "node_modules/remirror/node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/remirror/node_modules/case-anything": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/remirror/node_modules/color2k": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-    },
-    "node_modules/remirror/node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/remirror/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/remove-accents": {
@@ -17854,8 +11649,7 @@
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -17978,13 +11772,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rtl-css-js": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -18035,12 +11822,46 @@
       "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
       "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -18206,18 +12027,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
-    "node_modules/screenfull": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -18380,7 +12189,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -18393,13 +12201,18 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/set-harmonic-interval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
-      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
-      "license": "Unlicense",
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
       "engines": {
-        "node": ">=6.9"
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -18456,7 +12269,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -18475,21 +12287,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -18576,6 +12373,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -18599,12 +12397,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "license": "MIT"
     },
     "node_modules/space-separated-tokens": {
       "version": "1.1.5",
@@ -18714,13 +12506,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/stack-generator": {
-      "version": "2.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -18740,38 +12525,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stackframe": {
-      "version": "1.2.0",
-      "license": "MIT"
-    },
-    "node_modules/stacktrace-gps": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.1.1"
-      }
-    },
-    "node_modules/stacktrace-gps/node_modules/source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stacktrace-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
-      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
-      "license": "MIT",
-      "dependencies": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
       }
     },
     "node_modules/statuses": {
@@ -18835,40 +12588,78 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+      "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
-        "has-symbols": "^1.0.1",
-        "internal-slot": "^1.0.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.2"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "regexp.prototype.flags": "^1.5.2",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -19030,6 +12821,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/table": {
       "version": "5.4.6",
@@ -19223,11 +13019,9 @@
       "license": "MIT"
     },
     "node_modules/tinycolor2": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -19260,12 +13054,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "license": "MIT"
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -19274,12 +13062,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/ts-easing": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
-      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
-      "license": "Unlicense"
     },
     "node_modules/ts-jest": {
       "version": "29.1.1",
@@ -19537,7 +13319,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -19613,16 +13396,101 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
+      "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.5.5",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unpipe": {
@@ -19677,10 +13545,11 @@
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -19696,15 +13565,14 @@
       }
     },
     "node_modules/use-previous": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-previous/-/use-previous-1.1.0.tgz",
-      "integrity": "sha512-t6ltKuYIpvcqD+VBnlUOaT+N94bN7HwUdB1u7rSpCIh9XvMJQIjsw/G8DoJlSDh029khFQ2L8q88oUWfKoWy5w==",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-previous/-/use-previous-1.2.0.tgz",
+      "integrity": "sha512-tK7Ne779nqTKGeh0rsFvxnQcEqePFRYlM0rfmNy9JH+h+2ndja7P0017nda0Q1gkqfcOD//pKZbDyyLIUH2s+Q==",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -19774,8 +13642,9 @@
       }
     },
     "node_modules/w3c-keyname": {
-      "version": "2.2.4",
-      "license": "MIT"
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -19784,15 +13653,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -20176,6 +14036,85 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
+      "integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.0",
+        "is-number-object": "^1.1.0",
+        "is-string": "^1.1.0",
+        "is-symbol": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
+      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.0.5",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.1.4",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
+      "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wildcard": {
@@ -20880,15 +14819,15 @@
       "dev": true
     },
     "@emotion/babel-plugin": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/serialize": "^1.1.2",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
@@ -20897,6 +14836,11 @@
         "stylis": "4.2.0"
       },
       "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -20910,25 +14854,39 @@
       }
     },
     "@emotion/cache": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "requires": {
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1",
-        "@emotion/weak-memoize": "^0.3.1",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+        },
+        "@emotion/weak-memoize": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+          "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+        }
       }
     },
     "@emotion/css": {
-      "version": "11.7.1",
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
       "requires": {
-        "@emotion/babel-plugin": "^11.7.1",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/serialize": "^1.0.0",
-        "@emotion/sheet": "^1.0.3",
-        "@emotion/utils": "^1.0.0"
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
       }
     },
     "@emotion/hash": {
@@ -20965,17 +14923,22 @@
       }
     },
     "@emotion/serialize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
-      "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "requires": {
-        "@emotion/hash": "^0.9.1",
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/unitless": "^0.8.1",
-        "@emotion/utils": "^1.2.1",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
       },
       "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+        },
         "csstype": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -20984,9 +14947,9 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "@emotion/styled": {
       "version": "11.11.0",
@@ -21002,9 +14965,9 @@
       }
     },
     "@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
     },
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
@@ -21013,9 +14976,9 @@
       "requires": {}
     },
     "@emotion/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
     },
     "@emotion/weak-memoize": {
       "version": "0.3.1",
@@ -21037,6 +15000,16 @@
       "requires": {
         "@floating-ui/core": "^1.0.0",
         "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
+      "integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+      "requires": {
+        "@floating-ui/react-dom": "^2.0.1",
+        "aria-hidden": "^1.2.3",
+        "tabbable": "^6.0.1"
       }
     },
     "@floating-ui/react-dom": {
@@ -21378,9 +15351,14 @@
       "dev": true
     },
     "@linaria/core": {
-      "version": "3.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-3.0.0-beta.13.tgz",
-      "integrity": "sha512-3zEi5plBCOsEzUneRVuQb+2SAx3qaC1dj0FfFAI6zIJQoDWu0dlSwKijMRack7oO9tUWrchfj3OkKQAd1LBdVg=="
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
+      "requires": {
+        "@linaria/logger": "^4.0.0",
+        "@linaria/tags": "^4.3.5",
+        "@linaria/utils": "^4.3.4"
+      }
     },
     "@linaria/logger": {
       "version": "4.5.0",
@@ -21487,19 +15465,19 @@
       }
     },
     "@lingui/core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.17.2.tgz",
-      "integrity": "sha512-YOd068NanznN8lLQqOKPlAY0ill3rrgmiAvPRKuYkrxzJMIHqlIFO/2Kcc/RH5vClOmLfg+wgR4rsHK/kLKelQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
+      "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@messageformat/parser": "^5.0.0",
-        "make-plural": "^6.2.2"
+        "@lingui/message-utils": "4.14.1",
+        "unraw": "^3.0.0"
       }
     },
     "@lingui/detect-locale": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-3.17.2.tgz",
-      "integrity": "sha512-rqyO16lj05WRfBuppo++mPzB1fQBFDhGqEFz5X97CbWXYp6AadOIkrm+pbn114Y2Yumy9QI7Cm4Ptbfk7CXO3Q=="
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
+      "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w=="
     },
     "@lingui/message-utils": {
       "version": "4.14.1",
@@ -21772,132 +15750,26 @@
         "@remirror/messages": "^2.0.6",
         "nanoevents": "^5.1.13",
         "tiny-warning": "^1.0.3"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@lingui/detect-locale": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
-          "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w=="
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/i18n": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
-          "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@lingui/detect-locale": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0",
-            "make-plural": "^6.2.2"
-          }
-        },
-        "@remirror/icons": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
-          "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/core-constants": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-1.0.2.tgz",
-      "integrity": "sha512-yiy+hqhjZwqR/pwLK4aXqzdR1helJytkz/xrfpgmSNh7Pj/HMl6gFxoGTI+5eS86mwsNecCcXQWKUhqVikWtiw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
     },
     "@remirror/core-helpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-1.0.6.tgz",
-      "integrity": "sha512-4n5eii/3L85B4SSY8/9Rerpcgl+4/Zl7gMojIm43AkDqyCJNejRkqNW7jtflbkugEBjJP+sb6hEVMsW4jKCOHw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
+      "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/types": "^0.1.1",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/types": "^1.0.1",
         "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.1",
+        "@types/object.pick": "^1.3.2",
         "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^1.1.3",
+        "case-anything": "^2.1.13",
         "dash-get": "^1.0.2",
-        "deepmerge": "^4.2.2",
+        "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
         "make-error": "^1.3.6",
         "object.omit": "^3.0.0",
@@ -21912,26 +15784,6 @@
       "requires": {
         "@remirror/core-constants": "^2.0.2",
         "@remirror/types": "^1.0.1"
-      },
-      "dependencies": {
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/core-utils": {
@@ -21949,71 +15801,6 @@
         "get-dom-document": "^0.1.3",
         "min-document": "^2.19.0",
         "parenthesis": "^3.1.8"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/dom": {
@@ -22035,71 +15822,6 @@
         "@remirror/core": "^2.0.13",
         "@remirror/extension-positioner": "^2.1.8",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-bidi": {
@@ -22112,71 +15834,6 @@
         "@remirror/messages": "^2.0.6",
         "@types/direction": "^1.0.0",
         "direction": "^1.0.4"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-blockquote": {
@@ -22188,103 +15845,6 @@
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3",
         "@remirror/theme": "^2.0.7"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-bold": {
@@ -22295,71 +15855,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-callout": {
@@ -22371,103 +15866,6 @@
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6",
         "@remirror/theme": "^2.0.9"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-code": {
@@ -22478,71 +15876,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-code-block": {
@@ -22556,103 +15889,6 @@
         "@remirror/theme": "^2.0.9",
         "@types/refractor": "^3.0.2",
         "refractor": "^3.6.0"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-codemirror5": {
@@ -22663,71 +15899,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-collaboration": {
@@ -22738,71 +15909,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-columns": {
@@ -22813,71 +15919,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-diff": {
@@ -22888,71 +15929,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-doc": {
@@ -22963,71 +15939,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-drop-cursor": {
@@ -23038,71 +15949,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-embed": {
@@ -23116,71 +15962,6 @@
         "@types/querystringify": "^2.0.0",
         "prosemirror-resizable-view": "^2.0.15",
         "querystringify": "^2.2.0"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-emoji": {
@@ -23200,105 +15981,10 @@
         "svgmoji": "^3.2.0"
       },
       "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -23321,71 +16007,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-events": {
@@ -23396,70 +16017,23 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
+      }
+    },
+    "@remirror/extension-find": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-find/-/extension-find-0.1.6.tgz",
+      "integrity": "sha512-WWcA6B4HXUU6kj4SP3OxKByFk07JQj99qQOw8nTFSTZ1AtUD4N2T/D5kSK2Uzmkreh/lCI5VJvTFwVEjft+3qg==",
+      "requires": {
+        "@remirror/core": "^2.0.13",
+        "@types/string.prototype.matchall": "^4.0.1",
+        "escape-string-regexp": "^4.0.0",
+        "string.prototype.matchall": "^4.0.8"
       },
       "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
     },
@@ -23471,71 +16045,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-font-size": {
@@ -23547,71 +16056,6 @@
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6",
         "round": "^2.0.1"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-gap-cursor": {
@@ -23622,71 +16066,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-hard-break": {
@@ -23697,71 +16076,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-heading": {
@@ -23772,71 +16086,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-history": {
@@ -23847,71 +16096,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-horizontal-rule": {
@@ -23922,71 +16106,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-image": {
@@ -23999,103 +16118,6 @@
         "@remirror/messages": "^2.0.6",
         "@remirror/theme": "^2.0.9",
         "prosemirror-resizable-view": "^2.0.15"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-italic": {
@@ -24106,71 +16128,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-link": {
@@ -24183,71 +16140,6 @@
         "@remirror/extension-events": "^2.1.17",
         "@remirror/messages": "^2.0.6",
         "extract-domain": "2.2.1"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-list": {
@@ -24260,103 +16152,6 @@
         "@remirror/extension-events": "^2.1.17",
         "@remirror/messages": "^2.0.6",
         "@remirror/theme": "^2.0.9"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-markdown": {
@@ -24372,71 +16167,6 @@
         "marked": "^4.3.0",
         "turndown": "^7.1.2",
         "turndown-plugin-gfm": "^1.0.2"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-mention": {
@@ -24451,73 +16181,10 @@
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -24531,103 +16198,6 @@
         "@remirror/extension-events": "^2.1.17",
         "@remirror/messages": "^2.0.6",
         "@remirror/theme": "^2.0.9"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-node-formatting": {
@@ -24638,71 +16208,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-paragraph": {
@@ -24713,71 +16218,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-placeholder": {
@@ -24789,103 +16229,6 @@
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3",
         "@remirror/theme": "^2.0.7"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-positioner": {
@@ -24899,103 +16242,38 @@
         "@remirror/messages": "^2.0.3",
         "@remirror/theme": "^2.0.7",
         "nanoevents": "^5.1.13"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
+      }
+    },
+    "@remirror/extension-react-component": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-react-component/-/extension-react-component-2.0.13.tgz",
+      "integrity": "sha512-xKzfgrmhncUQXkTjGqlYUxjG/QmxWjtEzpXRpND3YYULTPcxlVK4dNXtPvk0aczD6cvZVZohOeRSl8ESSLSo6A==",
+      "requires": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/messages": "^2.0.3",
+        "nanoevents": "^5.1.13"
+      }
+    },
+    "@remirror/extension-react-tables": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@remirror/extension-react-tables/-/extension-react-tables-2.2.21.tgz",
+      "integrity": "sha512-cPhWYXjyCGyGPAD/z1xcGQHnrowmw6EPT57qsRFPrEbGUJuRUKGgeP24dnE08T058Qja18ImrqFZEsCquLLs4A==",
+      "requires": {
+        "@babel/runtime": "^7.22.3",
+        "@emotion/css": "^11.11.0",
+        "@linaria/core": "4.2.10",
+        "@remirror/core": "^2.0.19",
+        "@remirror/core-utils": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-tables": "^2.4.3",
+        "@remirror/icons": "^2.0.3",
+        "@remirror/messages": "^2.0.6",
+        "@remirror/preset-core": "^2.0.16",
+        "@remirror/react-components": "^2.1.17",
+        "@remirror/react-core": "^2.0.21",
+        "@remirror/react-hooks": "^2.0.25",
+        "@remirror/theme": "^2.0.9"
       }
     },
     "@remirror/extension-search": {
@@ -25009,73 +16287,10 @@
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -25096,71 +16311,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-sub": {
@@ -25171,71 +16321,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-sup": {
@@ -25246,71 +16331,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-tables": {
@@ -25324,103 +16344,6 @@
         "@remirror/extension-positioner": "^2.1.8",
         "@remirror/messages": "^2.0.6",
         "@remirror/theme": "^2.0.9"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-text": {
@@ -25431,71 +16354,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-text-case": {
@@ -25506,71 +16364,6 @@
         "@babel/runtime": "^7.22.3",
         "@remirror/core": "^2.0.19",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-text-color": {
@@ -25584,120 +16377,6 @@
         "@remirror/messages": "^2.0.6",
         "@remirror/theme": "^2.0.9",
         "color2k": "^2.0.2"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@lingui/detect-locale": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/detect-locale/-/detect-locale-4.14.1.tgz",
-          "integrity": "sha512-w3sS+tVcZ8uDVJxLjHYArTjzUFK0NyMh2wukVGU52UO1WYjCCujf1DPboooIm5zeMquuTpa5XK017lnPJzB21w=="
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/i18n": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
-          "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@lingui/detect-locale": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0",
-            "make-plural": "^6.2.2"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-text-highlight": {
@@ -25709,71 +16388,6 @@
         "@remirror/core": "^2.0.19",
         "@remirror/extension-text-color": "^2.0.17",
         "@remirror/messages": "^2.0.6"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-trailing-node": {
@@ -25784,71 +16398,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-underline": {
@@ -25859,71 +16408,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-whitespace": {
@@ -25934,71 +16418,6 @@
         "@babel/runtime": "^7.21.0",
         "@remirror/core": "^2.0.13",
         "@remirror/messages": "^2.0.3"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/extension-yjs": {
@@ -26014,102 +16433,37 @@
         "prosemirror-view": "^1.33.8",
         "y-prosemirror": "^1.0.19",
         "y-protocols": "^1.0.5"
-      },
-      "dependencies": {
-        "@lingui/core": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/@lingui/core/-/core-4.14.1.tgz",
-          "integrity": "sha512-3O6bnNzApWjb+jIdXa7G2VbrP6jZ5nfCeYSVloEYg6YFIfsQ3GunccK6I2nL80mWgr2qGP4VilGD+ODCeXHITA==",
-          "requires": {
-            "@babel/runtime": "^7.20.13",
-            "@lingui/message-utils": "4.14.1",
-            "unraw": "^3.0.0"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/messages": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
-          "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@lingui/core": "^4.2.0",
-            "@remirror/core-helpers": "^3.0.0"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/i18n": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-1.0.9.tgz",
-      "integrity": "sha512-uWYuFTuD5+4WEdHIvkrkimhAa3jIL89Z2KMRi2aj0pA8PDwD+svDNz8E1B1SUP2Th8JmGd0XfHRtg+OsiDTjTA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@remirror/i18n/-/i18n-2.0.5.tgz",
+      "integrity": "sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@lingui/detect-locale": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.6",
-        "make-plural": "^6.2.1"
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@lingui/detect-locale": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0",
+        "make-plural": "^6.2.2"
       }
     },
     "@remirror/icons": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-1.0.8.tgz",
-      "integrity": "sha512-aS8wssUaH5yfJoeEPOPLKCsK7OSmXZlmSxxQ10j5REaw9UlyEWrFAb+GjGpFqeM8o7xS9T7W0M6yWyVSaKIeng==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
+      "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-helpers": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "^3.0.0"
       }
     },
     "@remirror/messages": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-1.0.7.tgz",
-      "integrity": "sha512-cnN5UxQGMW2rCJFqjzYzHG0qvCugraKc0r4b3atDE8HokVIJO1DHoVYux5A7UkfYVe5Enow/UUy/nj5zf3MhgA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@remirror/messages/-/messages-2.0.6.tgz",
+      "integrity": "sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@lingui/core": "^3.10.4",
-        "@remirror/core-helpers": "^1.0.6"
+        "@babel/runtime": "^7.22.3",
+        "@lingui/core": "^4.2.0",
+        "@remirror/core-helpers": "^3.0.0"
       }
     },
     "@remirror/pm": {
@@ -26136,51 +16490,6 @@
         "prosemirror-trailing-node": "^2.0.9",
         "prosemirror-transform": "^1.9.0",
         "prosemirror-view": "^1.33.8"
-      },
-      "dependencies": {
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "@remirror/preset-core": {
@@ -26222,6 +16531,18 @@
         "@remirror/extension-whitespace": "^2.0.13"
       }
     },
+    "@remirror/preset-react": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@remirror/preset-react/-/preset-react-2.0.14.tgz",
+      "integrity": "sha512-brsNceisHfXbBqmuCFEj8bBlc3Ggnz8uGynS5bHDzfFP7EZgsOjIaHu6BpkifX/3qaJlzPSj3p1keoUgeqt6Zg==",
+      "requires": {
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13",
+        "@remirror/extension-placeholder": "^2.0.14",
+        "@remirror/extension-react-component": "^2.0.13",
+        "@remirror/react-utils": "^2.0.5"
+      }
+    },
     "@remirror/preset-wysiwyg": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/@remirror/preset-wysiwyg/-/preset-wysiwyg-2.0.19.tgz",
@@ -26253,1396 +16574,166 @@
       }
     },
     "@remirror/react": {
-      "version": "1.0.21",
+      "version": "2.0.35",
+      "resolved": "https://registry.npmjs.org/@remirror/react/-/react-2.0.35.tgz",
+      "integrity": "sha512-SFs64SiQoHUatR+guSo9G1EVwBLqZec+tUtxdun11zC/5iiye0qIk+gnvu2h5pl0zwdqpK+b0ZQ/lR7JKzwagA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/extension-placeholder": "^1.0.15",
-        "@remirror/extension-positioner": "^1.1.14",
-        "@remirror/extension-react-component": "^1.1.4",
-        "@remirror/extension-react-ssr": "^1.0.15",
-        "@remirror/extension-react-tables": "^1.0.21",
-        "@remirror/preset-react": "^1.0.16",
-        "@remirror/react-components": "^1.0.20",
-        "@remirror/react-core": "^1.0.19",
-        "@remirror/react-hooks": "^1.0.20",
-        "@remirror/react-renderer": "^1.0.15",
-        "@remirror/react-ssr": "^1.0.15",
-        "@remirror/react-utils": "^1.0.6"
-      },
-      "dependencies": {
-        "@remirror/core": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
-          "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@linaria/core": "3.0.0-beta.13",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/core-types": "^1.0.4",
-            "@remirror/core-utils": "^1.1.11",
-            "@remirror/i18n": "^1.0.9",
-            "@remirror/icons": "^1.0.8",
-            "@remirror/messages": "^1.0.7",
-            "nanoevents": "^5.1.13",
-            "tiny-warning": "^1.0.3"
-          }
-        },
-        "@remirror/core-types": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-          "requires": {
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/types": "^0.1.1"
-          }
-        },
-        "@remirror/core-utils": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
-          "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/core-types": "^1.0.4",
-            "@remirror/messages": "^1.0.7",
-            "@types/min-document": "^2.19.0",
-            "css-in-js-utils": "^3.1.0",
-            "min-document": "^2.19.0",
-            "parenthesis": "^3.1.8"
-          }
-        },
-        "@remirror/extension-doc": {
-          "version": "1.0.25",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-doc/-/extension-doc-1.0.25.tgz",
-          "integrity": "sha512-bC6YTkldMQ6/YT2HbN4AM2UtpoBDAmglj06UI6YspsUzJLhH+z+O6n5sgWQ89j9r3jKx9768YK9CPmtk6EIfLg==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7"
-          }
-        },
-        "@remirror/extension-emoji": {
-          "version": "1.0.29",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-emoji/-/extension-emoji-1.0.29.tgz",
-          "integrity": "sha512-kegqTYJORylKGCcefj5c9S/+vZ9aUGtECpreF2fo0P8Njs7EOxzJxwoc/DRogLNLDjWVJxoQpS4nllNw/XA3lA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/theme": "^1.2.2",
-            "emojibase": "^6.0.0",
-            "emojibase-data": "^6.1.0",
-            "emojibase-regex": "^6.0.0",
-            "escape-string-regexp": "^4.0.0",
-            "svgmoji": "^3.2.0"
-          }
-        },
-        "@remirror/extension-events": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-events/-/extension-events-1.1.5.tgz",
-          "integrity": "sha512-l8+r6TMphdJ1khnKYy+PlqjhlEDvLTyHZ89BJRJmPaDfpsw7IhgcDbtvklYPtaJC9TkWRbxc9hfz/NOY8qwHHA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7"
-          }
-        },
-        "@remirror/extension-gap-cursor": {
-          "version": "1.0.24",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-gap-cursor/-/extension-gap-cursor-1.0.24.tgz",
-          "integrity": "sha512-WiiBzcDRwwfbFbCUaR+lUFmjvNaZidJrOdfVswcUXe/LoxKqaQEZ7l7x3WIpuEXMIO/RCP6f+tb4ppzuJ9Erhg==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7"
-          }
-        },
-        "@remirror/extension-history": {
-          "version": "1.0.24",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-history/-/extension-history-1.0.24.tgz",
-          "integrity": "sha512-f7OMtCAuzVis/fPOiZvkQ3Ay8My032HhRHcDNX1d0yqiYNN6XWsD93sAYbC7c6ymLZ9GP1YNiorJ4GmXd8mBsQ==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7"
-          }
-        },
-        "@remirror/extension-mention": {
-          "version": "1.0.25",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-mention/-/extension-mention-1.0.25.tgz",
-          "integrity": "sha512-tlzdpb4XEt+9v5408M/SPtRZlX+0DOE+2iycvu7H0mrc8TYWEG23YDznu7w86wr3PGEg9+LzofVUDK+rpfmbDg==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/extension-events": "^1.1.5",
-            "@remirror/messages": "^1.0.7",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "@remirror/extension-mention-atom": {
-          "version": "1.0.29",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-mention-atom/-/extension-mention-atom-1.0.29.tgz",
-          "integrity": "sha512-5JE6EVVFP2HPa9Drzfxuas1ehhQgt2fNnVtTCusk5eznoMAsRiMzM6XrtsKXw5ZUqbfZ0MoDZjRniQYwnhUdXA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/extension-events": "^1.1.5",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/theme": "^1.2.2"
-          }
-        },
-        "@remirror/extension-paragraph": {
-          "version": "1.0.24",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-paragraph/-/extension-paragraph-1.0.24.tgz",
-          "integrity": "sha512-sfsir4HSUKX6Dags+6KHFywHhwx+C6SUqKgp+MakrqEw9rKFOZs4yNDY25MsTxBZTVQ3dq/2vi1nCdt6Q6trAA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7"
-          }
-        },
-        "@remirror/extension-placeholder": {
-          "version": "1.0.28",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-placeholder/-/extension-placeholder-1.0.28.tgz",
-          "integrity": "sha512-siAI6ugWEBu7uu3zMlpizf3bXGpy9tHNtc9558XRpRyOQu6DaKyAZq/A9h4Vf2xqN8VYit8zJ8KckaBuAp2a5A==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/theme": "^1.2.2"
-          }
-        },
-        "@remirror/extension-positioner": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-positioner/-/extension-positioner-1.2.9.tgz",
-          "integrity": "sha512-2LThtxAeDBJNzZlYAB7gI5H3dULKvt5NH5UVHKzhXXxkO2q3OCCs9oz5sNOxphrS1K31Oh54gCEoiKUta6fppA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/extension-events": "^1.1.5",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/theme": "^1.2.2",
-            "nanoevents": "^5.1.13"
-          }
-        },
-        "@remirror/extension-react-component": {
-          "version": "1.1.16",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-react-component/-/extension-react-component-1.1.16.tgz",
-          "integrity": "sha512-X4x8STuDcz5Pz68YLMOb9ps1STFl3ZqdjhrILolLxXjfkJmLeCLRNwMUFTs9KrIJX842HAKwLevOTrA0vjlxkA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7",
-            "nanoevents": "^5.1.13"
-          }
-        },
-        "@remirror/extension-react-ssr": {
-          "version": "1.0.28",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-react-ssr/-/extension-react-ssr-1.0.28.tgz",
-          "integrity": "sha512-X7TV3FkMc/NGLnEBDaFUAckNXuPe1sjcoG2XkSuoOYG0DfiBTfv5SD11/QJT2a2lRNqxlB9QpXS2Ngz4sRHaYw==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/extension-react-component": "^1.1.16",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/react-utils": "^1.0.7"
-          }
-        },
-        "@remirror/extension-react-tables": {
-          "version": "1.0.21",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@emotion/css": "^11.1.3",
-            "@linaria/core": "3.0.0-beta.13",
-            "@remirror/core": "^1.3.3",
-            "@remirror/core-utils": "^1.1.4",
-            "@remirror/extension-positioner": "^1.1.14",
-            "@remirror/extension-tables": "^1.0.15",
-            "@remirror/icons": "^1.0.7",
-            "@remirror/messages": "^1.0.6",
-            "@remirror/preset-core": "^1.0.17",
-            "@remirror/react-components": "^1.0.20",
-            "@remirror/react-core": "^1.0.19",
-            "@remirror/react-hooks": "^1.0.20",
-            "@remirror/theme": "^1.2.0",
-            "jsx-dom": "^6.4.23"
-          }
-        },
-        "@remirror/extension-tables": {
-          "version": "1.0.28",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-tables/-/extension-tables-1.0.28.tgz",
-          "integrity": "sha512-erG70aN6WoyV6i/5n2hVgcGRq28Ahz8XBYWKF/GpVuReO0nA3FvBUIa2jKYrAVYnnYVfv/lMyTs9fJL4HRQOrA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/theme": "^1.2.2"
-          }
-        },
-        "@remirror/extension-text": {
-          "version": "1.0.24",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-text/-/extension-text-1.0.24.tgz",
-          "integrity": "sha512-+WpPwJnZNWrWNNH4lX8yMFvSjQ6/ueRXCjqmtC5KulfMxjIce6PEJOBsBLIgGVwLXqJDdXxBEnTmj7BqtoqolQ==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/messages": "^1.0.7"
-          }
-        },
-        "@remirror/extension-text-color": {
-          "version": "1.0.28",
-          "resolved": "https://registry.npmjs.org/@remirror/extension-text-color/-/extension-text-color-1.0.28.tgz",
-          "integrity": "sha512-blau7PEy/53T8cJ2fpKIa76krsQ1KllCLUc7yXL1/cw3zHACV4up9lUTqD5jTQnPxSKUacI6ZykJekC+9fjq5Q==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/i18n": "^1.0.9",
-            "@remirror/messages": "^1.0.7",
-            "@remirror/theme": "^1.2.2",
-            "color2k": "^1.2.4"
-          }
-        },
-        "@remirror/pm": {
-          "version": "1.0.22",
-          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@types/prosemirror-collab": "^1.1.2",
-            "@types/prosemirror-commands": "^1.0.4",
-            "@types/prosemirror-dropcursor": "^1.0.3",
-            "@types/prosemirror-gapcursor": "^1.0.4",
-            "@types/prosemirror-history": "^1.0.3",
-            "@types/prosemirror-inputrules": "^1.0.4",
-            "@types/prosemirror-keymap": "^1.0.4",
-            "@types/prosemirror-model": "^1.16.2",
-            "@types/prosemirror-schema-list": "^1.0.3",
-            "@types/prosemirror-state": "^1.3.0",
-            "@types/prosemirror-transform": "^1.4.0",
-            "@types/prosemirror-view": "^1.23.2",
-            "prosemirror-collab": "<1.3.0",
-            "prosemirror-commands": "<1.3.0",
-            "prosemirror-dropcursor": "<1.5.0",
-            "prosemirror-gapcursor": "<1.3.0",
-            "prosemirror-history": "<1.3.0",
-            "prosemirror-inputrules": "<1.2.0",
-            "prosemirror-keymap": "<1.2.0",
-            "prosemirror-model": "<1.17.0",
-            "prosemirror-paste-rules": "^1.1.3",
-            "prosemirror-schema-list": "<1.2.0",
-            "prosemirror-state": "<1.4.0",
-            "prosemirror-suggest": "^1.1.4",
-            "prosemirror-tables": "<1.2.0",
-            "prosemirror-trailing-node": "^1.0.11",
-            "prosemirror-transform": "<1.5.0",
-            "prosemirror-view": "<1.24.0"
-          }
-        },
-        "@remirror/preset-core": {
-          "version": "1.0.31",
-          "resolved": "https://registry.npmjs.org/@remirror/preset-core/-/preset-core-1.0.31.tgz",
-          "integrity": "sha512-mPW9dm1ynrRTezMrzf+6a0N10MVyoJTBsWRN8tG2o68XXR4c8NnUfbAZeQzv1OTUuOdL86ea+JUR6PWD4jhhAw==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.4.7",
-            "@remirror/extension-doc": "^1.0.25",
-            "@remirror/extension-events": "^1.1.5",
-            "@remirror/extension-gap-cursor": "^1.0.24",
-            "@remirror/extension-history": "^1.0.24",
-            "@remirror/extension-paragraph": "^1.0.24",
-            "@remirror/extension-positioner": "^1.2.9",
-            "@remirror/extension-text": "^1.0.24"
-          }
-        },
-        "@remirror/preset-react": {
-          "version": "1.0.16",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/extension-placeholder": "^1.0.15",
-            "@remirror/extension-react-component": "^1.1.4",
-            "@remirror/extension-react-ssr": "^1.0.15",
-            "@remirror/react-utils": "^1.0.6"
-          }
-        },
-        "@remirror/react-components": {
-          "version": "1.0.20",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@lingui/core": "^3.10.4",
-            "@popperjs/core": "^2.9.2",
-            "@remirror/core": "^1.3.3",
-            "@remirror/extension-positioner": "^1.1.14",
-            "@remirror/extension-text-color": "^1.0.15",
-            "@remirror/i18n": "^1.0.8",
-            "@remirror/icons": "^1.0.7",
-            "@remirror/messages": "^1.0.6",
-            "@remirror/react-core": "^1.0.19",
-            "@remirror/react-hooks": "^1.0.20",
-            "@remirror/react-utils": "^1.0.6",
-            "@remirror/theme": "^1.2.0",
-            "@seznam/compose-react-refs": "^1.0.6",
-            "@types/react-color": "^3.0.5",
-            "create-context-state": "^1.0.1",
-            "match-sorter": "^6.3.0",
-            "multishift": "^1.0.6",
-            "react-color": "^2.19.3",
-            "react-popper": "^2.2.5",
-            "reakit": "^1.3.8",
-            "reakit-system-palette": "^0.14.1",
-            "reakit-utils": "^0.15.1",
-            "use-isomorphic-layout-effect": "^1.1.1",
-            "use-previous": "^1.1.0"
-          },
-          "dependencies": {
-            "reakit": {
-              "version": "1.3.11",
-              "requires": {
-                "@popperjs/core": "^2.5.4",
-                "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.2",
-                "reakit-utils": "^0.15.2",
-                "reakit-warning": "^0.6.2"
-              }
-            },
-            "reakit-system-palette": {
-              "version": "0.14.2",
-              "requires": {
-                "color": "3.1.3",
-                "reakit-system": "^0.15.2"
-              }
-            }
-          }
-        },
-        "@remirror/react-core": {
-          "version": "1.0.19",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/extension-positioner": "^1.1.14",
-            "@remirror/extension-react-component": "^1.1.4",
-            "@remirror/extension-react-ssr": "^1.0.15",
-            "@remirror/i18n": "^1.0.8",
-            "@remirror/preset-core": "^1.0.17",
-            "@remirror/preset-react": "^1.0.16",
-            "@remirror/react-renderer": "^1.0.15",
-            "@remirror/react-ssr": "^1.0.15",
-            "@remirror/react-utils": "^1.0.6",
-            "@remirror/theme": "^1.2.0",
-            "@seznam/compose-react-refs": "^1.0.6",
-            "create-context-state": "^1.0.1",
-            "fast-deep-equal": "^3.1.3",
-            "resize-observer-polyfill": "^1.5.1",
-            "tiny-warning": "^1.0.3",
-            "use-isomorphic-layout-effect": "^1.1.1",
-            "use-previous": "^1.1.0"
-          }
-        },
-        "@remirror/react-hooks": {
-          "version": "1.0.20",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/extension-emoji": "^1.0.15",
-            "@remirror/extension-events": "^1.0.14",
-            "@remirror/extension-history": "^1.0.13",
-            "@remirror/extension-mention": "^1.0.14",
-            "@remirror/extension-mention-atom": "^1.0.16",
-            "@remirror/extension-positioner": "^1.1.14",
-            "@remirror/i18n": "^1.0.8",
-            "@remirror/react-core": "^1.0.19",
-            "@remirror/react-utils": "^1.0.6",
-            "multishift": "^1.0.6",
-            "use-isomorphic-layout-effect": "^1.1.1",
-            "use-previous": "^1.1.0"
-          }
-        },
-        "@remirror/react-ssr": {
-          "version": "1.0.15",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core": "^1.3.3",
-            "@remirror/extension-react-ssr": "^1.0.15"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "orderedmap": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-          "peer": true
-        },
-        "prosemirror-collab": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0"
-          }
-        },
-        "prosemirror-commands": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-dropcursor": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0",
-            "prosemirror-view": "^1.1.0"
-          }
-        },
-        "prosemirror-gapcursor": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.0.0",
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-view": "^1.0.0"
-          }
-        },
-        "prosemirror-history": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.2.2",
-            "prosemirror-transform": "^1.0.0",
-            "rope-sequence": "^1.3.0"
-          }
-        },
-        "prosemirror-inputrules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-keymap": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "w3c-keyname": "^2.2.0"
-          }
-        },
-        "prosemirror-model": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-          "peer": true,
-          "requires": {
-            "orderedmap": "^1.1.0"
-          }
-        },
-        "prosemirror-paste-rules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-schema-list": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-state": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-suggest": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/types": "^0.1.1",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-tables": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.1.2",
-            "prosemirror-model": "^1.8.1",
-            "prosemirror-state": "^1.3.1",
-            "prosemirror-transform": "^1.2.1",
-            "prosemirror-view": "^1.13.3"
-          }
-        },
-        "prosemirror-trailing-node": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-transform": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0"
-          }
-        },
-        "prosemirror-view": {
-          "version": "1.23.13",
-          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.16.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0"
-          }
-        }
+        "@babel/runtime": "^7.22.3",
+        "@remirror/extension-placeholder": "^2.0.14",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-react-component": "^2.0.13",
+        "@remirror/extension-react-tables": "^2.2.18",
+        "@remirror/preset-react": "^2.0.14",
+        "@remirror/react-components": "^2.1.17",
+        "@remirror/react-core": "^2.0.21",
+        "@remirror/react-hooks": "^2.0.25",
+        "@remirror/react-renderer": "^2.0.13",
+        "@remirror/react-utils": "^2.0.7"
+      }
+    },
+    "@remirror/react-components": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@remirror/react-components/-/react-components-2.1.17.tgz",
+      "integrity": "sha512-25BIEfYJO10cxpChyA2fKdmQw5VSDD/Ltcjlxps9DuXTYtjPD1WQnwVdpUyW43W2r7UsvZ2OcVGtQLdJw+RBiw==",
+      "requires": {
+        "@babel/runtime": "^7.22.3",
+        "@emotion/react": "^11.11.0",
+        "@emotion/styled": "^11.11.0",
+        "@floating-ui/react": "^0.24.3",
+        "@lingui/core": "^4.2.0",
+        "@mui/material": "^5.13.2",
+        "@remirror/core": "^2.0.17",
+        "@remirror/extension-blockquote": "^2.0.14",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-callout": "^2.0.15",
+        "@remirror/extension-code": "^2.0.13",
+        "@remirror/extension-code-block": "^2.0.15",
+        "@remirror/extension-columns": "^2.0.14",
+        "@remirror/extension-find": "^0.1.6",
+        "@remirror/extension-font-size": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.14",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-horizontal-rule": "^2.0.13",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-list": "^2.0.16",
+        "@remirror/extension-node-formatting": "^2.0.13",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-sub": "^2.0.13",
+        "@remirror/extension-sup": "^2.0.13",
+        "@remirror/extension-tables": "^2.2.10",
+        "@remirror/extension-text-color": "^2.0.15",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/extension-whitespace": "^2.0.13",
+        "@remirror/i18n": "^2.0.4",
+        "@remirror/icons": "^2.0.2",
+        "@remirror/messages": "^2.0.5",
+        "@remirror/react-core": "^2.0.20",
+        "@remirror/react-hooks": "^2.0.25",
+        "@remirror/react-utils": "^2.0.5",
+        "@remirror/theme": "^2.0.8",
+        "@seznam/compose-react-refs": "^1.0.6",
+        "@types/react-color": "^3.0.6",
+        "create-context-state": "^2.0.2",
+        "match-sorter": "^6.3.1",
+        "multishift": "^2.0.8",
+        "react-color": "^2.19.3"
+      }
+    },
+    "@remirror/react-core": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@remirror/react-core/-/react-core-2.0.21.tgz",
+      "integrity": "sha512-8c7+e0Y0LmwErqR4nPdUs73WLFKGqVs/DuE9q0wxSfXWbArAFVAAZB4PWrpcbYMbb0jSvG7rKDgnFN8NM/1f5A==",
+      "requires": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.18",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-react-component": "^2.0.13",
+        "@remirror/i18n": "^2.0.4",
+        "@remirror/preset-core": "^2.0.16",
+        "@remirror/preset-react": "^2.0.14",
+        "@remirror/react-renderer": "^2.0.13",
+        "@remirror/react-utils": "^2.0.5",
+        "@remirror/theme": "^2.0.8",
+        "@seznam/compose-react-refs": "^1.0.6",
+        "create-context-state": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "@remirror/react-hooks": {
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/@remirror/react-hooks/-/react-hooks-2.0.25.tgz",
+      "integrity": "sha512-/qByk9+OSDVBFD5N3CalsXNvbHF0GEfOEhNstsBGvg0xxf0NsuvPj1rYcXnVHk+9mgx2TMh+EiOhfURRR2A9vg==",
+      "requires": {
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.17",
+        "@remirror/extension-emoji": "^2.0.17",
+        "@remirror/extension-events": "^2.1.15",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-mention": "^2.0.15",
+        "@remirror/extension-mention-atom": "^2.0.17",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/i18n": "^2.0.4",
+        "@remirror/react-core": "^2.0.20",
+        "@remirror/react-utils": "^2.0.5",
+        "multishift": "^2.0.8",
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-previous": "^1.2.0"
       }
     },
     "@remirror/react-renderer": {
-      "version": "1.0.15",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@remirror/react-renderer/-/react-renderer-2.0.13.tgz",
+      "integrity": "sha512-72K/+j+6H1QPPXzQJT3DxY4I+Anc9W5XvqEyPE2GQST4Q6W1Lib10Rvdh/hxcC0TuPEa+Nam2DkRWBxSSsIATw==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^1.3.3"
-      },
-      "dependencies": {
-        "@remirror/core": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/@remirror/core/-/core-1.4.7.tgz",
-          "integrity": "sha512-k12bLw1id5VEGuYyY76nemW374hi1LtnOsGsLo12L4btflP2fr7r30Zt6AfgmqKnwR4KNYR3Q0Db6+0MHtfQ/A==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@linaria/core": "3.0.0-beta.13",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/core-types": "^1.0.4",
-            "@remirror/core-utils": "^1.1.11",
-            "@remirror/i18n": "^1.0.9",
-            "@remirror/icons": "^1.0.8",
-            "@remirror/messages": "^1.0.7",
-            "nanoevents": "^5.1.13",
-            "tiny-warning": "^1.0.3"
-          }
-        },
-        "@remirror/core-types": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-          "requires": {
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/types": "^0.1.1"
-          }
-        },
-        "@remirror/core-utils": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/@remirror/core-utils/-/core-utils-1.1.11.tgz",
-          "integrity": "sha512-zUJdkv2Rb18lkUCs2rMwalrZ/1DCg8Pl3X4RwW3sPFS9+LdyFFq5v1gDXJQmYWvLP7r6hubYKfRUwD97pxdJxA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/core-types": "^1.0.4",
-            "@remirror/messages": "^1.0.7",
-            "@types/min-document": "^2.19.0",
-            "css-in-js-utils": "^3.1.0",
-            "min-document": "^2.19.0",
-            "parenthesis": "^3.1.8"
-          }
-        },
-        "@remirror/pm": {
-          "version": "1.0.22",
-          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@types/prosemirror-collab": "^1.1.2",
-            "@types/prosemirror-commands": "^1.0.4",
-            "@types/prosemirror-dropcursor": "^1.0.3",
-            "@types/prosemirror-gapcursor": "^1.0.4",
-            "@types/prosemirror-history": "^1.0.3",
-            "@types/prosemirror-inputrules": "^1.0.4",
-            "@types/prosemirror-keymap": "^1.0.4",
-            "@types/prosemirror-model": "^1.16.2",
-            "@types/prosemirror-schema-list": "^1.0.3",
-            "@types/prosemirror-state": "^1.3.0",
-            "@types/prosemirror-transform": "^1.4.0",
-            "@types/prosemirror-view": "^1.23.2",
-            "prosemirror-collab": "<1.3.0",
-            "prosemirror-commands": "<1.3.0",
-            "prosemirror-dropcursor": "<1.5.0",
-            "prosemirror-gapcursor": "<1.3.0",
-            "prosemirror-history": "<1.3.0",
-            "prosemirror-inputrules": "<1.2.0",
-            "prosemirror-keymap": "<1.2.0",
-            "prosemirror-model": "<1.17.0",
-            "prosemirror-paste-rules": "^1.1.3",
-            "prosemirror-schema-list": "<1.2.0",
-            "prosemirror-state": "<1.4.0",
-            "prosemirror-suggest": "^1.1.4",
-            "prosemirror-tables": "<1.2.0",
-            "prosemirror-trailing-node": "^1.0.11",
-            "prosemirror-transform": "<1.5.0",
-            "prosemirror-view": "<1.24.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
-        },
-        "orderedmap": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-          "peer": true
-        },
-        "prosemirror-collab": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0"
-          }
-        },
-        "prosemirror-commands": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-dropcursor": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0",
-            "prosemirror-view": "^1.1.0"
-          }
-        },
-        "prosemirror-gapcursor": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.0.0",
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-view": "^1.0.0"
-          }
-        },
-        "prosemirror-history": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.2.2",
-            "prosemirror-transform": "^1.0.0",
-            "rope-sequence": "^1.3.0"
-          }
-        },
-        "prosemirror-inputrules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-keymap": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "w3c-keyname": "^2.2.0"
-          }
-        },
-        "prosemirror-model": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-          "peer": true,
-          "requires": {
-            "orderedmap": "^1.1.0"
-          }
-        },
-        "prosemirror-paste-rules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-schema-list": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-state": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-suggest": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/types": "^0.1.1",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-tables": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.1.2",
-            "prosemirror-model": "^1.8.1",
-            "prosemirror-state": "^1.3.1",
-            "prosemirror-transform": "^1.2.1",
-            "prosemirror-view": "^1.13.3"
-          }
-        },
-        "prosemirror-trailing-node": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-transform": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0"
-          }
-        },
-        "prosemirror-view": {
-          "version": "1.23.13",
-          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.16.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0"
-          }
-        }
+        "@babel/runtime": "^7.21.0",
+        "@remirror/core": "^2.0.13"
       }
     },
     "@remirror/react-utils": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@remirror/react-utils/-/react-utils-1.0.7.tgz",
-      "integrity": "sha512-Pth2OppgT7jtpzZkZPYaKKXpiXmGKjrin08KuRuPRywL4ra3q75lpVFs4Yf+lYu/IvUda61yXew2oHfWsM9ktg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@remirror/react-utils/-/react-utils-2.0.7.tgz",
+      "integrity": "sha512-FowQ47k0IV+8qVvQZu5OOS014FTPQ1x2BsXgfikvrMlggx5mRgsFkJ5Sf56iieyUUHqBwVXIWHtR2KVanQWbVQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core-constants": "^1.0.2",
-        "@remirror/core-helpers": "^1.0.6",
-        "@remirror/core-types": "^1.0.4"
-      },
-      "dependencies": {
-        "@remirror/core-types": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-          "requires": {
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/types": "^0.1.1"
-          }
-        },
-        "@remirror/pm": {
-          "version": "1.0.22",
-          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@types/prosemirror-collab": "^1.1.2",
-            "@types/prosemirror-commands": "^1.0.4",
-            "@types/prosemirror-dropcursor": "^1.0.3",
-            "@types/prosemirror-gapcursor": "^1.0.4",
-            "@types/prosemirror-history": "^1.0.3",
-            "@types/prosemirror-inputrules": "^1.0.4",
-            "@types/prosemirror-keymap": "^1.0.4",
-            "@types/prosemirror-model": "^1.16.2",
-            "@types/prosemirror-schema-list": "^1.0.3",
-            "@types/prosemirror-state": "^1.3.0",
-            "@types/prosemirror-transform": "^1.4.0",
-            "@types/prosemirror-view": "^1.23.2",
-            "prosemirror-collab": "<1.3.0",
-            "prosemirror-commands": "<1.3.0",
-            "prosemirror-dropcursor": "<1.5.0",
-            "prosemirror-gapcursor": "<1.3.0",
-            "prosemirror-history": "<1.3.0",
-            "prosemirror-inputrules": "<1.2.0",
-            "prosemirror-keymap": "<1.2.0",
-            "prosemirror-model": "<1.17.0",
-            "prosemirror-paste-rules": "^1.1.3",
-            "prosemirror-schema-list": "<1.2.0",
-            "prosemirror-state": "<1.4.0",
-            "prosemirror-suggest": "^1.1.4",
-            "prosemirror-tables": "<1.2.0",
-            "prosemirror-trailing-node": "^1.0.11",
-            "prosemirror-transform": "<1.5.0",
-            "prosemirror-view": "<1.24.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
-        },
-        "orderedmap": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-          "peer": true
-        },
-        "prosemirror-collab": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0"
-          }
-        },
-        "prosemirror-commands": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-dropcursor": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0",
-            "prosemirror-view": "^1.1.0"
-          }
-        },
-        "prosemirror-gapcursor": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.0.0",
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-view": "^1.0.0"
-          }
-        },
-        "prosemirror-history": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.2.2",
-            "prosemirror-transform": "^1.0.0",
-            "rope-sequence": "^1.3.0"
-          }
-        },
-        "prosemirror-inputrules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-keymap": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "w3c-keyname": "^2.2.0"
-          }
-        },
-        "prosemirror-model": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-          "peer": true,
-          "requires": {
-            "orderedmap": "^1.1.0"
-          }
-        },
-        "prosemirror-paste-rules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-schema-list": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-state": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-suggest": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/types": "^0.1.1",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-tables": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.1.2",
-            "prosemirror-model": "^1.8.1",
-            "prosemirror-state": "^1.3.1",
-            "prosemirror-transform": "^1.2.1",
-            "prosemirror-view": "^1.13.3"
-          }
-        },
-        "prosemirror-trailing-node": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-transform": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0"
-          }
-        },
-        "prosemirror-view": {
-          "version": "1.23.13",
-          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.16.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0"
-          }
-        }
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.5"
       }
     },
     "@remirror/theme": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-1.2.2.tgz",
-      "integrity": "sha512-tT171xQWEneqq4kesRUfRB29CgT2VoG5NtCTD69ZuiKK+j481f6tXcyquQG15PSxwEr5AVC8aB75qKiZJBlHWQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
+      "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@linaria/core": "3.0.0-beta.13",
-        "@remirror/core-types": "^1.0.4",
-        "case-anything": "^1.1.3",
-        "color2k": "^1.2.4",
-        "csstype": "^3.0.7"
+        "@babel/runtime": "^7.22.3",
+        "@linaria/core": "4.2.10",
+        "@remirror/core-types": "^2.0.5",
+        "color2k": "^2.0.2",
+        "csstype": "^3.1.2"
       },
       "dependencies": {
-        "@remirror/core-types": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
-          "requires": {
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/types": "^0.1.1"
-          }
-        },
-        "@remirror/pm": {
-          "version": "1.0.22",
-          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@types/prosemirror-collab": "^1.1.2",
-            "@types/prosemirror-commands": "^1.0.4",
-            "@types/prosemirror-dropcursor": "^1.0.3",
-            "@types/prosemirror-gapcursor": "^1.0.4",
-            "@types/prosemirror-history": "^1.0.3",
-            "@types/prosemirror-inputrules": "^1.0.4",
-            "@types/prosemirror-keymap": "^1.0.4",
-            "@types/prosemirror-model": "^1.16.2",
-            "@types/prosemirror-schema-list": "^1.0.3",
-            "@types/prosemirror-state": "^1.3.0",
-            "@types/prosemirror-transform": "^1.4.0",
-            "@types/prosemirror-view": "^1.23.2",
-            "prosemirror-collab": "<1.3.0",
-            "prosemirror-commands": "<1.3.0",
-            "prosemirror-dropcursor": "<1.5.0",
-            "prosemirror-gapcursor": "<1.3.0",
-            "prosemirror-history": "<1.3.0",
-            "prosemirror-inputrules": "<1.2.0",
-            "prosemirror-keymap": "<1.2.0",
-            "prosemirror-model": "<1.17.0",
-            "prosemirror-paste-rules": "^1.1.3",
-            "prosemirror-schema-list": "<1.2.0",
-            "prosemirror-state": "<1.4.0",
-            "prosemirror-suggest": "^1.1.4",
-            "prosemirror-tables": "<1.2.0",
-            "prosemirror-trailing-node": "^1.0.11",
-            "prosemirror-transform": "<1.5.0",
-            "prosemirror-view": "<1.24.0"
-          }
-        },
         "csstype": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
           "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
-        },
-        "orderedmap": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-          "peer": true
-        },
-        "prosemirror-collab": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0"
-          }
-        },
-        "prosemirror-commands": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-dropcursor": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0",
-            "prosemirror-view": "^1.1.0"
-          }
-        },
-        "prosemirror-gapcursor": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.0.0",
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-view": "^1.0.0"
-          }
-        },
-        "prosemirror-history": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.2.2",
-            "prosemirror-transform": "^1.0.0",
-            "rope-sequence": "^1.3.0"
-          }
-        },
-        "prosemirror-inputrules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-keymap": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "w3c-keyname": "^2.2.0"
-          }
-        },
-        "prosemirror-model": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-          "peer": true,
-          "requires": {
-            "orderedmap": "^1.1.0"
-          }
-        },
-        "prosemirror-paste-rules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-schema-list": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-state": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-suggest": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/types": "^0.1.1",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-tables": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.1.2",
-            "prosemirror-model": "^1.8.1",
-            "prosemirror-state": "^1.3.1",
-            "prosemirror-transform": "^1.2.1",
-            "prosemirror-view": "^1.13.3"
-          }
-        },
-        "prosemirror-trailing-node": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-transform": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0"
-          }
-        },
-        "prosemirror-view": {
-          "version": "1.23.13",
-          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.16.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0"
-          }
         }
       }
     },
     "@remirror/types": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-0.1.1.tgz",
-      "integrity": "sha512-v0f6HF+hFyJs8VJuHRXEh7REKyuUi5rMHhxxTqwiKj/QxMMaVjKlPY0L1kFu+0dZ3gHmlKs8jmlSSIhgn4NpaA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
       "requires": {
-        "type-fest": "^1.2.2"
+        "type-fest": "^2.19.0"
       },
       "dependencies": {
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -27807,7 +16898,9 @@
       }
     },
     "@types/codemirror": {
-      "version": "5.60.5",
+      "version": "5.60.15",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
+      "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
       "requires": {
         "@types/tern": "*"
       }
@@ -27997,11 +17090,6 @@
         "jest-diff": "*"
       }
     },
-    "@types/js-cookie": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
-    },
     "@types/json-schema": {
       "version": "7.0.9",
       "dev": true
@@ -28076,114 +17164,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
-    "@types/prosemirror-collab": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-collab/-/prosemirror-collab-1.3.0.tgz",
-      "integrity": "sha512-3jdIU0Du8qrdm8K8DuP2I9gg8j5LQLwiZiuovQmAWnuyMbqoheXwyJlF3wtGZAAnBmwb6JAJvDUXx1ffHBjMDw==",
-      "peer": true,
-      "requires": {
-        "prosemirror-collab": "*"
-      }
-    },
-    "@types/prosemirror-commands": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-commands/-/prosemirror-commands-1.3.0.tgz",
-      "integrity": "sha512-3UV4Pk4WRhrU7sGI5q/DAFS0DDIWYdaJwFqgrCblYRSOrJDLU8GIaZK5GmUaZtYF07E29XMKo9D2cDDh5pZBGg==",
-      "peer": true,
-      "requires": {
-        "prosemirror-commands": "*"
-      }
-    },
-    "@types/prosemirror-dropcursor": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-dropcursor/-/prosemirror-dropcursor-1.5.0.tgz",
-      "integrity": "sha512-Xa13THoY0YkvYP/peH995ahT79w3ErdsmFUIaTY21nshxxnn5mdSgG+RTpkqXwZ85v+n28MvNfLF2gm+c8RZ1A==",
-      "peer": true,
-      "requires": {
-        "prosemirror-dropcursor": "*"
-      }
-    },
-    "@types/prosemirror-gapcursor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.0.tgz",
-      "integrity": "sha512-KbZbwrr2i6+AAOtTTQhbgXlAL1ZTY+FE8PsGz4vqRLeS4ow7sppdI3oHGMn0xmCgqXI+ajEDYENKHUQ2WZkXew==",
-      "peer": true,
-      "requires": {
-        "prosemirror-gapcursor": "*"
-      }
-    },
-    "@types/prosemirror-history": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-history/-/prosemirror-history-1.3.0.tgz",
-      "integrity": "sha512-Cs3jtZvk+9N5ygsry2gEwkgMq11YwSFaChoxIRq75nGbDp8ZVAiYEqF6iAunsrExQC3zh0ojmf+XxP5X3j2Ztw==",
-      "peer": true,
-      "requires": {
-        "prosemirror-history": "*"
-      }
-    },
-    "@types/prosemirror-inputrules": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz",
-      "integrity": "sha512-N30wadmd6uVnGR97JvX2mEOEoqsLr/nv96SkTb3JKfTLqtdLW6UHjDf3fiOPPQkj2hMqhS9ENnsIbDKfsYrSdw==",
-      "peer": true,
-      "requires": {
-        "prosemirror-inputrules": "*"
-      }
-    },
-    "@types/prosemirror-keymap": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-keymap/-/prosemirror-keymap-1.2.0.tgz",
-      "integrity": "sha512-Vv/hOlNsDBOkqmxWUjgK7Ch5mFNRnvG88mfl2WhLFp4awdg3oQiZeTPN0wosWSO4mpK9aAWtZEhvJ/639HTLTQ==",
-      "peer": true,
-      "requires": {
-        "prosemirror-keymap": "*"
-      }
-    },
-    "@types/prosemirror-model": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.17.0.tgz",
-      "integrity": "sha512-lG5xEMkE8r8Soa80KdWPTbCLUaSHBHVHpTIEsQiebfONpvmS5061IMGzHUdb1oWjgrwh8EJq0GgMNwXHUx5mVg==",
-      "peer": true,
-      "requires": {
-        "prosemirror-model": "*"
-      }
-    },
-    "@types/prosemirror-schema-list": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-schema-list/-/prosemirror-schema-list-1.2.0.tgz",
-      "integrity": "sha512-njvba73mgBanQOt2/piYMeP+nsu8lzomA350Lh7/sdr6NPsRvYPggwJDIZEG0Cb/MB0fnv4PdRaTi93PoLHArw==",
-      "peer": true,
-      "requires": {
-        "prosemirror-schema-list": "*"
-      }
-    },
-    "@types/prosemirror-state": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-state/-/prosemirror-state-1.4.0.tgz",
-      "integrity": "sha512-71epLy1HD2H7Qn6iOoQrFdbdFP32Cg5U7OvlCXMuYO8ygUdz07dfqA1lNj1y+KLf3HkRCXVkfvi3OnNa/tFZ3A==",
-      "peer": true,
-      "requires": {
-        "prosemirror-state": "*"
-      }
-    },
-    "@types/prosemirror-transform": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-transform/-/prosemirror-transform-1.5.0.tgz",
-      "integrity": "sha512-++krMS5bt3SxNOqjrftispPLRkvfXXw2BtVq4VPJ8Vpf+Sne1MhxVoj0EFCM+14MFlX0EHYQvX3k9AaQzob9ZQ==",
-      "peer": true,
-      "requires": {
-        "prosemirror-transform": "*"
-      }
-    },
-    "@types/prosemirror-view": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.24.0.tgz",
-      "integrity": "sha512-Swn08/O+QIOKOSfFFa+KKF19eeHetwA+pBMAHZ7wbF0wPrMS3zJ+G9wbOGqSkUv6JOVpuhlOP8Xg5nA3MyIXgQ==",
-      "peer": true,
-      "requires": {
-        "prosemirror-view": "*"
-      }
-    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -28235,9 +17215,10 @@
       }
     },
     "@types/react-color": {
-      "version": "3.0.6",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.13.tgz",
+      "integrity": "sha512-2c/9FZ4ixC5T3JzN0LP5Cke2Mf0MKOP2Eh0NPDPWmuVH3NjPyhEjqNMQpN1Phr5m74egAy+p2lYNAFrX1z9Yrg==",
       "requires": {
-        "@types/react": "*",
         "@types/reactcss": "*"
       }
     },
@@ -28245,6 +17226,7 @@
       "version": "18.2.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
       "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
@@ -28277,12 +17259,10 @@
       }
     },
     "@types/reactcss": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.6.tgz",
-      "integrity": "sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==",
-      "requires": {
-        "@types/react": "*"
-      }
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.13.tgz",
+      "integrity": "sha512-gi3S+aUi6kpkF5vdhUsnkwbiSEIU/BEJyD7kBy2SudWBUuKmJk8AQKE0OVcQQeEy40Azh0lV6uynxlikYIJuwg==",
+      "requires": {}
     },
     "@types/refractor": {
       "version": "3.4.1",
@@ -28336,6 +17316,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/string.prototype.matchall": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
+      "integrity": "sha512-E0KMS5FrWafbfKTGsoTZgrPHxBVknPeBxUTNwJima3t5KLdOlY285sisQC0mkVPTNNBc4nxza5ldly/ct+ISrQ=="
     },
     "@types/tern": {
       "version": "0.23.4",
@@ -28752,11 +17737,6 @@
       "dev": true,
       "requires": {}
     },
-    "@xobotyi/scrollbar-width": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
-      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -28770,11 +17750,11 @@
       "dev": true
     },
     "a11y-status": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/a11y-status/-/a11y-status-1.0.0.tgz",
-      "integrity": "sha512-n+umejjHj6aQAxcmkeatE4eOMlvX5BcMvg75W9tAO1ZWksC2ZlM1+6pv1zLhVIGSSZEUAn395jsx4EZZe17+xg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/a11y-status/-/a11y-status-2.0.2.tgz",
+      "integrity": "sha512-aFT18wXwGG6QHe/HsFJeQqknZ+TVi7A/3xfYMIQI5EEHIJ9ak+fa7T9uuDSpFPzNCF/4oAZyG9d/nKJMOfKgPQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
+        "@babel/runtime": "^7.22.3",
         "@types/throttle-debounce": "^2.1.0",
         "throttle-debounce": "^3.0.1"
       }
@@ -28905,6 +17885,30 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "requires": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      }
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -28929,11 +17933,34 @@
         "function-bind": "^1.1.1"
       }
     },
+    "arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "requires": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      }
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "requires": {
+        "possible-typed-array-names": "^1.0.0"
+      }
     },
     "babel-jest": {
       "version": "29.6.1",
@@ -29084,11 +18111,6 @@
         }
       }
     },
-    "body-scroll-lock": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
-      "integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
-    },
     "bonjour-service": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -29160,16 +18182,32 @@
       "dev": true
     },
     "call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "requires": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
+      "integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+      "requires": {
+        "call-bind": "^1.0.8",
+        "get-intrinsic": "^1.2.5"
       }
     },
     "callsites": {
@@ -29189,9 +18227,9 @@
       "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ=="
     },
     "case-anything": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-1.1.5.tgz",
-      "integrity": "sha512-UsoMDAMnOaD3mkNmbRg7WoCi6tViuqCihsUCVvHojgsVYJ6kcDjhrvzNwv8nZqjqatYTeQbfoDlJ+2xJVWwp4A=="
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -29358,30 +18396,6 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
-    "color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        }
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -29394,19 +18408,13 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "color-string": {
-      "version": "1.9.0",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "color2k": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/color2k/-/color2k-1.2.5.tgz",
-      "integrity": "sha512-G39qNMGyM/fhl8hcy1YqpfXzQ810zSGyiJAgdMFlreCI7Hpwu3Jpu4tuBM/Oxu1Bek1FwyaBbtrtdkTr4HDhLA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
     },
     "colorette": {
       "version": "2.0.20",
@@ -29450,7 +18458,9 @@
       }
     },
     "compute-scroll-into-view": {
-      "version": "1.0.17"
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -29504,12 +18514,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
-    "copy-to-clipboard": {
-      "version": "3.3.1",
-      "requires": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "core-util-is": {
       "version": "1.0.2",
       "dev": true
@@ -29527,11 +18531,11 @@
       }
     },
     "create-context-state": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/create-context-state/-/create-context-state-1.0.1.tgz",
-      "integrity": "sha512-51cEufc3OD4BjfLG6rKTu9d9HJPgYsJ4r/5rljf/LLB3IWc5cBp/VKCZ2BNseS8hy0lZu0OJNfZS1mEnnYywCQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/create-context-state/-/create-context-state-2.0.3.tgz",
+      "integrity": "sha512-txC1IX5nQcgT4OiPsZviciHXs5v7zTiqcymNQvUsRNSnvxi7cDSpQFTtdq8z1JE7JmmtVnwWzc6a8/PcpPwpXg==",
       "requires": {
-        "@babel/runtime": "^7.13.10"
+        "@babel/runtime": "^7.22.3"
       }
     },
     "cross-spawn": {
@@ -29585,15 +18589,6 @@
           "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         }
-      }
-    },
-    "css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "requires": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
       }
     },
     "css-vendor": {
@@ -29699,6 +18694,36 @@
       "resolved": "https://registry.npmjs.org/dash-get/-/dash-get-1.0.2.tgz",
       "integrity": "sha512-4FbVrHDwfOASx7uQVxeiCTo7ggSdYZbqs8lH+WU6ViypPlDbe9y6IP5VVUDQBv9DcnyaiPT5XT0UWHgJ64zLeQ=="
     },
+    "data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
+    "data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
+    "data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
     "date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -29746,7 +18771,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "requires": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -29760,10 +18784,13 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.3",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "requires": {
-        "object-keys": "^1.0.12"
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "depd": {
@@ -29853,6 +18880,16 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
+    "dunder-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
+      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -29936,43 +18973,68 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "error-stack-parser": {
-      "version": "2.0.6",
-      "requires": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "es-abstract": {
-      "version": "1.17.6",
-      "dev": true,
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
       "requires": {
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.3",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.13",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.15"
       }
     },
     "es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.2.4"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
     "es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-module-lexer": {
       "version": "1.2.1",
@@ -29980,11 +19042,28 @@
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true
     },
+    "es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "requires": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -30486,11 +19565,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "fast-shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
-    },
     "fast-uri": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
@@ -30502,11 +19576,6 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true
-    },
-    "fastest-stable-stringify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -30632,6 +19701,14 @@
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -30668,11 +19745,27 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "function.prototype.name": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -30692,16 +19785,20 @@
       "requires": {}
     },
     "get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
       }
     },
     "get-package-type": {
@@ -30721,6 +19818,16 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
+    },
+    "get-symbol-description": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "requires": {
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -30754,14 +19861,19 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
+    "globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "requires": {
-        "get-intrinsic": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "graceful-fs": {
       "version": "4.2.11",
@@ -30783,6 +19895,11 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -30793,7 +19910,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "requires": {
         "es-define-property": "^1.0.0"
       }
@@ -30801,20 +19917,25 @@
     "has-proto": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
     },
     "hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -31023,21 +20144,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "inline-style-prefixer": {
-      "version": "6.0.1",
-      "requires": {
-        "css-in-js-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "css-in-js-utils": {
-          "version": "2.0.1",
-          "requires": {
-            "hyphenate-style-name": "^1.0.2",
-            "isobject": "^3.0.1"
-          }
-        }
-      }
-    },
     "inquirer": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
@@ -31094,12 +20200,13 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.2",
-      "dev": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
       "requires": {
-        "es-abstract": "^1.17.0-next.1",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
       }
     },
     "internmap": {
@@ -31133,10 +20240,35 @@
         "is-decimal": "^1.0.0"
       }
     },
+    "is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+    },
+    "is-async-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "requires": {
+        "has-bigints": "^1.0.2"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -31147,9 +20279,19 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-callable": {
+    "is-boolean-object": {
       "version": "1.2.0",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
+      "integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "has-tostringtag": "^1.0.2"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
       "version": "2.12.0",
@@ -31159,9 +20301,23 @@
         "has": "^1.0.3"
       }
     },
-    "is-date-object": {
+    "is-data-view": {
       "version": "1.0.2",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-decimal": {
       "version": "1.0.4",
@@ -31179,6 +20335,14 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
+    },
+    "is-finalizationregistry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
+      "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+      "requires": {
+        "call-bind": "^1.0.7"
+      }
     },
     "is-finite": {
       "version": "1.0.2",
@@ -31199,6 +20363,14 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.1",
@@ -31225,11 +20397,30 @@
         "is-finite": "^1.0.0"
       }
     },
+    "is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
+    },
+    "is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
+    },
+    "is-number-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
+      "integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "has-tostringtag": "^1.0.2"
+      }
     },
     "is-plain-obj": {
       "version": "3.0.0",
@@ -31246,10 +20437,27 @@
       }
     },
     "is-regex": {
-      "version": "1.1.1",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "requires": {
-        "has-symbols": "^1.0.1"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
+    },
+    "is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "requires": {
+        "call-bind": "^1.0.7"
       }
     },
     "is-stream": {
@@ -31259,14 +20467,52 @@
       "dev": true
     },
     "is-string": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
+      "integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "has-tostringtag": "^1.0.2"
+      }
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
+      "integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
       "requires": {
-        "has-symbols": "^1.0.1"
+        "call-bind": "^1.0.7",
+        "has-symbols": "^1.0.3",
+        "safe-regex-test": "^1.0.3"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "requires": {
+        "which-typed-array": "^1.1.14"
+      }
+    },
+    "is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4"
       }
     },
     "is-wsl": {
@@ -31277,6 +20523,11 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -31856,11 +21107,6 @@
         }
       }
     },
-    "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
-    },
     "js-sha256": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
@@ -31997,21 +21243,6 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
-      }
-    },
-    "jsx-dom": {
-      "version": "6.4.23",
-      "resolved": "https://registry.npmjs.org/jsx-dom/-/jsx-dom-6.4.23.tgz",
-      "integrity": "sha512-Y0ax82xa4nzqFdbUXs3ma2haDZy4pB638kMZsGRzZqdmtyzY2nAKs7Bh3DrLn0vqMuxmvZQ3g9hq3NtnI5yXtQ==",
-      "requires": {
-        "csstype": "^3.0.3"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        }
       }
     },
     "kind-of": {
@@ -32188,10 +21419,10 @@
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
-    "mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    "math-intrinsics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
+      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -32340,90 +21571,89 @@
       }
     },
     "multishift": {
-      "version": "1.0.6",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/multishift/-/multishift-2.0.10.tgz",
+      "integrity": "sha512-zXNW/JXDHsl9VYc4ch/qQmA7XsbS1G77IjDCL1x1Q651S16DZBGw4Gus5XFwbPoD14TYKE/OfhtaW2W/74q+PA==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@reach/auto-id": "^0.16.0",
-        "@remirror/core-helpers": "^1.0.5",
-        "@remirror/core-types": "^1.0.4",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core-helpers": "4.0.0",
+        "@remirror/core-types": "3.0.0",
         "@seznam/compose-react-refs": "^1.0.6",
-        "a11y-status": "^1.0.0",
-        "compute-scroll-into-view": "^1.0.17",
-        "react-use": "^17.2.3",
+        "a11y-status": "2.0.2",
+        "compute-scroll-into-view": "^1.0.20",
         "tiny-warning": "^1.0.3",
-        "w3c-keyname": "^2.2.4"
+        "w3c-keyname": "^2.2.7"
       },
       "dependencies": {
-        "@reach/auto-id": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-          "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
+        "@remirror/core-constants": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+          "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="
         },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+        "@remirror/core-helpers": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-4.0.0.tgz",
+          "integrity": "sha512-w90bJ+SLim25DWLN0Y6KjBwDhSgyzWwPxazwHQj7s3Px9dF69sG4cq3nA8RP2TCq1CV4bZmtW4+hCV26pHvgeA==",
           "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
+            "@remirror/core-constants": "3.0.0",
+            "@remirror/types": "2.0.0",
+            "@types/object.omit": "^3.0.0",
+            "@types/object.pick": "^1.3.2",
+            "@types/throttle-debounce": "^2.1.0",
+            "case-anything": "^2.1.13",
+            "clsx": "^2.1.1",
+            "dash-get": "^1.0.2",
+            "deepmerge": "^4.3.1",
+            "fast-deep-equal": "^3.1.3",
+            "make-error": "^1.3.6",
+            "object.omit": "^3.0.0",
+            "object.pick": "^1.3.0",
+            "throttle-debounce": "^3.0.1"
           }
         },
         "@remirror/core-types": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-1.0.4.tgz",
-          "integrity": "sha512-X36LsYdoxtrESQCXDUkgoA8Gt6neKT3Ic+vNiDoazQUb2ZMH5jQ96v2yByo8Tr2cgJLR9kqedyUEarXrMNluyg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/core-types/-/core-types-3.0.0.tgz",
+          "integrity": "sha512-69Os/+iC5hqTEwix59ceX+FZ4T49f8Zqo477s0hdVCUcBmt5gxM/qxYwOv7PWUGt99TrkQ0gxWwvXT+ZMVOOtQ==",
           "requires": {
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/types": "^0.1.1"
+            "@remirror/core-constants": "3.0.0",
+            "@remirror/types": "2.0.0"
           }
         },
         "@remirror/pm": {
-          "version": "1.0.22",
-          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-1.0.22.tgz",
-          "integrity": "sha512-HWmPMVeABQNb5vCisG92pEIoNBGK5kM6Cudpzrej4ubs0Ypnal4kC3ZBT2vMq7uig+bIioKPMZeLDVsRBnukyA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/pm/-/pm-3.0.0.tgz",
+          "integrity": "sha512-cVZK42NmmcdkrwM3fGXywOL67NTO9lXD3Hii/+8fldX88BRECuiBm/siUM9tHwnq4Y3hmIxxFrQ6DtS23c3FKA==",
           "peer": true,
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@types/prosemirror-collab": "^1.1.2",
-            "@types/prosemirror-commands": "^1.0.4",
-            "@types/prosemirror-dropcursor": "^1.0.3",
-            "@types/prosemirror-gapcursor": "^1.0.4",
-            "@types/prosemirror-history": "^1.0.3",
-            "@types/prosemirror-inputrules": "^1.0.4",
-            "@types/prosemirror-keymap": "^1.0.4",
-            "@types/prosemirror-model": "^1.16.2",
-            "@types/prosemirror-schema-list": "^1.0.3",
-            "@types/prosemirror-state": "^1.3.0",
-            "@types/prosemirror-transform": "^1.4.0",
-            "@types/prosemirror-view": "^1.23.2",
-            "prosemirror-collab": "<1.3.0",
-            "prosemirror-commands": "<1.3.0",
-            "prosemirror-dropcursor": "<1.5.0",
-            "prosemirror-gapcursor": "<1.3.0",
-            "prosemirror-history": "<1.3.0",
-            "prosemirror-inputrules": "<1.2.0",
-            "prosemirror-keymap": "<1.2.0",
-            "prosemirror-model": "<1.17.0",
-            "prosemirror-paste-rules": "^1.1.3",
-            "prosemirror-schema-list": "<1.2.0",
-            "prosemirror-state": "<1.4.0",
-            "prosemirror-suggest": "^1.1.4",
-            "prosemirror-tables": "<1.2.0",
-            "prosemirror-trailing-node": "^1.0.11",
-            "prosemirror-transform": "<1.5.0",
-            "prosemirror-view": "<1.24.0"
+            "@babel/runtime": "^7.22.3",
+            "@remirror/core-constants": "3.0.0",
+            "@remirror/core-helpers": "4.0.0",
+            "prosemirror-collab": "^1.3.1",
+            "prosemirror-commands": "^1.5.2",
+            "prosemirror-dropcursor": "^1.8.1",
+            "prosemirror-gapcursor": "^1.3.2",
+            "prosemirror-history": "^1.4.1",
+            "prosemirror-inputrules": "^1.4.0",
+            "prosemirror-keymap": "^1.2.2",
+            "prosemirror-model": "^1.22.1",
+            "prosemirror-paste-rules": "3.0.0",
+            "prosemirror-schema-list": "^1.4.1",
+            "prosemirror-state": "^1.4.3",
+            "prosemirror-suggest": "3.0.0",
+            "prosemirror-tables": "^1.3.7",
+            "prosemirror-trailing-node": "3.0.0",
+            "prosemirror-transform": "^1.9.0",
+            "prosemirror-view": "^1.33.8"
           }
         },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        "@remirror/types": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-2.0.0.tgz",
+          "integrity": "sha512-j7G+hpyJ3SsZts0RpANYrTkQSWyP1+uy3txZPWgDwXGv3R45wtqRfoDzGO45vFcE9aNno/ThGPvClORZjjbrpw==",
+          "requires": {
+            "type-fest": "^3.10.0"
+          }
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -32431,221 +21661,45 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "peer": true
         },
-        "nano-css": {
-          "version": "5.3.4",
-          "requires": {
-            "css-tree": "^1.1.2",
-            "csstype": "^3.0.6",
-            "fastest-stable-stringify": "^2.0.2",
-            "inline-style-prefixer": "^6.0.0",
-            "rtl-css-js": "^1.14.0",
-            "sourcemap-codec": "^1.4.8",
-            "stacktrace-js": "^2.0.2",
-            "stylis": "^4.0.6"
-          }
-        },
-        "orderedmap": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.8.tgz",
-          "integrity": "sha512-eWEYOAggZZpZbJ9CTsqAKOTxlbBHdHZ8pzcfEvNTxGrjQ/m+Q25nSWUiMlT9MTbgpB6FOiBDKqsgJ2FlLDVNaw==",
-          "peer": true
-        },
-        "prosemirror-collab": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
-          "integrity": "sha512-tBnHKMLgy5Qmx9MYVcLfs3pAyjtcqYYDd9kp3y+LSiQzkhMQDfZSV3NXWe4Gsly32adSef173BvObwfoSQL5MA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0"
-          }
-        },
-        "prosemirror-commands": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.2.tgz",
-          "integrity": "sha512-TX+KpWudMon06frryfpO/u7hsQv2hu8L4VSVbCpi3/7wXHBgl+35mV85qfa3RpT8xD2f3MdeoTqH0vy5JdbXPg==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-dropcursor": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.4.0.tgz",
-          "integrity": "sha512-6+YwTjmqDwlA/Dm+5wK67ezgqgjA/MhSDgaNxKUzH97SmeuWFXyLeDRxxOPZeSo7yTxcDGUCWTEjmQZsVBuMrQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0",
-            "prosemirror-view": "^1.1.0"
-          }
-        },
-        "prosemirror-gapcursor": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.2.2.tgz",
-          "integrity": "sha512-7YzuRBbu9W7HGQde84kCHfIjaRLNcAdeijbgqrm/R9dsdTWkV+rrdcmic/sCc+bptiNpvjCEE+R6hrbT8zFQeQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.0.0",
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-view": "^1.0.0"
-          }
-        },
-        "prosemirror-history": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
-          "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.2.2",
-            "prosemirror-transform": "^1.0.0",
-            "rope-sequence": "^1.3.0"
-          }
-        },
-        "prosemirror-inputrules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-          "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-keymap": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
-          "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-state": "^1.0.0",
-            "w3c-keyname": "^2.2.0"
-          }
-        },
-        "prosemirror-model": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
-          "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
-          "peer": true,
-          "requires": {
-            "orderedmap": "^1.1.0"
-          }
-        },
         "prosemirror-paste-rules": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-1.1.3.tgz",
-          "integrity": "sha512-e9gCKb+nJbDplNHs0gk2D3pgqMSbHSMuGGwEkqb8ifFMjrsM/g+5cb/SLsXNDD42rR/0vYN3bXDc0vCjowWMVA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-paste-rules/-/prosemirror-paste-rules-3.0.0.tgz",
+          "integrity": "sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==",
           "peer": true,
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
+            "@babel/runtime": "^7.22.3",
+            "@remirror/core-constants": "3.0.0",
+            "@remirror/core-helpers": "4.0.0",
             "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-schema-list": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz",
-          "integrity": "sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
-          }
-        },
-        "prosemirror-state": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
-          "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0",
-            "prosemirror-transform": "^1.0.0"
           }
         },
         "prosemirror-suggest": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-1.1.4.tgz",
-          "integrity": "sha512-4giinewUi0zs5qF3570qJaDR6KtAd0/pldz6u06ZkOI9T02jZQMdmhuj3M3sTtaWOwrvp8o8XzVIma3S+BBNWg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-suggest/-/prosemirror-suggest-3.0.0.tgz",
+          "integrity": "sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==",
           "peer": true,
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
-            "@remirror/types": "^0.1.1",
+            "@babel/runtime": "^7.22.3",
+            "@remirror/core-constants": "3.0.0",
+            "@remirror/core-helpers": "4.0.0",
+            "@remirror/types": "2.0.0",
             "escape-string-regexp": "^4.0.0"
-          }
-        },
-        "prosemirror-tables": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.1.2.tgz",
-          "integrity": "sha512-u2Rsx2s62bXU9VTSNi3oriwBpABE8XuiwXCelkkdjSMlR2Xr3JDt5t+yJy9EfItqruFEJcm8jCqfB3zv0akFeA==",
-          "peer": true,
-          "requires": {
-            "prosemirror-keymap": "^1.1.2",
-            "prosemirror-model": "^1.8.1",
-            "prosemirror-state": "^1.3.1",
-            "prosemirror-transform": "^1.2.1",
-            "prosemirror-view": "^1.13.3"
           }
         },
         "prosemirror-trailing-node": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-1.0.11.tgz",
-          "integrity": "sha512-nUEWbMLrbucMkBWOGu+X/tER31dsn38lRdscp4Zd/9T05rtqIMsgnE/SiI3Aqy918ZL6OzOIWfUpnSkQSPZwGQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+          "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
           "peer": true,
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@remirror/core-constants": "^1.0.2",
-            "@remirror/core-helpers": "^1.0.6",
+            "@remirror/core-constants": "3.0.0",
             "escape-string-regexp": "^4.0.0"
           }
         },
-        "prosemirror-transform": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.4.2.tgz",
-          "integrity": "sha512-bcIsf3uRZhfab0xRfyyxOEh6eqSszq/hJbDbmUumFnbHBoWhB/uXbpz6vvUxfk0XiEvrZDJ+5pXRrNDc1Hu3vQ==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.0.0"
-          }
-        },
-        "prosemirror-view": {
-          "version": "1.23.13",
-          "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.13.tgz",
-          "integrity": "sha512-X/NcwZv8pgcEWfs3n++Wz4nDgqDIeDvJ9kfCk6DCoC9XUlDekqJLFt9wCcCUBXedb8hs/dmd+JmcaLgbr67XZw==",
-          "peer": true,
-          "requires": {
-            "prosemirror-model": "^1.16.0",
-            "prosemirror-state": "^1.0.0",
-            "prosemirror-transform": "^1.1.0"
-          }
-        },
-        "react-use": {
-          "version": "17.3.2",
-          "requires": {
-            "@types/js-cookie": "^2.2.6",
-            "@xobotyi/scrollbar-width": "^1.9.5",
-            "copy-to-clipboard": "^3.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "fast-shallow-equal": "^1.0.0",
-            "js-cookie": "^2.2.1",
-            "nano-css": "^5.3.1",
-            "react-universal-interface": "^0.6.2",
-            "resize-observer-polyfill": "^1.5.1",
-            "screenfull": "^5.1.0",
-            "set-harmonic-interval": "^1.0.1",
-            "throttle-debounce": "^3.0.1",
-            "ts-easing": "^0.2.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        "type-fest": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+          "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
         }
       }
     },
@@ -32741,25 +21795,24 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-      "dev": true
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.0",
-      "dev": true,
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
       }
     },
     "object.entries": {
@@ -33033,6 +22086,11 @@
         "find-up": "^4.0.0"
       }
     },
+    "possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
+    },
     "postcss": {
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
@@ -33283,53 +22341,10 @@
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -33343,51 +22358,6 @@
         "@remirror/core-utils": "^2.0.13",
         "prosemirror-model": "^1.22.1",
         "prosemirror-view": "^1.33.8"
-      },
-      "dependencies": {
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "prosemirror-schema-list": {
@@ -33422,53 +22392,10 @@
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-          "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-          "requires": {
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
         }
       }
     },
@@ -33493,11 +22420,6 @@
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -33671,11 +22593,6 @@
         "scheduler": "^0.23.0"
       }
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "react-hook-form": {
       "version": "6.15.8",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
@@ -33686,13 +22603,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-popper": {
-      "version": "2.2.5",
-      "requires": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      }
     },
     "react-qr-code": {
       "version": "2.0.7",
@@ -33749,12 +22659,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-universal-interface": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-      "requires": {}
-    },
     "reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
@@ -33793,28 +22697,6 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "reakit-system": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-      "requires": {
-        "reakit-utils": "^0.15.2"
-      }
-    },
-    "reakit-utils": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-      "requires": {}
-    },
-    "reakit-warning": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
-      "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
-      "requires": {
-        "reakit-utils": "^0.15.2"
       }
     },
     "recharts": {
@@ -33856,6 +22738,21 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "reflect.getprototypeof": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.8.tgz",
+      "integrity": "sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==",
+      "requires": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "dunder-proto": "^1.0.0",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.2.0",
+        "which-builtin-type": "^1.2.0"
+      }
+    },
     "refractor": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
@@ -33872,11 +22769,14 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regexp.prototype.flags": {
-      "version": "1.3.0",
-      "dev": true,
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.2"
       }
     },
     "regexpp": {
@@ -33886,186 +22786,77 @@
       "dev": true
     },
     "remirror": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/remirror/-/remirror-2.0.4.tgz",
-      "integrity": "sha512-zsOH7wm/yLk7FSC8BjCNH8zq4JdkHFid4HwJg05elqPMx8GQ91vPcIqupZxa6kyOTM1ZbYiRtXPMFecCCRh5jg==",
+      "version": "2.0.40",
+      "resolved": "https://registry.npmjs.org/remirror/-/remirror-2.0.40.tgz",
+      "integrity": "sha512-l60kVS9Ad+rlmLK7WxEaExcUXmNHX+jREH1ZhqGJ7Qv6Cr68He3rkbHeUQtJabGYYQ2ZfchJ/QfnEmQ3hHwaxQ==",
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@remirror/core": "^2.0.3",
-        "@remirror/core-constants": "^2.0.0",
-        "@remirror/core-helpers": "^2.0.0",
-        "@remirror/core-types": "^2.0.0",
-        "@remirror/core-utils": "^2.0.3",
-        "@remirror/dom": "^2.0.4",
-        "@remirror/extension-annotation": "^2.0.4",
-        "@remirror/extension-bidi": "^2.0.3",
-        "@remirror/extension-blockquote": "^2.0.3",
-        "@remirror/extension-bold": "^2.0.3",
-        "@remirror/extension-callout": "^2.0.3",
-        "@remirror/extension-code": "^2.0.3",
-        "@remirror/extension-code-block": "^2.0.3",
-        "@remirror/extension-codemirror5": "^2.0.3",
-        "@remirror/extension-collaboration": "^2.0.3",
-        "@remirror/extension-columns": "^2.0.3",
-        "@remirror/extension-diff": "^2.0.3",
-        "@remirror/extension-doc": "^2.0.3",
-        "@remirror/extension-drop-cursor": "^2.0.3",
-        "@remirror/extension-embed": "^2.0.3",
-        "@remirror/extension-emoji": "^2.0.3",
-        "@remirror/extension-entity-reference": "^2.0.4",
-        "@remirror/extension-epic-mode": "^2.0.3",
-        "@remirror/extension-events": "^2.1.3",
-        "@remirror/extension-font-family": "^2.0.3",
-        "@remirror/extension-font-size": "^2.0.3",
-        "@remirror/extension-gap-cursor": "^2.0.3",
-        "@remirror/extension-hard-break": "^2.0.3",
-        "@remirror/extension-heading": "^2.0.3",
-        "@remirror/extension-history": "^2.0.3",
-        "@remirror/extension-horizontal-rule": "^2.0.3",
-        "@remirror/extension-image": "^2.0.3",
-        "@remirror/extension-italic": "^2.0.3",
-        "@remirror/extension-link": "^2.0.4",
-        "@remirror/extension-list": "^2.0.4",
-        "@remirror/extension-markdown": "^2.0.3",
-        "@remirror/extension-mention": "^2.0.4",
-        "@remirror/extension-mention-atom": "^2.0.4",
-        "@remirror/extension-node-formatting": "^2.0.3",
-        "@remirror/extension-paragraph": "^2.0.3",
-        "@remirror/extension-placeholder": "^2.0.3",
-        "@remirror/extension-positioner": "^2.0.4",
-        "@remirror/extension-search": "^2.0.3",
-        "@remirror/extension-shortcuts": "^2.0.3",
-        "@remirror/extension-strike": "^2.0.3",
-        "@remirror/extension-sub": "^2.0.3",
-        "@remirror/extension-sup": "^2.0.3",
-        "@remirror/extension-tables": "^2.0.3",
-        "@remirror/extension-text": "^2.0.3",
-        "@remirror/extension-text-case": "^2.0.3",
-        "@remirror/extension-text-color": "^2.0.3",
-        "@remirror/extension-text-highlight": "^2.0.3",
-        "@remirror/extension-trailing-node": "^2.0.3",
-        "@remirror/extension-underline": "^2.0.3",
-        "@remirror/extension-whitespace": "^2.0.3",
-        "@remirror/extension-yjs": "^3.0.3",
-        "@remirror/icons": "^2.0.0",
-        "@remirror/preset-core": "^2.0.4",
-        "@remirror/preset-formatting": "^2.0.3",
-        "@remirror/preset-wysiwyg": "^2.0.4",
-        "@remirror/theme": "^2.0.0",
-        "@types/codemirror": "^5.60.2",
+        "@babel/runtime": "^7.22.3",
+        "@remirror/core": "^2.0.19",
+        "@remirror/core-constants": "^2.0.2",
+        "@remirror/core-helpers": "^3.0.0",
+        "@remirror/core-types": "^2.0.6",
+        "@remirror/core-utils": "^2.0.13",
+        "@remirror/dom": "^2.0.16",
+        "@remirror/extension-annotation": "^2.0.16",
+        "@remirror/extension-bidi": "^2.0.15",
+        "@remirror/extension-blockquote": "^2.0.14",
+        "@remirror/extension-bold": "^2.0.13",
+        "@remirror/extension-callout": "^2.0.16",
+        "@remirror/extension-code": "^2.0.13",
+        "@remirror/extension-code-block": "^2.0.19",
+        "@remirror/extension-codemirror5": "^2.0.14",
+        "@remirror/extension-collaboration": "^2.0.13",
+        "@remirror/extension-columns": "^2.0.15",
+        "@remirror/extension-diff": "^2.0.13",
+        "@remirror/extension-doc": "^2.1.6",
+        "@remirror/extension-drop-cursor": "^2.0.13",
+        "@remirror/extension-embed": "^2.0.15",
+        "@remirror/extension-emoji": "^2.0.18",
+        "@remirror/extension-entity-reference": "^2.2.7",
+        "@remirror/extension-epic-mode": "^2.0.13",
+        "@remirror/extension-events": "^2.1.17",
+        "@remirror/extension-font-family": "^2.0.14",
+        "@remirror/extension-font-size": "^2.0.14",
+        "@remirror/extension-gap-cursor": "^2.0.13",
+        "@remirror/extension-hard-break": "^2.0.13",
+        "@remirror/extension-heading": "^2.0.15",
+        "@remirror/extension-history": "^2.0.13",
+        "@remirror/extension-horizontal-rule": "^2.0.13",
+        "@remirror/extension-image": "^2.1.11",
+        "@remirror/extension-italic": "^2.0.13",
+        "@remirror/extension-link": "^2.0.18",
+        "@remirror/extension-list": "^2.0.17",
+        "@remirror/extension-markdown": "^2.0.14",
+        "@remirror/extension-mention": "^2.0.16",
+        "@remirror/extension-mention-atom": "^2.0.18",
+        "@remirror/extension-node-formatting": "^2.0.14",
+        "@remirror/extension-paragraph": "^2.0.13",
+        "@remirror/extension-placeholder": "^2.0.14",
+        "@remirror/extension-positioner": "^2.1.8",
+        "@remirror/extension-search": "^2.0.14",
+        "@remirror/extension-shortcuts": "^2.0.13",
+        "@remirror/extension-strike": "^2.0.13",
+        "@remirror/extension-sub": "^2.0.13",
+        "@remirror/extension-sup": "^2.0.13",
+        "@remirror/extension-tables": "^2.4.2",
+        "@remirror/extension-text": "^2.0.13",
+        "@remirror/extension-text-case": "^2.0.14",
+        "@remirror/extension-text-color": "^2.0.16",
+        "@remirror/extension-text-highlight": "^2.0.15",
+        "@remirror/extension-trailing-node": "^2.0.13",
+        "@remirror/extension-underline": "^2.0.13",
+        "@remirror/extension-whitespace": "^2.0.13",
+        "@remirror/extension-yjs": "^3.0.16",
+        "@remirror/icons": "^2.0.3",
+        "@remirror/preset-core": "^2.0.16",
+        "@remirror/preset-formatting": "^2.0.14",
+        "@remirror/preset-wysiwyg": "^2.0.19",
+        "@remirror/theme": "^2.0.9",
+        "@types/codemirror": "^5.60.7",
         "@types/refractor": "^3.0.2",
-        "codemirror": "^5.62.0",
-        "refractor": "^3.3.1",
-        "yjs": "^13.5.23"
-      },
-      "dependencies": {
-        "@linaria/core": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@linaria/core/-/core-4.2.10.tgz",
-          "integrity": "sha512-S1W01W7L4SQnGpWzp8awyCpPIYUOEJ+OLjjXqKpIXOU+ozPwBt86Mjjdas9aZccVhNBWDja74cMCUAVp8yUpDQ==",
-          "requires": {
-            "@linaria/logger": "^4.0.0",
-            "@linaria/tags": "^4.3.5",
-            "@linaria/utils": "^4.3.4"
-          }
-        },
-        "@remirror/core-constants": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
-          "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
-        },
-        "@remirror/core-helpers": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-2.0.4.tgz",
-          "integrity": "sha512-aYoiJ8x/Sxc4OIZCcZI2tSa92rOufzpDkVTHtwh8+HEsGj0PumUrXbwVd3jHZRSoOUNYNG8fPnOmzuVOsO9CMQ==",
-          "requires": {
-            "@linaria/core": "4.2.10",
-            "@remirror/core-constants": "^2.0.2",
-            "@remirror/types": "^1.0.1",
-            "@types/object.omit": "^3.0.0",
-            "@types/object.pick": "^1.3.2",
-            "@types/throttle-debounce": "^2.1.0",
-            "case-anything": "^2.1.13",
-            "dash-get": "^1.0.2",
-            "deepmerge": "^4.3.1",
-            "fast-deep-equal": "^3.1.3",
-            "make-error": "^1.3.6",
-            "object.omit": "^3.0.0",
-            "object.pick": "^1.3.0",
-            "throttle-debounce": "^3.0.1"
-          }
-        },
-        "@remirror/icons": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@remirror/icons/-/icons-2.0.3.tgz",
-          "integrity": "sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@remirror/core-helpers": "^3.0.0"
-          },
-          "dependencies": {
-            "@remirror/core-helpers": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@remirror/core-helpers/-/core-helpers-3.0.0.tgz",
-              "integrity": "sha512-tusEgQJIqg4qKj6HSBUFcyRnWnziw3neh4T9wOmsPGHFC3w9kl5KSrDb9UAgE8uX6y32FnS7vJ955mWOl3n50A==",
-              "requires": {
-                "@remirror/core-constants": "^2.0.2",
-                "@remirror/types": "^1.0.1",
-                "@types/object.omit": "^3.0.0",
-                "@types/object.pick": "^1.3.2",
-                "@types/throttle-debounce": "^2.1.0",
-                "case-anything": "^2.1.13",
-                "dash-get": "^1.0.2",
-                "deepmerge": "^4.3.1",
-                "fast-deep-equal": "^3.1.3",
-                "make-error": "^1.3.6",
-                "object.omit": "^3.0.0",
-                "object.pick": "^1.3.0",
-                "throttle-debounce": "^3.0.1"
-              }
-            }
-          }
-        },
-        "@remirror/theme": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/@remirror/theme/-/theme-2.0.9.tgz",
-          "integrity": "sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==",
-          "requires": {
-            "@babel/runtime": "^7.22.3",
-            "@linaria/core": "4.2.10",
-            "@remirror/core-types": "^2.0.5",
-            "color2k": "^2.0.2",
-            "csstype": "^3.1.2"
-          }
-        },
-        "@remirror/types": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@remirror/types/-/types-1.0.1.tgz",
-          "integrity": "sha512-VlZQxwGnt1jtQ18D6JqdIF+uFZo525WEqrfp9BOc3COPpK4+AWCgdnAWL+ho6imWcoINlGjR/+3b6y5C1vBVEA==",
-          "requires": {
-            "type-fest": "^2.19.0"
-          }
-        },
-        "case-anything": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
-          "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="
-        },
-        "color2k": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-          "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
-        },
-        "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
+        "codemirror": "^5.65.13",
+        "refractor": "^3.6.0",
+        "yjs": "^13.6.1"
       }
     },
     "remove-accents": {
@@ -34186,12 +22977,6 @@
         "is-integer": "~1.0.4"
       }
     },
-    "rtl-css-js": {
-      "version": "1.15.0",
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -34219,11 +23004,33 @@
       "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
       "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
     },
+    "safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "requires": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-regex-test": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.1.4"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -34329,11 +23136,6 @@
           "dev": true
         }
       }
-    },
-    "screenfull": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -34469,7 +23271,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "requires": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -34479,10 +23280,16 @@
         "has-property-descriptors": "^1.0.2"
       }
     },
-    "set-harmonic-interval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
-      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
+    "set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      }
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -34524,7 +23331,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -34537,21 +23343,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        }
-      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -34624,7 +23415,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.2.0",
@@ -34641,11 +23433,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "space-separated-tokens": {
       "version": "1.1.5",
@@ -34730,12 +23517,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "stack-generator": {
-      "version": "2.0.5",
-      "requires": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -34751,33 +23532,6 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
-      }
-    },
-    "stackframe": {
-      "version": "1.2.0"
-    },
-    "stacktrace-gps": {
-      "version": "3.0.4",
-      "requires": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.1.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA=="
-        }
-      }
-    },
-    "stacktrace-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
-      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
-      "requires": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
       }
     },
     "statuses": {
@@ -34828,31 +23582,57 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.2",
-      "dev": true,
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+      "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
-        "has-symbols": "^1.0.1",
-        "internal-slot": "^1.0.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.2"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "regexp.prototype.flags": "^1.5.2",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.0.6"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "requires": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "dev": true,
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "dev": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -34958,6 +23738,11 @@
     },
     "symbol-observable": {
       "version": "1.2.0"
+    },
+    "tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "table": {
       "version": "5.4.6",
@@ -35088,7 +23873,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinycolor2": {
-      "version": "1.4.2"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -35114,21 +23901,11 @@
         "is-number": "^7.0.0"
       }
     },
-    "toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
-    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
-    },
-    "ts-easing": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
-      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "ts-jest": {
       "version": "29.1.1",
@@ -35310,7 +24087,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -35365,9 +24143,71 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "typed-array-byte-offset": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
+      "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "reflect.getprototypeof": "^1.0.6"
+      }
+    },
+    "typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      }
+    },
     "typescript": {
-      "version": "4.5.5",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -35397,7 +24237,9 @@
       }
     },
     "use-isomorphic-layout-effect": {
-      "version": "1.1.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
       "requires": {}
     },
     "use-memo-one": {
@@ -35405,9 +24247,9 @@
       "requires": {}
     },
     "use-previous": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-previous/-/use-previous-1.1.0.tgz",
-      "integrity": "sha512-t6ltKuYIpvcqD+VBnlUOaT+N94bN7HwUdB1u7rSpCIh9XvMJQIjsw/G8DoJlSDh029khFQ2L8q88oUWfKoWy5w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-previous/-/use-previous-1.2.0.tgz",
+      "integrity": "sha512-tK7Ne779nqTKGeh0rsFvxnQcEqePFRYlM0rfmNy9JH+h+2ndja7P0017nda0Q1gkqfcOD//pKZbDyyLIUH2s+Q==",
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.0"
       }
@@ -35467,7 +24309,9 @@
       }
     },
     "w3c-keyname": {
-      "version": "2.2.4"
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "walker": {
       "version": "1.0.8",
@@ -35476,14 +24320,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -35739,6 +24575,61 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
+      "integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+      "requires": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.0",
+        "is-number-object": "^1.1.0",
+        "is-string": "^1.1.0",
+        "is-symbol": "^1.1.0"
+      }
+    },
+    "which-builtin-type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
+      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.0.5",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.1.4",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.15"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "requires": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
+      "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.2"
       }
     },
     "wildcard": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mui/material": "^5.15.10",
     "@mui/styles": "^5.15.10",
     "@mui/x-data-grid": "^5.17.12",
-    "@remirror/pm": "^1.0.11",
+    "@remirror/pm": "^2.0.9",
     "@remirror/react": "^1.0.21",
     "@types/lodash": "^4.14.176",
     "@types/react-beautiful-dnd": "^13.0.0",
@@ -50,7 +50,7 @@
     "react-qr-code": "^2.0.7",
     "react-router-dom": "^6.2.1",
     "recharts": "2.12.6",
-    "remirror": "^1.0.60"
+    "remirror": "^2.0.4"
   },
   "resolutions": {
     "csstype": "^2.6.18"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ts-jest": "^29.1.1",
     "ts-loader": "^6.1.2",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
-    "typescript": "^4.5.5",
+    "typescript": "^5.7.2",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.0.2",
     "webpack-dev-server": "^4.13.3"
@@ -35,7 +35,7 @@
     "@mui/styles": "^5.15.10",
     "@mui/x-data-grid": "^5.17.12",
     "@remirror/pm": "^2.0.9",
-    "@remirror/react": "^1.0.21",
+    "@remirror/react": "^2.0.35",
     "@types/lodash": "^4.14.176",
     "@types/react-beautiful-dnd": "^13.0.0",
     "date-fns": "^2.29.3",
@@ -50,7 +50,7 @@
     "react-qr-code": "^2.0.7",
     "react-router-dom": "^6.2.1",
     "recharts": "2.12.6",
-    "remirror": "^2.0.4"
+    "remirror": "^2.0.40"
   },
   "resolutions": {
     "csstype": "^2.6.18"

--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -9,12 +9,11 @@ import {
   createMarkPositioner,
 } from 'remirror/extensions';
 import {
-  ComponentItem,
+  CommandButtonGroup,
   EditorComponent,
   FloatingToolbar,
   FloatingWrapper,
   Remirror,
-  ToolbarItemUnion,
   useActive,
   useAttrs,
   useChainedCommands,
@@ -225,11 +224,9 @@ function useFloatingLinkState() {
   );
 }
 
-// ReMirror/ProseMirror FLOATING LINK MENU BUTTONS
 const FloatingLinkToolbar = () => {
   const {
     isEditing,
-    linkPositioner,
     clickEdit,
     onRemove,
     submitHref,
@@ -239,34 +236,36 @@ const FloatingLinkToolbar = () => {
   } = useFloatingLinkState();
   const active = useActive();
   const activeLink = active.link();
-  const { empty } = useCurrentSelection();
-  const linkEditItems: ToolbarItemUnion[] = useMemo(
-    () => [
-      {
-        type: ComponentItem.ToolbarGroup,
-        label: 'Link',
-        items: activeLink
-          ? [
-              { type: ComponentItem.ToolbarButton, onClick: () => clickEdit(), label: 'Edit link' },
-              { type: ComponentItem.ToolbarButton, onClick: onRemove, label: 'Remove link' },
-            ]
-          : [{ type: ComponentItem.ToolbarButton, onClick: () => clickEdit(), label: 'Add link' }],
-      },
-    ],
-    [clickEdit, onRemove, activeLink],
-  );
-
-  const items: ToolbarItemUnion[] = useMemo(() => linkEditItems, [linkEditItems]);
-
   return (
     <>
-      <FloatingToolbar items={items} positioner="selection" placement="top" enabled={!isEditing} />
-      <FloatingToolbar
-        items={linkEditItems}
-        positioner={linkPositioner}
-        placement="bottom"
-        enabled={!isEditing && empty}
-      />
+      <FloatingToolbar placement="top">
+        <CommandButtonGroup>
+          {activeLink ? (
+            <>
+              <button
+                className={`remirror-button ${active.bold() && 'remirror-button-active'}`}
+                onClick={clickEdit}
+              >
+                Edit link
+              </button>
+              <button
+                className={`remirror-button ${active.bold() && 'remirror-button-active'}`}
+                onClick={onRemove}
+              >
+                Remove link
+              </button>
+            </>
+          ) : (
+            <button
+              className={`remirror-button ${active.bold() && 'remirror-button-active'}`}
+              onClick={clickEdit}
+            >
+              Add link
+            </button>
+          )}
+        </CommandButtonGroup>
+      </FloatingToolbar>
+
       <FloatingWrapper
         positioner="always"
         placement="bottom"

--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -541,10 +541,10 @@ const RichTextEditor: React.FC<RichTextEditorProps<string[]>> = ({
   // Instantiate the Remirror RTE component
   const { manager, state } = useRemirror({
     extensions: () => [
-      new MyBoldExtension(),
+      new MyBoldExtension({}),
       new MyItalicExtension(),
       new LinkExtension({ autoLink: true }),
-      new TextHighlightExtension(),
+      new TextHighlightExtension({}),
       new RemovePastedHtmlExtension(),
     ],
     content: parseCopyForParagraphs(copyData),

--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -242,24 +242,15 @@ const FloatingLinkToolbar = () => {
         <CommandButtonGroup>
           {activeLink ? (
             <>
-              <button
-                className={`remirror-button ${active.bold() && 'remirror-button-active'}`}
-                onClick={clickEdit}
-              >
+              <button className="remirror-button" onClick={clickEdit}>
                 Edit link
               </button>
-              <button
-                className={`remirror-button ${active.bold() && 'remirror-button-active'}`}
-                onClick={onRemove}
-              >
+              <button className="remirror-button" onClick={onRemove}>
                 Remove link
               </button>
             </>
           ) : (
-            <button
-              className={`remirror-button ${active.bold() && 'remirror-button-active'}`}
-              onClick={clickEdit}
-            >
+            <button className="remirror-button" onClick={clickEdit}>
               Add link
             </button>
           )}


### PR DESCRIPTION
## What does this change?

Upgrades remirror, remirror/pm, remirror/react and Typescript to the next major version and removes the high vulnerability on Marked.

Also removes some minor vulnerabilities through the use of npm audit fix.

Tested locally in a banner and seems to work fine.

## Screenshot of testing

<img width="587" alt="Screenshot 2024-12-12 at 15 21 29" src="https://github.com/user-attachments/assets/73c1eef0-db75-4c07-9dc7-3a168411c6d2">
