### PR TITLE
Fetch audit history immediately if from url

### DIFF
--- a/public/src/components/channelManagement/auditTests/auditTestsDashboard.tsx
+++ b/public/src/components/channelManagement/auditTests/auditTestsDashboard.tsx
@@ -45,6 +45,7 @@ export const AuditTestsDashboard: React.FC = () => {
   const classes = useStyles();
   const testNameInQueryParams = useParams().testName;
   const channelInQueryParams = useParams().channel;
+  const [fromUrl, setFromUrl] = useState(false); // used to trigger initial fetch once if set from url
 
   const [testName, setTestName] = useState('');
   const [channel, setChannel] = useState('');
@@ -60,11 +61,19 @@ export const AuditTestsDashboard: React.FC = () => {
   };
 
   useEffect(() => {
-    if (testNameInQueryParams != null && channelInQueryParams != null) {
+    if (testNameInQueryParams && channelInQueryParams) {
       setTestName(testNameInQueryParams);
       setChannel(channelInQueryParams);
+      setFromUrl(true);
     }
   }, [testNameInQueryParams, channelInQueryParams]);
+
+  useEffect(() => {
+    if (fromUrl && testName && channel) {
+      setFromUrl(false);
+      fetchAuditData();
+    }
+  }, [testName, channel]);
 
   return (
     <div>


### PR DESCRIPTION
A small UX improvement.
If the user clicks through to the audit page then the channel + test name are in the url (e.g. `/audit-tests/Epic/TESTEPIC`).
Currently the user still has to click "Get audit" before the data is fetched.
This PR changes the audit page to immediately fetch the data in this case.