### PR TITLE
simplify locations deprecation

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Region } from '../../../utils/models';
 import {
   ArticlesViewedSettings,
   ConsentStatus,
@@ -132,36 +131,11 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
     onVariantsChange(test.variants.filter(variant => variant.name !== deletedVariantName));
   };
 
-  const onRegionsChange = (updatedRegions: Region[]): void => {
-    updateTest({ ...test, locations: updatedRegions });
-  };
-
-  function concatUniqueLocations(countryGroups: Region[], locations: Region[]) {
-    //This function is needed , otherwise for existing tests, on selecting All regions for targeting,
-    // the locations field will be added to the targetedCountryGroups field, which ends up in the test having same region multiple times
-    const existingLocations = new Set(countryGroups);
-
-    // Iterate through locations and add only unique ones to countryGroups
-    for (const location of locations) {
-      if (!existingLocations.has(location)) {
-        countryGroups.push(location);
-      }
-    }
-
-    return countryGroups;
-  }
-
   const onRegionTargetingChange = (updatedRegionTargeting: RegionTargeting): void => {
     updateTest({
       ...test,
-      regionTargeting: {
-        targetedCountryGroups: concatUniqueLocations(
-          updatedRegionTargeting.targetedCountryGroups,
-          test.locations,
-        ),
-        targetedCountryCodes: updatedRegionTargeting.targetedCountryCodes ?? [],
-      },
-      locations: [],
+      regionTargeting: updatedRegionTargeting,
+      locations: [], // deprecated
     });
   };
 
@@ -325,10 +299,12 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
           </Typography>
 
           <TestEditorTargetAudienceSelector
-            selectedRegions={test.locations}
-            onRegionsUpdate={onRegionsChange}
             regionTargeting={
-              test.regionTargeting ?? { targetedCountryGroups: [], targetedCountryCodes: [] }
+              test.regionTargeting ?? {
+                // For backwards compatibility with the deprecated locations field
+                targetedCountryGroups: test.locations,
+                targetedCountryCodes: [],
+              }
             }
             onRegionTargetingUpdate={onRegionTargetingChange}
             selectedCohort={test.userCohort}

--- a/public/src/components/channelManagement/epicTests/testEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/testEditor.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Region } from '../../../utils/models';
 import { EpicTest, EpicVariant, MaxEpicViews } from '../../../models/epic';
 import {
   ArticlesViewedSettings,
@@ -151,36 +150,11 @@ export const getEpicTestEditor = (
       });
     };
 
-    const onRegionsChange = (updatedRegions: Region[]): void => {
-      updateTest({ ...test, locations: updatedRegions });
-    };
-
-    function concatUniqueLocations(countryGroups: Region[], locations: Region[]) {
-      //This function is needed , otherwise for existing tests, on selecting All regions for targeting,
-      // the locations field will be added to the targetedCountryGroups field, which ends up in the test having same region multiple times
-      const existingLocations = new Set(countryGroups);
-
-      // Iterate through locations and add only unique ones to countryGroups
-      for (const location of locations) {
-        if (!existingLocations.has(location)) {
-          countryGroups.push(location);
-        }
-      }
-
-      return countryGroups;
-    }
-
     const onRegionTargetingChange = (updatedRegionTargeting: RegionTargeting): void => {
       updateTest({
         ...test,
-        regionTargeting: {
-          targetedCountryGroups: concatUniqueLocations(
-            updatedRegionTargeting.targetedCountryGroups,
-            test.locations,
-          ),
-          targetedCountryCodes: updatedRegionTargeting.targetedCountryCodes ?? [],
-        },
-        locations: [], //This is a hack to prevent the test from being saved with the locations field});
+        regionTargeting: updatedRegionTargeting,
+        locations: [], // deprecated
       });
     };
 
