### PR TITLE
minor renaming in the header tests

### DIFF
--- a/public/src/components/channelManagement/headerTests/headerTestVariantCtasEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantCtasEditor.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
 }));
 
-interface HeaderTestVariantEditorCtasEditorProps {
+interface HeaderTestVariantCtasEditorProps {
   primaryCta?: Cta;
   secondaryCta?: Cta;
   updatePrimaryCta: (updatedCta?: Cta) => void;
@@ -25,7 +25,7 @@ interface HeaderTestVariantEditorCtasEditorProps {
   supportSecondaryCta: boolean;
 }
 
-const HeaderTestVariantEditorCtasEditor: React.FC<HeaderTestVariantEditorCtasEditorProps> = ({
+const HeaderTestVariantCtasEditor: React.FC<HeaderTestVariantCtasEditorProps> = ({
   primaryCta,
   secondaryCta,
   updatePrimaryCta,
@@ -33,7 +33,7 @@ const HeaderTestVariantEditorCtasEditor: React.FC<HeaderTestVariantEditorCtasEdi
   onValidationChange,
   isDisabled,
   supportSecondaryCta,
-}: HeaderTestVariantEditorCtasEditorProps) => {
+}: HeaderTestVariantCtasEditorProps) => {
   const classes = useStyles();
 
   return (
@@ -61,4 +61,4 @@ const HeaderTestVariantEditorCtasEditor: React.FC<HeaderTestVariantEditorCtasEdi
   );
 };
 
-export default HeaderTestVariantEditorCtasEditor;
+export default HeaderTestVariantCtasEditor;

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { TextField, Theme, Typography, RadioGroup, FormControlLabel, Radio } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import HeaderTestVariantEditorCtasEditor from './headerTestVariantEditorCtasEditor';
+import HeaderTestVariantCtasEditor from './headerTestVariantCtasEditor';
 import VariantCopyLengthWarning from '../../tests/variants/variantCopyLengthWarning';
 import { templateValidatorForPlatform } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
@@ -174,7 +174,7 @@ const HeaderTestVariantContentEditor: React.FC<HeaderTestVariantContentEditorPro
       </Typography>
 
       <div className={classes.buttonsContainer}>
-        <HeaderTestVariantEditorCtasEditor
+        <HeaderTestVariantCtasEditor
           primaryCta={content.primaryCta}
           secondaryCta={content.secondaryCta}
           updatePrimaryCta={updatePrimaryCta}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
A minor renaming in the header tests as it was slightly confusing!

## How to test
Tested on CODE RRCP and checked that the header tests worked as it did previously 
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
