### PR TITLE
Products config in LP tool

### DIFF
--- a/app/models/SupportLandingPageTest.scala
+++ b/app/models/SupportLandingPageTest.scala
@@ -41,7 +41,7 @@ case class Products(
 case class SupportLandingPageVariant(
   name: String,
   copy: SupportLandingPageCopy,
-  products: Option[Products],
+  products: Products,
 )
 
 case class SupportLandingPageTest(

--- a/app/models/SupportLandingPageTest.scala
+++ b/app/models/SupportLandingPageTest.scala
@@ -11,9 +11,37 @@ case class SupportLandingPageCopy(
   subheading: String,
 )
 
+case class ProductBenefit(
+  copy: String,
+  tooltip: Option[String] = None,
+  label: Option[Label] = None,
+)
+
+case class Label(
+  copy: String,
+)
+
+case class LandingPageProductDescription(
+  title: String,
+  label: Option[Label] = None,
+  benefits: List[ProductBenefit],
+  cta: LandingPageCta,
+)
+
+case class LandingPageCta(
+  copy: String,
+)
+
+case class Products(
+  Contribution: LandingPageProductDescription,
+  SupporterPlus: LandingPageProductDescription,
+  TierThree: LandingPageProductDescription,
+)
+
 case class SupportLandingPageVariant(
   name: String,
   copy: SupportLandingPageCopy,
+  products: Option[Products],
 )
 
 case class SupportLandingPageTest(

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -6,51 +6,9 @@ import { getRteCopyLength, RichTextEditorSingleLine } from '../richTextEditor/ri
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
-  container: {
-    width: '100%',
-    paddingTop: spacing(2),
-    paddingLeft: spacing(4),
-    paddingRight: spacing(10),
-
-    '& > * + *': {
-      marginTop: spacing(3),
-    },
-  },
-  hook: {
-    maxWidth: '400px',
-  },
-  sectionHeader: {
-    fontSize: 16,
-    color: palette.grey[900],
-    fontWeight: 500,
-  },
-  sectionContainer: {
-    paddingTop: spacing(2),
-    paddingBottom: spacing(2),
-    borderBottom: `1px solid ${palette.grey[500]}`,
-    '& > * + *': {
-      marginTop: spacing(3),
-    },
-  },
+const useStyles = makeStyles(({ spacing }: Theme) => ({
   contentContainer: {
     marginLeft: spacing(2),
-  },
-  buttonsContainer: {
-    marginTop: spacing(2),
-  },
-  switchContainer: {
-    display: 'flex',
-    alignItems: 'center',
-
-    '& > * + *': {
-      marginLeft: spacing(1),
-    },
-  },
-  switchLabel: {
-    fontSize: '14px',
-    fontWeight: 500,
   },
 }));
 
@@ -87,13 +45,6 @@ export const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
     subheading: copy.subheading || '',
   };
 
-  /**
-   * Only some fields are validated by the useForm here.
-   * Ideally we'd combine the validated fields with the rest of the variant fields in a callback (inside the RTE Controllers below).
-   * But the callback closes over the old state of `content`, causing it to overwrite changes to non-validated fields.
-   * So instead we write updates to the validated fields to the `validatedFields` state, and merge with the rest of
-   * `content` in a useEffect.
-   */
   const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
   const { handleSubmit, control, errors, trigger } = useForm<FormData>({
     mode: 'onChange',

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -1,0 +1,215 @@
+import { SupportLandingPageCopy } from '../../../models/supportLandingPage';
+import React, { useEffect, useState } from 'react';
+import { templateValidatorForPlatform } from '../helpers/validation';
+import { Controller, useForm } from 'react-hook-form';
+import { getRteCopyLength, RichTextEditorSingleLine } from '../richTextEditor/richTextEditor';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
+  container: {
+    width: '100%',
+    paddingTop: spacing(2),
+    paddingLeft: spacing(4),
+    paddingRight: spacing(10),
+
+    '& > * + *': {
+      marginTop: spacing(3),
+    },
+  },
+  hook: {
+    maxWidth: '400px',
+  },
+  sectionHeader: {
+    fontSize: 16,
+    color: palette.grey[900],
+    fontWeight: 500,
+  },
+  sectionContainer: {
+    paddingTop: spacing(2),
+    paddingBottom: spacing(2),
+    borderBottom: `1px solid ${palette.grey[500]}`,
+    '& > * + *': {
+      marginTop: spacing(3),
+    },
+  },
+  contentContainer: {
+    marginLeft: spacing(2),
+  },
+  buttonsContainer: {
+    marginTop: spacing(2),
+  },
+  switchContainer: {
+    display: 'flex',
+    alignItems: 'center',
+
+    '& > * + *': {
+      marginLeft: spacing(1),
+    },
+  },
+  switchLabel: {
+    fontSize: '14px',
+    fontWeight: 500,
+  },
+}));
+
+const HEADER_DEFAULT_HELPER_TEXT = 'Heading text';
+const SUBHEADING_DEFAULT_HELPER_TEXT = 'Subheading text';
+
+const headingCopyRecommendedLength = 500;
+const subheadingCopyRecommendedLength = 500;
+
+interface VariantContentEditorProps {
+  copy: SupportLandingPageCopy;
+  onChange: (updatedCopy: SupportLandingPageCopy) => void;
+  onValidationChange?: (isValid: boolean) => void;
+  editMode: boolean;
+}
+
+interface FormData {
+  heading?: string;
+  subheading?: string;
+}
+
+export const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
+  copy,
+  onChange,
+  onValidationChange,
+  editMode,
+}: VariantContentEditorProps) => {
+  const classes = useStyles();
+
+  const templateValidator = templateValidatorForPlatform('DOTCOM');
+
+  const defaultValues: FormData = {
+    heading: copy.heading || '',
+    subheading: copy.subheading || '',
+  };
+
+  /**
+   * Only some fields are validated by the useForm here.
+   * Ideally we'd combine the validated fields with the rest of the variant fields in a callback (inside the RTE Controllers below).
+   * But the callback closes over the old state of `content`, causing it to overwrite changes to non-validated fields.
+   * So instead we write updates to the validated fields to the `validatedFields` state, and merge with the rest of
+   * `content` in a useEffect.
+   */
+  const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
+  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    trigger();
+  }, []);
+
+  useEffect(() => {
+    onChange({
+      ...copy,
+      ...validatedFields,
+    });
+  }, [validatedFields]);
+
+  useEffect(() => {
+    const isValid = Object.keys(errors).length === 0;
+    if (onValidationChange) {
+      onValidationChange(isValid);
+    }
+  }, [errors.heading, errors.subheading]);
+
+  const getSubheadingCopyLength = () => {
+    if (copy.heading != null) {
+      return [
+        getRteCopyLength([...copy.heading, copy.heading || '']),
+        headingCopyRecommendedLength,
+      ];
+    }
+    return [
+      getRteCopyLength([copy.subheading, copy.subheading || '']),
+      subheadingCopyRecommendedLength,
+    ];
+  };
+
+  const [copyLength, recommendedLength] = getSubheadingCopyLength();
+
+  return (
+    <>
+      <div className={classes.contentContainer}>
+        <Controller
+          name="heading"
+          control={control}
+          rules={{
+            validate: templateValidator,
+          }}
+          render={data => {
+            return (
+              <RichTextEditorSingleLine
+                error={errors.heading !== undefined}
+                helperText={
+                  errors.heading
+                    ? errors.heading.message || errors.heading.type
+                    : HEADER_DEFAULT_HELPER_TEXT
+                }
+                copyData={data.value}
+                updateCopy={pars => {
+                  data.onChange(pars);
+                  handleSubmit(setValidatedFields)();
+                }}
+                name="heading"
+                label="Heading copy"
+                disabled={!editMode}
+                rteMenuConstraints={{
+                  noArticleCountTemplate: true,
+                  noCurrencyTemplate: true,
+                  noCountryNameTemplate: true,
+                  noDayTemplate: true,
+                  noDateTemplate: true,
+                  noPriceTemplates: true,
+                }}
+              />
+            );
+          }}
+        />
+
+        <div>
+          <Controller
+            name="subheading"
+            control={control}
+            rules={{
+              validate: templateValidator,
+            }}
+            render={data => {
+              return (
+                <RichTextEditorSingleLine
+                  error={errors.subheading !== undefined || copyLength > recommendedLength}
+                  helperText={
+                    errors.subheading
+                      ? errors.subheading.message || errors.subheading.type
+                      : SUBHEADING_DEFAULT_HELPER_TEXT
+                  }
+                  copyData={data.value}
+                  updateCopy={pars => {
+                    data.onChange(pars);
+                    handleSubmit(setValidatedFields)();
+                  }}
+                  name="subheading"
+                  label="Subheading copy"
+                  disabled={!editMode}
+                  rteMenuConstraints={{
+                    noArticleCountTemplate: true,
+                    noCurrencyTemplate: true,
+                    noCountryNameTemplate: true,
+                    noDayTemplate: true,
+                    noDateTemplate: true,
+                    noPriceTemplates: true,
+                  }}
+                />
+              );
+            }}
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -12,9 +12,6 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
 }));
 
