### PR TITLE
Remove emotion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@emotion/react": "^11.11.3",
-        "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.15.10",
         "@mui/lab": "^5.0.0-alpha.165",
         "@mui/material": "^5.15.10",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "webpack-dev-server": "^5.2.0"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.3",
-    "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.10",
     "@mui/lab": "^5.0.0-alpha.165",
     "@mui/material": "^5.15.10",

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -52,34 +52,13 @@ type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   interface Window {
-    remoteImport: (url: string) => Promise<any>;
     guardian: {
       stage: Stage;
-      automat: {
-        react: any;
-        preact: any;
-        emotionReact: any;
-        emotionReactJsxRuntime: any;
-      };
       sdcUrlOverride: string | undefined;
     };
   }
   /* eslint-enable @typescript-eslint/no-explicit-any */
 }
-
-const initialiseDynamicImport = (): void => {
-  try {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    window.remoteImport = new Function('url', `return import(url)`) as (
-      url: string,
-    ) => Promise<any>;
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-  } catch (e) {
-    console.log('failed to init import');
-  }
-};
-
-initialiseDynamicImport();
 
 const useStyles = makeStyles(({ palette, mixins, typography, transitions }: Theme) => ({
   root: {


### PR DESCRIPTION
In the past we used a different mechanism for the live preview in the RRCP. This involved a remote import of the components, and making emotion + react available on the `window` object.
The last PR to remove that was here: https://github.com/guardian/support-admin-console/pull/622/files#diff-e012e468187c418c61d6a1520f4258958c30c2d5aaa6e085306d31cdc110bb1a
We now use the DCR storybook for the live preview.

This PR removes some dependencies and code that are no longer needed.