### PR TITLE
Ensure the web preview uses the correct force name to pick up gutter-liveblog

### DIFF
--- a/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
+++ b/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
@@ -23,6 +23,8 @@ const getHostName = (stage: Stage, platform: TestPlatform): string => {
 const getChannelName = (testType: TestType, articleType: ArticleType): string => {
   if (testType === 'EPIC' && articleType === 'Liveblog') {
     return 'liveblog-epic';
+  } else if (testType === 'GUTTER' && articleType === 'Liveblog') {
+    return 'gutter-liveblog';
   } else {
     return testType.toLowerCase();
   }


### PR DESCRIPTION
## What does this change?

This changes the value of the channel name used when forcing an AB test and variant in a web-preview. This is used to check that the variant looks correct before making it live.

## How to test

This requires the branch in [DCR PR13326](https://github.com/guardian/dotcom-rendering/pull/13326) is deployed to CODE (or is merged to PROD) and this branch is deployed to CODE. Create a new gutter-liveblog-ask variant and hit the web preview button.

## How can we measure success?

You can view a changed variant you are requesting via the web preview button.
