### PR TITLE
devrun script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Refresh automatically:
 pnpm watch
 ```
 
+Or you can use the devrun.sh script to build and run both client + server (and watch for changes):
+```
+./devrun.sh
+```
+
 ### Running scala tests
 The scala backend tests use dynamodb-local. This doesn't support Apple Silicon (M1).
 

--- a/devrun.sh
+++ b/devrun.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+pnpm concurrently \
+  --prefix-colors auto \
+  --names webpack,sbt \
+  "pnpm watch" \
+  "sbt run"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.0.0",
+    "concurrently": "^9.1.2",
     "css-loader": "^6.7.3",
     "csstype": "^2.6.18",
     "eslint": "^8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^6.0.0
     version: 6.21.0(eslint@8.57.1)(typescript@5.8.2)
+  concurrently:
+    specifier: ^9.1.2
+    version: 9.1.2
   css-loader:
     specifier: ^6.7.3
     version: 6.11.0(webpack@5.98.0)
@@ -4108,6 +4111,20 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
+  /concurrently@9.1.2:
+    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+    dev: true
+
   /connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
@@ -6509,7 +6526,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -7792,6 +7808,12 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
+  /rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+    dependencies:
+      tslib: 2.8.1
+    dev: true
+
   /safari-14-idb-fix@1.0.6:
     resolution: {integrity: sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA==}
     dev: false
@@ -8389,6 +8411,11 @@ packages:
       tslib: '2'
     dependencies:
       tslib: 2.8.1
+    dev: true
+
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /ts-api-utils@1.4.3(typescript@5.8.2):

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -36,4 +36,8 @@ module.exports = {
     port: 9001,
     publicPath: '/public/build',
   },
+  watchOptions: {
+    aggregateTimeout: 200,
+    poll: 500,
+  },
 };


### PR DESCRIPTION
Adds a script which uses [concurrently](https://www.npmjs.com/package/concurrently) to run webpack and sbt concurrently.
This means we can run the server and watch for client changes in a single terminal:
![Screenshot 2025-04-04 at 08 23 38](https://github.com/user-attachments/assets/4d80e377-80d7-4d49-9feb-299b68e76cef)

I've also adjusted the webpack watch options to pick up client changes a little faster.