### PR TITLE
Fix incorrect values in methodology editor

### DIFF
--- a/public/src/components/channelManagement/TestMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/TestMethodologyEditor.tsx
@@ -286,7 +286,7 @@ export const TestMethodologyEditor: React.FC<TestMethodologyEditorProps> = ({
 
       {methodologies.map((method, idx) => (
         <TestMethodology
-          key={`methodology-${idx}`}
+          key={`methodology-${testName}-${idx}`}
           methodology={method}
           testName={testName}
           channel={channel}


### PR DESCRIPTION
Bug:
1. first view a test with a methodology that has the "window" field defined
2. then view a test with a methodology that does not have a "window" field defined.

The "window" value from the first test will incorrectly also show in the field for the second test, even though it's not part of that test's data.

This is because the `key` on the `TestMethodology` component is not unique across tests, so React isn't re-rendering how we'd like it to.
The solution is to include the test name in the `key`