### PR TITLE
landing page tool improvements

### DIFF
--- a/app/models/RegionTargeting.scala
+++ b/app/models/RegionTargeting.scala
@@ -1,6 +1,6 @@
 package models
 
 case class RegionTargeting(
-                            targetedCountryGroups: List[Region]= Nil,
-                            targetedCountryCodes: Option[List[String]] = None,
-                          )
+  targetedCountryGroups: List[Region]= Nil,
+  targetedCountryCodes: Option[List[String]] = None,
+)

--- a/app/models/SupportLandingPageTest.scala
+++ b/app/models/SupportLandingPageTest.scala
@@ -3,29 +3,31 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.auto._
 import io.circe.generic.extras.semiauto._
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, Encoder}
 import models.Methodology.defaultMethodologies
-case class  SupportLandingPageCopy(
-                                       heading: String,
-                                       subheading: String,
-                                     )
-case class  SupportLandingPageVariant(
-                                       name: String,
-                                       copy: SupportLandingPageCopy,
-                                     )
+
+case class SupportLandingPageCopy(
+  heading: String,
+  subheading: String,
+)
+
+case class SupportLandingPageVariant(
+  name: String,
+  copy: SupportLandingPageCopy,
+)
 
 case class SupportLandingPageTest(
-                                   name: String,
-                                   channel: Option[Channel],
-                                   status: Option[Status],
-                                   lockStatus: Option[LockStatus],
-                                   priority: Option[Int],
-                                   nickname: Option[String],
-                                   regionTargeting: Option[RegionTargeting]=None,
-                                   variants: List[SupportLandingPageVariant],
-                                   campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-                                   methodologies: List[Methodology] = defaultMethodologies,
-                                 ) extends ChannelTest[SupportLandingPageTest] {
+  name: String,
+  channel: Option[Channel],
+  status: Option[Status],
+  lockStatus: Option[LockStatus],
+  priority: Option[Int],
+  nickname: Option[String],
+  regionTargeting: Option[RegionTargeting] = None,
+  variants: List[SupportLandingPageVariant],
+  campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
+  methodologies: List[Methodology] = defaultMethodologies,
+) extends ChannelTest[SupportLandingPageTest] {
 
   override def withChannel(channel: Channel): SupportLandingPageTest =
     this.copy(channel = Some(channel))
@@ -40,5 +42,3 @@ object SupportLandingPageTest {
   implicit val landingPageTestEncoder: Encoder[SupportLandingPageTest] =
     deriveConfiguredEncoder[SupportLandingPageTest]
 }
-
-

--- a/app/models/SupportLandingPageTest.scala
+++ b/app/models/SupportLandingPageTest.scala
@@ -14,10 +14,6 @@ case class  SupportLandingPageVariant(
                                        copy: SupportLandingPageCopy,
                                      )
 
-case class SupportLandingPageTestTargeting(
-                                            regionTargeting: RegionTargeting,
-                                           )
-
 case class SupportLandingPageTest(
                                    name: String,
                                    channel: Option[Channel],
@@ -25,7 +21,7 @@ case class SupportLandingPageTest(
                                    lockStatus: Option[LockStatus],
                                    priority: Option[Int],
                                    nickname: Option[String],
-                                   targeting: SupportLandingPageTestTargeting,
+                                   regionTargeting: Option[RegionTargeting]=None,
                                    variants: List[SupportLandingPageVariant],
                                    campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
                                    methodologies: List[Methodology] = defaultMethodologies,

--- a/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
@@ -54,9 +54,7 @@ const SupportLandingPageTestEditor: React.FC<ValidatedTestEditorProps<SupportLan
   const onTargetingChange = (updatedTargeting: RegionTargeting): void => {
     updateTest({
       ...test,
-      targeting: {
-        regionTargeting: updatedTargeting,
-      },
+      regionTargeting: updatedTargeting,
     });
   };
 
@@ -124,7 +122,7 @@ const SupportLandingPageTestEditor: React.FC<ValidatedTestEditorProps<SupportLan
           </Typography>
 
           <TestEditorTargetRegionsSelector
-            regionTargeting={test.targeting.regionTargeting}
+            regionTargeting={test.regionTargeting}
             onRegionTargetingUpdate={onTargetingChange}
             isDisabled={!userHasTestLocked}
           />

--- a/public/src/components/channelManagement/supportLandingPage/utils/defaults.ts
+++ b/public/src/components/channelManagement/supportLandingPage/utils/defaults.ts
@@ -1,35 +1,25 @@
-import { Cta, RegionTargeting } from '../../helpers/shared';
+import { RegionTargeting } from '../../helpers/shared';
 import { getStage } from '../../../../utils/stage';
 import {
   SupportLandingPageTest,
-  SupportLandingPageTestTargeting,
   SupportLandingPageVariant,
 } from '../../../../models/supportLandingPage';
-
-export const DEFAULT_PRIMARY_CTA: Cta = {
-  text: 'Support the Guardian',
-  baseUrl: 'https://support.theguardian.com/contribute',
-};
-
-export const DEFAULT_SECONDARY_CTA: Cta = {
-  text: 'Support the Guardian',
-  baseUrl: 'https://support.theguardian.com/contribute',
-};
 
 const DEV_AND_CODE_DEFAULT_VARIANT: SupportLandingPageVariant = {
   name: 'CONTROL',
   copy: {
-    heading: 'We chose a different approach. Will you support it?',
+    heading: 'Support fearless, independent journalism',
     subheading:
-      'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+      'We’re not owned by a billionaire or shareholders - our readers support us. Choose to join with one of the options below. <strong>Cancel anytime.</strong>',
   },
 };
 
 const PROD_DEFAULT_VARIANT: SupportLandingPageVariant = {
   name: 'CONTROL',
   copy: {
-    heading: 'Support the Guardian',
-    subheading: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+    heading: 'Support fearless, independent journalism',
+    subheading:
+      'We’re not owned by a billionaire or shareholders - our readers support us. Choose to join with one of the options below. <strong>Cancel anytime.</strong>',
   },
 };
 
@@ -41,13 +31,6 @@ export const getDefaultVariant = (): SupportLandingPageVariant => {
   return PROD_DEFAULT_VARIANT;
 };
 
-export const DEFAULT_TARGETING: SupportLandingPageTestTargeting = {
-  regionTargeting: {
-    targetedCountryGroups: [],
-    targetedCountryCodes: [],
-  },
-};
-
 export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryGroups: [],
   targetedCountryCodes: [],
@@ -57,7 +40,6 @@ const DEV_AND_CODE_DEFAULT_LANDING_PAGE_TEST: SupportLandingPageTest = {
   name: 'TEST',
   nickname: 'TEST',
   status: 'Draft',
-  targeting: DEFAULT_TARGETING,
   locations: [],
   regionTargeting: DEFAULT_REGION_TARGETING,
   variants: [DEV_AND_CODE_DEFAULT_VARIANT],
@@ -68,7 +50,6 @@ const PROD_DEFAULT_LANDING_PAGE: SupportLandingPageTest = {
   name: '',
   nickname: '',
   status: 'Draft',
-  targeting: DEFAULT_TARGETING,
   locations: [],
   regionTargeting: DEFAULT_REGION_TARGETING,
   variants: [],

--- a/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
@@ -211,7 +211,6 @@ export const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
               );
             }}
           />
-          =
         </div>
       </div>
     </>

--- a/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Theme, Typography } from '@mui/material';
+import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { templateValidatorForPlatform } from '../helpers/validation';
 import { getRteCopyLength, RichTextEditorSingleLine } from '../richTextEditor/richTextEditor';
@@ -235,9 +235,6 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
 
   return (
     <div className={classes.container}>
-      <Typography variant={'h3'} className={classes.sectionHeader}>
-        Configure Components
-      </Typography>
       <div>
         <VariantContentEditor
           copy={variant.copy}

--- a/public/src/models/supportLandingPage.ts
+++ b/public/src/models/supportLandingPage.ts
@@ -1,10 +1,4 @@
-import {
-  Methodology,
-  RegionTargeting,
-  Status,
-  Test,
-  Variant,
-} from '../components/channelManagement/helpers/shared';
+import { Methodology, Status, Test, Variant } from '../components/channelManagement/helpers/shared';
 
 export interface SupportLandingPageCopy {
   heading: string;
@@ -16,15 +10,10 @@ export interface SupportLandingPageVariant extends Variant {
   copy: SupportLandingPageCopy;
 }
 
-export interface SupportLandingPageTestTargeting {
-  regionTargeting: RegionTargeting;
-}
-
 export interface SupportLandingPageTest extends Test {
   name: string;
   nickname?: string;
   status: Status;
-  targeting: SupportLandingPageTestTargeting;
   variants: SupportLandingPageVariant[];
   methodologies: Methodology[];
 }


### PR DESCRIPTION
1. removes a stray "="
2. moves `regionTargeting` field to the root of the model. This is because the existing generic `Test` model already has the field there
3. formats the scala

I've also updated the default copy to match what we have in support-frontend currently