### PR TITLE
Add sbt-buildinfo plugin and embed the commit id

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,7 +1,7 @@
 {
   "checkpoints": {
     "PROD": {
-      "url": "https://support.gutools.co.uk",
+      "url": "https://support.gutools.co.uk/healthcheck",
       "overdue": "30M",
       "messages": {
         "seen": "prout/seen.md"

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.googleauth.AuthAction
+import play.api.libs.json.Json
 import play.api.mvc._
 
 class Application(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
@@ -9,8 +10,9 @@ class Application(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyC
                   sdcUrlOverride: Option[String])
     extends AbstractController(components) {
   def healthcheck = Action {
-    Ok("healthy")
+    Ok(Json.obj("status" -> "ok", "gitCommitId" -> app.BuildInfo.gitCommitId))
   }
+
 
   def index = authAction {
     Ok(views.html.index(stage, sdcUrlOverride))

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -20,5 +20,6 @@
       }
     </script>
     <script src="@routes.Assets.at("build/app.bundle.js")"></script>
+      <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
   </body>
 </html>

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,13 @@ val circeVersion = "0.14.1"
 val awsVersion = "2.20.162"
 val zioVersion = "1.0.14"
 
+lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, SbtWeb, JDebPackaging, SystemdPlugin,BuildInfoPlugin)
+  .settings(
+    buildInfoKeys := BuildInfoSettings.buildInfoKeys,
+    buildInfoPackage := "app",
+  )
+
+
 asciiGraphWidth := 999999999 // to ensure Snyk can read the the deeeeep dependency tree
 
 libraryDependencies ++= Seq(
@@ -58,8 +65,6 @@ Test / testOptions += {dynamoDBLocalTestCleanup.value}
 sources in(Compile, doc) := Seq.empty
 
 publishArtifact in(Compile, packageDoc) := false
-
-enablePlugins(PlayScala, RiffRaffArtifact, SbtWeb, JDebPackaging, SystemdPlugin)
 
 pipelineStages := Seq(digest)
 

--- a/project/BuildInfoSettings.scala
+++ b/project/BuildInfoSettings.scala
@@ -1,0 +1,20 @@
+import sbt.Keys.name
+import sbtbuildinfo.BuildInfoPlugin.autoImport.{BuildInfoKey, buildInfoKeys}
+
+import scala.sys.process._
+
+object BuildInfoSettings {
+  def env(key: String, default: String): String = Option(System.getenv(key)).getOrElse(default)
+
+  def commitId(): String = try {
+    "git rev-parse HEAD".!!.trim
+  } catch {
+    case _: Exception => "unknown"
+  }
+
+  val buildInfoKeys: Seq[BuildInfoKey] = Seq[BuildInfoKey](
+    name,
+    "gitCommitId" -> (Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse commitId()),
+  )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds the wiring for [PROUT](https://github.com/guardian/prout). This will allow us to see when our new work is live in PROD and serve as a reminder to monitor the changes in production and make sure we haven't broken anything.
The first step to add the Prout Configuration is done in the [PR](https://github.com/guardian/support-admin-console/pull/680)
How does it work?

The sbt-buildinfo plugin allows us to store the Git commit id in our artifact, and then expose that value in our production site
The /healthcheck endpoint  as well as the app/views/index.scala.html now exposes the Git commit id . 
We are checking  /heathcheck  for Prout.
The .prout.json config file defines what endpoints PROUT needs to hit in order to obtain the Git commit id as well as the amount of time before a build is considered Overdue
A Webhook on the apple-news Github repo hits PROUT on every push or pull-request event
Prout-bot has write access to the apple-news repo to update the PR with the correct labels