### PR TITLE
Permissions service

### DIFF
--- a/app/services/DynamoPermissionsCache.scala
+++ b/app/services/DynamoPermissionsCache.scala
@@ -1,0 +1,91 @@
+package services
+
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+import io.circe.generic.auto._
+import models.DynamoErrors.DynamoGetError
+import services.UserPermissions.{UserPermissions, decoder}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ScanRequest}
+import utils.Circe.dynamoMapToJson
+import zio.blocking.effectBlocking
+import zio.duration.durationInt
+import zio.{Schedule, ZEnv, ZIO}
+
+import scala.jdk.CollectionConverters._
+import java.util.concurrent.atomic.AtomicReference
+
+object UserPermissions {
+  // The model for the user permissions that we store in DynamoDb
+  sealed trait Permission
+  object Permission {
+    case object Read extends Permission
+    case object Write extends Permission
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
+    implicit val decoder: Decoder[Permission] = deriveEnumerationDecoder[Permission]
+    implicit val encoder: Encoder[Permission] = deriveEnumerationEncoder[Permission]
+  }
+  case class PagePermission(name: String, permission: Permission)
+  case class UserPermissions(email: String, permissions: List[PagePermission])
+
+  implicit val encoder = Encoder[UserPermissions]
+  implicit val decoder = Decoder[UserPermissions]
+}
+
+/**
+ * Polls the user permissions DynamoDb table and caches all permissions in memory
+ */
+class DynamoPermissionsCache(
+  stage: String,
+  client: DynamoDbClient,
+  runtime: zio.Runtime[ZEnv]
+) extends DynamoService(stage, client) with StrictLogging {
+  type Email = String
+
+  protected val tableName = s"support-admin-console-permissions-$stage"
+
+  private val permissionsCache = new AtomicReference[Map[Email, UserPermissions]](Map.empty)
+
+  private def getAll: ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
+    effectBlocking {
+      client
+        .scan(
+          ScanRequest
+            .builder()
+            .tableName(tableName)
+            .build()
+        )
+        .items()
+    }.mapError(DynamoGetError)
+
+  private def fetchPermissions(): ZIO[ZEnv, DynamoGetError, Map[Email, UserPermissions]] =
+    getAll.map(
+      results =>
+        results.asScala
+          .map(item => dynamoMapToJson(item).as[UserPermissions])
+          .flatMap {
+            case Right(userPermissions) => Some(userPermissions)
+            case Left(error) =>
+              logger.error(
+                s"Failed to decode UserPermissions from Dynamo: ${error.getMessage}")
+              None
+          }
+          .map(userPermissions => userPermissions.email -> userPermissions)
+          .toMap
+    )
+
+  private def updatePermissions(permissions: Map[Email, UserPermissions]) =
+    ZIO.succeed(permissionsCache.set(permissions))
+
+  // Poll every minute in the background
+  runtime.unsafeRunAsync_ {
+    fetchPermissions()
+      .map(updatePermissions)
+      .repeat(Schedule.fixed(1.minute))
+  }
+
+  def getPermissionsForUser(email: Email): Option[UserPermissions] =
+    permissionsCache.get().get(email)
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -12,7 +12,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.{Aws, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoChannelTestsAudit, DynamoSuperMode, S3}
+import services.{Aws, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoChannelTestsAudit, DynamoPermissionsCache, DynamoSuperMode, S3}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
@@ -68,6 +68,8 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     .region(Aws.region)
     .credentialsProvider(Aws.credentialsProvider.build)
     .build
+
+  val permissionsService = new DynamoPermissionsCache(stage, dynamoClient, runtime)
 
   val dynamoTestsService = new DynamoChannelTests(stage, dynamoClient)
   val dynamoArchivedChannelTests = new DynamoArchivedChannelTests(stage, dynamoClient)


### PR DESCRIPTION
A step towards more granular permissioning in the RRCP.

This PR adds a service that polls the permissions table and caches it in memory.
The table was added [here](https://github.com/guardian/support-admin-console/pull/715).

This data will be used to add permissioning to certain endpoints, and to limit functionality in the UI.