-const HEADER_DEFAULT_HELPER_TEXT = 'Heading text';
-const SUBHEADING_DEFAULT_HELPER_TEXT = 'Subheading text';
-
 const headingCopyRecommendedLength = 500;
 const subheadingCopyRecommendedLength = 500;
 
@@ -26,8 +23,8 @@ interface CopyEditorProps {
 }
 
 interface FormData {
-  heading?: string;
-  subheading?: string;
+  heading: string;
+  subheading: string;
 }
 
 export const CopyEditor: React.FC<CopyEditorProps> = ({
@@ -91,17 +88,14 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
           name="heading"
           control={control}
           rules={{
+            required: true,
             validate: templateValidator,
           }}
           render={data => {
             return (
               <RichTextEditorSingleLine
                 error={errors.heading !== undefined}
-                helperText={
-                  errors.heading
-                    ? errors.heading.message || errors.heading.type
-                    : HEADER_DEFAULT_HELPER_TEXT
-                }
+                helperText={errors?.heading?.message || errors?.heading?.type}
                 copyData={data.value}
                 updateCopy={pars => {
                   data.onChange(pars);
@@ -128,17 +122,14 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
             name="subheading"
             control={control}
             rules={{
+              required: true,
               validate: templateValidator,
             }}
             render={data => {
               return (
                 <RichTextEditorSingleLine
                   error={errors.subheading !== undefined || copyLength > recommendedLength}
-                  helperText={
-                    errors.subheading
-                      ? errors.subheading.message || errors.subheading.type
-                      : SUBHEADING_DEFAULT_HELPER_TEXT
-                  }
+                  helperText={errors?.subheading?.message || errors?.subheading?.type}
                   copyData={data.value}
                   updateCopy={pars => {
                     data.onChange(pars);

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -7,7 +7,7 @@ import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
-  contentContainer: {
+  container: {
     marginLeft: spacing(2),
   },
 }));
@@ -18,7 +18,7 @@ const SUBHEADING_DEFAULT_HELPER_TEXT = 'Subheading text';
 const headingCopyRecommendedLength = 500;
 const subheadingCopyRecommendedLength = 500;
 
-interface VariantContentEditorProps {
+interface CopyEditorProps {
   copy: SupportLandingPageCopy;
   onChange: (updatedCopy: SupportLandingPageCopy) => void;
   onValidationChange?: (isValid: boolean) => void;
@@ -30,12 +30,12 @@ interface FormData {
   subheading?: string;
 }
 
-export const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
+export const CopyEditor: React.FC<CopyEditorProps> = ({
   copy,
   onChange,
   onValidationChange,
   editMode,
-}: VariantContentEditorProps) => {
+}: CopyEditorProps) => {
   const classes = useStyles();
 
   const templateValidator = templateValidatorForPlatform('DOTCOM');
@@ -86,7 +86,7 @@ export const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
 
   return (
     <>
-      <div className={classes.contentContainer}>
+      <div className={classes.container}>
         <Controller
           name="heading"
           control={control}

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -47,33 +47,22 @@ const buildBenefitsHeading = (product: keyof Products) => {
   }
 };
 
-interface ProductsEditorProps {
-  products: Products;
-  onProductsChange: (updatedProducts: Products) => void;
+interface ProductEditorProps {
   editMode: boolean;
+  productKey: keyof Products;
+  product: LandingPageProductDescription;
+  onProductChange: (updatedProduct: LandingPageProductDescription) => void;
 }
 
-export const ProductsEditor: React.FC<ProductsEditorProps> = ({
-  products,
-  onProductsChange,
+export const ProductEditor: React.FC<ProductEditorProps> = ({
   editMode,
-}) => {
+  productKey,
+  product,
+  onProductChange,
+}: ProductEditorProps) => {
   const classes = useStyles();
 
-  const handleProductChange = (
-    productKey: keyof Products,
-    updatedProduct: LandingPageProductDescription,
-  ) => {
-    onProductsChange({
-      ...products,
-      [productKey]: updatedProduct,
-    });
-  };
-
-  const renderProductEditor = (
-    productKey: keyof Products,
-    product: LandingPageProductDescription,
-  ) => (
+  return (
     <Accordion key={productKey}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Typography variant="h6">{productKey}</Typography>
@@ -83,7 +72,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
           label="Title"
           required={true}
           value={product.title}
-          onChange={e => handleProductChange(productKey, { ...product, title: e.target.value })}
+          onChange={e => onProductChange({ ...product, title: e.target.value })}
           disabled={!editMode}
           fullWidth
         />
@@ -92,7 +81,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
           required={true}
           value={product.cta.copy}
           onChange={e => {
-            handleProductChange(productKey, { ...product, cta: { copy: e.target.value } });
+            onProductChange({ ...product, cta: { copy: e.target.value } });
           }}
           disabled={!editMode}
           fullWidth
@@ -102,12 +91,14 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
           value={product.label?.copy}
           onChange={e => {
             const label = e.target.value ? { copy: e.target.value } : undefined;
-            handleProductChange(productKey, { ...product, label });
+            onProductChange({ ...product, label });
           }}
           disabled={!editMode}
           fullWidth
         />
+
         <div className={classes.benefitsHeading}>{buildBenefitsHeading(productKey)}</div>
+
         {product.benefits.map((benefit, index) => {
           const updateBenefit = (updatedBenefit: ProductBenefit) => {
             const updatedBenefits = [
@@ -115,7 +106,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
               updatedBenefit,
               ...product.benefits.slice(index + 1),
             ];
-            handleProductChange(productKey, {
+            onProductChange({
               ...product,
               benefits: updatedBenefits,
             });
@@ -167,7 +158,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
                       ...product.benefits.slice(0, index),
                       ...product.benefits.slice(index + 1),
                     ];
-                    handleProductChange(productKey, { ...product, benefits: updatedBenefits });
+                    onProductChange({ ...product, benefits: updatedBenefits });
                   }}
                   disabled={!editMode}
                   variant="outlined"
@@ -181,7 +172,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
         })}
         <Button
           onClick={() =>
-            handleProductChange(productKey, {
+            onProductChange({
               ...product,
               benefits: [...product.benefits, { copy: '' }],
             })
@@ -195,13 +186,41 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
       </AccordionDetails>
     </Accordion>
   );
+};
+
+interface ProductsEditorProps {
+  products: Products;
+  onProductsChange: (updatedProducts: Products) => void;
+  editMode: boolean;
+}
+
+export const ProductsEditor: React.FC<ProductsEditorProps> = ({
+  products,
+  onProductsChange,
+  editMode,
+}) => {
+  const classes = useStyles();
 
   return (
     <div>
       <Typography className={classes.heading} variant="h5">
         Products
       </Typography>
-      {productKeys.map(productKey => renderProductEditor(productKey, products[productKey]))}
+
+      {productKeys.map(productKey => (
+        <ProductEditor
+          key={productKey}
+          productKey={productKey}
+          editMode={editMode}
+          product={products[productKey]}
+          onProductChange={updatedProduct =>
+            onProductsChange({
+              ...products,
+              [productKey]: updatedProduct,
+            })
+          }
+        />
+      ))}
     </div>
   );
 };

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -53,7 +53,7 @@ interface ProductsEditorProps {
   editMode: boolean;
 }
 
-const ProductsEditor: React.FC<ProductsEditorProps> = ({
+export const ProductsEditor: React.FC<ProductsEditorProps> = ({
   products,
   onProductsChange,
   editMode,
@@ -203,5 +203,3 @@ const ProductsEditor: React.FC<ProductsEditorProps> = ({
     </div>
   );
 };
-
-export default ProductsEditor;

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -81,6 +81,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
       <AccordionDetails className={classes.accordionDetails}>
         <TextField
           label="Title"
+          required={true}
           value={product.title}
           onChange={e => handleProductChange(productKey, { ...product, title: e.target.value })}
           disabled={!editMode}
@@ -88,6 +89,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
         />
         <TextField
           label="CTA Copy"
+          required={true}
           value={product.cta.copy}
           onChange={e => {
             handleProductChange(productKey, { ...product, cta: { copy: e.target.value } });
@@ -124,8 +126,8 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
               <Grid item xs={3}>
                 <TextField
                   label="Benefit Copy"
-                  value={benefit.copy}
                   required={true}
+                  value={benefit.copy}
                   onChange={e => updateBenefit({ ...benefit, copy: e.target.value })}
                   disabled={!editMode}
                   fullWidth

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import {
+  Products,
+  LandingPageProductDescription,
+  ProductBenefit,
+} from '../../../models/supportLandingPage';
+import {
+  TextField,
+  Typography,
+  Grid,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Theme,
+  Button,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
+import CloseIcon from '@mui/icons-material/Close';
+
+const productKeys: (keyof Products)[] = ['Contribution', 'SupporterPlus', 'TierThree'];
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  heading: {
+    marginBottom: spacing(1),
+  },
+  accordionDetails: {
+    paddingTop: spacing(2),
+    '& > * + *': {
+      marginTop: spacing(3),
+    },
+  },
+  benefitsHeading: {
+    fontWeight: 700,
+  },
+  deleteButton: {
+    height: '100%',
+  },
+}));
+
+const buildBenefitsHeading = (product: keyof Products) => {
+  if (product === 'TierThree') {
+    return 'Benefits (in addition to Supporter Plus benefits):';
+  } else {
+    return 'Benefits:';
+  }
+};
+
+interface ProductsEditorProps {
+  products: Products;
+  onProductsChange: (updatedProducts: Products) => void;
+  editMode: boolean;
+}
+
+const ProductsEditor: React.FC<ProductsEditorProps> = ({
+  products,
+  onProductsChange,
+  editMode,
+}) => {
+  const classes = useStyles();
+
+  const handleProductChange = (
+    productKey: keyof Products,
+    updatedProduct: LandingPageProductDescription,
+  ) => {
+    onProductsChange({
+      ...products,
+      [productKey]: updatedProduct,
+    });
+  };
+
+  const renderProductEditor = (
+    productKey: keyof Products,
+    product: LandingPageProductDescription,
+  ) => (
+    <Accordion key={productKey}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="h6">{productKey}</Typography>
+      </AccordionSummary>
+      <AccordionDetails className={classes.accordionDetails}>
+        <TextField
+          label="Title"
+          value={product.title}
+          onChange={e => handleProductChange(productKey, { ...product, title: e.target.value })}
+          disabled={!editMode}
+          fullWidth
+        />
+        <TextField
+          label="CTA Copy"
+          value={product.cta.copy}
+          onChange={e => {
+            handleProductChange(productKey, { ...product, cta: { copy: e.target.value } });
+          }}
+          disabled={!editMode}
+          fullWidth
+        />
+        <TextField
+          label="Pill (optional)"
+          value={product.label?.copy}
+          onChange={e => {
+            const label = e.target.value ? { copy: e.target.value } : undefined;
+            handleProductChange(productKey, { ...product, label });
+          }}
+          disabled={!editMode}
+          fullWidth
+        />
+        <div className={classes.benefitsHeading}>{buildBenefitsHeading(productKey)}</div>
+        {product.benefits.map((benefit, index) => {
+          const updateBenefit = (updatedBenefit: ProductBenefit) => {
+            const updatedBenefits = [
+              ...product.benefits.slice(0, index),
+              updatedBenefit,
+              ...product.benefits.slice(index + 1),
+            ];
+            handleProductChange(productKey, {
+              ...product,
+              benefits: updatedBenefits,
+            });
+          };
+
+          return (
+            <Grid container columns={9} spacing={1} key={index}>
+              <Grid item xs={3}>
+                <TextField
+                  label="Benefit Copy"
+                  value={benefit.copy}
+                  required={true}
+                  onChange={e => updateBenefit({ ...benefit, copy: e.target.value })}
+                  disabled={!editMode}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={3}>
+                <TextField
+                  label="Tooltip (optional)"
+                  value={benefit.tooltip || ''}
+                  required={false}
+                  onChange={e => {
+                    const tooltip = e.target.value || undefined;
+                    updateBenefit({ ...benefit, tooltip });
+                  }}
+                  disabled={!editMode}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={2}>
+                <TextField
+                  label="Pill (optional)"
+                  value={benefit.label?.copy || ''}
+                  required={false}
+                  onChange={e => {
+                    const label = e.target.value ? { copy: e.target.value } : undefined;
+                    updateBenefit({ ...benefit, label });
+                  }}
+                  disabled={!editMode}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={1}>
+                <Button
+                  className={classes.deleteButton}
+                  onClick={() => {
+                    const updatedBenefits = [
+                      ...product.benefits.slice(0, index),
+                      ...product.benefits.slice(index + 1),
+                    ];
+                    handleProductChange(productKey, { ...product, benefits: updatedBenefits });
+                  }}
+                  disabled={!editMode}
+                  variant="outlined"
+                  size="medium"
+                >
+                  <CloseIcon />
+                </Button>
+              </Grid>
+            </Grid>
+          );
+        })}
+        <Button
+          onClick={() =>
+            handleProductChange(productKey, {
+              ...product,
+              benefits: [...product.benefits, { copy: '' }],
+            })
+          }
+          disabled={!editMode}
+          variant="outlined"
+          size="medium"
+        >
+          <AddIcon />
+        </Button>
+      </AccordionDetails>
+    </Accordion>
+  );
+
+  return (
+    <div>
+      <Typography className={classes.heading} variant="h5">
+        Products
+      </Typography>
+      {productKeys.map(productKey => renderProductEditor(productKey, products[productKey]))}
+    </div>
+  );
+};
+
+export default ProductsEditor;

--- a/public/src/components/channelManagement/supportLandingPage/utils/defaults.ts
+++ b/public/src/components/channelManagement/supportLandingPage/utils/defaults.ts
@@ -5,6 +5,60 @@ import {
   SupportLandingPageVariant,
 } from '../../../../models/supportLandingPage';
 
+const defaultProducts = {
+  Contribution: {
+    title: 'Support',
+    benefits: [
+      {
+        copy: 'Give to the Guardian every month with Support',
+      },
+    ],
+    cta: { copy: 'Support' },
+  },
+  SupporterPlus: {
+    title: 'All-access digital',
+    benefits: [
+      {
+        copy: 'Unlimited access to the Guardian app',
+        tooltip:
+          'Read beyond our 20 article-per-month limit, enjoy offline access and personalised recommendations, and access our full archive of journalism. Never miss a story with the Guardian News app – a beautiful, intuitive reading experience.',
+      },
+      {
+        copy: 'Ad-free reading on all your devices',
+      },
+      {
+        copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+      },
+      {
+        copy: 'Far fewer asks for support',
+        tooltip:
+          "You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.",
+      },
+      {
+        copy: 'Unlimited access to the Guardian Feast app',
+        tooltip:
+          'Make a feast out of anything with the Guardian’s new recipe app. Feast has thousands of recipes including quick and budget-friendly weeknight dinners, and showstopping weekend dishes – plus smart app features to make mealtimes inspiring.',
+        label: { copy: 'New' },
+      },
+    ],
+    cta: {
+      copy: 'Support',
+    },
+    label: { copy: 'Recommended' },
+  },
+  TierThree: {
+    title: 'Digital + print',
+    benefits: [
+      {
+        copy: 'Guardian Weekly print magazine delivered to your door every week',
+        tooltip:
+          'Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.',
+      },
+    ],
+    cta: { copy: 'Support' },
+  },
+};
+
 const DEV_AND_CODE_DEFAULT_VARIANT: SupportLandingPageVariant = {
   name: 'CONTROL',
   copy: {
@@ -12,6 +66,7 @@ const DEV_AND_CODE_DEFAULT_VARIANT: SupportLandingPageVariant = {
     subheading:
       'We’re not owned by a billionaire or shareholders - our readers support us. Choose to join with one of the options below. <strong>Cancel anytime.</strong>',
   },
+  products: defaultProducts,
 };
 
 const PROD_DEFAULT_VARIANT: SupportLandingPageVariant = {
@@ -21,6 +76,7 @@ const PROD_DEFAULT_VARIANT: SupportLandingPageVariant = {
     subheading:
       'We’re not owned by a billionaire or shareholders - our readers support us. Choose to join with one of the options below. <strong>Cancel anytime.</strong>',
   },
+  products: defaultProducts,
 };
 
 export const getDefaultVariant = (): SupportLandingPageVariant => {

--- a/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
@@ -5,8 +5,8 @@ import {
   SupportLandingPageCopy,
   SupportLandingPageVariant,
 } from '../../../models/supportLandingPage';
-import { VariantContentEditor } from './copyEditor';
-import ProductsEditor from './productsEditor';
+import { CopyEditor } from './copyEditor';
+import { ProductsEditor } from './productsEditor';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -40,7 +40,7 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
   return (
     <div className={classes.container}>
       <div>
-        <VariantContentEditor
+        <CopyEditor
           copy={variant.copy}
           onChange={(updatedCopy: SupportLandingPageCopy): void =>
             onVariantChange({ ...variant, copy: updatedCopy })

--- a/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
@@ -1,16 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import React from 'react';
 import { Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { templateValidatorForPlatform } from '../helpers/validation';
-import { getRteCopyLength, RichTextEditorSingleLine } from '../richTextEditor/richTextEditor';
 import {
   SupportLandingPageCopy,
   SupportLandingPageVariant,
 } from '../../../models/supportLandingPage';
+import { VariantContentEditor } from './copyEditor';
+import ProductsEditor from './productsEditor';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
+const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
     width: '100%',
     paddingTop: spacing(2),
@@ -21,201 +19,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
       marginTop: spacing(3),
     },
   },
-  hook: {
-    maxWidth: '400px',
-  },
-  sectionHeader: {
-    fontSize: 16,
-    color: palette.grey[900],
-    fontWeight: 500,
-  },
-  sectionContainer: {
-    paddingTop: spacing(2),
-    paddingBottom: spacing(2),
-    borderBottom: `1px solid ${palette.grey[500]}`,
-    '& > * + *': {
-      marginTop: spacing(3),
-    },
-  },
-  contentContainer: {
-    marginLeft: spacing(2),
-  },
-  buttonsContainer: {
-    marginTop: spacing(2),
-  },
-  switchContainer: {
-    display: 'flex',
-    alignItems: 'center',
-
-    '& > * + *': {
-      marginLeft: spacing(1),
-    },
-  },
-  switchLabel: {
-    fontSize: '14px',
-    fontWeight: 500,
-  },
 }));
-
-const HEADER_DEFAULT_HELPER_TEXT = 'Heading text';
-const SUBHEADING_DEFAULT_HELPER_TEXT = 'Subheading text';
-
-const headingCopyRecommendedLength = 500;
-const subheadingCopyRecommendedLength = 500;
-
-interface VariantContentEditorProps {
-  copy: SupportLandingPageCopy;
-  onChange: (updatedCopy: SupportLandingPageCopy) => void;
-  onValidationChange?: (isValid: boolean) => void;
-  editMode: boolean;
-}
-
-interface FormData {
-  heading?: string;
-  subheading?: string;
-}
-
-export const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
-  copy,
-  onChange,
-  onValidationChange,
-  editMode,
-}: VariantContentEditorProps) => {
-  const classes = useStyles();
-
-  const templateValidator = templateValidatorForPlatform('DOTCOM');
-
-  const defaultValues: FormData = {
-    heading: copy.heading || '',
-    subheading: copy.subheading || '',
-  };
-
-  /**
-   * Only some fields are validated by the useForm here.
-   * Ideally we'd combine the validated fields with the rest of the variant fields in a callback (inside the RTE Controllers below).
-   * But the callback closes over the old state of `content`, causing it to overwrite changes to non-validated fields.
-   * So instead we write updates to the validated fields to the `validatedFields` state, and merge with the rest of
-   * `content` in a useEffect.
-   */
-  const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
-  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
-    mode: 'onChange',
-    defaultValues,
-  });
-
-  useEffect(() => {
-    trigger();
-  }, []);
-
-  useEffect(() => {
-    onChange({
-      ...copy,
-      ...validatedFields,
-    });
-  }, [validatedFields]);
-
-  useEffect(() => {
-    const isValid = Object.keys(errors).length === 0;
-    if (onValidationChange) {
-      onValidationChange(isValid);
-    }
-  }, [errors.heading, errors.subheading]);
-
-  const getSubheadingCopyLength = () => {
-    if (copy.heading != null) {
-      return [
-        getRteCopyLength([...copy.heading, copy.heading || '']),
-        headingCopyRecommendedLength,
-      ];
-    }
-    return [
-      getRteCopyLength([copy.subheading, copy.subheading || '']),
-      subheadingCopyRecommendedLength,
-    ];
-  };
-
-  const [copyLength, recommendedLength] = getSubheadingCopyLength();
-
-  return (
-    <>
-      <div className={classes.contentContainer}>
-        <Controller
-          name="heading"
-          control={control}
-          rules={{
-            validate: templateValidator,
-          }}
-          render={data => {
-            return (
-              <RichTextEditorSingleLine
-                error={errors.heading !== undefined}
-                helperText={
-                  errors.heading
-                    ? errors.heading.message || errors.heading.type
-                    : HEADER_DEFAULT_HELPER_TEXT
-                }
-                copyData={data.value}
-                updateCopy={pars => {
-                  data.onChange(pars);
-                  handleSubmit(setValidatedFields)();
-                }}
-                name="heading"
-                label="Heading copy"
-                disabled={!editMode}
-                rteMenuConstraints={{
-                  noArticleCountTemplate: true,
-                  noCurrencyTemplate: true,
-                  noCountryNameTemplate: true,
-                  noDayTemplate: true,
-                  noDateTemplate: true,
-                  noPriceTemplates: true,
-                }}
-              />
-            );
-          }}
-        />
-
-        <div>
-          <Controller
-            name="subheading"
-            control={control}
-            rules={{
-              validate: templateValidator,
-            }}
-            render={data => {
-              return (
-                <RichTextEditorSingleLine
-                  error={errors.subheading !== undefined || copyLength > recommendedLength}
-                  helperText={
-                    errors.subheading
-                      ? errors.subheading.message || errors.subheading.type
-                      : SUBHEADING_DEFAULT_HELPER_TEXT
-                  }
-                  copyData={data.value}
-                  updateCopy={pars => {
-                    data.onChange(pars);
-                    handleSubmit(setValidatedFields)();
-                  }}
-                  name="subheading"
-                  label="Subheading copy"
-                  disabled={!editMode}
-                  rteMenuConstraints={{
-                    noArticleCountTemplate: true,
-                    noCurrencyTemplate: true,
-                    noCountryNameTemplate: true,
-                    noDayTemplate: true,
-                    noDateTemplate: true,
-                    noPriceTemplates: true,
-                  }}
-                />
-              );
-            }}
-          />
-        </div>
-      </div>
-    </>
-  );
-};
 
 interface VariantEditorProps {
   variant: SupportLandingPageVariant;
@@ -245,6 +49,13 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
           editMode={editMode}
         />
       </div>
+      <ProductsEditor
+        products={variant.products}
+        onProductsChange={updatedProducts =>
+          onVariantChange({ ...variant, products: updatedProducts })
+        }
+        editMode={editMode}
+      />
     </div>
   );
 };

--- a/public/src/models/supportLandingPage.ts
+++ b/public/src/models/supportLandingPage.ts
@@ -5,9 +5,35 @@ export interface SupportLandingPageCopy {
   subheading: string;
 }
 
+export interface ProductBenefit {
+  copy: string;
+  tooltip?: string;
+  label?: {
+    copy: string;
+  };
+}
+
+export interface LandingPageProductDescription {
+  title: string;
+  label?: {
+    copy: string;
+  };
+  benefits: ProductBenefit[];
+  cta: {
+    copy: string;
+  };
+}
+
+export interface Products {
+  Contribution: LandingPageProductDescription;
+  SupporterPlus: LandingPageProductDescription;
+  TierThree: LandingPageProductDescription;
+}
+
 export interface SupportLandingPageVariant extends Variant {
   name: string;
   copy: SupportLandingPageCopy;
+  products: Products;
 }
 
 export interface SupportLandingPageTest extends Test {


### PR DESCRIPTION
Adds a section to the Landing Page variant editor for the products config.
support-frontend PR: https://github.com/guardian/support-frontend/pull/6808

This is for configuring the copy. Pricing still comes from zuora.

It's an "accordion" component, with each product expandable:
<img width="1000" alt="Screenshot 2025-03-04 at 13 52 40" src="https://github.com/user-attachments/assets/48e9a63f-9d3e-4cd0-8bc6-d8ed0110b0c2" />

Expanded product:

<img width="886" alt="Screenshot 2025-03-04 at 16 07 36" src="https://github.com/user-attachments/assets/503fd9c6-2da5-49f9-8eea-e1ab12e1d620" />
