### PR TITLE
RRCP Super mode dashboard to use new super-mode-calculator DynamoDB tables

### DIFF
--- a/app/services/DynamoSuperMode.scala
+++ b/app/services/DynamoSuperMode.scala
@@ -17,7 +17,7 @@ import java.util.Date
 import scala.jdk.CollectionConverters._
 
 class DynamoSuperMode(client: DynamoDbClient) extends StrictLogging {
-  private val tableName = s"super-mode-PROD"
+  private val tableName = s"super-mode-calculator-PROD"
 
   private val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
   private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -1117,7 +1117,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DynamoReadsupermodeA2B60FEA": {
+    "DynamoReadsupermodecalculatorEF384DA0": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1143,7 +1143,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-PROD",
+                      ":table/super-mode-calculator-PROD",
                     ],
                   ],
                 },
@@ -1159,7 +1159,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-PROD/index/*",
+                      ":table/super-mode-calculator-PROD/index/*",
                     ],
                   ],
                 },
@@ -1168,7 +1168,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DynamoReadsupermodeA2B60FEA",
+        "PolicyName": "DynamoReadsupermodecalculatorEF384DA0",
         "Roles": [
           {
             "Ref": "InstanceRoleAdminconsole347DA627",
@@ -1177,7 +1177,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DynamoReadsupermodeindexendFE67AC4E": {
+    "DynamoReadsupermodecalculatorindexend02A5F75C": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1203,7 +1203,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-PROD/index/end",
+                      ":table/super-mode-calculator-PROD/index/end",
                     ],
                   ],
                 },
@@ -1219,7 +1219,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-PROD/index/end/index/*",
+                      ":table/super-mode-calculator-PROD/index/end/index/*",
                     ],
                   ],
                 },
@@ -1228,7 +1228,7 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DynamoReadsupermodeindexendFE67AC4E",
+        "PolicyName": "DynamoReadsupermodecalculatorindexend02A5F75C",
         "Roles": [
           {
             "Ref": "InstanceRoleAdminconsole347DA627",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -252,11 +252,11 @@ export class AdminConsole extends GuStack {
       ...archivedTestsDynamoPolicies,
       ...bannerDesignsDynamoPolicies,
       ...archivedBannerDesignsDynamoPolicies,
-      new GuDynamoDBReadPolicy(this, `DynamoRead-super-mode`, {
-        tableName: 'super-mode-PROD', // always PROD for super mode
+      new GuDynamoDBReadPolicy(this, `DynamoRead-super-mode-calculator`, {
+        tableName: 'super-mode-calculator-PROD', // always PROD for super mode
       }),
-      new GuDynamoDBReadPolicy(this, `DynamoRead-super-mode/index/end`, {
-        tableName: `super-mode-PROD/index/end`,
+      new GuDynamoDBReadPolicy(this, `DynamoRead-super-mode-calculator/index/end`, {
+        tableName: `super-mode-calculator-PROD/index/end`,
       }),
       new GuDynamoDBReadPolicy(this, `DynamoRead-bandit-data`, {
         tableName: `support-bandit-${this.stage}`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR is to point the  Super Mode Dashboard  in the RRCP to the new super-mode-calculator-  DynamoDB  tables

## How to test

Tested in CODE

## Before Change
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/fe3c6391-e744-46da-9dd2-2b7349d1cef0" />


## After  Change

<img width="1117" alt="image" src="https://github.com/user-attachments/assets/57c9a853-55c6-4ec8-ab6c-1ff47b1b68c0" />


Note:

The number of super mode articles jumped from 95 to about 135 when we switched to new table