### PR TITLE
Write audits for status updates

### DIFF
--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -140,6 +140,19 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
     }.mapError(DynamoGetError)
   }
 
+  def getTests[T <: ChannelTest[T] : Decoder](channel: Channel, testNames: List[String]): ZIO[ZEnv, DynamoGetError, List[T]] = {
+    getRawTests(channel, testNames).map(rawTests => {
+      rawTests.flatMap(rawTest =>
+        dynamoMapToJson(rawTest).as[T] match {
+          case Right(test) => Some(test)
+          case Left(error) =>
+            logger.error(s"Failed to decode item from Dynamo: ${error.getMessage}")
+            None
+        }
+      )
+    })
+  }
+
   // Returns all tests in a campaign, sorted by channel
   import models.ChannelTest.channelTestDecoder
   def getAllTestsInCampaign(campaignName: String): ZIO[ZEnv, DynamoGetError, List[ChannelTest[_]]] =


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/support-admin-console/pull/700) began writing to the audit table for each create + update request.

There was still one case that was not audited: updating the status of tests (between draft/live).
This is a bit more complex because we have to first fetch the full data for the test before writing to the audit table.
Also, the status update endpoint can take a set of test names, so we have to fetch and write in batch.