### PR TITLE
Add ticker Config  in Support Landing Page Tests

### DIFF
--- a/app/models/SupportLandingPageTest.scala
+++ b/app/models/SupportLandingPageTest.scala
@@ -42,6 +42,7 @@ case class SupportLandingPageVariant(
   name: String,
   copy: SupportLandingPageCopy,
   products: Products,
+  tickerSettings: Option[TickerSettings] = None,
 )
 
 case class SupportLandingPageTest(

--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -2,19 +2,10 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 
-sealed trait TickerEndType
-object TickerEndType {
-  case object unlimited extends TickerEndType
-  case object hardstop extends TickerEndType
-
-  implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val encoder = deriveEnumerationEncoder[TickerEndType]
-  implicit val decoder = deriveEnumerationDecoder[TickerEndType]
-}
-
 sealed trait TickerCountType
 object TickerCountType {
   case object money extends TickerCountType
+  case object supporterCount extends TickerCountType
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val encoder = deriveEnumerationEncoder[TickerCountType]
@@ -25,6 +16,7 @@ sealed trait TickerName
 object TickerName {
   case object US extends TickerName
   case object AU extends TickerName
+  case object global extends TickerName
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val encoder = deriveEnumerationEncoder[TickerName]
@@ -38,7 +30,6 @@ case class TickerCopy(
 )
 
 case class TickerSettings(
-  endType: TickerEndType,
   countType: TickerCountType,
   currencySymbol: String,
   copy: TickerCopy,

--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -2,15 +2,6 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 
-sealed trait TickerCountType
-object TickerCountType {
-  case object money extends TickerCountType
-  case object supporterCount extends TickerCountType
-
-  implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val encoder = deriveEnumerationEncoder[TickerCountType]
-  implicit val decoder = deriveEnumerationDecoder[TickerCountType]
-}
 
 sealed trait TickerName
 object TickerName {
@@ -25,12 +16,9 @@ object TickerName {
 
 case class TickerCopy(
   countLabel: String,
-  goalReachedPrimary: Option[String] , //deprecated
-  goalReachedSecondary: Option[String] //deprecated
 )
 
 case class TickerSettings(
-  countType: TickerCountType,
   currencySymbol: String,
   copy: TickerCopy,
   name: TickerName

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -3,7 +3,7 @@ import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
 import { BannerDesign } from '../../../models/bannerDesign';
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { BannerVariant } from '../../../models/banner';
-import { SecondaryCtaType, TickerCountType, TickerEndType, TickerName } from '../helpers/shared';
+import { SecondaryCtaType, TickerCountType, TickerName } from '../helpers/shared';
 
 interface Props {
   design: BannerDesign;
@@ -77,7 +77,6 @@ const buildVariantForPreview = (
   tickerSettings: shouldShowTicker
     ? {
         countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
         currencySymbol: '£',
         copy: {
           countLabel: 'contributions in May',

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -3,7 +3,7 @@ import BannerVariantPreview from '../bannerTests/bannerVariantPreview';
 import { BannerDesign } from '../../../models/bannerDesign';
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { BannerVariant } from '../../../models/banner';
-import { SecondaryCtaType, TickerCountType, TickerName } from '../helpers/shared';
+import { SecondaryCtaType, TickerName } from '../helpers/shared';
 
 interface Props {
   design: BannerDesign;
@@ -76,12 +76,9 @@ const buildVariantForPreview = (
   separateArticleCount: true,
   tickerSettings: shouldShowTicker
     ? {
-        countType: TickerCountType.money,
         currencySymbol: '£',
         copy: {
           countLabel: 'contributions in May',
-          goalReachedPrimary: '',
-          goalReachedSecondary: '',
         },
         name: TickerName.US,
       }

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -273,16 +273,14 @@ export interface TestEditorState {
   validationStatus: ValidationStatus;
 }
 
-export enum TickerEndType {
-  unlimited = 'unlimited',
-  hardstop = 'hardstop',
-}
 export enum TickerCountType {
   money = 'money',
+  supporterCount = 'supporterCount',
 }
 export enum TickerName {
   US = 'US',
   AU = 'AU',
+  GLOBAL = 'global',
 }
 
 interface TickerCopy {
@@ -291,7 +289,6 @@ interface TickerCopy {
   goalReachedSecondary?: string;
 }
 export interface TickerSettings {
-  endType: TickerEndType;
   countType: TickerCountType;
   currencySymbol: string;
   copy: TickerCopy;

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -273,10 +273,6 @@ export interface TestEditorState {
   validationStatus: ValidationStatus;
 }
 
-export enum TickerCountType {
-  money = 'money',
-  supporterCount = 'supporterCount',
-}
 export enum TickerName {
   US = 'US',
   AU = 'AU',

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -285,11 +285,8 @@ export enum TickerName {
 
 interface TickerCopy {
   countLabel: string;
-  goalReachedPrimary?: string;
-  goalReachedSecondary?: string;
 }
 export interface TickerSettings {
-  countType: TickerCountType;
   currencySymbol: string;
   copy: TickerCopy;
   name: TickerName;

--- a/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/variantEditor.tsx
@@ -7,6 +7,8 @@ import {
 } from '../../../models/supportLandingPage';
 import { CopyEditor } from './copyEditor';
 import { ProductsEditor } from './productsEditor';
+import { TickerSettings } from '../helpers/shared';
+import TickerEditor from '../tickerEditor';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -56,6 +58,14 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
         }
         onValidationChange={onValidationChange}
         editMode={editMode}
+      />
+      <TickerEditor
+        tickerSettings={variant.tickerSettings}
+        updateTickerSettings={(updatedTickerSettings?: TickerSettings): void => {
+          onVariantChange({ ...variant, tickerSettings: updatedTickerSettings });
+        }}
+        isDisabled={!editMode}
+        onValidationChange={onValidationChange}
       />
     </div>
   );

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -94,7 +94,7 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
       updateTickerSettings({
         ...tickerSettings,
         copy: { countLabel },
-        currencySymbol: currencySymbol,
+        currencySymbol: currencySymbol ?? '',
       });
   };
 

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { TickerCountType, TickerEndType, TickerName, TickerSettings } from './helpers/shared';
+import { TickerCountType, TickerName, TickerSettings } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
@@ -35,7 +35,6 @@ interface FormData {
 }
 
 const DEFAULT_TICKER_SETTINGS: TickerSettings = {
-  endType: TickerEndType.unlimited,
   countType: TickerCountType.money,
   copy: {
     countLabel: 'Contributions',
@@ -97,17 +96,18 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
     updateTickerSettings(isChecked ? DEFAULT_TICKER_SETTINGS : undefined);
   };
 
-  const onEndTypeChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const selectedType = event.target.value as TickerEndType;
-    tickerSettings && updateTickerSettings({ ...tickerSettings, endType: selectedType });
-  };
-
   const onNameChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const selectedName = event.target.value as TickerName;
-    tickerSettings && updateTickerSettings({ ...tickerSettings, name: selectedName });
+    tickerSettings &&
+      updateTickerSettings({
+        ...tickerSettings,
+        name: selectedName,
+        currencySymbol: selectedName === TickerName.GLOBAL ? '' : '$',
+      });
   };
 
   const onSubmit = ({ countLabel, currencySymbol }: FormData): void => {
+    console.log('onSubmit', currencySymbol);
     tickerSettings &&
       updateTickerSettings({
         ...tickerSettings,
@@ -153,6 +153,12 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
                   label="AU"
                   disabled={isDisabled}
                 />
+                <FormControlLabel
+                  value={TickerName.GLOBAL}
+                  control={<Radio />}
+                  label="GLOBAL"
+                  disabled={isDisabled}
+                />
               </RadioGroup>
             </FormControl>
           </div>
@@ -170,39 +176,18 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             fullWidth
           />
 
-          {tickerSettings.countType === 'money' && (
-            <TextField
-              inputRef={register({ required: true })}
-              error={!!errors.currencySymbol}
-              helperText={errors?.currencySymbol?.message}
-              onBlur={handleSubmit(onSubmit)}
-              name="currencySymbol"
-              label="Currency"
-              margin="normal"
-              variant="outlined"
-              disabled={isDisabled}
-              fullWidth
-            />
-          )}
-
-          <div>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">Ticker end type</FormLabel>
-              <RadioGroup
-                value={TickerEndType.hardstop}
-                onChange={onEndTypeChanged}
-                aria-label="ticker-end-type"
-                name="ticker-end-type"
-              >
-                <FormControlLabel
-                  value={TickerEndType.hardstop}
-                  control={<Radio />}
-                  label="Hard stop"
-                  disabled={isDisabled}
-                />
-              </RadioGroup>
-            </FormControl>
-          </div>
+          <TextField
+            inputRef={register({ required: true })}
+            error={!!errors.currencySymbol}
+            helperText={errors?.currencySymbol?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="currencySymbol"
+            label="Currency"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
         </div>
       )}
     </div>

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { TickerCountType, TickerName, TickerSettings } from './helpers/shared';
+import { TickerName, TickerSettings } from './helpers/shared';
 import { EMPTY_ERROR_HELPER_TEXT } from './helpers/validation';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
@@ -29,17 +29,12 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 
 interface FormData {
   countLabel: string;
-  goalReachedPrimary?: string; //deprecated for now
-  goalReachedSecondary?: string; //deprecated for now
   currencySymbol: string;
 }
 
 const DEFAULT_TICKER_SETTINGS: TickerSettings = {
-  countType: TickerCountType.money,
   copy: {
     countLabel: 'Contributions',
-    goalReachedPrimary: '', //deprecated for now
-    goalReachedSecondary: '', //deprecated for now
   },
   currencySymbol: '$',
   name: TickerName.US,
@@ -62,8 +57,6 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
 
   const defaultValues: FormData = {
     countLabel: tickerSettings?.copy.countLabel || '',
-    goalReachedPrimary: tickerSettings?.copy.goalReachedPrimary || '',
-    goalReachedSecondary: tickerSettings?.copy.goalReachedSecondary || '',
     currencySymbol: tickerSettings?.currencySymbol || '',
   };
 
@@ -74,22 +67,12 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
 
   useEffect(() => {
     reset(defaultValues);
-  }, [
-    defaultValues.countLabel,
-    defaultValues.goalReachedPrimary,
-    defaultValues.goalReachedSecondary,
-    defaultValues.currencySymbol,
-  ]);
+  }, [defaultValues.countLabel, defaultValues.currencySymbol]);
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [
-    errors.countLabel,
-    errors.goalReachedPrimary,
-    errors.goalReachedSecondary,
-    errors.currencySymbol,
-  ]);
+  }, [errors.countLabel, errors.currencySymbol]);
 
   const onCheckboxChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const isChecked = event.target.checked;
@@ -107,12 +90,11 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
   };
 
   const onSubmit = ({ countLabel, currencySymbol }: FormData): void => {
-    console.log('onSubmit', currencySymbol);
     tickerSettings &&
       updateTickerSettings({
         ...tickerSettings,
         copy: { countLabel },
-        currencySymbol: currencySymbol || '$',
+        currencySymbol: currencySymbol,
       });
   };
 
@@ -176,18 +158,20 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             fullWidth
           />
 
-          <TextField
-            inputRef={register({ required: true })}
-            error={!!errors.currencySymbol}
-            helperText={errors?.currencySymbol?.message}
-            onBlur={handleSubmit(onSubmit)}
-            name="currencySymbol"
-            label="Currency"
-            margin="normal"
-            variant="outlined"
-            disabled={isDisabled}
-            fullWidth
-          />
+          {(tickerSettings.name === 'US' || tickerSettings.name === 'AU') && (
+            <TextField
+              inputRef={register({ required: true })}
+              error={!!errors.currencySymbol}
+              helperText={errors?.currencySymbol?.message}
+              onBlur={handleSubmit(onSubmit)}
+              name="currencySymbol"
+              label="Currency"
+              margin="normal"
+              variant="outlined"
+              disabled={isDisabled}
+              fullWidth
+            />
+          )}
         </div>
       )}
     </div>

--- a/public/src/models/supportLandingPage.ts
+++ b/public/src/models/supportLandingPage.ts
@@ -1,4 +1,10 @@
-import { Methodology, Status, Test, Variant } from '../components/channelManagement/helpers/shared';
+import {
+  Methodology,
+  Status,
+  Test,
+  TickerSettings,
+  Variant,
+} from '../components/channelManagement/helpers/shared';
 
 export interface SupportLandingPageCopy {
   heading: string;
@@ -34,6 +40,7 @@ export interface SupportLandingPageVariant extends Variant {
   name: string;
   copy: SupportLandingPageCopy;
   products: Products;
+  tickerSettings?: TickerSettings;
 }
 
 export interface SupportLandingPageTest extends Test {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is to add ticker to the landing page tests


## How to test



## Images

We will have a new checkbox for ticker 

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/16a53c83-54d2-4c60-bc9d-744ea588ce0f" />

On selection, the ticker configuration would allow the user to set the headline copy, campaign name and the currency symbol to be set in LP tests

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/1baab09e-5c8c-4b28-a30e-a435682e701a" />


NOTE:

Ticker campaign "GLOBAL" won't allow used to set a currencySymbol as it show the supporter count instead of the money raised
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/fe71f5fe-09d1-480f-8747-074121894c69" />


The related changes in the support landing page are in  the [Support Frontend PR] (https://github.com/guardian/support-frontend/pull/6970)
