### PR TITLE
Update methodology testName when copying test

### DIFF
--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -17,6 +17,7 @@ import {
   updateStatuses,
 } from '../../utils/requests';
 import { useParams } from 'react-router-dom';
+import { addMethodologyToTestName } from './helpers/methodology';
 
 const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
   viewTextContainer: {
@@ -221,6 +222,10 @@ export const TestsForm = <T extends Test>(
           },
           isNew: true,
           campaignName,
+          methodologies: oldTest.methodologies.map(methodology => ({
+            ...methodology,
+            testName: addMethodologyToTestName(newName, methodology),
+          })),
         };
         setTests([...tests, newTest]);
         setSelectedTestName(newName);


### PR DESCRIPTION
In the RRCP users can copy a test - this is commonly used for regional variations, where a separate (but very similar) test is created for another region.

Separately, if a test has more than one methodology then we track those methodologies with different test names.

If a test with more than one methodology is copied, currently the methodology data is also copied as is. This is wrong, because it leads to a clash in names. This can then break the bandit data lambda when it tries to write multiple rows to dynamodb with the same name.

This PR changes the `onTestCopy` function to modify the `testName` field on each methodology to be based on the new test name.