### PR TITLE
Add audit table

### DIFF
--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -15,6 +15,8 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       "GuDynamoDBWritePolicy",
       "GuDynamoDBReadPolicy",
       "GuDynamoDBWritePolicy",
+      "GuDynamoDBReadPolicy",
+      "GuDynamoDBWritePolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuGetS3ObjectsPolicy",
@@ -475,6 +477,60 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
     },
+    "ChannelTestsAuditDynamoTable": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "channelAndName",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "timestamp",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "channelAndName",
+            "KeyType": "HASH",
+          },
+          {
+            "AttributeName": "timestamp",
+            "KeyType": "RANGE",
+          },
+        ],
+        "PointInTimeRecoverySpecification": {
+          "PointInTimeRecoveryEnabled": true,
+        },
+        "TableName": "support-admin-console-channel-tests-audit-PROD",
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-admin-console",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
     "ChannelTestsDynamoTable": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -862,6 +918,73 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "DynamoReadCampaignsDynamoTable13FF797A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleAdminconsole347DA627",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DynamoReadChannelTestsAuditDynamoTableFCA49D1C": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:GetRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/",
+                      {
+                        "Ref": "ChannelTestsAuditDynamoTable",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/",
+                      {
+                        "Ref": "ChannelTestsAuditDynamoTable",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoReadChannelTestsAuditDynamoTableFCA49D1C",
         "Roles": [
           {
             "Ref": "InstanceRoleAdminconsole347DA627",
@@ -1441,6 +1564,72 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "DynamoWriteCampaignsDynamoTableB29B2DDA",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleAdminconsole347DA627",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DynamoWriteChannelTestsAuditDynamoTableEECEA480": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/",
+                      {
+                        "Ref": "ChannelTestsAuditDynamoTable",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/",
+                      {
+                        "Ref": "ChannelTestsAuditDynamoTable",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoWriteChannelTestsAuditDynamoTableEECEA480",
         "Roles": [
           {
             "Ref": "InstanceRoleAdminconsole347DA627",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -1,8 +1,8 @@
-import {GuEc2App} from '@guardian/cdk';
-import {AccessScope} from '@guardian/cdk/lib/constants';
-import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
-import {GuStack, GuStringParameter} from '@guardian/cdk/lib/constructs/core';
-import {GuCname} from '@guardian/cdk/lib/constructs/dns';
+import { GuEc2App } from '@guardian/cdk';
+import { AccessScope } from '@guardian/cdk/lib/constants';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
@@ -10,14 +10,18 @@ import {
   GuGetS3ObjectsPolicy,
   GuPutS3ObjectsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
-import type {App, CfnElement} from 'aws-cdk-lib';
-import {Duration, RemovalPolicy, Tags} from 'aws-cdk-lib';
-import {AttributeType, BillingMode, ProjectionType, Table} from 'aws-cdk-lib/aws-dynamodb';
-import {InstanceClass, InstanceSize, InstanceType} from 'aws-cdk-lib/aws-ec2';
-import {ApplicationListenerRule, ListenerAction, ListenerCondition} from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import type {Policy} from 'aws-cdk-lib/aws-iam';
-import {AccountPrincipal, Role} from 'aws-cdk-lib/aws-iam';
-import {ParameterDataType, ParameterTier, StringParameter} from 'aws-cdk-lib/aws-ssm';
+import type { App, CfnElement } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy, Tags } from 'aws-cdk-lib';
+import { AttributeType, BillingMode, ProjectionType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import {
+  ApplicationListenerRule,
+  ListenerAction,
+  ListenerCondition,
+} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Policy } from 'aws-cdk-lib/aws-iam';
+import { AccountPrincipal, Role } from 'aws-cdk-lib/aws-iam';
+import { ParameterDataType, ParameterTier, StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface AdminConsoleProps extends GuStackProps {
   domainName: string;
@@ -335,11 +339,10 @@ export class AdminConsole extends GuStack {
     new ApplicationListenerRule(this, 'BlockUnknownMethods', {
       listener: ec2App.listener,
       priority: 2,
-      conditions: [ListenerCondition.pathPatterns(['*'])],  // anything
+      conditions: [ListenerCondition.pathPatterns(['*'])], // anything
       action: ListenerAction.fixedResponse(400, {
         contentType: 'application/json',
-        messageBody:
-          'Unsupported http method',
+        messageBody: 'Unsupported http method',
       }),
     });
 
@@ -359,9 +362,9 @@ export class AdminConsole extends GuStack {
       tableName: channelTestsDynamoTable.tableName,
     });
     const s3ReadPolicyForCapi = new GuGetS3ObjectsPolicy(this, 's3Get-for-capi', {
-        bucketName: 'support-admin-console',
-        paths: [`${this.stage}/*`, 'channel-switches.json'],
-      });
+      bucketName: 'support-admin-console',
+      paths: [`${this.stage}/*`, 'channel-switches.json'],
+    });
 
     new Role(this, 'capi-role', {
       roleName: `support-admin-console-channel-tests-capi-role-${this.stage}`,


### PR DESCRIPTION
For storing the audit history of each channel test.
Each create/update in the tools will add a new item in the audit table. The item will contain all the data from the updated test.
The partition key is composed of the channel name and the test name. This is necessary because DynamoDb limits us to a single partition key and a sort key, and we need the sort key to be the timestamp of the update (we do something like this in the multi-armed bandit table).

This is just the cdk change. Follow-up PRs will actually use this table.