### PR TITLE
Field validation in the landing page tool

### DIFF
--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -84,3 +84,6 @@ export const templateValidatorForPlatform = (platform: TestPlatform) => (
 
 export const noHtmlValidator = (s: string): string | undefined =>
   /<\/?[a-z][\s\S]*>/i.test(s) ? 'HTML is not allowed' : undefined;
+
+export const copyLengthValidator = (maxLength: number) => (copy: string): string | undefined =>
+  copy.length > maxLength ? `Max length is ${maxLength}` : undefined;

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -2,7 +2,7 @@ import { SupportLandingPageCopy } from '../../../models/supportLandingPage';
 import React, { useEffect, useState } from 'react';
 import { copyLengthValidator, templateValidatorForPlatform } from '../helpers/validation';
 import { Controller, useForm } from 'react-hook-form';
-import { getRteCopyLength, RichTextEditorSingleLine } from '../richTextEditor/richTextEditor';
+import { RichTextEditorSingleLine } from '../richTextEditor/richTextEditor';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
 
@@ -11,9 +11,6 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
     marginLeft: spacing(2),
   },
 }));
-
-const headingCopyRecommendedLength = 500;
-const subheadingCopyRecommendedLength = 500;
 
 interface CopyEditorProps {
   copy: SupportLandingPageCopy;
@@ -66,21 +63,6 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
     }
   }, [errors.heading, errors.subheading]);
 
-  const getSubheadingCopyLength = () => {
-    if (copy.heading != null) {
-      return [
-        getRteCopyLength([...copy.heading, copy.heading || '']),
-        headingCopyRecommendedLength,
-      ];
-    }
-    return [
-      getRteCopyLength([copy.subheading, copy.subheading || '']),
-      subheadingCopyRecommendedLength,
-    ];
-  };
-
-  const [copyLength, recommendedLength] = getSubheadingCopyLength();
-
   return (
     <>
       <div className={classes.container}>
@@ -128,7 +110,7 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
             render={data => {
               return (
                 <RichTextEditorSingleLine
-                  error={errors.subheading !== undefined || copyLength > recommendedLength}
+                  error={errors.subheading !== undefined}
                   helperText={errors?.subheading?.message || errors?.subheading?.type}
                   copyData={data.value}
                   updateCopy={pars => {

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -1,6 +1,6 @@
 import { SupportLandingPageCopy } from '../../../models/supportLandingPage';
 import React, { useEffect, useState } from 'react';
-import { templateValidatorForPlatform } from '../helpers/validation';
+import { copyLengthValidator, templateValidatorForPlatform } from '../helpers/validation';
 import { Controller, useForm } from 'react-hook-form';
 import { getRteCopyLength, RichTextEditorSingleLine } from '../richTextEditor/richTextEditor';
 import { makeStyles } from '@mui/styles';
@@ -89,7 +89,7 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
           control={control}
           rules={{
             required: true,
-            validate: templateValidator,
+            validate: copy => templateValidator(copy) ?? copyLengthValidator(75)(copy),
           }}
           render={data => {
             return (
@@ -123,7 +123,7 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
             control={control}
             rules={{
               required: true,
-              validate: templateValidator,
+              validate: copy => templateValidator(copy) ?? copyLengthValidator(165)(copy),
             }}
             render={data => {
               return (

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -63,10 +63,12 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
   const classes = useStyles();
 
   // Validation for this product as a whole
-  const { control, handleSubmit, errors, register } = useForm<LandingPageProductDescription>({
-    mode: 'onChange',
-    defaultValues: product,
-  });
+  const { control, handleSubmit, errors, register, reset } = useForm<LandingPageProductDescription>(
+    {
+      mode: 'onChange',
+      defaultValues: product,
+    },
+  );
 
   // Validation specifically for the benefits array
   const { fields: benefits, append, remove } = useFieldArray({
@@ -78,6 +80,10 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
   }, [errors.title, errors.cta, errors.label, errors.benefits]);
+
+  useEffect(() => {
+    reset(product);
+  }, [product, reset]);
 
   return (
     <Accordion key={productKey}>
@@ -129,8 +135,12 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
                 label="Benefit Copy"
                 required={true}
                 name={`benefits[${index}].copy`}
-                inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
+                inputRef={register({
+                  required: EMPTY_ERROR_HELPER_TEXT,
+                  validate: copyLengthValidator(116),
+                })}
                 error={!!errors.benefits?.[index]?.copy}
+                helperText={errors.benefits?.[index]?.copy?.message}
                 defaultValue={benefit.copy}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
@@ -182,7 +192,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
         ))}
         <Button
           onClick={() => append({ copy: '' })}
-          disabled={!editMode}
+          disabled={!editMode || benefits.length >= 8}
           variant="outlined"
           size="medium"
         >
@@ -209,7 +219,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
   const classes = useStyles();
 
   // Validation for all 3 products
-  const { control, setError, clearErrors, errors } = useForm<Products>({
+  const { control, setError, clearErrors, errors, reset } = useForm<Products>({
     mode: 'onChange',
     defaultValues: products,
   });
@@ -218,6 +228,10 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
   }, [errors.Contribution, errors.SupporterPlus, errors.TierThree]);
+
+  useEffect(() => {
+    reset(products);
+  }, [products, reset]);
 
   return (
     <div>

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -15,7 +15,7 @@ import { makeStyles } from '@mui/styles';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
 import { useFieldArray, useForm, Controller } from 'react-hook-form';
-import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import { copyLengthValidator, EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 
 const productKeys: (keyof Products)[] = ['Contribution', 'SupporterPlus', 'TierThree'];
 
@@ -77,7 +77,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.title, errors.cta, errors.benefits]);
+  }, [errors.title, errors.cta, errors.label, errors.benefits]);
 
   return (
     <Accordion key={productKey}>
@@ -88,6 +88,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
         <TextField
           inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
           error={!!errors.title}
+          helperText={errors?.title?.message}
           label="Title"
           name="title"
           required={true}
@@ -98,6 +99,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
         <TextField
           inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
           error={!!errors.cta?.copy}
+          helperText={errors?.cta?.copy?.message}
           label="CTA Copy"
           name="cta.copy"
           required={true}
@@ -106,11 +108,13 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
           fullWidth
         />
         <TextField
-          inputRef={register()}
+          inputRef={register({
+            validate: copyLengthValidator(30),
+          })}
           error={!!errors.label?.copy}
+          helperText={errors?.label?.copy?.message}
           label="Pill (optional)"
           name="label.copy"
-          value={product.label?.copy}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
           fullWidth

--- a/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
@@ -54,6 +54,7 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
         onProductsChange={updatedProducts =>
           onVariantChange({ ...variant, products: updatedProducts })
         }
+        onValidationChange={onValidationChange}
         editMode={editMode}
       />
     </div>


### PR DESCRIPTION
This PR introduces react-hook-form to the landing page tool. We use this library elsewhere in the RRCP for field validation. This means the library now has control over the value and validation of the fields in the tool.

We now validate:
1. heading + subheading length
2. product card pill length
3. benefit copy length
4. number of benefits (max 8). We do this by disabling the button for adding benefits

![Screenshot 2025-03-26 at 11 01 23](https://github.com/user-attachments/assets/5e4cfe0f-4216-414d-b7b4-b4ccb592399b)

![Screenshot 2025-03-26 at 11 46 28](https://github.com/user-attachments/assets/f298b61b-8b72-4618-948b-5d3df7898001)
![Screenshot 2025-03-26 at 11 46 57](https://github.com/user-attachments/assets/89867f8c-8696-4b2c-aeb1-ebc67ed025ea)

