### PR TITLE
Build preview component to pass as props to storybook

### DIFF
--- a/public/src/components/channelManagement/gutterTests/gutterVariantPreview.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterVariantPreview.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
-import { GutterVariant } from '../../../models/gutter';
+import { GutterContent, GutterVariant } from '../../../models/gutter';
 import { buildStorybookUrl } from '../helpers/dcrStorybook';
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 interface GutterProps {
-  url: string;
-  onCtaClick: () => void; // current props.
-  // TODO: once DCR done, implement the rest
+  variant: GutterContent;
+  enrichedUrl: string;
+  onCtaClick: () => void;
 }
-// TODO: remove this lint line when props passed in properly later
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 const buildProps = (variant: GutterVariant): GutterProps => ({
-  url: ' ',
+  variant: {
+    image: {
+      mainUrl: variant.content.image.mainUrl,
+      altText: variant.content.image.altText,
+    },
+    bodyCopy: variant.content.bodyCopy,
+    cta: {
+      baseUrl: variant.content.cta!.baseUrl,
+      text: variant.content.cta!.text,
+    },
+  },
+  enrichedUrl: ' ',
   onCtaClick: () => {},
-  // TODO: update with proper props later!
 });
 
 const useStyles = makeStyles(({}: Theme) => ({
@@ -43,6 +52,7 @@ const GutterVariantPreview: React.FC<GutterVariantPreviewProps> = ({
 
   const storyName = 'components-marketing-gutterask--default';
   const storybookUrl = buildStorybookUrl(storyName, props);
+  console.log(storybookUrl);
 
   return (
     <div>


### PR DESCRIPTION
## What does this change?

This builds the props to pass to storybook based on those passed into it so that we can preview the test variants individually or side by side.

## How to test

Run locally, create at least one test with a variant and alter the text of the variant from the evergreen version so that you can identify the difference.  Select either the preview tab inside the variant or the Preview All Variants button at the top of the test.  You should see the difference from the evergreen version.
