### PR TITLE
Small changes including updating change to storybook renamed

### DIFF
--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -41,8 +41,8 @@ object ChannelTest {
         case Header => HeaderTest.headerTestDecoder(c)
         case Banner1 | Banner2 => BannerTest.bannerTestDecoder(c)
         case GutterLiveblog => GutterTest.gutterTestDecoder(c)
-        case epic => EpicTest.epicTestDecoder(c)
         case SupportLandingPage =>SupportLandingPageTest.landingPageTestDecoder(c)
+        case epic => EpicTest.epicTestDecoder(c)
       }
     }
   }
@@ -52,8 +52,8 @@ object ChannelTest {
       case header: HeaderTest => HeaderTest.headerTestEncoder(header)
       case banner: BannerTest => BannerTest.bannerTestEncoder(banner)
       case gutter: GutterTest => GutterTest.gutterTestEncoder(gutter)
-      case epic: EpicTest => EpicTest.epicTestEncoder(epic)
       case landingPage :SupportLandingPageTest => SupportLandingPageTest.landingPageTestEncoder(landingPage)
+      case epic: EpicTest => EpicTest.epicTestEncoder(epic)
     }
   }
 }

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -40,6 +40,7 @@ object ChannelTest {
       c.downField("channel").as[Channel].flatMap {
         case Header => HeaderTest.headerTestDecoder(c)
         case Banner1 | Banner2 => BannerTest.bannerTestDecoder(c)
+        case GutterLiveblog => GutterTest.gutterTestDecoder(c)
         case epic => EpicTest.epicTestDecoder(c)
       }
     }
@@ -49,6 +50,7 @@ object ChannelTest {
     override def apply(test: ChannelTest[_]): Json = test match {
       case header: HeaderTest => HeaderTest.headerTestEncoder(header)
       case banner: BannerTest => BannerTest.bannerTestEncoder(banner)
+      case gutter: GutterTest => GutterTest.gutterTestEncoder(gutter)
       case epic: EpicTest => EpicTest.epicTestEncoder(epic)
     }
   }

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -50,6 +50,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   },
 }));
 
+// TODO: when making the feature live, add the commented out Gutter Liveblog sections below.
 export const testChannelOrder = [
   'Header',
   'Epic',
@@ -58,6 +59,7 @@ export const testChannelOrder = [
   'EpicAMP',
   'Banner1',
   'Banner2',
+  // 'GutterLiveblog',
 ];
 
 export interface TestChannelItem {
@@ -98,6 +100,10 @@ export const testChannelData: TestChannelData = {
     name: 'Banner 2',
     link: 'banner-tests2',
   },
+  // GutterLiveblog: {
+  //   name: 'Gutter Liveblog',
+  //   link: 'gutter-liveblog-tests',
+  // },
 };
 
 interface FormData {

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -50,7 +50,6 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   },
 }));
 
-// TODO: when making the feature live, add the commented out Gutter Liveblog sections below.
 export const testChannelOrder = [
   'Header',
   'Epic',
@@ -59,7 +58,7 @@ export const testChannelOrder = [
   'EpicAMP',
   'Banner1',
   'Banner2',
-  // 'GutterLiveblog',
+  'GutterLiveblog',
 ];
 
 export interface TestChannelItem {
@@ -100,10 +99,10 @@ export const testChannelData: TestChannelData = {
     name: 'Banner 2',
     link: 'banner-tests2',
   },
-  // GutterLiveblog: {
-  //   name: 'Gutter Liveblog',
-  //   link: 'gutter-liveblog-tests',
-  // },
+  GutterLiveblog: {
+    name: 'Gutter Liveblog',
+    link: 'gutter-liveblog-tests',
+  },
 };
 
 interface FormData {

--- a/public/src/components/channelManagement/gutterTests/gutterVariantPreview.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterVariantPreview.tsx
@@ -41,7 +41,7 @@ const GutterVariantPreview: React.FC<GutterVariantPreviewProps> = ({
 
   const props = buildProps(variant);
 
-  const storyName = 'components-marketing-stickyliveblogask--default';
+  const storyName = 'components-marketing-gutterask--default';
   const storybookUrl = buildStorybookUrl(storyName, props);
 
   return (


### PR DESCRIPTION
## What does this change?

The [DCR PR13326](https://github.com/guardian/dotcom-rendering/pull/13326) renames the story name in gutterVariantPreview to match the new naming planned for storybook.  This name is used to find the story and pass the props to it so that the variants can be displayed side by side.

Adds Gutter Liveblogs to Campaigns.

## How to test

**NOTE**: Web preview relies on the DCR PR to be merged in order to test since there is no CODE version of storybook. 

## Have we considered potential risks?

Since this requires the DCR PR to be merged first to test the preview, we will not be able to test until after that.  Since the Gutter Ask menu item is still hidden and the feature is not available, this should not be problematic for MRR.
