### PR TITLE
Add missing region targeting to model

### DIFF
--- a/app/models/GutterTests.scala
+++ b/app/models/GutterTests.scala
@@ -26,6 +26,7 @@ case class GutterTest(
     nickname: Option[String],
     userCohort: UserCohort,
     locations: List[Region] = Nil,
+    regionTargeting: Option[RegionTargeting]=None,
     contextTargeting: PageContextTargeting = PageContextTargeting(Nil,Nil,Nil,Nil), 
     variants: List[GutterVariant],
     controlProportionSettings: Option[ControlProportionSettings] = None,


### PR DESCRIPTION
## What does this change?

Following some recent changes to the region and location test targeting, the regions were not saving correctly. This PR adds the missing regionTargeting field in the GutterTests model.

## How to test

Deploy to CODE or run locally and access the end point /gutter-liveblog-tests
