### PR TITLE
Disable buttons if user does not have write permission

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,10 +3,12 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.libs.json.Json
 import play.api.mvc._
+import services.DynamoPermissionsCache
 
 class Application(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
                   components: ControllerComponents,
                   stage: String,
+                  permissionsService: DynamoPermissionsCache,
                   sdcUrlOverride: Option[String])
     extends AbstractController(components) {
   def healthcheck = Action {
@@ -14,8 +16,9 @@ class Application(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyC
   }
 
 
-  def index = authAction {
-    Ok(views.html.index(stage, sdcUrlOverride))
+  def index = authAction { request =>
+    val permissions = permissionsService.getPermissionsForUser(request.user.email).getOrElse(Nil)
+    Ok(views.html.index(stage, permissions, sdcUrlOverride))
       .withHeaders(CACHE_CONTROL -> "no-cache")
   }
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,8 @@
-@(stage: String, sdcUrlOverride: Option[String])
+@import services.UserPermissions.PagePermission
+@import io.circe.generic.auto._
+
+@import io.circe.syntax.EncoderOps
+@(stage: String, permissions: List[PagePermission], sdcUrlOverride: Option[String])
 <!DOCTYPE html>
 <html>
   <head>
@@ -18,6 +22,7 @@
       @if(sdcUrlOverride.isDefined) {
         window.guardian.sdcUrlOverride = "@sdcUrlOverride.get";
       }
+      window.guardian.permissions = @Html(permissions.asJson.spaces2)
     </script>
     <script src="@routes.Assets.at("build/app.bundle.js")"></script>
       <!-- build-commit-id: @app.BuildInfo.gitCommitId -->

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -91,7 +91,7 @@ class AppComponents(context: Context, stage: String) extends BuiltInComponentsFr
 
   override lazy val router: Router = new Routes(
     httpErrorHandler,
-    new Application(authAction, controllerComponents, stage, sdcUrlOverride),
+    new Application(authAction, controllerComponents, stage, permissionsService, sdcUrlOverride),
     new Login(authConfig, wsClient, controllerComponents),
     new SwitchesController(authAction, controllerComponents, stage, runtime),
     new AmountsController(authAction, controllerComponents, stage, runtime),

--- a/public/src/components/channelManagement/batchProcessTestButton.tsx
+++ b/public/src/components/channelManagement/batchProcessTestButton.tsx
@@ -23,11 +23,13 @@ const useStyles = makeStyles(() => ({
 interface BatchProcessTestButtonProps {
   draftTests: Test[];
   onBatchTestArchive: (batchTestNames: string[]) => void;
+  disabled: boolean;
 }
 
 const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
   draftTests,
   onBatchTestArchive,
+  disabled,
 }: BatchProcessTestButtonProps) => {
   const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
@@ -38,6 +40,7 @@ const BatchProcessTestButton: React.FC<BatchProcessTestButtonProps> = ({
         className={classes.button}
         startIcon={<ArchiveIcon />}
         onClick={open}
+        disabled={disabled}
       >
         <Typography className={classes.text}>Batch archive tests</Typography>
       </Button>

--- a/public/src/components/channelManagement/sidebar.tsx
+++ b/public/src/components/channelManagement/sidebar.tsx
@@ -62,6 +62,7 @@ interface SidebarProps<T extends Test> {
   testListLockStatus: LockStatus;
   userHasTestListLocked: boolean;
   savingTestList: boolean;
+  allowEditing: boolean;
 }
 
 function Sidebar<T extends Test>({
@@ -77,6 +78,7 @@ function Sidebar<T extends Test>({
   testListLockStatus,
   userHasTestListLocked,
   savingTestList,
+  allowEditing,
 }: SidebarProps<T>): React.ReactElement<SidebarProps<T>> {
   const classes = useStyles();
   const [regionFilter, setRegionFilter] = useState<RegionsAndAll>('ALL');
@@ -101,13 +103,14 @@ function Sidebar<T extends Test>({
           existingNicknames={tests.map(t => t.nickname || '')}
           testNamePrefix={testNamePrefix}
           createTest={createTest}
-          disabled={userHasTestListLocked}
+          disabled={userHasTestListLocked || !allowEditing}
         />
 
         <BatchProcessTestButton
           // filter out live tests and any test currently being edited
           draftTests={tests.filter(t => !(t.status === 'Live' && t.name !== selectedTestName))}
           onBatchTestArchive={onBatchTestArchive}
+          disabled={!allowEditing}
         />
 
         {userHasTestListLocked && (
@@ -136,6 +139,7 @@ function Sidebar<T extends Test>({
               startIcon={<EditIcon />}
               className={classes.reorderListButton}
               onClick={() => onTestListLock(true)}
+              disabled={!allowEditing}
             >
               <Typography className={classes.buttonText}>Take control</Typography>
             </Button>
@@ -152,6 +156,7 @@ function Sidebar<T extends Test>({
             startIcon={<EditIcon />}
             className={classes.reorderListButton}
             onClick={() => onTestListLock(false)}
+            disabled={!allowEditing}
           >
             <Typography className={classes.buttonText}>Reorder test list</Typography>
           </Button>

--- a/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/stickyTopBar.tsx
@@ -61,12 +61,14 @@ const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
     },
     marginLeft: spacing(1),
   },
-  buttonText: {
-    fontSize: '14px',
-    fontWeight: 500,
-    textTransform: 'uppercase',
-    letterSpacing: '1px',
+  button: {
     color: palette.grey[800],
+    '& > p': {
+      fontSize: '14px',
+      textTransform: 'uppercase',
+      letterSpacing: '1px',
+      fontWeight: 500,
+    },
   },
   icon: {
     color: grey[700],
@@ -102,6 +104,7 @@ interface StickyTopBarProps {
   onTestAudit: (testName: string, channel?: string) => void;
   onStatusChange: (status: Status) => void;
   settingsType: FrontendSettingsType;
+  allowEditing: boolean;
 }
 
 const StickyTopBar: React.FC<StickyTopBarProps> = ({
@@ -124,6 +127,7 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
   onTestAudit,
   onStatusChange,
   settingsType,
+  allowEditing,
 }: StickyTopBarProps) => {
   const classes = useStyles();
   const mainHeader = nickname ? nickname : name;
@@ -155,7 +159,7 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
           <TestLiveSwitch
             isLive={status === 'Live'}
             onChange={(isLive: boolean) => onStatusChange(isLive ? 'Live' : 'Draft')}
-            disabled={userHasTestLocked && lockStatus.locked} // cannot change test status while still editing it
+            disabled={(userHasTestLocked && lockStatus.locked) || !allowEditing} // cannot change test status while still editing it
           />
         </div>
         <div className={classes.lockContainer}>
@@ -168,15 +172,17 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
                 sourceNickname={nickname}
                 testNamePrefix={testNamePrefix}
                 onTestCopy={onTestCopy}
-                disabled={userHasTestListLocked}
+                disabled={userHasTestListLocked || !allowEditing}
               />
               <Button
+                className={classes.button}
                 variant="outlined"
                 size="medium"
                 startIcon={<EditIcon className={classes.icon} />}
                 onClick={() => onTestLock(name, false)}
+                disabled={!allowEditing}
               >
-                <Typography className={classes.buttonText}>Edit test</Typography>
+                <Typography>Edit test</Typography>
               </Button>
             </>
           )}
@@ -184,12 +190,13 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
             <>
               <TestLockDetails email={lockStatus.email} timestamp={lockStatus.timestamp} />
               <Button
+                className={classes.button}
                 variant="outlined"
                 size="medium"
                 startIcon={<LockIcon className={classes.icon} />}
                 onClick={() => onTestLock(name, true)}
               >
-                <Typography className={classes.buttonText}>Take control</Typography>
+                <Typography>Take control</Typography>
               </Button>
             </>
           )}
@@ -197,30 +204,33 @@ const StickyTopBar: React.FC<StickyTopBarProps> = ({
             <>
               {!isNew && <TestArchiveButton onTestArchive={onTestArchive} />}
               <Button
+                className={classes.button}
                 variant="outlined"
                 size="medium"
                 startIcon={<CloseIcon className={classes.icon} />}
                 onClick={() => onTestUnlock(name)}
               >
-                <Typography className={classes.buttonText}>Discard</Typography>
+                <Typography>Discard</Typography>
               </Button>
               <Button
+                className={classes.button}
                 variant="outlined"
                 size="medium"
                 startIcon={<SaveIcon className={classes.icon} />}
                 onClick={() => onTestSave(name)}
               >
-                <Typography className={classes.buttonText}>Save test</Typography>
+                <Typography>Save test</Typography>
               </Button>
             </>
           )}
           <Button
+            className={classes.button}
             variant="outlined"
             size="medium"
             startIcon={<HistoryIcon className={classes.icon} />}
             onClick={() => onTestAudit(name, channel)}
           >
-            <Typography className={classes.buttonText}>Audit</Typography>
+            <Typography>Audit</Typography>
           </Button>
         </div>
       </div>

--- a/public/src/components/channelManagement/stickyTopBar/testCopyButton.tsx
+++ b/public/src/components/channelManagement/stickyTopBar/testCopyButton.tsx
@@ -7,12 +7,14 @@ import { grey } from '@mui/material/colors';
 import CreateTestDialog from '../createTestDialog';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
-  buttonText: {
-    fontSize: '14px',
-    fontWeight: 500,
-    textTransform: 'uppercase',
-    letterSpacing: '1px',
+  button: {
     color: palette.grey[800],
+    '& > p': {
+      fontSize: '14px',
+      fontWeight: 500,
+      textTransform: 'uppercase',
+      letterSpacing: '1px',
+    },
   },
 }));
 
@@ -46,13 +48,14 @@ export const TestCopyButton: React.FC<TestCopyButtonProps> = ({
   return (
     <>
       <Button
+        className={classes.button}
         onClick={open}
         variant="outlined"
         startIcon={<FileCopyIcon style={{ color: grey[700] }} />}
         size="medium"
         disabled={disabled}
       >
-        <Typography className={classes.buttonText}>Copy test</Typography>
+        <Typography>Copy test</Typography>
       </Button>
       <CreateTestDialog
         isOpen={isOpen}

--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../utils/requests';
 import { useParams } from 'react-router-dom';
 import { addMethodologyToTestName } from './helpers/methodology';
+import { hasPermission } from '../../utils/permissions';
 
 const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
   viewTextContainer: {
@@ -74,6 +75,7 @@ export interface TestEditorProps<T extends Test> {
   existingNames: string[];
   existingNicknames: string[];
   settingsType: FrontendSettingsType;
+  allowEditing: boolean;
 }
 
 /**
@@ -282,6 +284,12 @@ export const TestsForm = <T extends Test>(
 
     const userHasTestListLocked = testListLockStatus.email === email;
 
+    // Currently only the Landing Page tool has permissioning
+    const allowEditing =
+      settingsType === FrontendSettingsType.supportLandingPageTests
+        ? hasPermission(FrontendSettingsType.supportLandingPageTests, 'Write')
+        : true;
+
     return (
       <div className={classes.body}>
         <div className={classes.leftCol}>
@@ -298,6 +306,7 @@ export const TestsForm = <T extends Test>(
             testListLockStatus={testListLockStatus}
             userHasTestListLocked={testListLockStatus.email === email}
             savingTestList={savingTestList}
+            allowEditing={allowEditing}
           />
         </div>
 
@@ -318,6 +327,7 @@ export const TestsForm = <T extends Test>(
               onTestAudit={onTestAudit}
               onStatusChange={status => onStatusChange(status, selectedTest.name)}
               settingsType={settingsType}
+              allowEditing={allowEditing}
             />
           ) : (
             <div className={classes.viewTextContainer}>

--- a/public/src/components/channelManagement/validatedTestEditor.tsx
+++ b/public/src/components/channelManagement/validatedTestEditor.tsx
@@ -53,6 +53,7 @@ export const ValidatedTestEditor = <T extends Test>(
     existingNicknames,
     settingsType,
     onStatusChange,
+    allowEditing,
   }: TestEditorProps<T>) => {
     const classes = useStyles();
     const [isValid, setIsValid] = useState<boolean>(true);
@@ -90,6 +91,7 @@ export const ValidatedTestEditor = <T extends Test>(
           onTestAudit={onTestAudit}
           onStatusChange={onStatusChange}
           settingsType={settingsType}
+          allowEditing={allowEditing}
         />
 
         <div className={classes.scrollableContainer}>

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -49,6 +49,11 @@ declare module '@mui/styles' {
   interface DefaultTheme extends Theme {}
 }
 
+interface PagePermission {
+  name: string;
+  permission: 'Read' | 'Write';
+}
+
 type Stage = 'DEV' | 'CODE' | 'PROD';
 declare global {
   /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -56,6 +61,7 @@ declare global {
     guardian: {
       stage: Stage;
       sdcUrlOverride: string | undefined;
+      permissions: PagePermission[];
     };
   }
   /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/public/src/utils/permissions.ts
+++ b/public/src/utils/permissions.ts
@@ -1,0 +1,12 @@
+export const hasPermission = (name: string, requiredPermission: 'Read' | 'Write') => {
+  const permissions = window.guardian.permissions;
+  const userPermission = permissions.find(perm => perm.name === name);
+  if (userPermission) {
+    if (requiredPermission === 'Write') {
+      return userPermission.permission === 'Write';
+    } else {
+      return true;
+    }
+  }
+  return false;
+};


### PR DESCRIPTION
For now, only the Landing Page tool requires `Write` permission.
On the backend the relevant endpoints are already behind permissioning, so users without `Write` permission are already unable to make changes.

This PR updates the client to check the user's permission, and if they don't have write permission then the various buttons for editing are disabled.
We do this by passing through the user's permissions on the `window.guardian` object, for the client to use.

No permission check (Epic tool):
<img width="1249" alt="Screenshot 2025-04-11 at 08 34 12" src="https://github.com/user-attachments/assets/e3577041-dfb4-49df-a246-2dde38d58416" />


With permission check and no write permission (Landing Page tool):
<img width="1249" alt="Screenshot 2025-04-11 at 08 34 16" src="https://github.com/user-attachments/assets/500e65f5-0805-47d4-afce-a66ec2ec6be9" />
