### PR TITLE
Permissioning of landing page tool endpoints

### DIFF
--- a/app/actions/PermissionAction.scala
+++ b/app/actions/PermissionAction.scala
@@ -43,6 +43,8 @@ object PermissionAction extends Results with LazyLogging {
     Forbidden(message)
   }
 
+  // In the filter function we return None if the user has permission to access the resource,
+  // otherwise we return a 403 Forbidden to the client
   def checkPermission(
     email: String,
     page: String,
@@ -73,9 +75,6 @@ class PermissionAction(
   val parse: PlayBodyParsers,
   val executionContext: ExecutionContext,
 ) extends ActionFilter[UserIdentityRequest] {
-
-  // In the filter function we return None if the user has permission to access the resource,
-  // otherwise we return a 403 Forbidden to the client
   override protected def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] = Future.successful {
     checkPermission(
       request.user.email,

--- a/app/actions/PermissionAction.scala
+++ b/app/actions/PermissionAction.scala
@@ -72,7 +72,7 @@ class PermissionAction(
   permissionsService: DynamoPermissionsCache,
   val parse: PlayBodyParsers,
   val executionContext: ExecutionContext,
-) extends ActionFilter[UserIdentityRequest] with Results with LazyLogging {
+) extends ActionFilter[UserIdentityRequest] {
 
   // In the filter function we return None if the user has permission to access the resource,
   // otherwise we return a 403 Forbidden to the client

--- a/app/actions/PermissionAction.scala
+++ b/app/actions/PermissionAction.scala
@@ -1,10 +1,11 @@
 package actions
 
+import actions.PermissionAction.checkPermission
 import com.gu.googleauth.AuthAction
 import com.gu.googleauth.AuthAction.UserIdentityRequest
 import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{ActionBuilder, ActionFilter, AnyContent, PlayBodyParsers, Result, Results}
-import services.DynamoPermissionsCache
+import services.{DynamoPermissionsCache, UserPermissions}
 import services.UserPermissions.Permission
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,6 +37,35 @@ object AuthAndPermissionActions {
     new AuthAndPermissionActions(authAction, None, None)
 }
 
+object PermissionAction extends Results with LazyLogging {
+  private def logAndForbid(message: String): Result = {
+    logger.info(message)
+    Forbidden(message)
+  }
+
+  def checkPermission(
+    email: String,
+    page: String,
+    requiredPermission: Permission,
+    userPermissions: Option[List[UserPermissions.PagePermission]]
+  ): Option[Result] = {
+    userPermissions match {
+      case Some(permissions) =>
+        permissions.find(permission => permission.name == page) match {
+          case Some(userPermission) =>
+            userPermission.permission match {
+              case Permission.Write => None // user has full access
+              case Permission.Read =>
+                if (requiredPermission != Permission.Write) None
+                else Some(logAndForbid(s"Invalid permission for user ${email}, for page $page"))
+            }
+          case None => Some(logAndForbid(s"No permission found for user ${email}, for page $page"))
+        }
+      case None => Some(logAndForbid(s"No permissions found for user ${email}"))
+    }
+  }
+}
+
 class PermissionAction(
   page: String,
   requiredPermission: Permission,
@@ -44,27 +74,14 @@ class PermissionAction(
   val executionContext: ExecutionContext,
 ) extends ActionFilter[UserIdentityRequest] with Results with LazyLogging {
 
-  private def logAndForbid(message: String): Result = {
-    logger.info(message)
-    Forbidden(message)
-  }
-
   // In the filter function we return None if the user has permission to access the resource,
   // otherwise we return a 403 Forbidden to the client
   override protected def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] = Future.successful {
-    permissionsService.getPermissionsForUser(request.user.email) match {
-      case Some(permissions) =>
-        permissions.find(permission => permission.name == page) match {
-          case Some(userPermission) =>
-            userPermission.permission match {
-              case Permission.Write => None // user has full access
-              case Permission.Read =>
-                if (requiredPermission != Permission.Write) None
-                else Some(logAndForbid(s"Invalid permission for user ${request.user.email}, for page $page"))
-            }
-          case None => Some(logAndForbid(s"No permission found for user ${request.user.email}, for page $page"))
-        }
-      case None => Some(logAndForbid(s"No permissions found for user ${request.user.email}"))
-    }
+    checkPermission(
+      request.user.email,
+      page,
+      requiredPermission,
+      permissionsService.getPermissionsForUser(request.user.email)
+    )
   }
 }

--- a/app/actions/PermissionsAction.scala
+++ b/app/actions/PermissionsAction.scala
@@ -21,9 +21,9 @@ object AuthAndPermissionActions {
 }
 
 class PermissionsAction(
-  permissionsService: DynamoPermissionsCache,
   page: String,
   requiredPermission: Permission,
+  permissionsService: DynamoPermissionsCache,
   val parse: PlayBodyParsers,
   val executionContext: ExecutionContext,
 ) extends ActionFilter[UserIdentityRequest] with Results with LazyLogging {

--- a/app/actions/PermissionsAction.scala
+++ b/app/actions/PermissionsAction.scala
@@ -1,0 +1,78 @@
+package actions
+
+import com.gu.googleauth.AuthAction
+import com.gu.googleauth.AuthAction.UserIdentityRequest
+import com.typesafe.scalalogging.LazyLogging
+import play.api.mvc.{ActionBuilder, ActionFilter, AnyContent, PlayBodyParsers, Result, Results}
+import services.DynamoPermissionsCache
+import services.UserPermissions.Permission
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class AuthAndPermissionActions(
+  read: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],  // ensures user has Read or Write permission
+  write: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent]  // ensures user has Write permission
+)
+
+object AuthAndPermissionActions {
+  def withPermissionsChecks(
+    name: String,
+    authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
+    permissionsService: DynamoPermissionsCache,
+    parse: PlayBodyParsers,
+    executionContext: ExecutionContext,
+  ): AuthAndPermissionActions = AuthAndPermissionActions(
+    read = authAction andThen
+      new PermissionsAction(
+        permissionsService,
+        name,
+        Permission.Read,
+        parse,
+        executionContext
+      ),
+    write = authAction andThen
+      new PermissionsAction(
+        permissionsService,
+        name,
+        Permission.Write,
+        parse,
+        executionContext
+      ),
+  )
+
+  def withoutPermissionsChecks(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent]): AuthAndPermissionActions =
+    AuthAndPermissionActions(authAction, authAction)
+}
+
+class PermissionsAction(
+  permissionsService: DynamoPermissionsCache,
+  page: String,
+  requiredPermission: Permission,
+  val parse: PlayBodyParsers,
+  val executionContext: ExecutionContext,
+) extends ActionFilter[UserIdentityRequest] with Results with LazyLogging {
+
+  private def logAndForbid(message: String): Result = {
+    logger.info(message)
+    Forbidden(message)
+  }
+
+  // In the filter function we return None if the user has permission to access the resource,
+  // otherwise we return a 403 Forbidden to the client
+  override protected def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] = Future.successful {
+    permissionsService.getPermissionsForUser(request.user.email) match {
+      case Some(permissions) =>
+        permissions.find(permission => permission.name == page) match {
+          case Some(userPermission) =>
+            userPermission.permission match {
+              case Permission.Write => None // user has full access
+              case Permission.Read =>
+                if (requiredPermission != Permission.Write) None
+                else Some(logAndForbid(s"Invalid permission for user, for page $page"))
+            }
+          case None => Some(logAndForbid(s"No permission found for user, for page $page"))
+        }
+      case None => Some(logAndForbid("No permissions found for user"))
+    }
+  }
+}

--- a/app/controllers/HeaderTestsController.scala
+++ b/app/controllers/HeaderTestsController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import models.{Channel, HeaderTest}
 import models.HeaderTest._
@@ -22,7 +23,7 @@ class HeaderTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[HeaderTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = HeaderTestsController.name,

--- a/app/controllers/SupportLandingPageController.scala
+++ b/app/controllers/SupportLandingPageController.scala
@@ -1,9 +1,8 @@
 package controllers
 
-import actions.{AuthAndPermissionActions, PermissionsAction}
+import actions.{AuthAndPermissionActions, PermissionAction}
 import com.gu.googleauth.AuthAction
-import models.{BannerTest, Channel, SupportLandingPageTest}
-import models.BannerTest._
+import models.{Channel, SupportLandingPageTest}
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.UserPermissions.Permission
@@ -26,18 +25,20 @@ class SupportLandingPageController(
   dynamoTestsAudit: DynamoChannelTestsAudit,
   permissionsService: DynamoPermissionsCache
 )(implicit ec: ExecutionContext) extends ChannelTestsController[SupportLandingPageTest](
-  AuthAndPermissionActions(
+  new AuthAndPermissionActions(
+    authAction,
     // all users have read access
-    read = authAction,
+    readPermissionAction = None,
     // users must have write access to make changes
-    write = authAction andThen
-      new PermissionsAction(
+    writePermissionAction = Some(
+      new PermissionAction(
         page = SupportLandingPageController.name,
         requiredPermission = Permission.Write,
         permissionsService,
         components.parsers,
         ec
-      ),
+      )
+    )
   ),
   components,
   stage,

--- a/app/controllers/SupportLandingPageController.scala
+++ b/app/controllers/SupportLandingPageController.scala
@@ -32,9 +32,9 @@ class SupportLandingPageController(
     // users must have write access to make changes
     write = authAction andThen
       new PermissionsAction(
+        page = SupportLandingPageController.name,
+        requiredPermission = Permission.Write,
         permissionsService,
-        SupportLandingPageController.name,
-        Permission.Write,
         components.parsers,
         ec
       ),

--- a/app/controllers/SupportLandingPageController.scala
+++ b/app/controllers/SupportLandingPageController.scala
@@ -1,11 +1,12 @@
 package controllers
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import models.{BannerTest, Channel, SupportLandingPageTest}
 import models.BannerTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
+import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit, DynamoPermissionsCache}
 import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
@@ -21,9 +22,16 @@ class SupportLandingPageController(
   runtime: zio.Runtime[ZEnv],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
-  dynamoTestsAudit: DynamoChannelTestsAudit
+  dynamoTestsAudit: DynamoChannelTestsAudit,
+  permissionsService: DynamoPermissionsCache
 )(implicit ec: ExecutionContext) extends ChannelTestsController[SupportLandingPageTest](
-  authAction,
+  AuthAndPermissionActions.withPermissionsChecks(
+    SupportLandingPageController.name,
+    authAction,
+    permissionsService,
+    components.parsers,
+    ec
+  ),
   components,
   stage,
   lockFileName = SupportLandingPageController.name,

--- a/app/controllers/SupportLandingPageController.scala
+++ b/app/controllers/SupportLandingPageController.scala
@@ -24,7 +24,7 @@ class SupportLandingPageController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit,
   permissionsService: DynamoPermissionsCache
-)(implicit ec: ExecutionContext) extends ChannelTestsController[SupportLandingPageTest](
+)(implicit executionContext: ExecutionContext) extends ChannelTestsController[SupportLandingPageTest](
   new AuthAndPermissionActions(
     authAction,
     // all users have read access
@@ -36,7 +36,7 @@ class SupportLandingPageController(
         requiredPermission = Permission.Write,
         permissionsService,
         components.parsers,
-        ec
+        executionContext
       )
     )
   ),

--- a/app/controllers/banner/BannerTestsController.scala
+++ b/app/controllers/banner/BannerTestsController.scala
@@ -1,5 +1,6 @@
 package controllers.banner
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{BannerTest, Channel}
@@ -24,7 +25,7 @@ class BannerTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[BannerTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = BannerTestsController.name,

--- a/app/controllers/banner/BannerTestsController2.scala
+++ b/app/controllers/banner/BannerTestsController2.scala
@@ -1,5 +1,6 @@
 package controllers.banner
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{BannerTest, Channel}
@@ -24,7 +25,7 @@ class BannerTestsController2(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[BannerTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = BannerTestsController.name,

--- a/app/controllers/epic/AMPEpicTestsController.scala
+++ b/app/controllers/epic/AMPEpicTestsController.scala
@@ -1,5 +1,6 @@
 package controllers.epic
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{Channel, EpicTest}
@@ -24,7 +25,7 @@ class AMPEpicTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = AMPEpicTestsController.name,

--- a/app/controllers/epic/AppleNewsEpicTestsController.scala
+++ b/app/controllers/epic/AppleNewsEpicTestsController.scala
@@ -1,5 +1,6 @@
 package controllers.epic
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{Channel, EpicTest}
@@ -24,7 +25,7 @@ class AppleNewsEpicTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = AppleNewsEpicTestsController.name,

--- a/app/controllers/epic/EpicTestsController.scala
+++ b/app/controllers/epic/EpicTestsController.scala
@@ -1,5 +1,6 @@
 package controllers.epic
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{Channel, EpicTest}
@@ -24,7 +25,7 @@ class EpicTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = EpicTestsController.name,

--- a/app/controllers/epic/LiveblogEpicTestsController.scala
+++ b/app/controllers/epic/LiveblogEpicTestsController.scala
@@ -1,5 +1,6 @@
 package controllers.epic
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{Channel, EpicTest}
@@ -24,7 +25,7 @@ class LiveblogEpicTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[EpicTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = LiveblogEpicTestsController.name,

--- a/app/controllers/gutter/GutterLiveblogTestsController.scala
+++ b/app/controllers/gutter/GutterLiveblogTestsController.scala
@@ -1,5 +1,6 @@
 package controllers.gutter
 
+import actions.AuthAndPermissionActions
 import com.gu.googleauth.AuthAction
 import controllers.ChannelTestsController
 import models.{Channel, GutterTest}
@@ -24,7 +25,7 @@ class GutterLiveblogTestsController(
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends ChannelTestsController[GutterTest](
-  authAction,
+  AuthAndPermissionActions.withoutPermissionsChecks(authAction),
   components,
   stage,
   lockFileName = GutterLiveblogTestsController.name,

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -115,6 +115,6 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
     new BanditDataController(authAction, controllerComponents, stage, runtime, dynamoBanditData, bigQueryService),
     new ChannelTestsAuditController(authAction, controllerComponents, stage, runtime, dynamoTestsAuditService),
     assets,
-    new SupportLandingPageController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService),
+    new SupportLandingPageController(authAction, controllerComponents, stage, runtime, dynamoTestsService, dynamoArchivedChannelTests, dynamoTestsAuditService, permissionsService),
   )
 }

--- a/test/actions/PermissionActionSpec.scala
+++ b/test/actions/PermissionActionSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.Future
 
 class PermissionActionSpec extends AsyncFlatSpec with Matchers {
 
-  private val stage = "TEST"
   private val page = "support-landing-page-tests"
 
   private val permissions = Map(
@@ -21,7 +20,7 @@ class PermissionActionSpec extends AsyncFlatSpec with Matchers {
   )
 
   it should "return 403 if no permissions for user" in {
-    val email = "no-permission@guardian.co.uk"
+    val email = "mr.test@guardian.co.uk"
     val result = PermissionAction.checkPermission(
       email,
       page,

--- a/test/actions/PermissionActionSpec.scala
+++ b/test/actions/PermissionActionSpec.scala
@@ -1,0 +1,68 @@
+package actions
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.http.Status
+import services.UserPermissions
+import services.UserPermissions.Permission
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class PermissionActionSpec extends AsyncFlatSpec with Matchers {
+
+  private val stage = "TEST"
+  private val page = "support-landing-page-tests"
+
+  private val permissions = Map(
+    "no-permission@guardian.co.uk" -> Nil,
+    "read-permission@guardian.co.uk" -> List(UserPermissions.PagePermission(page, Permission.Read)),
+    "write-permission@guardian.co.uk" -> List(UserPermissions.PagePermission(page, Permission.Write))
+  )
+
+  it should "return 403 if no permissions for user" in {
+    val email = "no-permission@guardian.co.uk"
+    val result = PermissionAction.checkPermission(
+      email,
+      page,
+      Permission.Write,
+      None
+    ).get
+    status(Future.successful(result)) should be(Status.FORBIDDEN)
+    contentAsString(Future.successful(result)) should be(s"No permissions found for user ${email}")
+  }
+
+  it should "return 403 if no permission for that page for user" in {
+    val email = "no-permission@guardian.co.uk"
+    val result = PermissionAction.checkPermission(
+      email,
+      page,
+      Permission.Write,
+      permissions.get(email)
+    ).get
+    status(Future.successful(result)) should be(Status.FORBIDDEN)
+    contentAsString(Future.successful(result)) should be(s"No permission found for user ${email}, for page $page")
+  }
+
+  it should "return 403 if user only has Read permission" in {
+    val email = "read-permission@guardian.co.uk"
+    val result = PermissionAction.checkPermission(
+      email,
+      page,
+      Permission.Write,
+      permissions.get(email)
+    ).get
+    status(Future.successful(result)) should be(Status.FORBIDDEN)
+    contentAsString(Future.successful(result)) should be(s"Invalid permission for user ${email}, for page $page")
+  }
+
+  it should "return None if user has Write permission" in {
+    val email = "write-permission@guardian.co.uk"
+    PermissionAction.checkPermission(
+      email,
+      page,
+      Permission.Write,
+      permissions.get(email)
+    ) should be(None)
+  }
+}


### PR DESCRIPTION
Uses the data from the permissions table to restrict access to the landing page tool endpoints.
It does this by introducing a new Play [Action](https://www.playframework.com/documentation/3.0.x/ScalaActions).

1. Adds the `PermissionsAction` Action, which ensures a user has the right permission, and returns a 403 if not.
2. Updates the `ChannelTestsController`, which is used by the landing page tool and all of the channel test tools. Previously this class received a single `authAction`, for google auth checks on all the endpoints. It now takes an instance of `AuthAndPermissionActions`, which contains separate Actions for `read` and for `write`. This means endpoints for reading and writing data now have separate Actions, with different permissions checks.
3. For now, only the landing page tool has permissions checks. The other channel tools do not

Note - this is all server-side for now. If a user without edit permission tries to edit a landing page test they'll get an error popup.
In a follow-up PR we'll update the client to disable the Edit button in the UI.