@@ -378,10 +352,12 @@ export const getEpicTestEditor = (
             </Typography>
 
             <TestEditorTargetAudienceSelector
-              selectedRegions={test.locations}
-              onRegionsUpdate={onRegionsChange}
               regionTargeting={
-                test.regionTargeting ?? { targetedCountryGroups: [], targetedCountryCodes: [] }
+                test.regionTargeting ?? {
+                  // For backwards compatibility with the deprecated locations field
+                  targetedCountryGroups: test.locations,
+                  targetedCountryCodes: [],
+                }
               }
               onRegionTargetingUpdate={onRegionTargetingChange}
               selectedCohort={test.userCohort}

--- a/public/src/components/channelManagement/gutterTests/gutterTestEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterTestEditor.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { GutterTest, GutterVariant } from '../../../models/gutter';
-import { Region } from '../../../utils/models';
 import {
   ConsentStatus,
   DeviceType,
@@ -76,12 +75,8 @@ const GutterTestEditor: React.FC<ValidatedTestEditorProps<GutterTest>> = ({
     });
   };
 
-  const onRegionsChange = (updatedRegions: Region[]): void => {
-    updateTest({ ...test, locations: updatedRegions });
-  };
-
   const onRegionTargetingChange = (updatedRegionTargeting: RegionTargeting): void => {
-    updateTest({ ...test, regionTargeting: updatedRegionTargeting });
+    updateTest({ ...test, regionTargeting: updatedRegionTargeting, locations: [] });
   };
 
   const onCohortChange = (updatedCohort: UserCohort): void => {
@@ -216,10 +211,12 @@ const GutterTestEditor: React.FC<ValidatedTestEditorProps<GutterTest>> = ({
         </Typography>
 
         <TestEditorTargetAudienceSelector
-          selectedRegions={test.locations}
-          onRegionsUpdate={onRegionsChange}
           regionTargeting={
-            test.regionTargeting ?? { targetedCountryGroups: [], targetedCountryCodes: [] }
+            test.regionTargeting ?? {
+              // For backwards compatibility with the deprecated locations field
+              targetedCountryGroups: test.locations,
+              targetedCountryCodes: [],
+            }
           }
           onRegionTargetingUpdate={onRegionTargetingChange}
           selectedCohort={test.userCohort}

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Region } from '../../../utils/models';
 
 import {
   ConsentStatus,
@@ -63,36 +62,11 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
     onVariantsChange(test.variants.filter(variant => variant.name !== deletedVariantName));
   };
 
-  const onRegionsChange = (updatedRegions: Region[]): void => {
-    onTestChange({ ...test, locations: updatedRegions });
-  };
-
-  function concatUniqueLocations(countryGroups: Region[], locations: Region[]) {
-    //This function is needed , otherwise for existing tests, on selecting All regions for targeting,
-    // the locations field will be added to the targetedCountryGroups field, which ends up in the test having same region multiple times
-    const existingLocations = new Set(countryGroups);
-
-    // Iterate through locations and add only unique ones to countryGroups
-    for (const location of locations) {
-      if (!existingLocations.has(location)) {
-        countryGroups.push(location);
-      }
-    }
-
-    return countryGroups;
-  }
-
   const onRegionTargetingChange = (updatedRegionTargeting: RegionTargeting): void => {
     onTestChange({
       ...test,
-      regionTargeting: {
-        targetedCountryGroups: concatUniqueLocations(
-          updatedRegionTargeting.targetedCountryGroups,
-          test.locations,
-        ),
-        targetedCountryCodes: updatedRegionTargeting.targetedCountryCodes ?? [],
-      },
-      locations: [],
+      regionTargeting: updatedRegionTargeting,
+      locations: [], // deprecated
     });
   };
 
@@ -209,10 +183,12 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
         </Typography>
 
         <TestEditorTargetAudienceSelector
-          selectedRegions={test.locations}
-          onRegionsUpdate={onRegionsChange}
           regionTargeting={
-            test.regionTargeting ?? { targetedCountryGroups: [], targetedCountryCodes: [] }
+            test.regionTargeting ?? {
+              // For backwards compatibility with the deprecated locations field
+              targetedCountryGroups: test.locations,
+              targetedCountryCodes: [],
+            }
           }
           onRegionTargetingUpdate={onRegionTargetingChange}
           selectedCohort={test.userCohort}

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -33,8 +33,6 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
 }));
 
 interface TestEditorTargetAudienceSelectorProps {
-  selectedRegions: Region[];
-  onRegionsUpdate: (selectedRegions: Region[]) => void;
   regionTargeting: RegionTargeting;
   onRegionTargetingUpdate: (regionTargeting: RegionTargeting) => void;
   selectedCohort: UserCohort;
@@ -54,8 +52,6 @@ interface TestEditorTargetAudienceSelectorProps {
   platform?: TestPlatform;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
-  selectedRegions,
-  onRegionsUpdate,
   regionTargeting,
   onRegionTargetingUpdate,
   selectedCohort,
@@ -81,8 +77,6 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
       <div className={classes.container1}>
         <Typography className={classes.heading}>Region</Typography>
         <TestEditorTargetRegionsSelector
-          selectedRegions={selectedRegions}
-          onRegionsUpdate={onRegionsUpdate}
           regionTargeting={regionTargeting}
           onRegionTargetingUpdate={onRegionTargetingUpdate}
           supportedRegions={supportedRegions}

--- a/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetRegionsSelector.tsx
@@ -12,8 +12,6 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 }));
 
 interface TestEditorTargetRegionsSelectorProps {
-  selectedRegions: Region[];
-  onRegionsUpdate: (selectedRegions: Region[]) => void;
   regionTargeting: RegionTargeting;
   onRegionTargetingUpdate: (regionTargeting: RegionTargeting) => void;
   supportedRegions?: Region[];
@@ -22,8 +20,6 @@ interface TestEditorTargetRegionsSelectorProps {
 }
 
 const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorProps> = ({
-  selectedRegions,
-  onRegionsUpdate,
   regionTargeting,
   onRegionTargetingUpdate,
   supportedRegions,
@@ -36,7 +32,6 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
   const onAllRegionsChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const updatedRegions = event.target.checked ? allRegions : [];
     const updatedAllRegionTargeting = { ...regionTargeting, targetedCountryGroups: updatedRegions };
-    onRegionsUpdate(updatedRegions);
     onRegionTargetingUpdate(updatedAllRegionTargeting);
   };
 
@@ -45,14 +40,11 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
     const changedRegion = event.target.value;
 
     if (checked) {
-      onRegionsUpdate([...selectedRegions, changedRegion as Region]);
       onRegionTargetingUpdate({
         ...regionTargeting,
         targetedCountryGroups: [...regionTargeting.targetedCountryGroups, changedRegion as Region],
       });
     } else {
-      const locationIndex = selectedRegions.indexOf(changedRegion as Region);
-      onRegionsUpdate(selectedRegions.filter((_, index) => index !== locationIndex));
       const regionIndex = regionTargeting.targetedCountryGroups.indexOf(changedRegion as Region);
       onRegionTargetingUpdate({
         ...regionTargeting,
@@ -75,10 +67,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
       <FormControlLabel
         control={
           <Checkbox
-            checked={
-              regionTargeting.targetedCountryGroups?.length === allRegions.length ||
-              selectedRegions.length === allRegions.length
-            }
+            checked={regionTargeting.targetedCountryGroups?.length === allRegions.length}
             value={'allRegions'}
             onChange={onAllRegionsChange}
             disabled={isDisabled}
@@ -92,10 +81,7 @@ const TestEditorTargetRegionsSelector: React.FC<TestEditorTargetRegionsSelectorP
             key={region}
             control={
               <Checkbox
-                checked={
-                  regionTargeting.targetedCountryGroups.includes(region) ||
-                  selectedRegions.includes(region)
-                }
+                checked={regionTargeting.targetedCountryGroups.includes(region)}
                 onChange={onSingleRegionChange}
                 value={region}
                 disabled={isDisabled}


### PR DESCRIPTION
Instead of handling both fields and merging them, we can initialise `regionTargeting` to have the country groups from `locations`.
This means `TestEditorTargetAudienceSelector` and `TestEditorTargetRegionsSelector` don't need to handle the old field