### PR TITLE
Link to the audit page from the channel test tools

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -21,4 +21,5 @@ class Application(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyC
 
   // Handler for endpoints with a resource name in the path. The client takes care of using the name
   def indexWithName(name: String) = index
+  def indexWithNameAndChannel(name: String,channel:String) = index
 }

--- a/conf/routes
+++ b/conf/routes
@@ -53,6 +53,7 @@ GET /banner-designs                                 controllers.Application.inde
 GET /banner-designs/:name                           controllers.Application.indexWithName(name: String)
 
 GET /audit-tests                                    controllers.Application.index
+GET /audit-tests/:channel/:name                     controllers.Application.indexWithNameAndChannel(name: String, channel: String)
 # ----- Authentication ----- #
 GET  /login                                         controllers.Login.login
 GET  /loginAction                                   controllers.Login.loginAction

--- a/public/src/components/channelManagement/auditTests/auditTestsDashboard.tsx
+++ b/public/src/components/channelManagement/auditTests/auditTestsDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Button,
   FormControl,
@@ -12,6 +12,7 @@ import {
 import { makeStyles } from '@mui/styles';
 import { grey } from '@mui/material/colors';
 import { AuditDataRow, AuditTestsTable } from './auditTestsTable';
+import { useParams } from 'react-router-dom';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   container: {
@@ -42,6 +43,9 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
 
 export const AuditTestsDashboard: React.FC = () => {
   const classes = useStyles();
+  const testNameInQueryParams = useParams().testName;
+  const channelInQueryParams = useParams().channel;
+
   const [testName, setTestName] = useState('');
   const [channel, setChannel] = useState('');
   const onSelectChannelChange = (event: SelectChangeEvent) => {
@@ -55,6 +59,13 @@ export const AuditTestsDashboard: React.FC = () => {
       .then(rows => setRows(rows));
   };
 
+  useEffect(() => {
+    if (testNameInQueryParams != null && channelInQueryParams != null) {
+      setTestName(testNameInQueryParams);
+      setChannel(channelInQueryParams);
+    }
+  }, [testNameInQueryParams, channelInQueryParams]);
+
   return (
     <div>
       <div className={classes.container}>
@@ -66,6 +77,7 @@ export const AuditTestsDashboard: React.FC = () => {
               name="name"
               margin="normal"
               variant="outlined"
+              value={testName}
               autoFocus
               fullWidth
               onChange={event => {

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -6,6 +6,7 @@ import { LockStatus, Status } from '../helpers/shared';
 import CloseIcon from '@mui/icons-material/Close';
 import SaveIcon from '@mui/icons-material/Save';
 import LockIcon from '@mui/icons-material/Lock';
+import HistoryIcon from '@mui/icons-material/History';
 import { TestLockDetails } from './testLockDetails';
 import { TestArchiveButton } from './testArchiveButton';
 import { TestCopyButton } from './testCopyButton';
@@ -213,8 +214,13 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
               </Button>
             </>
           )}
-          <Button variant="outlined" size="medium" onClick={() => onTestAudit(name, channel)}>
-            <Typography className={classes.buttonText}>Audit details</Typography>
+          <Button
+            variant="outlined"
+            size="medium"
+            startIcon={<HistoryIcon className={classes.icon} />}
+            onClick={() => onTestAudit(name, channel)}
+          >
+            <Typography className={classes.buttonText}>Audit</Typography>
           </Button>
         </div>
       </div>

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -83,6 +83,7 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
 interface StickyTopBarProps {
   name: string;
   nickname?: string;
+  channel?: string;
   campaignName?: string;
   isNew: boolean;
   status: Status;
@@ -97,6 +98,7 @@ interface StickyTopBarProps {
   onTestSave: (testName: string) => void;
   onTestArchive: () => void;
   onTestCopy: (oldName: string, newName: string, newNickname: string) => void;
+  onTestAudit: (testName: string, channel?: string) => void;
   onStatusChange: (status: Status) => void;
   settingsType: FrontendSettingsType;
 }
@@ -104,6 +106,7 @@ interface StickyTopBarProps {
 const StickyTopBar: React.FC<StickyTopBarProps> = ({
   name,
   nickname,
+  channel,
   isNew,
   status,
   lockStatus,
@@ -117,6 +120,7 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
   onTestSave,
   onTestArchive,
   onTestCopy,
+  onTestAudit,
   onStatusChange,
   settingsType,
 }: StickyTopBarProps) => {
@@ -209,6 +213,9 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
               </Button>
             </>
           )}
+          <Button variant="outlined" size="medium" onClick={() => onTestAudit(name, channel)}>
+            <Typography className={classes.buttonText}>Audit details</Typography>
+          </Button>
         </div>
       </div>
     </header>

--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -69,6 +69,7 @@ export interface TestEditorProps<T extends Test> {
   onTestSave: (testName: string) => void;
   onTestArchive: (testName: string) => void;
   onTestCopy: (oldName: string, newName: string, newNickname: string) => void;
+  onTestAudit: (testName: string, channel?: string) => void;
   onStatusChange: (status: Status) => void;
   existingNames: string[];
   existingNicknames: string[];
@@ -175,6 +176,14 @@ export const TestsForm = <T extends Test>(
         .catch(error => {
           alert(`Error while archiving test: ${error}`);
         });
+    };
+
+    const onTestAudit = (testName: string, channel?: string): void => {
+      const redirectPathname = window.location.pathname.replace(
+        window.location.pathname,
+        `audit-tests/${channel}/${testName}`,
+      );
+      window.location.href = redirectPathname; // Redirect to the audit page
     };
 
     const onStatusChange = (status: Status, testName: string): void => {
@@ -306,6 +315,7 @@ export const TestsForm = <T extends Test>(
               onTestSave={onTestSave}
               onTestArchive={onTestArchive}
               onTestCopy={onTestCopy}
+              onTestAudit={onTestAudit}
               onStatusChange={status => onStatusChange(status, selectedTest.name)}
               settingsType={settingsType}
             />

--- a/public/src/components/channelManagement/validatedTestEditor.tsx
+++ b/public/src/components/channelManagement/validatedTestEditor.tsx
@@ -48,6 +48,7 @@ export const ValidatedTestEditor = <T extends Test>(
     onTestSave,
     onTestArchive,
     onTestCopy,
+    onTestAudit,
     existingNames,
     existingNicknames,
     settingsType,
@@ -71,6 +72,7 @@ export const ValidatedTestEditor = <T extends Test>(
         <StickyTopBar
           name={test.name}
           nickname={test.nickname}
+          channel={test.channel}
           campaignName={test.campaignName}
           isNew={!!test.isNew}
           status={test.status}
@@ -85,6 +87,7 @@ export const ValidatedTestEditor = <T extends Test>(
           onTestSave={onSave}
           onTestArchive={() => onTestArchive(test.name)}
           onTestCopy={onTestCopy}
+          onTestAudit={onTestAudit}
           onStatusChange={onStatusChange}
           settingsType={settingsType}
         />

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -212,7 +212,7 @@ const AppRouter = () => {
             element={createComponent(<BannerDesigns />, 'Banner Designs')}
           />
           <Route
-            path="/audit-tests"
+            path="/audit-tests/:channel?/:testName?"
             element={createComponent(<AuditTestsDashboard />, 'Test Audits')}
           />
         </Routes>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR is to link to the audit page from the channel tests.

In RRCP , for each test , in the top sticky bar , we will provide a button for "Audit" .On clicking this button , user will be redirected to the 'Test audits' page and the test name and channel will be pre populated in the related textboxes.From the page user can click on the "Get Audit" button to see the audit details for that test.

## How to test
Test in CODE

## Images

We added the 'Audit' button to the channel tests

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/5d2c5e89-9729-4692-81a3-102ad70726ea" />

Clicking on the  'Audit' button will redirect user to test audits page
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/0d5c2dc7-1127-4a1b-ab24-3581e06cceba" />


Click on 'Get Audit" button 

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/4dfda53a-b89b-4864-866d-716019c4070c" />

