### PR TITLE
Enable web preview in landing page tool

### DIFF
--- a/public/src/components/tests/variants/variantSummary.tsx
+++ b/public/src/components/tests/variants/variantSummary.tsx
@@ -73,16 +73,14 @@ const VariantSummary: React.FC<VariantSummaryProps> = ({
         </div>
         <div className={classes.buttonsContainer}>
           {topButton}
-          {testType !== 'LANDING_PAGE' && (
-            <VariantSummaryWebPreviewButton
-              name={name}
-              testName={testName}
-              testType={testType}
-              platform={platform}
-              isDisabled={isInEditMode}
-              articleType={articleType}
-            />
-          )}
+          <VariantSummaryWebPreviewButton
+            name={name}
+            testName={testName}
+            testType={testType}
+            platform={platform}
+            isDisabled={isInEditMode}
+            articleType={articleType}
+          />
         </div>
       </div>
     </AccordionSummary>

--- a/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
+++ b/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
@@ -26,7 +26,7 @@ const getChannelName = (testType: TestType, articleType: ArticleType): string =>
   } else if (testType === 'GUTTER' && articleType === 'Liveblog') {
     return 'gutter-liveblog';
   } else {
-    return testType.toLowerCase();
+    return testType.toLowerCase().replace('_', '-');
   }
 };
 

--- a/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
+++ b/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
@@ -39,9 +39,16 @@ const getPreviewUrl = (
 ): string => {
   const stage = getStage();
   const channelName = getChannelName(testType, articleType);
-  const queryString = `?dcr&force-${channelName}=${testName}:${variantName}`;
+  const queryString = `?force-${channelName}=${testName}:${variantName}`;
 
-  return `https://${getHostName(stage, platform)}/${ArticlePaths[articleType]}${queryString}`;
+  if (testType === 'LANDING_PAGE') {
+    // link to the support site landing page
+    return `https://support.${
+      stage !== 'PROD' ? 'code.dev-' : ''
+    }theguardian.com/contribute${queryString}`;
+  } else {
+    return `https://${getHostName(stage, platform)}/${ArticlePaths[articleType]}${queryString}`;
+  }
 };
 
 interface VariantSummaryPreviewButtonProps {


### PR DESCRIPTION
The support site now looks for the `force-landing-page` querystring param: https://github.com/guardian/support-frontend/pull/6898
Which means we can show the web preview button in the landing page tool