### PR TITLE
Add override for commons io vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ node_modules/
 .bloop/
 .metals/
 .bsp/
-project
+project/project
 dynamodb-local/
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,9 @@ dependencyOverrides ++= List(
   "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2",
   // The version of netty-handler currently used by athena has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-handler" % "4.1.100.Final",
-  "io.netty" % "netty-codec-http2" % "4.1.100.Final"
+  "io.netty" % "netty-codec-http2" % "4.1.100.Final",
+  // Related to Play 3.0.2-6 currently brings in a vulnerable version of commons-io
+  "commons-io" % "commons-io" % "2.14.0" % Test
 )
 
 excludeDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
## What does this change?

Adds a fix for the vulnerability on Apache commons-io that introduces a high vulnerabillity - [Apache Commons IO](https://github.com/guardian/support-admin-console/security/dependabot/130) which is introduced via org.playframework.  

Unfortunately, upgrading org.playframework to the latest version does not remove the vulnerable transient dependency, hence the override.

Also fixes an issue with the .gitignore file which ignored the plugins.sbt.

## How to test

Run sbt test
