### PR TITLE
Write audits

### DIFF
--- a/app/controllers/ChannelTestsAuditController.scala
+++ b/app/controllers/ChannelTestsAuditController.scala
@@ -1,0 +1,35 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax.EncoderOps
+import play.api.mvc.{AbstractController, Action, ActionBuilder, AnyContent, ControllerComponents, Result}
+import services.DynamoChannelTestsAudit
+import utils.Circe.noNulls
+import zio.{IO, ZEnv, ZIO}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ChannelTestsAuditController(
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
+  components: ControllerComponents,
+  stage: String,
+  runtime: zio.Runtime[ZEnv],
+  dynamo: DynamoChannelTestsAudit
+)(implicit ec: ExecutionContext) extends AbstractController(components) with LazyLogging {
+
+  private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
+    runtime.unsafeRunToFuture {
+      f.catchAll(error => {
+        logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
+        IO.succeed(InternalServerError(error.getMessage))
+      })
+    }
+
+  def getAuditsForChannelTest(channel: String, testName: String): Action[AnyContent] = authAction.async { request =>
+    run {
+      dynamo.getAuditsForChannelTest(channel, testName)
+        .map(tests => Ok(noNulls(tests.asJson)))
+    }
+  }
+}

--- a/app/controllers/HeaderTestsController.scala
+++ b/app/controllers/HeaderTestsController.scala
@@ -4,7 +4,7 @@ import com.gu.googleauth.AuthAction
 import models.{Channel, HeaderTest}
 import models.HeaderTest._
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -20,6 +20,7 @@ class HeaderTestsController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[HeaderTest](
   authAction,
   components,
@@ -28,5 +29,6 @@ class HeaderTestsController(
   channel = Channel.Header,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 )

--- a/app/controllers/SupportLandingPageController.scala
+++ b/app/controllers/SupportLandingPageController.scala
@@ -5,7 +5,7 @@ import models.{BannerTest, Channel, SupportLandingPageTest}
 import models.BannerTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -15,13 +15,14 @@ object SupportLandingPageController {
 }
 
 class SupportLandingPageController(
-                                    authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
-                                    components: ControllerComponents,
-                                    stage: String,
-                                    runtime: zio.Runtime[ZEnv],
-                                    dynamoTests: DynamoChannelTests,
-                                    dynamoArchivedTests: DynamoArchivedChannelTests,
-                                  )(implicit ec: ExecutionContext) extends ChannelTestsController[SupportLandingPageTest](
+  authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
+  components: ControllerComponents,
+  stage: String,
+  runtime: zio.Runtime[ZEnv],
+  dynamoTests: DynamoChannelTests,
+  dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
+)(implicit ec: ExecutionContext) extends ChannelTestsController[SupportLandingPageTest](
   authAction,
   components,
   stage,
@@ -29,5 +30,6 @@ class SupportLandingPageController(
   channel = Channel.SupportLandingPage,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/banner/BannerTestsController.scala
+++ b/app/controllers/banner/BannerTestsController.scala
@@ -6,7 +6,7 @@ import models.{BannerTest, Channel}
 import models.BannerTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ class BannerTestsController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[BannerTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class BannerTestsController(
   channel = Channel.Banner1,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/banner/BannerTestsController2.scala
+++ b/app/controllers/banner/BannerTestsController2.scala
@@ -6,7 +6,7 @@ import models.{BannerTest, Channel}
 import models.BannerTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ class BannerTestsController2(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[BannerTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class BannerTestsController2(
   channel = Channel.Banner2,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/epic/AMPEpicTestsController.scala
+++ b/app/controllers/epic/AMPEpicTestsController.scala
@@ -6,7 +6,7 @@ import models.{Channel, EpicTest}
 import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ class AMPEpicTestsController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class AMPEpicTestsController(
   channel = Channel.EpicAMP,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/epic/AppleNewsEpicTestsController.scala
+++ b/app/controllers/epic/AppleNewsEpicTestsController.scala
@@ -6,7 +6,7 @@ import models.{Channel, EpicTest}
 import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ class AppleNewsEpicTestsController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class AppleNewsEpicTestsController(
   channel = Channel.EpicAppleNews,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/epic/EpicTestsController.scala
+++ b/app/controllers/epic/EpicTestsController.scala
@@ -6,7 +6,7 @@ import models.{Channel, EpicTest}
 import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ class EpicTestsController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class EpicTestsController(
   channel = Channel.Epic,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/epic/LiveblogEpicTestsController.scala
+++ b/app/controllers/epic/LiveblogEpicTestsController.scala
@@ -6,7 +6,7 @@ import models.{Channel, EpicTest}
 import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ class LiveblogEpicTestsController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class LiveblogEpicTestsController(
   channel = Channel.EpicLiveblog,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/controllers/gutter/GutterLiveblogTestsController.scala
+++ b/app/controllers/gutter/GutterLiveblogTestsController.scala
@@ -2,11 +2,11 @@ package controllers.gutter
 
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
-import models.{GutterTest, Channel}
+import models.{Channel, GutterTest}
 import models.GutterTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import services.{DynamoArchivedChannelTests, DynamoChannelTests}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -21,7 +21,8 @@ class GutterLiveblogTestsController(
   stage: String,
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
-  dynamoArchivedTests: DynamoArchivedChannelTests
+  dynamoArchivedTests: DynamoArchivedChannelTests,
+  dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[GutterTest](
   authAction,
   components,
@@ -30,5 +31,6 @@ class GutterLiveblogTestsController(
   channel = Channel.GutterLiveblog,
   runtime = runtime,
   dynamoTests,
-  dynamoArchivedTests
+  dynamoArchivedTests,
+  dynamoTestsAudit
 ) with Circe

--- a/app/services/DynamoArchivedBannerDesigns.scala
+++ b/app/services/DynamoArchivedBannerDesigns.scala
@@ -15,16 +15,6 @@ class DynamoArchivedBannerDesigns(stage: String, client: DynamoDbClient) extends
 
   protected val tableName = s"support-admin-console-archived-banner-designs-$stage"
 
-  private def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
-      val result = client.putItem(putRequest)
-      logger.info(s"PutItemResponse: $result")
-      ()
-    }.mapError {
-      case err: ConditionalCheckFailedException => DynamoDuplicateNameError(err)
-      case other => DynamoPutError(other)
-    }
-
   def putRaw(item: java.util.Map[String, AttributeValue]): ZIO[ZEnv, DynamoError, Unit] = {
     // Add date attribute, which is the sort key. We first have to build a mutable Map, otherwise the Java Map throws when we insert
     val mutableItem = new util.HashMap(item)

--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -74,16 +74,6 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
         .items()
     }.mapError(DynamoGetError)
 
-  private def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
-      val result = client.putItem(putRequest)
-      logger.info(s"PutItemResponse: $result")
-      ()
-    }.mapError {
-      case err: ConditionalCheckFailedException => DynamoDuplicateNameError(err)
-      case other                                => DynamoPutError(other)
-    }
-
   private def update(
       updateRequest: UpdateItemRequest): ZIO[ZEnv, DynamoError, Unit] =
     effectBlocking {

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -92,16 +92,6 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
       ).items
     }.mapError(DynamoGetError)
 
-  private def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
-      val result = client.putItem(putRequest)
-      logger.info(s"PutItemResponse: $result")
-      ()
-    }.mapError {
-      case err: ConditionalCheckFailedException => DynamoDuplicateNameError(err)
-      case other => DynamoPutError(other)
-    }
-
   private def update(updateRequest: UpdateItemRequest): ZIO[ZEnv, DynamoError, Unit] =
     effectBlocking {
       val result = client.updateItem(updateRequest)
@@ -227,11 +217,12 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
       .map(allTests => allTests.flatMap(_.priority).maxOption.getOrElse(0))
 
   // Creates a new test, with bottom priority
-  def createTest[T <: ChannelTest[T] : Encoder : Decoder](test: T, channel: Channel): ZIO[ZEnv, DynamoError, Unit] =
+  def createTest[T <: ChannelTest[T] : Encoder : Decoder](test: T, channel: Channel): ZIO[ZEnv, DynamoError, T] =
     getBottomPriority[T](channel)
       .flatMap(bottomPriority => {
         val priority = bottomPriority + 1
-        val item = jsonToDynamo(test.withChannel(channel).withPriority(priority).asJson).m()
+        val enrichedTest = test.withChannel(channel).withPriority(priority)
+        val item = jsonToDynamo(enrichedTest.asJson).m()
         val request = PutItemRequest
           .builder
           .tableName(tableName)
@@ -240,7 +231,8 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
           .conditionExpression("attribute_not_exists(#name)")
           .expressionAttributeNames(Map("#name" -> "name").asJava)
           .build()
-        put(request)
+
+        put(request).map(_ => enrichedTest)
       })
 
   def lockTest(testName: String, channel: Channel, email: String, force: Boolean): ZIO[ZEnv, DynamoError, Unit] = {

--- a/app/services/DynamoChannelTestsAudit.scala
+++ b/app/services/DynamoChannelTestsAudit.scala
@@ -1,0 +1,54 @@
+package services
+
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder}
+import models.ChannelTest
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
+import zio.{ZEnv, ZIO}
+import models.DynamoErrors._
+import services.DynamoChannelTestsAudit.ChannelTestAudit
+import utils.Circe.jsonToDynamo
+
+import java.time.OffsetDateTime
+
+object DynamoChannelTestsAudit {
+  // The model that we write to the audit table
+  case class ChannelTestAudit[T <: ChannelTest[T] : Encoder : Decoder](
+    channelAndName: String,     // The partition key is the channel and test name combined
+    timestamp: OffsetDateTime,  // The range key is the timestamp of the change
+    userEmail: String,          // The email address of the user making the change
+    item: T                     // The new state of the item being changed
+  )
+
+  implicit def encoder[T <: ChannelTest[T] : Encoder : Decoder] = deriveEncoder[ChannelTestAudit[T]]
+  implicit def decoder[T <: ChannelTest[T] : Encoder : Decoder] = deriveDecoder[ChannelTestAudit[T]]
+}
+
+class DynamoChannelTestsAudit(stage: String, client: DynamoDbClient) extends DynamoService(stage, client) with StrictLogging {
+  protected val tableName = s"support-admin-console-channel-tests-audit-$stage"
+
+  def createAudit[T <: ChannelTest[T] : Encoder : Decoder](test: T, userEmail: String): ZIO[ZEnv, DynamoError, Unit] = {
+    val channelAndName = s"${test.channel.get}_${test.name}"
+    val timestamp = OffsetDateTime.now()
+
+    val audit = ChannelTestAudit(
+      channelAndName,
+      timestamp,
+      userEmail,
+      item = test
+    )
+
+    val request = PutItemRequest
+      .builder
+      .tableName(tableName)
+      .item(
+        jsonToDynamo(audit.asJson).m()
+      )
+      .build()
+
+    put(request)
+  }
+}

--- a/app/services/DynamoChannelTestsAudit.scala
+++ b/app/services/DynamoChannelTestsAudit.scala
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model._
 import zio.{ZEnv, ZIO}
 import models.DynamoErrors._
-import services.DynamoChannelTestsAudit.ChannelTestAudit
+import services.DynamoChannelTestsAudit.{ChannelTestAudit, getTimeToLive}
 import utils.Circe.jsonToDynamo
 
 import java.time.OffsetDateTime
@@ -17,14 +17,18 @@ import java.time.OffsetDateTime
 object DynamoChannelTestsAudit {
   // The model that we write to the audit table
   case class ChannelTestAudit[T <: ChannelTest[T] : Encoder : Decoder](
-    channelAndName: String,     // The partition key is the channel and test name combined
-    timestamp: OffsetDateTime,  // The range key is the timestamp of the change
-    userEmail: String,          // The email address of the user making the change
-    item: T                     // The new state of the item being changed
+    channelAndName: String,       // The partition key is the channel and test name combined
+    timestamp: OffsetDateTime,    // The range key is the timestamp of the change
+    ttlInSecondsSinceEpoch: Long, // Expiry time in seconds since Epoch
+    userEmail: String,            // The email address of the user making the change
+    item: T                       // The new state of the item being changed
   )
 
   implicit def encoder[T <: ChannelTest[T] : Encoder : Decoder] = deriveEncoder[ChannelTestAudit[T]]
   implicit def decoder[T <: ChannelTest[T] : Encoder : Decoder] = deriveDecoder[ChannelTestAudit[T]]
+
+  private val RetentionPeriodInYears = 3
+  def getTimeToLive(timestamp: OffsetDateTime): OffsetDateTime = timestamp.plusYears(RetentionPeriodInYears)
 }
 
 class DynamoChannelTestsAudit(stage: String, client: DynamoDbClient) extends DynamoService(stage, client) with StrictLogging {
@@ -33,10 +37,12 @@ class DynamoChannelTestsAudit(stage: String, client: DynamoDbClient) extends Dyn
   def createAudit[T <: ChannelTest[T] : Encoder : Decoder](test: T, userEmail: String): ZIO[ZEnv, DynamoError, Unit] = {
     val channelAndName = s"${test.channel.get}_${test.name}"
     val timestamp = OffsetDateTime.now()
+    val ttlInSecondsSinceEpoch = getTimeToLive(timestamp).toInstant.getEpochSecond
 
     val audit = ChannelTestAudit(
       channelAndName,
       timestamp,
+      ttlInSecondsSinceEpoch,
       userEmail,
       item = test
     )

--- a/app/services/DynamoChannelTestsAudit.scala
+++ b/app/services/DynamoChannelTestsAudit.scala
@@ -27,7 +27,7 @@ object DynamoChannelTestsAudit {
   implicit def encoder[T <: ChannelTest[T] : Encoder : Decoder] = deriveEncoder[ChannelTestAudit[T]]
   implicit def decoder[T <: ChannelTest[T] : Encoder : Decoder] = deriveDecoder[ChannelTestAudit[T]]
 
-  private val RetentionPeriodInYears = 3
+  private val RetentionPeriodInYears = 1
   def getTimeToLive(timestamp: OffsetDateTime): OffsetDateTime = timestamp.plusYears(RetentionPeriodInYears)
 }
 

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -12,7 +12,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.{Aws, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoSuperMode, S3}
+import services.{Aws, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoChannelTestsAudit, DynamoSuperMode, S3}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
@@ -71,6 +71,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
 
   val dynamoTestsService = new DynamoChannelTests(stage, dynamoClient)
   val dynamoArchivedChannelTests = new DynamoArchivedChannelTests(stage, dynamoClient)
+  val dynamoTestsAuditService = new DynamoChannelTestsAudit(stage, dynamoClient)
 
   val dynamoCampaignsService = new DynamoCampaigns(stage, dynamoClient)
 
@@ -89,16 +90,16 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new Login(authConfig, wsClient, controllerComponents),
     new SwitchesController(authAction, controllerComponents, stage, runtime),
     new AmountsController(authAction, controllerComponents, stage, runtime),
-    new EpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
-    new HeaderTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
-    new LiveblogEpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
-    new AppleNewsEpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
-    new AMPEpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
-    new BannerTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
-    new BannerTestsController2(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
+    new EpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new HeaderTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new LiveblogEpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new AppleNewsEpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new AMPEpicTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new BannerTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new BannerTestsController2(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
     new BannerDeployController(authAction, controllerComponents, stage, runtime),
     new BannerDeployController2(authAction, controllerComponents, stage, runtime),
-    new GutterLiveblogTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
+    new GutterLiveblogTestsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
     new ChannelSwitchesController(authAction, controllerComponents, stage, runtime),
     new CampaignsController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoCampaignsService),
     new BannerDesignsController(authAction, controllerComponents, stage, runtime, dynamoBannerDesigns, dynamoTestsService, dynamoArchivedBannerDesigns),
@@ -108,6 +109,6 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new SuperModeController(authAction, controllerComponents, stage, runtime, dynamoSuperModeService),
     new BanditDataController(authAction, controllerComponents, stage, runtime, dynamoBanditData),
     assets,
-    new SupportLandingPageController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests),
+    new SupportLandingPageController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
   )
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -108,6 +108,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new DefaultPromosController(authAction,controllerComponents, stage, runtime),
     new SuperModeController(authAction, controllerComponents, stage, runtime, dynamoSuperModeService),
     new BanditDataController(authAction, controllerComponents, stage, runtime, dynamoBanditData),
+    new ChannelTestsAuditController(authAction, controllerComponents, stage, runtime, dynamoTestsAuditService),
     assets,
     new SupportLandingPageController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
   )

--- a/cdk/lib/__snapshots__/admin-console.test.ts.snap
+++ b/cdk/lib/__snapshots__/admin-console.test.ts.snap
@@ -527,6 +527,10 @@ exports[`The AdminConsole stack matches the snapshot 1`] = `
             "Value": "PROD",
           },
         ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "ttlInSecondsSinceEpoch",
+          "Enabled": true,
+        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",

--- a/cdk/lib/admin-console.ts
+++ b/cdk/lib/admin-console.ts
@@ -140,6 +140,7 @@ export class AdminConsole extends GuStack {
         name: 'timestamp',
         type: AttributeType.STRING,
       },
+      timeToLiveAttribute: 'ttlInSecondsSinceEpoch',
     });
 
     // Give it a better name

--- a/conf/routes
+++ b/conf/routes
@@ -250,6 +250,9 @@ GET   /frontend/super-mode                             controllers.SuperModeCont
 # ----- analytics ----- #
 GET   /frontend/bandit/:channel/:testName              controllers.BanditDataController.getDataForTest(channel: String, testName: String)
 
+# ----- audit ----- #
+GET   /frontend/audit/:channel/:testName              controllers.ChannelTestsAuditController.getAuditsForChannelTest(channel: String, testName: String)
+
 # Map static resources from the /public folder to the /assets URL path
 GET  /assets/*file                                  controllers.Assets.at(path="/public", file)
 

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -204,9 +204,9 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
     expectToSucceedWith {
       for {
         _ <- dynamoAudit.createAudit(epicTests.head, "mr.test@guardian.co.uk")
-        _ <- dynamoAudit.createAudit(epicTests.head.copy(nickname = Some("new nickname")), "mr.test@guardian.co.uk")
+        _ <- dynamoAudit.createAudit(epicTests.head, "ms.test@guardian.co.uk")
         audits <- dynamoAudit.getAuditsForChannelTest(epicTests.head.channel.get.toString, epicTests.head.name)
       } yield audits
-    }(tests => tests.length should be(2))
+    }(tests => tests.map(_.userEmail) should be(List("mr.test@guardian.co.uk", "ms.test@guardian.co.uk")))
   }
 }

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import models.{Channel, ChannelTest, EpicTest, Status}
+import models.{Channel, EpicTest, Status}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}

--- a/test/services/DynamoChannelTestsSpec.scala
+++ b/test/services/DynamoChannelTestsSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import models.{Channel, EpicTest, Status}
+import models.{Channel, ChannelTest, EpicTest, Status}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
@@ -27,7 +27,9 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
     .build
 
   private val dynamo = new DynamoChannelTests(stage, client)
+  private val dynamoAudit = new DynamoChannelTestsAudit(stage, client)
   private val tableName = s"support-admin-console-channel-tests-$stage"
+  private val auditTableName = s"support-admin-console-channel-tests-audit-$stage"
 
   def buildEpic(name: String, priority: Option[Int] = None): EpicTest =
     EpicTest(
@@ -76,11 +78,28 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
         .billingMode(BillingMode.PAY_PER_REQUEST)
         .build
     )
+
+    client.createTable(
+      CreateTableRequest
+        .builder
+        .tableName(auditTableName)
+        .attributeDefinitions(
+          AttributeDefinition.builder.attributeName("channelAndName").attributeType("S").build,
+          AttributeDefinition.builder.attributeName("timestamp").attributeType("S").build
+        )
+        .keySchema(
+          KeySchemaElement.builder.attributeName("channelAndName").keyType(KeyType.HASH).build,
+          KeySchemaElement.builder.attributeName("timestamp").keyType(KeyType.RANGE).build
+        )
+        .billingMode(BillingMode.PAY_PER_REQUEST)
+        .build
+    )
   }
 
   override def afterEach(): Unit = {
     // Drop the table for the next test
     client.deleteTable(DeleteTableRequest.builder.tableName(tableName).build)
+    client.deleteTable(DeleteTableRequest.builder.tableName(auditTableName).build)
   }
 
   it should "create and then fetch epic tests" in {
@@ -179,5 +198,15 @@ class DynamoChannelTestsSpec extends AsyncFlatSpec with Matchers with BeforeAndA
         tests <- dynamo.getAllTests(Channel.Epic) // excludes archived tests
       } yield tests
     }(tests => tests.map(_.name) should be(List("test1")))
+  }
+
+  it should "create and fetch audits" in {
+    expectToSucceedWith {
+      for {
+        _ <- dynamoAudit.createAudit(epicTests.head, "mr.test@guardian.co.uk")
+        _ <- dynamoAudit.createAudit(epicTests.head.copy(nickname = Some("new nickname")), "mr.test@guardian.co.uk")
+        audits <- dynamoAudit.getAuditsForChannelTest(epicTests.head.channel.get.toString, epicTests.head.name)
+      } yield audits
+    }(tests => tests.length should be(2))
   }
 }


### PR DESCRIPTION
Uses the new channel tests audit table.
- adds the `DynamoChannelTestsAudit` service, which we pass into each channel tests Controller.
- changes the create and update handlers in the `ChannelTestsController` class. These now also write to the audit table. The entire channel test config is included in the audit record, along with the user's email and a timestamp.
- adds the `ttlInSecondsSinceEpoch` field to the table, which tells Dynamodb when to auto-expire items
- adds the `ChannelTestsAuditController`, which has a single endpoint for getting the audit history of a test. For now nothing will use this endpoint

This PR does not handle changes to the `status` field when going between draft/live. I'll do this in the separate PR as it involves fetching the current data.