### PR TITLE
Make bandit sample count configurable

### DIFF
--- a/app/controllers/BanditDataController.scala
+++ b/app/controllers/BanditDataController.scala
@@ -9,6 +9,7 @@ import utils.Circe.noNulls
 import zio.{IO, ZEnv, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 class BanditDataController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
@@ -28,8 +29,9 @@ class BanditDataController(
 
   def getDataForTest(channel: String, testName: String): Action[AnyContent] = authAction.async { request =>
     run {
+      val sampleCount: Option[Int] = request.getQueryString("sampleCount").flatMap(s => Try(Integer.parseInt(s)).toOption)
       dynamo
-        .getDataForTest(testName, channel)
+        .getDataForTest(testName, channel, sampleCount)
         .map(data => Ok(noNulls(data.asJson)))
     }
   }

--- a/app/models/Methodology.scala
+++ b/app/models/Methodology.scala
@@ -16,12 +16,14 @@ case class ABTest(
 case class EpsilonGreedyBandit(
   name: String = "EpsilonGreedyBandit",
   epsilon: Double,
-  testName: Option[String] = None
+  testName: Option[String] = None,
+  sampleCount: Option[Int] = None
 ) extends Methodology
 
 case class Roulette(
   name: String = "Roulette",
-  testName: Option[String] = None
+  testName: Option[String] = None,
+  sampleCount: Option[Int] = None
 ) extends Methodology
 
 case object Methodology {

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -42,7 +42,7 @@ object BanditData {
 
 class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogging {
   // No DEV table for bandit data
-  private val tableName = s"support-bandit-${if (stage == "PROD") "PROD" else "PROD"}"
+  private val tableName = s"support-bandit-${if (stage == "PROD") "PROD" else "CODE"}"
 
   private def query(testName: String, channel: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] = {
     effectBlocking {

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -86,7 +86,7 @@ class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogg
       .zipWithIndex
       .foldLeft(Array.empty[EnrichedTestSampleData]) { case (enrichedSamples, (sample, idx)) =>
         val variants = sample.variants.map(currentVariantSample => {
-          val startIdx = idx - sampleCount.getOrElse(0)
+          val startIdx = sampleCount.map(n => Math.max(idx - n, 0)).getOrElse(0)  // only use the last sampleCount samples, if defined
           val previousSamples = samplesByVariant(currentVariantSample.variantName).slice(startIdx, idx+1)
 
           val population = previousSamples.map(_.views).sum

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -41,7 +41,8 @@ object BanditData {
 }
 
 class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogging {
-  private val tableName = s"support-bandit-$stage"
+  // No DEV table for bandit data
+  private val tableName = s"support-bandit-${if (stage == "PROD") "PROD" else "CODE"}"
 
   private def query(testName: String, channel: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] = {
     effectBlocking {

--- a/public/src/components/channelManagement/BanditAnalyticsButton.tsx
+++ b/public/src/components/channelManagement/BanditAnalyticsButton.tsx
@@ -84,11 +84,13 @@ const SamplesChart = ({ data, variantNames, fieldName }: SamplesChartProps) => {
 interface BanditAnalyticsButton {
   testName: string;
   channel: string;
+  sampleCount?: number;
 }
 
 export const BanditAnalyticsButton: React.FC<BanditAnalyticsButton> = ({
   testName,
   channel,
+  sampleCount,
 }: BanditAnalyticsButton) => {
   const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
@@ -98,7 +100,8 @@ export const BanditAnalyticsButton: React.FC<BanditAnalyticsButton> = ({
   useEffect(() => {
     setLoading(true);
 
-    fetch(`/frontend/bandit/${channel}/${testName}`)
+    const queryString = sampleCount ? `?sampleCount=${sampleCount}` : '';
+    fetch(`/frontend/bandit/${channel}/${testName}${queryString}`)
       .then(resp => resp.json())
       .then(data => {
         setData(data);

--- a/public/src/components/channelManagement/BanditAnalyticsButton.tsx
+++ b/public/src/components/channelManagement/BanditAnalyticsButton.tsx
@@ -9,6 +9,9 @@ const useStyles = makeStyles(({}: Theme) => ({
   dialog: {
     padding: '10px',
   },
+  analyticsButton: {
+    height: '100%',
+  },
   heading: {
     margin: '6px 12px 0 12px',
     fontSize: 18,
@@ -107,7 +110,7 @@ export const BanditAnalyticsButton: React.FC<BanditAnalyticsButton> = ({
 
   return (
     <>
-      <Button variant="outlined" onClick={open}>
+      <Button className={classes.analyticsButton} variant="outlined" onClick={open}>
         Analytics
       </Button>
 

--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -215,7 +215,11 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
       )}
       {isBandit(methodology) && (
         <div>
-          <BanditAnalyticsButton testName={methodology.testName ?? testName} channel={channel} />
+          <BanditAnalyticsButton
+            testName={methodology.testName ?? testName}
+            channel={channel}
+            sampleCount={methodology.sampleCount}
+          />
         </div>
       )}
       <div className={classes.testNameAndDeleteButton}>

--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Methodology } from './helpers/shared';
+import { BanditMethodology, Methodology } from './helpers/shared';
 import { makeStyles } from '@mui/styles';
 import { BanditAnalyticsButton } from './BanditAnalyticsButton';
 import {
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Select,
   SelectChangeEvent,
+  Switch,
   TextField,
   Theme,
   Tooltip,
@@ -15,8 +16,10 @@ import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import Alert from '@mui/lab/Alert';
 import { addMethodologyToTestName } from './helpers/methodology';
+import FileCopyIcon from '@mui/icons-material/FileCopy';
+import { grey } from '@mui/material/colors';
 
-const isBandit = (methodology: Methodology): boolean =>
+const isBandit = (methodology: Methodology): methodology is BanditMethodology =>
   methodology.name === 'EpsilonGreedyBandit' || methodology.name === 'Roulette';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
@@ -32,7 +35,9 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     borderRadius: '4px',
     padding: spacing(1),
     '& > * + *': {
-      marginLeft: spacing(1),
+      marginLeft: spacing(2),
+      paddingLeft: spacing(2),
+      borderLeft: `1px solid ${palette.grey[400]}`,
     },
   },
   audiencePercentage: {
@@ -51,18 +56,80 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
       height: '100%',
     },
   },
-  testName: {
+  copyNameButton: {
     marginRight: spacing(2),
-    fontWeight: 500,
+    fontSize: '14px',
+    fontWeight: 'normal',
+    color: palette.grey[700],
+    lineHeight: 1.5,
   },
   error: {
     color: 'red',
+  },
+  sampleCountContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '14px',
+    fontWeight: 500,
+  },
+  sampleCountInput: {
+    maxWidth: '90px',
+    marginLeft: spacing(1),
   },
 }));
 
 const defaultEpsilonGreedyBandit: Methodology = {
   name: 'EpsilonGreedyBandit',
   epsilon: 0.1,
+};
+
+interface MethodologySampleCountProps {
+  sampleCount?: number;
+  onChange: (sampleCount?: number) => void;
+  isDisabled: boolean;
+}
+const MethodologySampleCount: React.FC<MethodologySampleCountProps> = ({
+  sampleCount,
+  onChange,
+  isDisabled,
+}: MethodologySampleCountProps) => {
+  const classes = useStyles();
+
+  const onSwitchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.checked) {
+      onChange(24);
+    } else {
+      onChange(undefined);
+    }
+  };
+
+  return (
+    <div className={classes.sampleCountContainer}>
+      <Tooltip
+        title={
+          'Only look back this many hours. If disabled, uses all data since the start of the test.'
+        }
+      >
+        <div>
+          <div>Window</div>
+          <Switch checked={!!sampleCount} onChange={onSwitchChange} disabled={isDisabled} />
+        </div>
+      </Tooltip>
+      <TextField
+        className={classes.sampleCountInput}
+        type={'number'}
+        InputProps={{ inputProps: { min: 6, step: 1 } }}
+        value={sampleCount}
+        label={'Hours'}
+        disabled={isDisabled || !sampleCount}
+        InputLabelProps={{ shrink: true }}
+        onChange={event => {
+          const samples = parseInt(event.target.value);
+          onChange(samples);
+        }}
+      />
+    </div>
+  );
 };
 
 interface TestMethodologyProps {
@@ -97,13 +164,15 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
     }
   };
 
+  const methodologyTestName = methodology.testName;
+
   return (
     <div className={classes.methodologyContainer}>
       <Tooltip title={'Percentage of the audience in this methodology'}>
         <div className={classes.audiencePercentage}>{audiencePercentage}%</div>
       </Tooltip>
       <div>
-        <Select value={methodology.name} onChange={onSelectChange}>
+        <Select value={methodology.name} disabled={isDisabled} onChange={onSelectChange}>
           <MenuItem value={'ABTest'} key={'ABTest'}>
             AB test
           </MenuItem>
@@ -115,6 +184,18 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
           </MenuItem>
         </Select>
       </div>
+      {isBandit(methodology) && (
+        <MethodologySampleCount
+          sampleCount={methodology.sampleCount}
+          onChange={sampleCount =>
+            onChange({
+              ...methodology,
+              sampleCount,
+            })
+          }
+          isDisabled={isDisabled}
+        />
+      )}
       {methodology.name === 'EpsilonGreedyBandit' && (
         <>
           <div>
@@ -133,10 +214,23 @@ const TestMethodology: React.FC<TestMethodologyProps> = ({
         </>
       )}
       {isBandit(methodology) && (
-        <BanditAnalyticsButton testName={methodology.testName ?? testName} channel={channel} />
+        <div>
+          <BanditAnalyticsButton testName={methodology.testName ?? testName} channel={channel} />
+        </div>
       )}
       <div className={classes.testNameAndDeleteButton}>
-        {methodology.testName && <div className={classes.testName}>{methodology.testName}</div>}
+        {methodologyTestName && (
+          <Button
+            className={classes.copyNameButton}
+            variant="outlined"
+            startIcon={<FileCopyIcon style={{ color: grey[700] }} />}
+            onClick={() => {
+              navigator.clipboard.writeText(methodologyTestName);
+            }}
+          >
+            Copy test name
+          </Button>
+        )}
         <div className={classes.deleteButton}>
           <Button onClick={onDelete} disabled={isDisabled} variant="outlined" size="medium">
             <CloseIcon />

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -19,9 +19,11 @@ interface ABTestMethodology {
 interface EpsilonGreedyBanditMethodology {
   name: 'EpsilonGreedyBandit';
   epsilon: number;
+  sampleCount?: number;
 }
 interface RouletteMethodology {
   name: 'Roulette';
+  sampleCount?: number;
 }
 // each methodology may have an optional testName, which should be used for tracking
 export type Methodology = { testName?: string } & (
@@ -29,6 +31,7 @@ export type Methodology = { testName?: string } & (
   | EpsilonGreedyBanditMethodology
   | RouletteMethodology
 );
+export type BanditMethodology = Exclude<Methodology, { name: 'ABTest' }>;
 
 export interface Test {
   name: string;


### PR DESCRIPTION
[Related SDC PR](https://github.com/guardian/support-dotcom-components/pull/1260).

Marketing would like to be able to configure a test to only query the most recent N hours.
This PR adds an optional `sampleCount` field to the methodology model, to configure the number hourly samples.

In the tool this is displayed as a "Window" toggle with a numeric input. If the toggle is off, the input is disabled and there is no limit on the data. If the toggle is on, the number of hours is configurable, with a minimum of 6.

I've also changed how the test name is displayed in the methodologies part of the tool. Previously it displayed the entire name, which can get very long. Now it's just a button that copies the test name to clipboard.

The data returned by the "analytics" button also changes, because it needs to reflect scores with the configured sampleCount.

### Before:
![Screenshot 2024-12-13 at 14 57 44](https://github.com/user-attachments/assets/5c98bfe6-3915-4e92-941b-d86d56ee2971)


### After:
![Screenshot 2024-12-13 at 14 56 50](https://github.com/user-attachments/assets/b1ce37f3-a3ef-4e24-be91-d5760857068c)
![Screenshot 2024-12-13 at 14 56 54](https://github.com/user-attachments/assets/76748c62-30be-4dd6-b310-b657b4072e4e)
