### PR TITLE
Use methodology test name for analytics data

### DIFF
--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -126,7 +126,9 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
           </div>
         </>
       )}
-      {isBandit(methodology) && <BanditAnalyticsButton testName={testName} channel={channel} />}
+      {isBandit(methodology) && (
+        <BanditAnalyticsButton testName={methodology.testName ?? testName} channel={channel} />
+      )}
       <div className={classes.testNameAndDeleteButton}>
         {methodology.testName && <div className={classes.testName}>{methodology.testName}</div>}
         <div className={classes.deleteButton}>


### PR DESCRIPTION
If there is more than one methodology then we give each methodology a separate test name, so that we can track them separately.
Currently the bandit analytics data feature uses the main test name, but it should use the methodology test name if available.
Currently this means that if there is more than one methodology then it queries for the wrong test name, and no data is displayed