### PR TITLE
Update Target Audience Layout

### DIFF
--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     color: palette.grey[900],
     fontWeight: 500,
   },
-  container1: {
+  containerSection: {
     display: 'inline',
     gap: spacing(12),
     flexWrap: 'wrap',
@@ -74,7 +74,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
 
   return (
     <div className={classes.container}>
-      <div className={classes.container1}>
+      <div className={classes.containerSection}>
         <Typography className={classes.heading}>Region</Typography>
         <TestEditorTargetRegionsSelector
           regionTargeting={regionTargeting}
@@ -91,71 +91,76 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
           />
         )}
       </div>
-      {showSupporterStatusSelector && (
-        <>
-          <Typography className={classes.heading}>Supporter Status</Typography>
-          <TypedRadioGroup
-            selectedValue={selectedCohort}
-            onChange={onCohortChange}
-            isDisabled={isDisabled}
-            labels={{
-              Everyone: 'Everyone',
-              AllNonSupporters: 'Non-supporters',
-              AllExistingSupporters: 'Existing supporters',
-            }}
-          />
-        </>
-      )}
-
-      {showDeviceTypeSelector && (
-        <>
-          <Typography className={classes.heading}>Device Type</Typography>
-          <TypedRadioGroup
-            selectedValue={selectedDeviceType}
-            onChange={onDeviceTypeChange}
-            isDisabled={isDisabled}
-            labels={{
-              All: 'All',
-              Desktop: 'Desktop',
-              Mobile: 'Mobile (All)',
-              iOS: 'Mobile (iOS)',
-              Android: 'Mobile (Android)',
-            }}
-          />
-        </>
-      )}
-
-      {showSignedInStatusSelector && (
-        <>
-          <Typography className={classes.heading}>Signed In Status</Typography>
-          <TypedRadioGroup
-            selectedValue={selectedSignedInStatus ?? 'All'}
-            onChange={onSignedInStatusChange}
-            isDisabled={isDisabled}
-            labels={{
-              All: 'All',
-              SignedIn: 'Signed in',
-              SignedOut: 'Signed out',
-            }}
-          />
-        </>
-      )}
-
-      {showConsentStatusSelector && (
-        <>
-          <Typography className={classes.heading}>Consent Status</Typography>
-          <TypedRadioGroup
-            selectedValue={selectedConsentStatus ?? 'All'}
-            onChange={onConsentStatusChange}
-            isDisabled={isDisabled}
-            labels={{
-              All: 'All',
-              HasConsented: 'Has consented',
-              HasNotConsented: 'Has not consented',
-            }}
-          />
-        </>
-      )}
+      <div className={classes.containerSection}>
+        {showSupporterStatusSelector && (
+          <>
+            <Typography className={classes.heading}>Supporter Status</Typography>
+            <TypedRadioGroup
+              selectedValue={selectedCohort}
+              onChange={onCohortChange}
+              isDisabled={isDisabled}
+              labels={{
+                Everyone: 'Everyone',
+                AllNonSupporters: 'Non-supporters',
+                AllExistingSupporters: 'Existing supporters',
+              }}
+            />
+          </>
+        )}
+      </div>
+      <div className={classes.containerSection}>
+        {showDeviceTypeSelector && (
+          <>
+            <Typography className={classes.heading}>Device Type</Typography>
+            <TypedRadioGroup
+              selectedValue={selectedDeviceType}
+              onChange={onDeviceTypeChange}
+              isDisabled={isDisabled}
+              labels={{
+                All: 'All',
+                Desktop: 'Desktop',
+                Mobile: 'Mobile (All)',
+                iOS: 'Mobile (iOS)',
+                Android: 'Mobile (Android)',
+              }}
+            />
+          </>
+        )}
+      </div>
+      <div className={classes.containerSection}>
+        {showSignedInStatusSelector && (
+          <>
+            <Typography className={classes.heading}>Signed In Status</Typography>
+            <TypedRadioGroup
+              selectedValue={selectedSignedInStatus ?? 'All'}
+              onChange={onSignedInStatusChange}
+              isDisabled={isDisabled}
+              labels={{
+                All: 'All',
+                SignedIn: 'Signed in',
+                SignedOut: 'Signed out',
+              }}
+            />
+          </>
+        )}
+      </div>
+      <div className={classes.containerSection}>
+        {showConsentStatusSelector && (
+          <>
+            <Typography className={classes.heading}>Consent Status</Typography>
+            <TypedRadioGroup
+              selectedValue={selectedConsentStatus ?? 'All'}
+              onChange={onConsentStatusChange}
+              isDisabled={isDisabled}
+              labels={{
+                All: 'All',
+                HasConsented: 'Has consented',
+                HasNotConsented: 'Has not consented',
+              }}
+            />
+          </>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

PR to update the  "Target Audience" section layout in RRCP tests

## Why do we need this?

Currently, the different sections under "Target Audience" are in multiple levels .The associated components, specifically the headings and radio buttons, are not maintaining their proper alignment.  This results in the headings and radio buttons appearing on separate lines causing user confusion. This pull request adjusts the layout.

## Images

## Before 
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/b5d3479c-e002-4f45-ba32-d49accd71221" />

## After

<img width="1446" alt="image" src="https://github.com/user-attachments/assets/b1df9f59-0689-402a-80aa-248f02385af1" />
