### PR TITLE
Changes for making goal copy in  ticker configurable

### DIFF
--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -16,6 +16,7 @@ object TickerName {
 
 case class TickerCopy(
   countLabel: String,
+  goalCopy: String = "goal" ,
 )
 
 case class TickerSettings(

--- a/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/BannerDesignPreview.tsx
@@ -79,6 +79,7 @@ const buildVariantForPreview = (
         currencySymbol: '£',
         copy: {
           countLabel: 'contributions in May',
+          goalCopy: 'goal',
         },
         name: TickerName.US,
       }

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -281,6 +281,7 @@ export enum TickerName {
 
 interface TickerCopy {
   countLabel: string;
+  goalCopy: string;
 }
 export interface TickerSettings {
   currencySymbol: string;

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -29,12 +29,14 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 
 interface FormData {
   countLabel: string;
+  goalCopy: string;
   currencySymbol: string;
 }
 
 const DEFAULT_TICKER_SETTINGS: TickerSettings = {
   copy: {
     countLabel: 'Contributions',
+    goalCopy: 'goal',
   },
   currencySymbol: '$',
   name: TickerName.US,
@@ -57,6 +59,7 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
 
   const defaultValues: FormData = {
     countLabel: tickerSettings?.copy.countLabel || '',
+    goalCopy: tickerSettings?.copy.goalCopy || '',
     currencySymbol: tickerSettings?.currencySymbol || '',
   };
 
@@ -67,12 +70,12 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
 
   useEffect(() => {
     reset(defaultValues);
-  }, [defaultValues.countLabel, defaultValues.currencySymbol]);
+  }, [defaultValues.countLabel, defaultValues.goalCopy, defaultValues.currencySymbol]);
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors.countLabel, errors.currencySymbol]);
+  }, [errors.countLabel, errors.goalCopy, errors.currencySymbol]);
 
   const onCheckboxChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const isChecked = event.target.checked;
@@ -89,11 +92,11 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
       });
   };
 
-  const onSubmit = ({ countLabel, currencySymbol }: FormData): void => {
+  const onSubmit = ({ countLabel, goalCopy, currencySymbol }: FormData): void => {
     tickerSettings &&
       updateTickerSettings({
         ...tickerSettings,
-        copy: { countLabel },
+        copy: { countLabel, goalCopy: goalCopy ?? 'goal' },
         currencySymbol: currencySymbol ?? '',
       });
   };
@@ -152,6 +155,19 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             onBlur={handleSubmit(onSubmit)}
             name="countLabel"
             label="Heading"
+            margin="normal"
+            variant="outlined"
+            disabled={isDisabled}
+            fullWidth
+          />
+
+          <TextField
+            inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
+            error={!!errors.goalCopy}
+            helperText={errors?.goalCopy?.message}
+            onBlur={handleSubmit(onSubmit)}
+            name="goalCopy"
+            label="Goal Copy"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The PR is to make the goal copy in ticker configurable ie the word "goal" after 50,000 on this ticker
<img width="462" alt="image" src="https://github.com/user-attachments/assets/86b7d348-c82c-4d4f-a548-098869dc78b4" />

Here we are adding a new field  in ticker configuration for the 'goal' copy 
[Trello card](https://trello.com/c/bDmwMfwB/1069-make-goal-in-tickercopy-configurable) 
## Why?

 This is to change word "goal" after 50,000 on this ticker to "readers" to show that it's for supporter count


## Images

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/fbeee3b8-7dd7-431d-9cfd-ac860aaf5074" />


