### PR TITLE
Upgrade react-hook-form to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^6.15.8",
+    "react-hook-form": "^7.56.3",
     "react-qr-code": "^2.0.7",
     "react-router-dom": "^6.2.1",
     "recharts": "2.12.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ dependencies:
     specifier: ^18.2.0
     version: 18.3.1(react@18.3.1)
   react-hook-form:
-    specifier: ^6.15.8
-    version: 6.15.8(react@18.3.1)
+    specifier: ^7.56.3
+    version: 7.56.3(react@18.3.1)
   react-qr-code:
     specifier: ^2.0.7
     version: 2.0.15(react@18.3.1)
@@ -7433,10 +7433,11 @@ packages:
       scheduler: 0.23.2
     dev: false
 
-  /react-hook-form@6.15.8(react@18.3.1):
-    resolution: {integrity: sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==}
+  /react-hook-form@7.56.3(react@18.3.1):
+    resolution: {integrity: sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17
+      react: ^16.8.0 || ^17 || ^18 || ^19
     dependencies:
       react: 18.3.1
     dev: false

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -81,7 +81,13 @@ const GenericColourInput = <T extends unknown>({
 
   const defaultValues = { colour: convertToString(colour) };
 
-  const { register, reset, handleSubmit, errors } = useForm<{ colour: string }>({
+  const {
+    register,
+    reset,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<{ colour: string }>({
     mode: 'onChange',
     defaultValues,
   });
@@ -123,7 +129,8 @@ const GenericColourInput = <T extends unknown>({
         variant="outlined"
         fullWidth={false}
         disabled={isDisabled}
-        required={required} />
+        required={required}
+      />
       <div className={classes.colour} onClick={() => !isDisabled && setIsPickerOpen(true)}>
         {isPickerOpen && (
           <ClickAwayListener onClickAway={() => setIsPickerOpen(false)}>

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -111,11 +111,10 @@ const GenericColourInput = <T extends unknown>({
     <div className={classes.container}>
       <TextField
         className={classes.field}
-        inputRef={register({
+        {...register('colour', {
           required: required ? EMPTY_ERROR_HELPER_TEXT : false,
           pattern: colourValidation,
         })}
-        name="colour"
         onBlur={handleSubmit(({ colour }) => handleColourChange(colour))}
         label={label}
         error={errors?.colour !== undefined}
@@ -124,8 +123,7 @@ const GenericColourInput = <T extends unknown>({
         variant="outlined"
         fullWidth={false}
         disabled={isDisabled}
-        required={required}
-      />
+        required={required} />
       <div className={classes.colour} onClick={() => !isDisabled && setIsPickerOpen(true)}>
         {isPickerOpen && (
           <ClickAwayListener onClickAway={() => setIsPickerOpen(false)}>

--- a/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ColourInput.tsx
@@ -95,7 +95,7 @@ const GenericColourInput = <T extends unknown>({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(name, isValid);
-  }, [errors]);
+  }, [errors.colour]);
 
   useEffect(() => {
     // necessary to reset fields if user discards changes

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -55,7 +55,12 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
     name: '',
   };
 
-  const { register, handleSubmit, errors } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({
     defaultValues,
   });
 
@@ -89,7 +94,8 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
           margin="normal"
           variant="outlined"
           autoFocus
-          fullWidth />
+          fullWidth
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CreateBannerDesignDialog.tsx
@@ -75,7 +75,9 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
       <DialogContent dividers>
         <TextField
           className={classes.input}
-          inputRef={register({
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : ''}
+          {...register('name', {
             required: EMPTY_ERROR_HELPER_TEXT,
             pattern: {
               value: VALID_CHARACTERS_REGEX,
@@ -83,15 +85,11 @@ const CreateBannerDesignDialog: React.FC<CreateBannerDesignDialogProps> = ({
             },
             validate: createDuplicateValidator(existingNames),
           })}
-          error={errors.name !== undefined}
-          helperText={errors.name ? errors.name.message : ''}
-          name="name"
           label="Banner design name"
           margin="normal"
           variant="outlined"
           autoFocus
-          fullWidth
-        />
+          fullWidth />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -31,7 +31,13 @@ export const HeaderImageEditor: React.FC<Props> = ({
     altText: headerImage?.altText ?? '',
   };
 
-  const { register, handleSubmit, errors, reset } = useForm<BannerDesignHeaderImage>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+
+    formState: { errors },
+  } = useForm<BannerDesignHeaderImage>({
     mode: 'onChange',
     defaultValues,
   });
@@ -101,7 +107,8 @@ export const HeaderImageEditor: React.FC<Props> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
           <TextField
             error={errors?.tabletUrl !== undefined}
             helperText={errors?.tabletUrl?.message}
@@ -113,7 +120,8 @@ export const HeaderImageEditor: React.FC<Props> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
           <TextField
             error={errors?.desktopUrl !== undefined}
             helperText={errors?.desktopUrl?.message}
@@ -125,7 +133,8 @@ export const HeaderImageEditor: React.FC<Props> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
           <TextField
             error={errors?.altText !== undefined}
             helperText={errors?.altText?.message}
@@ -137,7 +146,8 @@ export const HeaderImageEditor: React.FC<Props> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
         </>
       )}
     </div>

--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -91,61 +91,53 @@ export const HeaderImageEditor: React.FC<Props> = ({
       {headerImage && (
         <>
           <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-            })}
             error={errors?.mobileUrl !== undefined}
             helperText={errors?.mobileUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="mobileUrl"
+            {...register('mobileUrl', {
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
             label="Header Image URL (Mobile)"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
           <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-            })}
             error={errors?.tabletUrl !== undefined}
             helperText={errors?.tabletUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="tabletUrl"
+            {...register('tabletUrl', {
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
             label="Header Image URL (Tablet)"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
           <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-            })}
             error={errors?.desktopUrl !== undefined}
             helperText={errors?.desktopUrl?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="desktopUrl"
+            {...register('desktopUrl', {
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
             label="Header Image URL (Dekstop and above)"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
           <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-            })}
             error={errors?.altText !== undefined}
             helperText={errors?.altText?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="altText"
+            {...register('altText', {
+              required: EMPTY_ERROR_HELPER_TEXT,
+            })}
             label="Header Image Description (alt text)"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
         </>
       )}
     </div>

--- a/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/HeaderImageEditor.tsx
@@ -99,10 +99,10 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             error={errors?.mobileUrl !== undefined}
             helperText={errors?.mobileUrl?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('mobileUrl', {
               required: EMPTY_ERROR_HELPER_TEXT,
             })}
+            onBlur={handleSubmit(onSubmit)}
             label="Header Image URL (Mobile)"
             margin="normal"
             variant="outlined"
@@ -112,10 +112,10 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             error={errors?.tabletUrl !== undefined}
             helperText={errors?.tabletUrl?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('tabletUrl', {
               required: EMPTY_ERROR_HELPER_TEXT,
             })}
+            onBlur={handleSubmit(onSubmit)}
             label="Header Image URL (Tablet)"
             margin="normal"
             variant="outlined"
@@ -125,10 +125,10 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             error={errors?.desktopUrl !== undefined}
             helperText={errors?.desktopUrl?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('desktopUrl', {
               required: EMPTY_ERROR_HELPER_TEXT,
             })}
+            onBlur={handleSubmit(onSubmit)}
             label="Header Image URL (Dekstop and above)"
             margin="normal"
             variant="outlined"
@@ -138,10 +138,10 @@ export const HeaderImageEditor: React.FC<Props> = ({
           <TextField
             error={errors?.altText !== undefined}
             helperText={errors?.altText?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('altText', {
               required: EMPTY_ERROR_HELPER_TEXT,
             })}
+            onBlur={handleSubmit(onSubmit)}
             label="Header Image Description (alt text)"
             margin="normal"
             variant="outlined"

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -45,10 +45,10 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         error={errors?.mobileUrl !== undefined}
         helperText={errors?.mobileUrl?.message}
-        onBlur={handleSubmit(onChange)}
         {...register('mobileUrl', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(onChange)}
         label="Banner Image URL (Mobile)"
         margin="normal"
         variant="outlined"
@@ -58,10 +58,10 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         error={errors?.tabletUrl !== undefined}
         helperText={errors?.tabletUrl?.message}
-        onBlur={handleSubmit(onChange)}
         {...register('tabletUrl', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(onChange)}
         label="Banner Image URL (Tablet)"
         margin="normal"
         variant="outlined"
@@ -71,10 +71,10 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         error={errors?.desktopUrl !== undefined}
         helperText={errors?.desktopUrl?.message}
-        onBlur={handleSubmit(onChange)}
         {...register('desktopUrl', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(onChange)}
         label="Banner Image URL (Desktop and above)"
         margin="normal"
         variant="outlined"
@@ -84,10 +84,10 @@ export const ImageEditor: React.FC<Props> = ({
       <TextField
         error={errors?.altText !== undefined}
         helperText={errors?.altText?.message}
-        onBlur={handleSubmit(onChange)}
         {...register('altText', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(onChange)}
         label="Banner Image Description (alt text)"
         margin="normal"
         variant="outlined"

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -33,7 +33,7 @@ export const ImageEditor: React.FC<Props> = ({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors]);
+  }, [errors.desktopUrl, errors.tabletUrl, errors.mobileUrl, errors.altText]);
 
   useEffect(() => {
     // necessary to reset fields if user discards changes

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -17,7 +17,13 @@ export const ImageEditor: React.FC<Props> = ({
   onValidationChange,
   onChange,
 }: Props) => {
-  const { register, handleSubmit, errors, reset } = useForm<BannerDesignImage>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+
+    formState: { errors },
+  } = useForm<BannerDesignImage>({
     mode: 'onChange',
     defaultValues: image,
   });
@@ -47,7 +53,8 @@ export const ImageEditor: React.FC<Props> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <TextField
         error={errors?.tabletUrl !== undefined}
         helperText={errors?.tabletUrl?.message}
@@ -59,7 +66,8 @@ export const ImageEditor: React.FC<Props> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <TextField
         error={errors?.desktopUrl !== undefined}
         helperText={errors?.desktopUrl?.message}
@@ -71,7 +79,8 @@ export const ImageEditor: React.FC<Props> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <TextField
         error={errors?.altText !== undefined}
         helperText={errors?.altText?.message}
@@ -83,7 +92,8 @@ export const ImageEditor: React.FC<Props> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/ImageEditor.tsx
@@ -37,61 +37,53 @@ export const ImageEditor: React.FC<Props> = ({
   return (
     <div>
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors?.mobileUrl !== undefined}
         helperText={errors?.mobileUrl?.message}
         onBlur={handleSubmit(onChange)}
-        name="mobileUrl"
+        {...register('mobileUrl', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Banner Image URL (Mobile)"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors?.tabletUrl !== undefined}
         helperText={errors?.tabletUrl?.message}
         onBlur={handleSubmit(onChange)}
-        name="tabletUrl"
+        {...register('tabletUrl', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Banner Image URL (Tablet)"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors?.desktopUrl !== undefined}
         helperText={errors?.desktopUrl?.message}
         onBlur={handleSubmit(onChange)}
-        name="desktopUrl"
+        {...register('desktopUrl', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Banner Image URL (Desktop and above)"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors?.altText !== undefined}
         helperText={errors?.altText?.message}
         onBlur={handleSubmit(onChange)}
-        name="altText"
+        {...register('altText', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Banner Image Description (alt text)"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@mui/styles';
 import { FormControl, FormControlLabel, Radio, RadioGroup, TextField, Theme } from '@mui/material';
 import { BannerTestDeploySchedule } from '../../../models/banner';
 import { useForm } from 'react-hook-form';
-import { EMPTY_ERROR_HELPER_TEXT, notNumberValidator } from '../helpers/validation';
+import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -84,7 +84,7 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
             helperText={errors.daysBetween?.message || 'Must be a number'}
             {...register('daysBetween', {
               required: EMPTY_ERROR_HELPER_TEXT,
-              validate: notNumberValidator,
+              valueAsNumber: true,
             })}
             onBlur={handleSubmit(onSubmit)}
             label="Days between deploys"

--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -82,11 +82,11 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
           <TextField
             error={errors.daysBetween !== undefined}
             helperText={errors.daysBetween?.message || 'Must be a number'}
-            onBlur={handleSubmit(onSubmit)}
             {...register('daysBetween', {
               required: EMPTY_ERROR_HELPER_TEXT,
               validate: notNumberValidator,
             })}
+            onBlur={handleSubmit(onSubmit)}
             label="Days between deploys"
             InputLabelProps={{ shrink: true }}
             variant="outlined"

--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -75,20 +75,18 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
 
         {deploySchedule && (
           <TextField
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              validate: notNumberValidator,
-            })}
             error={errors.daysBetween !== undefined}
             helperText={errors.daysBetween?.message || 'Must be a number'}
             onBlur={handleSubmit(onSubmit)}
-            name="daysBetween"
+            {...register('daysBetween', {
+              required: EMPTY_ERROR_HELPER_TEXT,
+              validate: notNumberValidator,
+            })}
             label="Days between deploys"
             InputLabelProps={{ shrink: true }}
             variant="outlined"
             fullWidth
-            disabled={isDisabled}
-          />
+            disabled={isDisabled} />
         )}
       </div>
     </FormControl>

--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -31,7 +31,12 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
   const defaultValues: BannerTestDeploySchedule = {
     daysBetween: 1,
   };
-  const { register, errors, handleSubmit } = useForm<BannerTestDeploySchedule>({
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<BannerTestDeploySchedule>({
     mode: 'onChange',
     defaultValues,
   });
@@ -86,7 +91,8 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
             InputLabelProps={{ shrink: true }}
             variant="outlined"
             fullWidth
-            disabled={isDisabled} />
+            disabled={isDisabled}
+          />
         )}
       </div>
     </FormControl>

--- a/public/src/components/channelManagement/bannerTests/newVariantButton.tsx
+++ b/public/src/components/channelManagement/bannerTests/newVariantButton.tsx
@@ -87,56 +87,52 @@ const NewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
     createVariant(name.toUpperCase());
   };
 
-  return (
-    <>
-      <Button className={classes.button} onClick={open} disabled={isDisabled}>
-        <div className={classes.container}>
-          <AddIcon />
-          <Typography className={classes.text}>New variant</Typography>
-        </div>
-      </Button>
-      <Dialog
-        open={isOpen}
-        onClose={close}
-        aria-labelledby="new-variant-dialog-title"
-        aria-describedby="new-variant-dialog-description"
-        fullWidth
-      >
-        <div className={classes.dialogHeader}>
-          <DialogTitle id="new-variant-dialog-title">Create a new variant</DialogTitle>
-          <IconButton onClick={close} aria-label="close">
-            <CloseIcon />
-          </IconButton>
-        </div>
-        <DialogContent dividers>
-          <TextField
-            className={classes.input}
-            inputRef={register({
-              required: EMPTY_ERROR_HELPER_TEXT,
-              pattern: {
-                value: VALID_CHARACTERS_REGEX,
-                message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
-              },
-              validate: createDuplicateValidator(existingNames),
-            })}
-            error={errors.name !== undefined}
-            helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
-            name="name"
-            label="Variant name"
-            margin="normal"
-            variant="outlined"
-            autoFocus
-            fullWidth
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleSubmit(onSubmit)} color="primary">
-            Create variant
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
-  );
+  return <>
+    <Button className={classes.button} onClick={open} disabled={isDisabled}>
+      <div className={classes.container}>
+        <AddIcon />
+        <Typography className={classes.text}>New variant</Typography>
+      </div>
+    </Button>
+    <Dialog
+      open={isOpen}
+      onClose={close}
+      aria-labelledby="new-variant-dialog-title"
+      aria-describedby="new-variant-dialog-description"
+      fullWidth
+    >
+      <div className={classes.dialogHeader}>
+        <DialogTitle id="new-variant-dialog-title">Create a new variant</DialogTitle>
+        <IconButton onClick={close} aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </div>
+      <DialogContent dividers>
+        <TextField
+          className={classes.input}
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
+          {...register('name', {
+            required: EMPTY_ERROR_HELPER_TEXT,
+            pattern: {
+              value: VALID_CHARACTERS_REGEX,
+              message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
+            },
+            validate: createDuplicateValidator(existingNames),
+          })}
+          label="Variant name"
+          margin="normal"
+          variant="outlined"
+          autoFocus
+          fullWidth />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSubmit(onSubmit)} color="primary">
+          Create variant
+        </Button>
+      </DialogActions>
+    </Dialog>
+  </>;
 };
 
 export default NewVariantButton;

--- a/public/src/components/channelManagement/bannerTests/newVariantButton.tsx
+++ b/public/src/components/channelManagement/bannerTests/newVariantButton.tsx
@@ -80,59 +80,67 @@ const NewVariantButton: React.FC<BannerTestNewVariantButtonProps> = ({
   const classes = useStyles();
   const [isOpen, open, close] = useOpenable();
 
-  const { register, handleSubmit, errors } = useForm<FormData>();
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>();
 
   const onSubmit = ({ name }: FormData): void => {
     close();
     createVariant(name.toUpperCase());
   };
 
-  return <>
-    <Button className={classes.button} onClick={open} disabled={isDisabled}>
-      <div className={classes.container}>
-        <AddIcon />
-        <Typography className={classes.text}>New variant</Typography>
-      </div>
-    </Button>
-    <Dialog
-      open={isOpen}
-      onClose={close}
-      aria-labelledby="new-variant-dialog-title"
-      aria-describedby="new-variant-dialog-description"
-      fullWidth
-    >
-      <div className={classes.dialogHeader}>
-        <DialogTitle id="new-variant-dialog-title">Create a new variant</DialogTitle>
-        <IconButton onClick={close} aria-label="close">
-          <CloseIcon />
-        </IconButton>
-      </div>
-      <DialogContent dividers>
-        <TextField
-          className={classes.input}
-          error={errors.name !== undefined}
-          helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
-          {...register('name', {
-            required: EMPTY_ERROR_HELPER_TEXT,
-            pattern: {
-              value: VALID_CHARACTERS_REGEX,
-              message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
-            },
-            validate: createDuplicateValidator(existingNames),
-          })}
-          label="Variant name"
-          margin="normal"
-          variant="outlined"
-          autoFocus
-          fullWidth />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleSubmit(onSubmit)} color="primary">
-          Create variant
-        </Button>
-      </DialogActions>
-    </Dialog>
-  </>;
+  return (
+    <>
+      <Button className={classes.button} onClick={open} disabled={isDisabled}>
+        <div className={classes.container}>
+          <AddIcon />
+          <Typography className={classes.text}>New variant</Typography>
+        </div>
+      </Button>
+      <Dialog
+        open={isOpen}
+        onClose={close}
+        aria-labelledby="new-variant-dialog-title"
+        aria-describedby="new-variant-dialog-description"
+        fullWidth
+      >
+        <div className={classes.dialogHeader}>
+          <DialogTitle id="new-variant-dialog-title">Create a new variant</DialogTitle>
+          <IconButton onClick={close} aria-label="close">
+            <CloseIcon />
+          </IconButton>
+        </div>
+        <DialogContent dividers>
+          <TextField
+            className={classes.input}
+            error={errors.name !== undefined}
+            helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
+            {...register('name', {
+              required: EMPTY_ERROR_HELPER_TEXT,
+              pattern: {
+                value: VALID_CHARACTERS_REGEX,
+                message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
+              },
+              validate: createDuplicateValidator(existingNames),
+            })}
+            label="Variant name"
+            margin="normal"
+            variant="outlined"
+            autoFocus
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleSubmit(onSubmit)} color="primary">
+            Create variant
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
 };
 
 export default NewVariantButton;

--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -145,7 +145,13 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
    * `content` in a useEffect.
    */
   const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
-  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
+  const {
+    handleSubmit,
+    control,
+    trigger,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });

--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -224,14 +224,14 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
           rules={{
             validate: templateValidator,
           }}
-          render={data => {
+          render={({ field }) => {
             return (
               <RichTextEditorSingleLine
                 error={errors.heading !== undefined}
                 helperText={errors.heading ? errors.heading.message || errors.heading.type : ''}
-                copyData={data.value}
+                copyData={field.value}
                 updateCopy={pars => {
-                  data.onChange(pars);
+                  field.onChange(pars);
                   handleSubmit(setValidatedFields)();
                 }}
                 name="heading"
@@ -255,7 +255,7 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
                 getEmptyParagraphsError(pars) ??
                 pars.map(templateValidator).find((result: string | undefined) => !!result),
             }}
-            render={data => {
+            render={({ field }) => {
               return (
                 <RichTextEditor
                   error={errors.paragraphs !== undefined || copyLength > recommendedLength}
@@ -265,9 +265,9 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
                         errors.paragraphs.message || errors.paragraphs.type
                       : getParagraphsHelperText()
                   }
-                  copyData={data.value}
+                  copyData={field.value}
                   updateCopy={pars => {
-                    data.onChange(pars);
+                    field.onChange(pars);
                     handleSubmit(setValidatedFields)();
                   }}
                   name="paragraphs"
@@ -284,7 +284,7 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
             rules={{
               validate: templateValidator,
             }}
-            render={data => {
+            render={({ field }) => {
               return (
                 <RichTextEditorSingleLine
                   error={errors.highlightedText !== undefined}
@@ -293,9 +293,9 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
                       ? errors.highlightedText.message || errors.highlightedText.type
                       : HIGHTLIGHTED_TEXT_HELPER_TEXT
                   }
-                  copyData={data.value}
+                  copyData={field.value}
                   updateCopy={pars => {
-                    data.onChange(pars);
+                    field.onChange(pars);
                     handleSubmit(setValidatedFields)();
                   }}
                   name="highlightedText"

--- a/public/src/components/channelManagement/bylineWithImageEditor.tsx
+++ b/public/src/components/channelManagement/bylineWithImageEditor.tsx
@@ -52,7 +52,7 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors]);
+  }, [errors.name, errors.description, errors.headshot]);
 
   const update = (byline: BylineWithImage): void => {
     if (!byline.headshot?.mainUrl && !byline.headshot?.altText) {

--- a/public/src/components/channelManagement/bylineWithImageEditor.tsx
+++ b/public/src/components/channelManagement/bylineWithImageEditor.tsx
@@ -61,35 +61,37 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
   return (
     <div>
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors.name !== undefined}
         helperText={errors.name?.message}
         onBlur={handleSubmit(update)}
-        name="name"
+        {...register('name', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Name"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <TextField
-        inputRef={register()}
         onBlur={handleSubmit(update)}
-        name="description"
+        {...register('description')}
         label="Title or description"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <p>
         Note: if including a headshot image alongside the byline, both of the following fields
         should be completed
       </p>
       <TextField
-        inputRef={register({
+        error={errors?.headshot?.mainUrl !== undefined}
+        helperText={
+          errors?.headshot?.mainUrl?.message ??
+          'Image dimensions should be roughly square, with a transparent background'
+        }
+        onBlur={handleSubmit(update)}
+        {...register('headshot.mainUrl', {
           validate: mainUrl => {
             // required if altText is set
             if (!mainUrl && getValues().headshot?.altText) {
@@ -98,21 +100,16 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
             return true;
           },
         })}
-        error={errors?.headshot?.mainUrl !== undefined}
-        helperText={
-          errors?.headshot?.mainUrl?.message ??
-          'Image dimensions should be roughly square, with a transparent background'
-        }
-        onBlur={handleSubmit(update)}
-        name="headshot.mainUrl"
         label="Image URL"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <TextField
-        inputRef={register({
+        error={errors?.headshot?.altText !== undefined}
+        helperText={errors?.headshot?.altText?.message ?? ''}
+        onBlur={handleSubmit(update)}
+        {...register('headshot.altText', {
           validate: altText => {
             // required if mainUrl is set
             if (!altText && getValues().headshot?.mainUrl) {
@@ -121,16 +118,11 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
             return true;
           },
         })}
-        error={errors?.headshot?.altText !== undefined}
-        helperText={errors?.headshot?.altText?.message ?? ''}
-        onBlur={handleSubmit(update)}
-        name="headshot.altText"
         label="Image alt-text"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
     </div>
   );
 };

--- a/public/src/components/channelManagement/bylineWithImageEditor.tsx
+++ b/public/src/components/channelManagement/bylineWithImageEditor.tsx
@@ -70,10 +70,10 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
       <TextField
         error={errors.name !== undefined}
         helperText={errors.name?.message}
-        onBlur={handleSubmit(update)}
         {...register('name', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(update)}
         label="Name"
         margin="normal"
         variant="outlined"
@@ -81,8 +81,8 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
         fullWidth
       />
       <TextField
-        onBlur={handleSubmit(update)}
         {...register('description')}
+        onBlur={handleSubmit(update)}
         label="Title or description"
         margin="normal"
         variant="outlined"
@@ -99,7 +99,6 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
           errors?.headshot?.mainUrl?.message ??
           'Image dimensions should be roughly square, with a transparent background'
         }
-        onBlur={handleSubmit(update)}
         {...register('headshot.mainUrl', {
           validate: mainUrl => {
             // required if altText is set
@@ -109,6 +108,7 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
             return true;
           },
         })}
+        onBlur={handleSubmit(update)}
         label="Image URL"
         margin="normal"
         variant="outlined"
@@ -118,7 +118,6 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
       <TextField
         error={errors?.headshot?.altText !== undefined}
         helperText={errors?.headshot?.altText?.message ?? ''}
-        onBlur={handleSubmit(update)}
         {...register('headshot.altText', {
           validate: altText => {
             // required if mainUrl is set
@@ -128,6 +127,7 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
             return true;
           },
         })}
+        onBlur={handleSubmit(update)}
         label="Image alt-text"
         margin="normal"
         variant="outlined"

--- a/public/src/components/channelManagement/bylineWithImageEditor.tsx
+++ b/public/src/components/channelManagement/bylineWithImageEditor.tsx
@@ -33,7 +33,14 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
     name: '',
   };
 
-  const { register, handleSubmit, errors, trigger, getValues } = useForm<BylineWithImage>({
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    getValues,
+
+    formState: { errors },
+  } = useForm<BylineWithImage>({
     mode: 'onChange',
     defaultValues,
   });
@@ -71,7 +78,8 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <TextField
         onBlur={handleSubmit(update)}
         {...register('description')}
@@ -79,7 +87,8 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <p>
         Note: if including a headshot image alongside the byline, both of the following fields
         should be completed
@@ -104,7 +113,8 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <TextField
         error={errors?.headshot?.altText !== undefined}
         helperText={errors?.headshot?.altText?.message ?? ''}
@@ -122,7 +132,8 @@ const BylineWithImageEditor: React.FC<BylineWithImageEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -196,17 +196,15 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
               </div>
 
               <TextField
-                inputRef={register()}
                 error={errors.description !== undefined}
                 helperText={errors.description ? errors.description.message : ''}
                 onBlur={handleSubmit(onSubmit)}
-                name="description"
+                {...register('description')}
                 label="Description"
                 margin="normal"
                 variant="outlined"
                 disabled={!editMode}
-                fullWidth
-              />
+                fullWidth />
 
               <Controller
                 name="isActive"
@@ -215,15 +213,13 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
                   <FormControlLabel
                     control={
                       <Switch
-                        inputRef={register()}
-                        name="isActive"
+                        {...register('isActive')}
                         onChange={e => {
                           data.onChange(e.target.checked);
                           handleSubmit(onSubmit)();
                         }}
                         checked={data.value}
-                        disabled={!editMode}
-                      />
+                        disabled={!editMode} />
                     }
                     label={'Include this campaign in Channel Test campaign selectors'}
                   />

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -217,16 +217,16 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
               <Controller
                 name="isActive"
                 control={control}
-                render={data => (
+                render={({ field }) => (
                   <FormControlLabel
                     control={
                       <Switch
                         {...register('isActive')}
                         onChange={e => {
-                          data.onChange(e.target.checked);
+                          field.onChange(e.target.checked);
                           handleSubmit(onSubmit)();
                         }}
-                        checked={data.value}
+                        checked={field.value}
                         disabled={!editMode}
                       />
                     }
@@ -238,13 +238,13 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
               <Controller
                 name="notes"
                 control={control}
-                render={data => {
+                render={({ field }) => {
                   return (
                     <RichTextEditor
                       error={errors.notes !== undefined}
-                      copyData={data.value}
+                      copyData={field.value}
                       updateCopy={pars => {
-                        data.onChange(pars);
+                        field.onChange(pars);
                         handleSubmit(onSubmit)();
                       }}
                       name="notes"

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -150,7 +150,14 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
 
   const updatePage = () => doDataFetch(name);
 
-  const { register, handleSubmit, errors, trigger, control } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    control,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -204,7 +211,8 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
                 margin="normal"
                 variant="outlined"
                 disabled={!editMode}
-                fullWidth />
+                fullWidth
+              />
 
               <Controller
                 name="isActive"
@@ -219,7 +227,8 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
                           handleSubmit(onSubmit)();
                         }}
                         checked={data.value}
-                        disabled={!editMode} />
+                        disabled={!editMode}
+                      />
                     }
                     label={'Include this campaign in Channel Test campaign selectors'}
                   />

--- a/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
+++ b/public/src/components/channelManagement/campaigns/CampaignsEditor.tsx
@@ -205,8 +205,8 @@ function CampaignsEditor({ campaign, updateCampaign }: CampaignsEditorProps): Re
               <TextField
                 error={errors.description !== undefined}
                 helperText={errors.description ? errors.description.message : ''}
-                onBlur={handleSubmit(onSubmit)}
                 {...register('description')}
+                onBlur={handleSubmit(onSubmit)}
                 label="Description"
                 margin="normal"
                 variant="outlined"

--- a/public/src/components/channelManagement/campaigns/CreateCampaignDialog.tsx
+++ b/public/src/components/channelManagement/campaigns/CreateCampaignDialog.tsx
@@ -85,7 +85,9 @@ const CreateCampaignDialog: React.FC<CreateCampaignDialogProps> = ({
       <DialogContent dividers>
         <TextField
           className={classes.input}
-          inputRef={register({
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : ''}
+          {...register('name', {
             required: EMPTY_ERROR_HELPER_TEXT,
             pattern: {
               value: VALID_CHARACTERS_REGEX,
@@ -93,39 +95,31 @@ const CreateCampaignDialog: React.FC<CreateCampaignDialogProps> = ({
             },
             validate: createDuplicateValidator(existingNames),
           })}
-          error={errors.name !== undefined}
-          helperText={errors.name ? errors.name.message : ''}
-          name="name"
           label="Campaign name"
           margin="normal"
           variant="outlined"
           autoFocus
-          fullWidth
-        />
+          fullWidth />
         <TextField
           className={classes.input}
-          inputRef={register({
+          error={errors.nickname !== undefined}
+          helperText={errors.nickname ? errors.nickname.message : ''}
+          {...register('nickname', {
             required: EMPTY_ERROR_HELPER_TEXT,
             validate: createDuplicateValidator(existingNicknames),
           })}
-          error={errors.nickname !== undefined}
-          helperText={errors.nickname ? errors.nickname.message : ''}
-          name="nickname"
           label="Nickname"
           margin="normal"
           variant="outlined"
-          fullWidth
-        />
+          fullWidth />
         <TextField
-          inputRef={register()}
           error={errors.description !== undefined}
           helperText={errors.description ? errors.description.message : ''}
-          name="description"
+          {...register('description')}
           label="Description"
           margin="normal"
           variant="outlined"
-          fullWidth
-        />
+          fullWidth />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/campaigns/CreateCampaignDialog.tsx
+++ b/public/src/components/channelManagement/campaigns/CreateCampaignDialog.tsx
@@ -61,7 +61,12 @@ const CreateCampaignDialog: React.FC<CreateCampaignDialogProps> = ({
     description: '',
   };
 
-  const { register, handleSubmit, errors } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({
     defaultValues,
   });
 
@@ -99,7 +104,8 @@ const CreateCampaignDialog: React.FC<CreateCampaignDialogProps> = ({
           margin="normal"
           variant="outlined"
           autoFocus
-          fullWidth />
+          fullWidth
+        />
         <TextField
           className={classes.input}
           error={errors.nickname !== undefined}
@@ -111,7 +117,8 @@ const CreateCampaignDialog: React.FC<CreateCampaignDialogProps> = ({
           label="Nickname"
           margin="normal"
           variant="outlined"
-          fullWidth />
+          fullWidth
+        />
         <TextField
           error={errors.description !== undefined}
           helperText={errors.description ? errors.description.message : ''}
@@ -119,7 +126,8 @@ const CreateCampaignDialog: React.FC<CreateCampaignDialogProps> = ({
           label="Description"
           margin="normal"
           variant="outlined"
-          fullWidth />
+          fullWidth
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/countdownEditor.tsx
+++ b/public/src/components/channelManagement/countdownEditor.tsx
@@ -166,8 +166,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
           <TextField
             error={!!errors.overwriteHeadingLabel}
             helperText={errors?.overwriteHeadingLabel?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('overwriteHeadingLabel', { required: EMPTY_ERROR_HELPER_TEXT })}
+            onBlur={handleSubmit(onSubmit)}
             label="Overwrite heading text"
             margin="normal"
             variant="outlined"
@@ -205,8 +205,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
           <TextField
             error={!!errors.countdownStartTimestamp}
             helperText={errors?.countdownStartTimestamp?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('countdownStartTimestamp', { required: EMPTY_ERROR_HELPER_TEXT })}
+            onBlur={handleSubmit(onSubmit)}
             label="Start Date"
             type={'datetime-local'}
             defaultValue={new Date().toISOString().slice(0, 19)}
@@ -219,8 +219,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
           <TextField
             error={!!errors.countdownDeadlineTimestamp}
             helperText={errors?.countdownDeadlineTimestamp?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('countdownDeadlineTimestamp', { required: EMPTY_ERROR_HELPER_TEXT })}
+            onBlur={handleSubmit(onSubmit)}
             label="End Date"
             type={'datetime-local'}
             defaultValue={new Date().toISOString().slice(0, 19)}
@@ -233,8 +233,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
           <TextField
             error={!!errors.backgroundColor}
             helperText={errors?.backgroundColor?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('backgroundColor', { required: true })}
+            onBlur={handleSubmit(onSubmit)}
             label="Background Color"
             margin="normal"
             variant="outlined"
@@ -245,8 +245,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
           <TextField
             error={!!errors.foregroundColor}
             helperText={errors?.foregroundColor?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('foregroundColor', { required: true })}
+            onBlur={handleSubmit(onSubmit)}
             label="Foreground Color"
             margin="normal"
             variant="outlined"

--- a/public/src/components/channelManagement/countdownEditor.tsx
+++ b/public/src/components/channelManagement/countdownEditor.tsx
@@ -79,7 +79,13 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
     foregroundColor: countdownSettings?.theme.foregroundColor || '#ffffff',
   };
 
-  const { register, handleSubmit, errors, reset } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -166,7 +172,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
 
           <div className={classes.switchContainer}>
             <Typography>UTC</Typography>
@@ -206,7 +213,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
 
           <TextField
             error={!!errors.countdownDeadlineTimestamp}
@@ -219,7 +227,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
 
           <TextField
             error={!!errors.backgroundColor}
@@ -230,7 +239,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
 
           <TextField
             error={!!errors.foregroundColor}
@@ -241,7 +251,8 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
         </div>
       )}
     </div>

--- a/public/src/components/channelManagement/countdownEditor.tsx
+++ b/public/src/components/channelManagement/countdownEditor.tsx
@@ -158,17 +158,15 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
       {!!countdownSettings && (
         <div className={classes.fieldsContainer}>
           <TextField
-            inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
             error={!!errors.overwriteHeadingLabel}
             helperText={errors?.overwriteHeadingLabel?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="overwriteHeadingLabel"
+            {...register('overwriteHeadingLabel', { required: EMPTY_ERROR_HELPER_TEXT })}
             label="Overwrite heading text"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
 
           <div className={classes.switchContainer}>
             <Typography>UTC</Typography>
@@ -198,60 +196,52 @@ const CountdownEditor: React.FC<CountdownEditorProps> = ({
           </Alert>
 
           <TextField
-            inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
             error={!!errors.countdownStartTimestamp}
             helperText={errors?.countdownStartTimestamp?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="countdownStartTimestamp"
+            {...register('countdownStartTimestamp', { required: EMPTY_ERROR_HELPER_TEXT })}
             label="Start Date"
             type={'datetime-local'}
             defaultValue={new Date().toISOString().slice(0, 19)}
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
 
           <TextField
-            inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
             error={!!errors.countdownDeadlineTimestamp}
             helperText={errors?.countdownDeadlineTimestamp?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="countdownDeadlineTimestamp"
+            {...register('countdownDeadlineTimestamp', { required: EMPTY_ERROR_HELPER_TEXT })}
             label="End Date"
             type={'datetime-local'}
             defaultValue={new Date().toISOString().slice(0, 19)}
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
 
           <TextField
-            inputRef={register({ required: true })}
             error={!!errors.backgroundColor}
             helperText={errors?.backgroundColor?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="backgroundColor"
+            {...register('backgroundColor', { required: true })}
             label="Background Color"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
 
           <TextField
-            inputRef={register({ required: true })}
             error={!!errors.foregroundColor}
             helperText={errors?.foregroundColor?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="foregroundColor"
+            {...register('foregroundColor', { required: true })}
             label="Foreground Color"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
         </div>
       )}
     </div>

--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -182,7 +182,9 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
         )}
         <TextField
           className={classes.input}
-          inputRef={register({
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
+          {...register('name', {
             required: EMPTY_ERROR_HELPER_TEXT,
             pattern: {
               value: VALID_CHARACTERS_REGEX,
@@ -196,9 +198,6 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
               );
             },
           })}
-          error={errors.name !== undefined}
-          helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
-          name="name"
           label="Full test name"
           margin="normal"
           variant="outlined"
@@ -206,22 +205,19 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
             startAdornment: <InputAdornment position="start">{buildPrefix()}</InputAdornment>,
           }}
           autoFocus
-          fullWidth
-        />
+          fullWidth />
         <TextField
           className={classes.input}
-          inputRef={register({
+          error={errors.nickname !== undefined}
+          helperText={errors.nickname ? errors.nickname.message : NICKNAME_DEFAULT_HELPER_TEXT}
+          {...register('nickname', {
             required: EMPTY_ERROR_HELPER_TEXT,
             validate: createDuplicateValidator(existingNicknames),
           })}
-          error={errors.nickname !== undefined}
-          helperText={errors.nickname ? errors.nickname.message : NICKNAME_DEFAULT_HELPER_TEXT}
-          name="nickname"
           label="Nickname"
           margin="normal"
           variant="outlined"
-          fullWidth
-        />
+          fullWidth />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/createTestDialog.tsx
+++ b/public/src/components/channelManagement/createTestDialog.tsx
@@ -91,7 +91,12 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
     nickname: sourceNickname || '',
   };
 
-  const { register, handleSubmit, errors } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({
     defaultValues,
   });
 
@@ -205,7 +210,8 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
             startAdornment: <InputAdornment position="start">{buildPrefix()}</InputAdornment>,
           }}
           autoFocus
-          fullWidth />
+          fullWidth
+        />
         <TextField
           className={classes.input}
           error={errors.nickname !== undefined}
@@ -217,7 +223,8 @@ const CreateTestDialog: React.FC<CreateTestDialogProps> = ({
           label="Nickname"
           margin="normal"
           variant="outlined"
-          fullWidth />
+          fullWidth
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/createVariantDialog.tsx
+++ b/public/src/components/channelManagement/createVariantDialog.tsx
@@ -82,7 +82,9 @@ const CreateVariantDialog: React.FC<CreateVariantDialogProps> = ({
       <DialogContent dividers>
         <TextField
           className={classes.input}
-          inputRef={register({
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
+          {...register('name', {
             required: EMPTY_ERROR_HELPER_TEXT,
             pattern: {
               value: VALID_CHARACTERS_REGEX,
@@ -90,15 +92,11 @@ const CreateVariantDialog: React.FC<CreateVariantDialogProps> = ({
             },
             validate: createDuplicateValidator(existingNames),
           })}
-          error={errors.name !== undefined}
-          helperText={errors.name ? errors.name.message : NAME_DEFAULT_HELPER_TEXT}
-          name="name"
           label="Variant name"
           margin="normal"
           variant="outlined"
           autoFocus
-          fullWidth
-        />
+          fullWidth />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/createVariantDialog.tsx
+++ b/public/src/components/channelManagement/createVariantDialog.tsx
@@ -56,7 +56,12 @@ const CreateVariantDialog: React.FC<CreateVariantDialogProps> = ({
 }: CreateVariantDialogProps) => {
   const classes = useStyles();
 
-  const { register, handleSubmit, errors } = useForm<FormData>();
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>();
 
   const onSubmit = ({ name }: FormData): void => {
     close();
@@ -96,7 +101,8 @@ const CreateVariantDialog: React.FC<CreateVariantDialogProps> = ({
           margin="normal"
           variant="outlined"
           autoFocus
-          fullWidth />
+          fullWidth
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/channelManagement/epicTests/maxViewsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/maxViewsEditor.tsx
@@ -49,7 +49,13 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
     minDaysBetweenViews: maxEpicViews?.minDaysBetweenViews.toString() || '',
   };
 
-  const { register, errors, handleSubmit, reset } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -115,7 +121,8 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
               InputLabelProps={{ shrink: true }}
               variant="filled"
               fullWidth
-              disabled={isDisabled} />
+              disabled={isDisabled}
+            />
           </div>
           <div>
             <TextField
@@ -130,7 +137,8 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
               InputLabelProps={{ shrink: true }}
               variant="filled"
               fullWidth
-              disabled={isDisabled} />
+              disabled={isDisabled}
+            />
           </div>
           <div>
             <TextField
@@ -145,7 +153,8 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
               InputLabelProps={{ shrink: true }}
               variant="filled"
               fullWidth
-              disabled={isDisabled} />
+              disabled={isDisabled}
+            />
           </div>
         </div>
       )}

--- a/public/src/components/channelManagement/epicTests/maxViewsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/maxViewsEditor.tsx
@@ -112,11 +112,11 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
             <TextField
               error={errors.maxViewsCount !== undefined}
               helperText={errors.maxViewsCount?.message}
-              onBlur={handleSubmit(onSubmit)}
               {...register('maxViewsCount', {
                 required: EMPTY_ERROR_HELPER_TEXT,
                 validate: notNumberValidator,
               })}
+              onBlur={handleSubmit(onSubmit)}
               label="Maximum view counts"
               InputLabelProps={{ shrink: true }}
               variant="filled"
@@ -128,11 +128,11 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
             <TextField
               error={errors.maxViewsDays !== undefined}
               helperText={errors.maxViewsDays?.message}
-              onBlur={handleSubmit(onSubmit)}
               {...register('maxViewsDays', {
                 required: EMPTY_ERROR_HELPER_TEXT,
                 validate: notNumberValidator,
               })}
+              onBlur={handleSubmit(onSubmit)}
               label="Number of days"
               InputLabelProps={{ shrink: true }}
               variant="filled"
@@ -144,11 +144,11 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
             <TextField
               error={errors.minDaysBetweenViews !== undefined}
               helperText={errors.minDaysBetweenViews?.message}
-              onBlur={handleSubmit(onSubmit)}
               {...register('minDaysBetweenViews', {
                 required: EMPTY_ERROR_HELPER_TEXT,
                 validate: notNumberValidator,
               })}
+              onBlur={handleSubmit(onSubmit)}
               label="Minimum days between views"
               InputLabelProps={{ shrink: true }}
               variant="filled"

--- a/public/src/components/channelManagement/epicTests/maxViewsEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/maxViewsEditor.tsx
@@ -104,54 +104,48 @@ const MaxViewsEditor: React.FC<TestEditorArticleCountEditorProps> = ({
         <div className={classes.formContainer}>
           <div>
             <TextField
-              inputRef={register({
-                required: EMPTY_ERROR_HELPER_TEXT,
-                validate: notNumberValidator,
-              })}
               error={errors.maxViewsCount !== undefined}
               helperText={errors.maxViewsCount?.message}
               onBlur={handleSubmit(onSubmit)}
-              name="maxViewsCount"
+              {...register('maxViewsCount', {
+                required: EMPTY_ERROR_HELPER_TEXT,
+                validate: notNumberValidator,
+              })}
               label="Maximum view counts"
               InputLabelProps={{ shrink: true }}
               variant="filled"
               fullWidth
-              disabled={isDisabled}
-            />
+              disabled={isDisabled} />
           </div>
           <div>
             <TextField
-              inputRef={register({
-                required: EMPTY_ERROR_HELPER_TEXT,
-                validate: notNumberValidator,
-              })}
               error={errors.maxViewsDays !== undefined}
               helperText={errors.maxViewsDays?.message}
               onBlur={handleSubmit(onSubmit)}
-              name="maxViewsDays"
+              {...register('maxViewsDays', {
+                required: EMPTY_ERROR_HELPER_TEXT,
+                validate: notNumberValidator,
+              })}
               label="Number of days"
               InputLabelProps={{ shrink: true }}
               variant="filled"
               fullWidth
-              disabled={isDisabled}
-            />
+              disabled={isDisabled} />
           </div>
           <div>
             <TextField
-              inputRef={register({
-                required: EMPTY_ERROR_HELPER_TEXT,
-                validate: notNumberValidator,
-              })}
               error={errors.minDaysBetweenViews !== undefined}
               helperText={errors.minDaysBetweenViews?.message}
               onBlur={handleSubmit(onSubmit)}
-              name="minDaysBetweenViews"
+              {...register('minDaysBetweenViews', {
+                required: EMPTY_ERROR_HELPER_TEXT,
+                validate: notNumberValidator,
+              })}
               label="Minimum days between views"
               InputLabelProps={{ shrink: true }}
               variant="filled"
               fullWidth
-              disabled={isDisabled}
-            />
+              disabled={isDisabled} />
           </div>
         </div>
       )}

--- a/public/src/components/channelManagement/epicTests/newsletterSignUp.tsx
+++ b/public/src/components/channelManagement/epicTests/newsletterSignUp.tsx
@@ -37,42 +37,36 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
     updateNewsletterSignup({ newsletterId, successDescription });
   };
 
-  return (
-    <>
-      <div>
-        <TextField
-          inputRef={register({
-            required: EMPTY_ERROR_HELPER_TEXT,
-          })}
-          error={errors.newsletterId !== undefined}
-          helperText={errors.newsletterId?.message}
-          onBlur={handleSubmit(onSubmit)}
-          name="newsletterId"
-          label="Newsletter Id"
-          margin="normal"
-          variant="outlined"
-          disabled={isDisabled}
-          fullWidth
-        />
-      </div>
-      <div>
-        <TextField
-          inputRef={register({
-            required: EMPTY_ERROR_HELPER_TEXT,
-          })}
-          error={errors.successDescription !== undefined}
-          helperText={errors.successDescription?.message}
-          onBlur={handleSubmit(onSubmit)}
-          name="successDescription"
-          label="Sign up success message"
-          margin="normal"
-          variant="outlined"
-          disabled={isDisabled}
-          fullWidth
-        />
-      </div>
-    </>
-  );
+  return <>
+    <div>
+      <TextField
+        error={errors.newsletterId !== undefined}
+        helperText={errors.newsletterId?.message}
+        onBlur={handleSubmit(onSubmit)}
+        {...register('newsletterId', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        label="Newsletter Id"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth />
+    </div>
+    <div>
+      <TextField
+        error={errors.successDescription !== undefined}
+        helperText={errors.successDescription?.message}
+        onBlur={handleSubmit(onSubmit)}
+        {...register('successDescription', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
+        label="Sign up success message"
+        margin="normal"
+        variant="outlined"
+        disabled={isDisabled}
+        fullWidth />
+    </div>
+  </>;
 };
 
 export default EpicTestNewsletter;

--- a/public/src/components/channelManagement/epicTests/newsletterSignUp.tsx
+++ b/public/src/components/channelManagement/epicTests/newsletterSignUp.tsx
@@ -48,10 +48,10 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
         <TextField
           error={errors.newsletterId !== undefined}
           helperText={errors.newsletterId?.message}
-          onBlur={handleSubmit(onSubmit)}
           {...register('newsletterId', {
             required: EMPTY_ERROR_HELPER_TEXT,
           })}
+          onBlur={handleSubmit(onSubmit)}
           label="Newsletter Id"
           margin="normal"
           variant="outlined"
@@ -63,10 +63,10 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
         <TextField
           error={errors.successDescription !== undefined}
           helperText={errors.successDescription?.message}
-          onBlur={handleSubmit(onSubmit)}
           {...register('successDescription', {
             required: EMPTY_ERROR_HELPER_TEXT,
           })}
+          onBlur={handleSubmit(onSubmit)}
           label="Sign up success message"
           margin="normal"
           variant="outlined"

--- a/public/src/components/channelManagement/epicTests/newsletterSignUp.tsx
+++ b/public/src/components/channelManagement/epicTests/newsletterSignUp.tsx
@@ -26,7 +26,12 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
     newsletterId: newsletterSignup.newsletterId,
     successDescription: newsletterSignup.successDescription,
   };
-  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({ mode: 'onChange', defaultValues });
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
@@ -37,36 +42,40 @@ const EpicTestNewsletter: React.FC<EpicTestNewsletterProps> = ({
     updateNewsletterSignup({ newsletterId, successDescription });
   };
 
-  return <>
-    <div>
-      <TextField
-        error={errors.newsletterId !== undefined}
-        helperText={errors.newsletterId?.message}
-        onBlur={handleSubmit(onSubmit)}
-        {...register('newsletterId', {
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
-        label="Newsletter Id"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth />
-    </div>
-    <div>
-      <TextField
-        error={errors.successDescription !== undefined}
-        helperText={errors.successDescription?.message}
-        onBlur={handleSubmit(onSubmit)}
-        {...register('successDescription', {
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
-        label="Sign up success message"
-        margin="normal"
-        variant="outlined"
-        disabled={isDisabled}
-        fullWidth />
-    </div>
-  </>;
+  return (
+    <>
+      <div>
+        <TextField
+          error={errors.newsletterId !== undefined}
+          helperText={errors.newsletterId?.message}
+          onBlur={handleSubmit(onSubmit)}
+          {...register('newsletterId', {
+            required: EMPTY_ERROR_HELPER_TEXT,
+          })}
+          label="Newsletter Id"
+          margin="normal"
+          variant="outlined"
+          disabled={isDisabled}
+          fullWidth
+        />
+      </div>
+      <div>
+        <TextField
+          error={errors.successDescription !== undefined}
+          helperText={errors.successDescription?.message}
+          onBlur={handleSubmit(onSubmit)}
+          {...register('successDescription', {
+            required: EMPTY_ERROR_HELPER_TEXT,
+          })}
+          label="Sign up success message"
+          margin="normal"
+          variant="outlined"
+          disabled={isDisabled}
+          fullWidth
+        />
+      </div>
+    </>
+  );
 };
 
 export default EpicTestNewsletter;

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -240,14 +240,14 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             required: requireVariantHeader ? EMPTY_ERROR_HELPER_TEXT : undefined,
             validate: lineValidator,
           }}
-          render={data => {
+          render={({ field }) => {
             return (
               <RichTextEditorSingleLine
                 error={errors.heading !== undefined}
                 helperText={errors.heading ? errors.heading.message || errors.heading.type : ''}
-                copyData={data.value}
+                copyData={field.value}
                 updateCopy={value => {
-                  data.onChange(value);
+                  field.onChange(value);
                   handleSubmit(setValidatedFields)();
                 }}
                 name="heading"
@@ -277,7 +277,7 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             getEmptyParagraphsError(pars) ??
             pars.map(lineValidator).find((result: string | undefined) => !!result),
         }}
-        render={data => {
+        render={({ field }) => {
           return (
             <RichTextEditor
               error={errors.paragraphs !== undefined}
@@ -287,9 +287,9 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                     errors.paragraphs.message || errors.paragraphs.type
                   : getParagraphsHelperText()
               }
-              copyData={data.value}
+              copyData={field.value}
               updateCopy={pars => {
-                data.onChange(pars);
+                field.onChange(pars);
                 handleSubmit(setValidatedFields)();
               }}
               name="paragraphs"
@@ -317,7 +317,7 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
             required: false,
             validate: lineValidator,
           }}
-          render={data => {
+          render={({ field }) => {
             return (
               <RichTextEditorSingleLine
                 error={errors.highlightedText !== undefined}
@@ -326,9 +326,9 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                     ? errors.highlightedText.message || errors.highlightedText.type
                     : HIGHTLIGHTED_TEXT_DEFAULT_HELPER_TEXT
                 }
-                copyData={data.value}
+                copyData={field.value}
                 updateCopy={pars => {
-                  data.onChange(pars);
+                  field.onChange(pars);
                   handleSubmit(setValidatedFields)();
                 }}
                 name="highlightedText"

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -139,7 +139,13 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
    * `variant` in a useEffect.
    */
   const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
-  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
+  const {
+    handleSubmit,
+    control,
+    trigger,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -121,7 +121,11 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   const classes = getUseStyles(allowMultipleVariants)();
 
   const templateValidator = templateValidatorForPlatform(platform);
-  const lineValidator = (text: string) => templateValidator(text) ?? htmlValidator(text);
+  const lineValidator = (text: string | undefined) => {
+    if (text) {
+      return templateValidator(text) ?? htmlValidator(text);
+    }
+  };
 
   const defaultValues: FormData = {
     heading: variant.heading,

--- a/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
@@ -121,7 +121,13 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
    * `content` in a useEffect.
    */
   const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
-  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
+  const {
+    handleSubmit,
+    control,
+    trigger,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });

--- a/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
@@ -196,7 +196,7 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
               getEmptyParagraphsError(paras) ??
               paras.map(templateValidator).find((result: string | undefined) => !!result),
           }}
-          render={data => {
+          render={({ field }) => {
             return (
               <RichTextEditor
                 error={errors.bodyCopy !== undefined || copyLength > recommendedLength}
@@ -206,9 +206,9 @@ const VariantContentEditor: React.FC<VariantContentEditorProps> = ({
                       errors.bodyCopy.message || errors.bodyCopy.type
                     : getParagraphsHelperText()
                 }
-                copyData={data.value}
+                copyData={field.value}
                 updateCopy={paras => {
-                  data.onChange(paras);
+                  field.onChange(paras);
                   handleSubmit(setValidatedFields)();
                 }}
                 name="copy"

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -87,7 +87,13 @@ const HeaderTestVariantContentEditor: React.FC<HeaderTestVariantContentEditorPro
     subheading: content.subheading || '',
   };
 
-  const { register, handleSubmit, errors, trigger } = useForm<HeaderContent>({
+  const {
+    register,
+    handleSubmit,
+    trigger,
+
+    formState: { errors },
+  } = useForm<HeaderContent>({
     mode: 'onChange',
     defaultValues,
   });
@@ -117,69 +123,73 @@ const HeaderTestVariantContentEditor: React.FC<HeaderTestVariantContentEditorPro
   const headingCopyLength = content.heading?.length ?? 0;
   const subheadingCopyLength = content.subheading?.length ?? 0;
 
-  return <>
-    {deviceType !== 'MOBILE' && (
-      <>
-        <Typography className={classes.sectionHeader} variant="h4">
-          {`Content${labelSuffix}`}
-        </Typography>
+  return (
+    <>
+      {deviceType !== 'MOBILE' && (
+        <>
+          <Typography className={classes.sectionHeader} variant="h4">
+            {`Content${labelSuffix}`}
+          </Typography>
 
-        <div className={classes.contentContainer}>
-          <div>
-            <TextField
-              error={errors.heading !== undefined}
-              helperText={errors.heading ? errors.heading.message : ''}
-              onBlur={handleSubmit(onSubmit)}
-              {...register('heading', { validate: templateValidator })}
-              label="Heading"
-              margin="normal"
-              variant="outlined"
-              disabled={!editMode}
-              fullWidth />
+          <div className={classes.contentContainer}>
+            <div>
+              <TextField
+                error={errors.heading !== undefined}
+                helperText={errors.heading ? errors.heading.message : ''}
+                onBlur={handleSubmit(onSubmit)}
+                {...register('heading', { validate: templateValidator })}
+                label="Heading"
+                margin="normal"
+                variant="outlined"
+                disabled={!editMode}
+                fullWidth
+              />
 
-            {headingCopyLength > HEADING_COPY_RECOMMENDED_LENGTH && (
-              <VariantCopyLengthWarning charLimit={HEADING_COPY_RECOMMENDED_LENGTH} />
-            )}
+              {headingCopyLength > HEADING_COPY_RECOMMENDED_LENGTH && (
+                <VariantCopyLengthWarning charLimit={HEADING_COPY_RECOMMENDED_LENGTH} />
+              )}
+            </div>
           </div>
-        </div>
 
-        <div className={classes.contentContainer}>
-          <div>
-            <TextField
-              error={errors.subheading !== undefined}
-              helperText={errors.subheading ? errors.subheading.message : ''}
-              onBlur={handleSubmit(onSubmit)}
-              {...register('subheading', { validate: templateValidator })}
-              label="Sub-heading"
-              margin="normal"
-              variant="outlined"
-              disabled={!editMode}
-              fullWidth />
+          <div className={classes.contentContainer}>
+            <div>
+              <TextField
+                error={errors.subheading !== undefined}
+                helperText={errors.subheading ? errors.subheading.message : ''}
+                onBlur={handleSubmit(onSubmit)}
+                {...register('subheading', { validate: templateValidator })}
+                label="Sub-heading"
+                margin="normal"
+                variant="outlined"
+                disabled={!editMode}
+                fullWidth
+              />
 
-            {subheadingCopyLength > SUBHEADING_COPY_RECOMMENDED_LENGTH && (
-              <VariantCopyLengthWarning charLimit={SUBHEADING_COPY_RECOMMENDED_LENGTH} />
-            )}
+              {subheadingCopyLength > SUBHEADING_COPY_RECOMMENDED_LENGTH && (
+                <VariantCopyLengthWarning charLimit={SUBHEADING_COPY_RECOMMENDED_LENGTH} />
+              )}
+            </div>
           </div>
-        </div>
-      </>
-    )}
+        </>
+      )}
 
-    <Typography className={classes.sectionHeader} variant="h4">
-      {`Buttons${labelSuffix}`}
-    </Typography>
+      <Typography className={classes.sectionHeader} variant="h4">
+        {`Buttons${labelSuffix}`}
+      </Typography>
 
-    <div className={classes.buttonsContainer}>
-      <HeaderTestVariantCtasEditor
-        primaryCta={content.primaryCta}
-        secondaryCta={content.secondaryCta}
-        updatePrimaryCta={updatePrimaryCta}
-        updateSecondaryCta={updateSecondaryCta}
-        isDisabled={!editMode}
-        onValidationChange={onValidationChange}
-        supportSecondaryCta={deviceType !== 'MOBILE'}
-      />
-    </div>
-  </>;
+      <div className={classes.buttonsContainer}>
+        <HeaderTestVariantCtasEditor
+          primaryCta={content.primaryCta}
+          secondaryCta={content.secondaryCta}
+          updatePrimaryCta={updatePrimaryCta}
+          updateSecondaryCta={updateSecondaryCta}
+          isDisabled={!editMode}
+          onValidationChange={onValidationChange}
+          supportSecondaryCta={deviceType !== 'MOBILE'}
+        />
+      </div>
+    </>
+  );
 };
 
 interface HeaderTestVariantEditorProps {

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -117,75 +117,69 @@ const HeaderTestVariantContentEditor: React.FC<HeaderTestVariantContentEditorPro
   const headingCopyLength = content.heading?.length ?? 0;
   const subheadingCopyLength = content.subheading?.length ?? 0;
 
-  return (
-    <>
-      {deviceType !== 'MOBILE' && (
-        <>
-          <Typography className={classes.sectionHeader} variant="h4">
-            {`Content${labelSuffix}`}
-          </Typography>
+  return <>
+    {deviceType !== 'MOBILE' && (
+      <>
+        <Typography className={classes.sectionHeader} variant="h4">
+          {`Content${labelSuffix}`}
+        </Typography>
 
-          <div className={classes.contentContainer}>
-            <div>
-              <TextField
-                inputRef={register({ validate: templateValidator })}
-                error={errors.heading !== undefined}
-                helperText={errors.heading ? errors.heading.message : ''}
-                onBlur={handleSubmit(onSubmit)}
-                name="heading"
-                label="Heading"
-                margin="normal"
-                variant="outlined"
-                disabled={!editMode}
-                fullWidth
-              />
+        <div className={classes.contentContainer}>
+          <div>
+            <TextField
+              error={errors.heading !== undefined}
+              helperText={errors.heading ? errors.heading.message : ''}
+              onBlur={handleSubmit(onSubmit)}
+              {...register('heading', { validate: templateValidator })}
+              label="Heading"
+              margin="normal"
+              variant="outlined"
+              disabled={!editMode}
+              fullWidth />
 
-              {headingCopyLength > HEADING_COPY_RECOMMENDED_LENGTH && (
-                <VariantCopyLengthWarning charLimit={HEADING_COPY_RECOMMENDED_LENGTH} />
-              )}
-            </div>
+            {headingCopyLength > HEADING_COPY_RECOMMENDED_LENGTH && (
+              <VariantCopyLengthWarning charLimit={HEADING_COPY_RECOMMENDED_LENGTH} />
+            )}
           </div>
+        </div>
 
-          <div className={classes.contentContainer}>
-            <div>
-              <TextField
-                inputRef={register({ validate: templateValidator })}
-                error={errors.subheading !== undefined}
-                helperText={errors.subheading ? errors.subheading.message : ''}
-                onBlur={handleSubmit(onSubmit)}
-                name="subheading"
-                label="Sub-heading"
-                margin="normal"
-                variant="outlined"
-                disabled={!editMode}
-                fullWidth
-              />
+        <div className={classes.contentContainer}>
+          <div>
+            <TextField
+              error={errors.subheading !== undefined}
+              helperText={errors.subheading ? errors.subheading.message : ''}
+              onBlur={handleSubmit(onSubmit)}
+              {...register('subheading', { validate: templateValidator })}
+              label="Sub-heading"
+              margin="normal"
+              variant="outlined"
+              disabled={!editMode}
+              fullWidth />
 
-              {subheadingCopyLength > SUBHEADING_COPY_RECOMMENDED_LENGTH && (
-                <VariantCopyLengthWarning charLimit={SUBHEADING_COPY_RECOMMENDED_LENGTH} />
-              )}
-            </div>
+            {subheadingCopyLength > SUBHEADING_COPY_RECOMMENDED_LENGTH && (
+              <VariantCopyLengthWarning charLimit={SUBHEADING_COPY_RECOMMENDED_LENGTH} />
+            )}
           </div>
-        </>
-      )}
+        </div>
+      </>
+    )}
 
-      <Typography className={classes.sectionHeader} variant="h4">
-        {`Buttons${labelSuffix}`}
-      </Typography>
+    <Typography className={classes.sectionHeader} variant="h4">
+      {`Buttons${labelSuffix}`}
+    </Typography>
 
-      <div className={classes.buttonsContainer}>
-        <HeaderTestVariantCtasEditor
-          primaryCta={content.primaryCta}
-          secondaryCta={content.secondaryCta}
-          updatePrimaryCta={updatePrimaryCta}
-          updateSecondaryCta={updateSecondaryCta}
-          isDisabled={!editMode}
-          onValidationChange={onValidationChange}
-          supportSecondaryCta={deviceType !== 'MOBILE'}
-        />
-      </div>
-    </>
-  );
+    <div className={classes.buttonsContainer}>
+      <HeaderTestVariantCtasEditor
+        primaryCta={content.primaryCta}
+        secondaryCta={content.secondaryCta}
+        updatePrimaryCta={updatePrimaryCta}
+        updateSecondaryCta={updateSecondaryCta}
+        isDisabled={!editMode}
+        onValidationChange={onValidationChange}
+        supportSecondaryCta={deviceType !== 'MOBILE'}
+      />
+    </div>
+  </>;
 };
 
 interface HeaderTestVariantEditorProps {

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -136,8 +136,8 @@ const HeaderTestVariantContentEditor: React.FC<HeaderTestVariantContentEditorPro
               <TextField
                 error={errors.heading !== undefined}
                 helperText={errors.heading ? errors.heading.message : ''}
-                onBlur={handleSubmit(onSubmit)}
                 {...register('heading', { validate: templateValidator })}
+                onBlur={handleSubmit(onSubmit)}
                 label="Heading"
                 margin="normal"
                 variant="outlined"
@@ -156,8 +156,8 @@ const HeaderTestVariantContentEditor: React.FC<HeaderTestVariantContentEditorPro
               <TextField
                 error={errors.subheading !== undefined}
                 helperText={errors.subheading ? errors.subheading.message : ''}
-                onBlur={handleSubmit(onSubmit)}
                 {...register('subheading', { validate: templateValidator })}
+                onBlur={handleSubmit(onSubmit)}
                 label="Sub-heading"
                 margin="normal"
                 variant="outlined"

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -68,10 +68,10 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
       <TextField
         error={errors.mainUrl !== undefined}
         helperText={errors.mainUrl?.message ?? guidance}
-        onBlur={handleSubmit(updateImage)}
         {...register('mainUrl', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(updateImage)}
         label="Image URL"
         margin="normal"
         variant="outlined"
@@ -81,10 +81,10 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
       <TextField
         error={errors.altText !== undefined}
         helperText={errors.altText?.message}
-        onBlur={handleSubmit(updateImage)}
         {...register('altText', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(updateImage)}
         label="Image alt-text"
         margin="normal"
         variant="outlined"

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -43,7 +43,13 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
 }: ImageEditorProps) => {
   const defaultValues: Image = image;
 
-  const { register, handleSubmit, errors, trigger } = useForm<Image>({
+  const {
+    register,
+    handleSubmit,
+    trigger,
+
+    formState: { errors },
+  } = useForm<Image>({
     mode: 'onChange',
     defaultValues,
   });
@@ -70,7 +76,8 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
       <TextField
         error={errors.altText !== undefined}
         helperText={errors.altText?.message}
@@ -82,7 +89,8 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -61,7 +61,7 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
     onValidationChange(isValid);
-  }, [errors]);
+  }, [errors.altText, errors.mainUrl]);
 
   return (
     <div>

--- a/public/src/components/channelManagement/imageEditor.tsx
+++ b/public/src/components/channelManagement/imageEditor.tsx
@@ -60,33 +60,29 @@ const ImageEditor: React.FC<ImageEditorProps> = ({
   return (
     <div>
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors.mainUrl !== undefined}
         helperText={errors.mainUrl?.message ?? guidance}
         onBlur={handleSubmit(updateImage)}
-        name="mainUrl"
+        {...register('mainUrl', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Image URL"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors.altText !== undefined}
         helperText={errors.altText?.message}
         onBlur={handleSubmit(updateImage)}
-        name="altText"
+        {...register('altText', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Image alt-text"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
     </div>
   );
 };

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -40,7 +40,13 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
   };
 
   const [validatedFields, setValidatedFields] = useState<FormData>(defaultValues);
-  const { handleSubmit, control, errors, trigger } = useForm<FormData>({
+  const {
+    handleSubmit,
+    control,
+    trigger,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });

--- a/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/copyEditor.tsx
@@ -79,14 +79,14 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
             required: true,
             validate: copy => templateValidator(copy) ?? copyLengthValidator(75)(copy),
           }}
-          render={data => {
+          render={({ field }) => {
             return (
               <RichTextEditorSingleLine
                 error={errors.heading !== undefined}
                 helperText={errors?.heading?.message || errors?.heading?.type}
-                copyData={data.value}
+                copyData={field.value}
                 updateCopy={pars => {
-                  data.onChange(pars);
+                  field.onChange(pars);
                   handleSubmit(setValidatedFields)();
                 }}
                 name="heading"
@@ -113,14 +113,14 @@ export const CopyEditor: React.FC<CopyEditorProps> = ({
               required: true,
               validate: templateValidator,
             }}
-            render={data => {
+            render={({ field }) => {
               return (
                 <RichTextEditorSingleLine
                   error={errors.subheading !== undefined}
                   helperText={errors?.subheading?.message || errors?.subheading?.type}
-                  copyData={data.value}
+                  copyData={field.value}
                   updateCopy={pars => {
-                    data.onChange(pars);
+                    field.onChange(pars);
                     handleSubmit(setValidatedFields)();
                   }}
                   name="subheading"

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -92,39 +92,33 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
       </AccordionSummary>
       <AccordionDetails className={classes.accordionDetails}>
         <TextField
-          inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
           error={!!errors.title}
           helperText={errors?.title?.message}
           label="Title"
-          name="title"
+          {...register('title', { required: EMPTY_ERROR_HELPER_TEXT })}
           required={true}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
-          fullWidth
-        />
+          fullWidth />
         <TextField
-          inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
           error={!!errors.cta?.copy}
           helperText={errors?.cta?.copy?.message}
           label="CTA Copy"
-          name="cta.copy"
+          {...register('cta.copy', { required: EMPTY_ERROR_HELPER_TEXT })}
           required={true}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
-          fullWidth
-        />
+          fullWidth />
         <TextField
-          inputRef={register({
-            validate: copyLengthValidator(30),
-          })}
           error={!!errors.label?.copy}
           helperText={errors?.label?.copy?.message}
           label="Pill (optional)"
-          name="label.copy"
+          {...register('label.copy', {
+            validate: copyLengthValidator(30),
+          })}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
-          fullWidth
-        />
+          fullWidth />
 
         <div className={classes.benefitsHeading}>{buildBenefitsHeading(productKey)}</div>
 
@@ -134,8 +128,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
               <TextField
                 label="Benefit Copy"
                 required={true}
-                name={`benefits[${index}].copy`}
-                inputRef={register({
+                {...register(`benefits[${index}].copy`, {
                   required: EMPTY_ERROR_HELPER_TEXT,
                   validate: copyLengthValidator(116),
                 })}
@@ -144,32 +137,27 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
                 defaultValue={benefit.copy}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
-                fullWidth
-              />
+                fullWidth />
             </Grid>
             <Grid item xs={3}>
               <TextField
                 label="Tooltip (optional)"
-                name={`benefits[${index}].tooltip`}
-                inputRef={register()}
+                {...register(`benefits[${index}].tooltip`)}
                 error={!!errors.benefits?.[index]?.tooltip}
                 defaultValue={benefit.tooltip}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
-                fullWidth
-              />
+                fullWidth />
             </Grid>
             <Grid item xs={2}>
               <TextField
                 label="Pill (optional)"
-                name={`benefits[${index}].label.copy`}
-                inputRef={register()}
+                {...register(`benefits[${index}].label.copy`)}
                 error={!!errors.benefits?.[index]?.label?.copy}
                 defaultValue={benefit.label?.copy}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
-                fullWidth
-              />
+                fullWidth />
             </Grid>
             <Grid item xs={1}>
               <Button

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -136,7 +136,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
               <TextField
                 label="Benefit Copy"
                 required={true}
-                {...register(`benefits[${index}].copy`, {
+                {...register(`benefits.${index}.copy`, {
                   required: EMPTY_ERROR_HELPER_TEXT,
                   validate: copyLengthValidator(116),
                 })}
@@ -151,7 +151,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
             <Grid item xs={3}>
               <TextField
                 label="Tooltip (optional)"
-                {...register(`benefits[${index}].tooltip`)}
+                {...register(`benefits.${index}.tooltip`)}
                 error={!!errors.benefits?.[index]?.tooltip}
                 defaultValue={benefit.tooltip}
                 onBlur={handleSubmit(onProductChange)}
@@ -162,7 +162,7 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
             <Grid item xs={2}>
               <TextField
                 label="Pill (optional)"
-                {...register(`benefits[${index}].label.copy`)}
+                {...register(`benefits.${index}.label.copy`)}
                 error={!!errors.benefits?.[index]?.label?.copy}
                 defaultValue={benefit.label?.copy}
                 onBlur={handleSubmit(onProductChange)}

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -250,7 +250,7 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
           key={productKey}
           control={control}
           name={productKey}
-          render={field => (
+          render={({ field }) => (
             <ProductEditor
               productKey={productKey}
               editMode={editMode}

--- a/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/productsEditor.tsx
@@ -63,12 +63,17 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
   const classes = useStyles();
 
   // Validation for this product as a whole
-  const { control, handleSubmit, errors, register, reset } = useForm<LandingPageProductDescription>(
-    {
-      mode: 'onChange',
-      defaultValues: product,
-    },
-  );
+  const {
+    control,
+    handleSubmit,
+    register,
+    reset,
+
+    formState: { errors },
+  } = useForm<LandingPageProductDescription>({
+    mode: 'onChange',
+    defaultValues: product,
+  });
 
   // Validation specifically for the benefits array
   const { fields: benefits, append, remove } = useFieldArray({
@@ -99,7 +104,8 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
           required={true}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
-          fullWidth />
+          fullWidth
+        />
         <TextField
           error={!!errors.cta?.copy}
           helperText={errors?.cta?.copy?.message}
@@ -108,7 +114,8 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
           required={true}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
-          fullWidth />
+          fullWidth
+        />
         <TextField
           error={!!errors.label?.copy}
           helperText={errors?.label?.copy?.message}
@@ -118,7 +125,8 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
           })}
           onBlur={handleSubmit(onProductChange)}
           disabled={!editMode}
-          fullWidth />
+          fullWidth
+        />
 
         <div className={classes.benefitsHeading}>{buildBenefitsHeading(productKey)}</div>
 
@@ -137,7 +145,8 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
                 defaultValue={benefit.copy}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
-                fullWidth />
+                fullWidth
+              />
             </Grid>
             <Grid item xs={3}>
               <TextField
@@ -147,7 +156,8 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
                 defaultValue={benefit.tooltip}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
-                fullWidth />
+                fullWidth
+              />
             </Grid>
             <Grid item xs={2}>
               <TextField
@@ -157,7 +167,8 @@ export const ProductEditor: React.FC<ProductEditorProps> = ({
                 defaultValue={benefit.label?.copy}
                 onBlur={handleSubmit(onProductChange)}
                 disabled={!editMode}
-                fullWidth />
+                fullWidth
+              />
             </Grid>
             <Grid item xs={1}>
               <Button
@@ -207,7 +218,14 @@ export const ProductsEditor: React.FC<ProductsEditorProps> = ({
   const classes = useStyles();
 
   // Validation for all 3 products
-  const { control, setError, clearErrors, errors, reset } = useForm<Products>({
+  const {
+    control,
+    setError,
+    clearErrors,
+    reset,
+
+    formState: { errors },
+  } = useForm<Products>({
     mode: 'onChange',
     defaultValues: products,
   });

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -132,11 +132,11 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               <TextField
                 error={errors.minViews !== undefined}
                 helperText={errors.minViews?.message}
-                onBlur={handleSubmit(onSubmit)}
                 {...register('minViews', {
                   required: EMPTY_ERROR_HELPER_TEXT,
                   validate: notNumberValidator,
                 })}
+                onBlur={handleSubmit(onSubmit)}
                 label="Minimum page views"
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
@@ -148,8 +148,8 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               <TextField
                 error={errors.maxViews !== undefined}
                 helperText={errors.maxViews?.message}
-                onBlur={handleSubmit(onSubmit)}
                 {...register('maxViews', { validate: notNumberValidator })}
+                onBlur={handleSubmit(onSubmit)}
                 label="Maximum page views"
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
@@ -161,11 +161,11 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
               <TextField
                 error={errors.periodInWeeks !== undefined}
                 helperText={errors.periodInWeeks?.message}
-                onBlur={handleSubmit(onSubmit)}
                 {...register('periodInWeeks', {
                   required: EMPTY_ERROR_HELPER_TEXT,
                   validate: notNumberValidator,
                 })}
+                onBlur={handleSubmit(onSubmit)}
                 label="Time period in weeks"
                 InputLabelProps={{ shrink: true }}
                 variant="filled"

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -124,51 +124,45 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
           <div className={classes.formContainer}>
             <div>
               <TextField
-                inputRef={register({
-                  required: EMPTY_ERROR_HELPER_TEXT,
-                  validate: notNumberValidator,
-                })}
                 error={errors.minViews !== undefined}
                 helperText={errors.minViews?.message}
                 onBlur={handleSubmit(onSubmit)}
-                name="minViews"
+                {...register('minViews', {
+                  required: EMPTY_ERROR_HELPER_TEXT,
+                  validate: notNumberValidator,
+                })}
                 label="Minimum page views"
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
                 fullWidth
-                disabled={isDisabled}
-              />
+                disabled={isDisabled} />
             </div>
             <div>
               <TextField
-                inputRef={register({ validate: notNumberValidator })}
                 error={errors.maxViews !== undefined}
                 helperText={errors.maxViews?.message}
                 onBlur={handleSubmit(onSubmit)}
-                name="maxViews"
+                {...register('maxViews', { validate: notNumberValidator })}
                 label="Maximum page views"
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
                 fullWidth
-                disabled={isDisabled}
-              />
+                disabled={isDisabled} />
             </div>
             <div>
               <TextField
-                inputRef={register({
-                  required: EMPTY_ERROR_HELPER_TEXT,
-                  validate: notNumberValidator,
-                })}
                 error={errors.periodInWeeks !== undefined}
                 helperText={errors.periodInWeeks?.message}
                 onBlur={handleSubmit(onSubmit)}
-                name="periodInWeeks"
+                {...register('periodInWeeks', {
+                  required: EMPTY_ERROR_HELPER_TEXT,
+                  validate: notNumberValidator,
+                })}
                 label="Time period in weeks"
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
                 fullWidth
-                disabled={isDisabled}
-              />
+                disabled={isDisabled} />
             </div>
           </div>
           <div>

--- a/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
+++ b/public/src/components/channelManagement/testEditorArticleCountEditor.tsx
@@ -58,7 +58,13 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
     tagIds: articlesViewedSettings?.tagIds || [],
   };
 
-  const { register, errors, handleSubmit, reset } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -135,7 +141,8 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
                 fullWidth
-                disabled={isDisabled} />
+                disabled={isDisabled}
+              />
             </div>
             <div>
               <TextField
@@ -147,7 +154,8 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
                 fullWidth
-                disabled={isDisabled} />
+                disabled={isDisabled}
+              />
             </div>
             <div>
               <TextField
@@ -162,7 +170,8 @@ const TestEditorArticleCountEditor: React.FC<TestEditorArticleCountEditorProps> 
                 InputLabelProps={{ shrink: true }}
                 variant="filled"
                 fullWidth
-                disabled={isDisabled} />
+                disabled={isDisabled}
+              />
             </div>
           </div>
           <div>

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -63,7 +63,13 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
     currencySymbol: tickerSettings?.currencySymbol || '',
   };
 
-  const { register, handleSubmit, errors, reset } = useForm<FormData>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+
+    formState: { errors },
+  } = useForm<FormData>({
     mode: 'onChange',
     defaultValues,
   });
@@ -157,7 +163,8 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
 
           <TextField
             error={!!errors.goalCopy}
@@ -168,7 +175,8 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth />
+            fullWidth
+          />
 
           {(tickerSettings.name === 'US' || tickerSettings.name === 'AU') && (
             <TextField
@@ -180,7 +188,8 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
               margin="normal"
               variant="outlined"
               disabled={isDisabled}
-              fullWidth />
+              fullWidth
+            />
           )}
         </div>
       )}

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -149,44 +149,38 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
           </div>
 
           <TextField
-            inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
             error={!!errors.countLabel}
             helperText={errors?.countLabel?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="countLabel"
+            {...register('countLabel', { required: EMPTY_ERROR_HELPER_TEXT })}
             label="Heading"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
 
           <TextField
-            inputRef={register({ required: EMPTY_ERROR_HELPER_TEXT })}
             error={!!errors.goalCopy}
             helperText={errors?.goalCopy?.message}
             onBlur={handleSubmit(onSubmit)}
-            name="goalCopy"
+            {...register('goalCopy', { required: EMPTY_ERROR_HELPER_TEXT })}
             label="Goal Copy"
             margin="normal"
             variant="outlined"
             disabled={isDisabled}
-            fullWidth
-          />
+            fullWidth />
 
           {(tickerSettings.name === 'US' || tickerSettings.name === 'AU') && (
             <TextField
-              inputRef={register({ required: true })}
               error={!!errors.currencySymbol}
               helperText={errors?.currencySymbol?.message}
               onBlur={handleSubmit(onSubmit)}
-              name="currencySymbol"
+              {...register('currencySymbol', { required: true })}
               label="Currency"
               margin="normal"
               variant="outlined"
               disabled={isDisabled}
-              fullWidth
-            />
+              fullWidth />
           )}
         </div>
       )}

--- a/public/src/components/channelManagement/tickerEditor.tsx
+++ b/public/src/components/channelManagement/tickerEditor.tsx
@@ -157,8 +157,8 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
           <TextField
             error={!!errors.countLabel}
             helperText={errors?.countLabel?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('countLabel', { required: EMPTY_ERROR_HELPER_TEXT })}
+            onBlur={handleSubmit(onSubmit)}
             label="Heading"
             margin="normal"
             variant="outlined"
@@ -169,8 +169,8 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
           <TextField
             error={!!errors.goalCopy}
             helperText={errors?.goalCopy?.message}
-            onBlur={handleSubmit(onSubmit)}
             {...register('goalCopy', { required: EMPTY_ERROR_HELPER_TEXT })}
+            onBlur={handleSubmit(onSubmit)}
             label="Goal Copy"
             margin="normal"
             variant="outlined"
@@ -182,8 +182,8 @@ const TickerEditor: React.FC<TickerEditorProps> = ({
             <TextField
               error={!!errors.currencySymbol}
               helperText={errors?.currencySymbol?.message}
-              onBlur={handleSubmit(onSubmit)}
               {...register('currencySymbol', { required: true })}
+              onBlur={handleSubmit(onSubmit)}
               label="Currency"
               margin="normal"
               variant="outlined"

--- a/public/src/components/linkTracking/LinkTrackingBuilder.tsx
+++ b/public/src/components/linkTracking/LinkTrackingBuilder.tsx
@@ -128,7 +128,8 @@ export const LinkTrackingBuilder: React.FC = () => {
           })}
           label="URL (without tracking)"
           error={!!errors.url}
-          helperText={errors?.url?.message} />
+          helperText={errors?.url?.message}
+        />
 
         <Typography className={classes.header} variant="h4">
           Campaign
@@ -137,7 +138,8 @@ export const LinkTrackingBuilder: React.FC = () => {
           {...register('campaign', { required: true })}
           label="Campaign"
           error={!!errors.campaign}
-          helperText={errors?.campaign?.message} />
+          helperText={errors?.campaign?.message}
+        />
 
         <Typography className={classes.header} variant="h4">
           Call to action / creative
@@ -146,12 +148,14 @@ export const LinkTrackingBuilder: React.FC = () => {
           {...register('content', { required: true })}
           label="Creative / utm_content / AB test name"
           error={!!errors.content}
-          helperText={errors?.content?.message} />
+          helperText={errors?.content?.message}
+        />
         <TextField
           {...register('term', { required: true })}
           label="Audience segment / utm_term / AB test variant name"
           error={!!errors.term}
-          helperText={errors?.term?.message} />
+          helperText={errors?.term?.message}
+        />
 
         <Typography className={classes.header} variant="h4">
           Placement

--- a/public/src/components/linkTracking/LinkTrackingBuilder.tsx
+++ b/public/src/components/linkTracking/LinkTrackingBuilder.tsx
@@ -111,9 +111,7 @@ export const LinkTrackingBuilder: React.FC = () => {
     >
       <div className={classes.fieldsContainer}>
         <TextField
-          name="url"
-          label="URL (without tracking)"
-          inputRef={register({
+          {...register('url', {
             required: true,
             validate: value => {
               // Check it's a valid url and has no querystring
@@ -128,38 +126,32 @@ export const LinkTrackingBuilder: React.FC = () => {
               }
             },
           })}
+          label="URL (without tracking)"
           error={!!errors.url}
-          helperText={errors?.url?.message}
-        />
+          helperText={errors?.url?.message} />
 
         <Typography className={classes.header} variant="h4">
           Campaign
         </Typography>
         <TextField
-          name="campaign"
+          {...register('campaign', { required: true })}
           label="Campaign"
-          inputRef={register({ required: true })}
           error={!!errors.campaign}
-          helperText={errors?.campaign?.message}
-        />
+          helperText={errors?.campaign?.message} />
 
         <Typography className={classes.header} variant="h4">
           Call to action / creative
         </Typography>
         <TextField
-          name="content"
+          {...register('content', { required: true })}
           label="Creative / utm_content / AB test name"
-          inputRef={register({ required: true })}
           error={!!errors.content}
-          helperText={errors?.content?.message}
-        />
+          helperText={errors?.content?.message} />
         <TextField
-          name="term"
+          {...register('term', { required: true })}
           label="Audience segment / utm_term / AB test variant name"
-          inputRef={register({ required: true })}
           error={!!errors.term}
-          helperText={errors?.term?.message}
-        />
+          helperText={errors?.term?.message} />
 
         <Typography className={classes.header} variant="h4">
           Placement

--- a/public/src/components/linkTracking/LinkTrackingBuilder.tsx
+++ b/public/src/components/linkTracking/LinkTrackingBuilder.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '@mui/styles';
 import { MediumSelector } from './MediumSelector';
 import lzstring from 'lz-string';
 import { Link as LinkIcon, OpenInNew } from '@mui/icons-material';
+import { LinkTrackingFormData } from './linkTrackingFormData';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -67,14 +68,6 @@ const addHttps = (url: string): string => {
   }
 };
 
-interface FormData {
-  url: string;
-  campaign: string;
-  content: string;
-  term: string;
-  sourceAndMedium: string; // This is the source and medium separated by a double underscore
-}
-
 export const LinkTrackingBuilder: React.FC = () => {
   const classes = useStyles();
   const [link, setLink] = React.useState<string>('');
@@ -84,13 +77,19 @@ export const LinkTrackingBuilder: React.FC = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormData>({
+  } = useForm<LinkTrackingFormData>({
     defaultValues: {
       url: 'https://support.theguardian.com',
     },
   });
 
-  const onSubmit: SubmitHandler<FormData> = ({ url, campaign, content, term, sourceAndMedium }) => {
+  const onSubmit: SubmitHandler<LinkTrackingFormData> = ({
+    url,
+    campaign,
+    content,
+    term,
+    sourceAndMedium,
+  }) => {
     const urlWithHttps = addHttps(url);
     const [source, medium] = sourceAndMedium.split('__');
 
@@ -160,7 +159,7 @@ export const LinkTrackingBuilder: React.FC = () => {
         <Typography className={classes.header} variant="h4">
           Placement
         </Typography>
-        <MediumSelector onUpdate={resetLink} control={control} />
+        <MediumSelector onUpdate={resetLink} errors={errors} control={control} />
       </div>
 
       <Button type="submit" variant="contained" color="primary" disabled={linkReady}>

--- a/public/src/components/linkTracking/MediumSelector.tsx
+++ b/public/src/components/linkTracking/MediumSelector.tsx
@@ -208,7 +208,8 @@ export const MediumSelector: React.FC<Props> = ({ control, onUpdate }: Props) =>
       <Controller
         name="sourceAndMedium"
         rules={{ required: true }}
-        render={({ onChange, value }) => (
+        // render={({ onChange, value }) => (
+        render={({ field: { onChange, value } }) => (
           <Select
             value={value}
             onChange={e => {

--- a/public/src/components/linkTracking/MediumSelector.tsx
+++ b/public/src/components/linkTracking/MediumSelector.tsx
@@ -1,7 +1,8 @@
 import { FormControl, MenuItem, Select, Theme } from '@mui/material';
 import React from 'react';
-import { Control, Controller } from 'react-hook-form';
+import { Control, Controller, FieldErrors } from 'react-hook-form';
 import { makeStyles } from '@mui/styles';
+import { LinkTrackingFormData } from './linkTrackingFormData';
 
 interface Option {
   value: string;
@@ -192,7 +193,9 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
 }));
 
 interface Props {
-  control: Control;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- any is expected
+  control: Control<LinkTrackingFormData, any, LinkTrackingFormData>;
+  errors: FieldErrors<LinkTrackingFormData>;
   onUpdate: () => void;
 }
 
@@ -200,7 +203,7 @@ interface Props {
  * A selector for choosing a medium. The value is the source and medium separated by a double underscore.
  * This is because the link tracking should contain both, but the source should not be chosen directly by the user.
  */
-export const MediumSelector: React.FC<Props> = ({ control, onUpdate }: Props) => {
+export const MediumSelector: React.FC<Props> = ({ control, errors, onUpdate }: Props) => {
   const classes = useStyles();
 
   return (
@@ -216,7 +219,7 @@ export const MediumSelector: React.FC<Props> = ({ control, onUpdate }: Props) =>
               onUpdate();
               onChange(e);
             }}
-            error={!!control.formState.errors?.medium}
+            error={!!errors?.sourceAndMedium}
           >
             {OPTIONS.map(group => {
               const groupItem = (

--- a/public/src/components/linkTracking/linkTrackingFormData.ts
+++ b/public/src/components/linkTracking/linkTrackingFormData.ts
@@ -1,0 +1,7 @@
+export interface LinkTrackingFormData {
+  url: string;
+  campaign: string;
+  content: string;
+  term: string;
+  sourceAndMedium: string; // This is the source and medium separated by a double underscore
+}

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -233,26 +233,26 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
           <TextField
             className={classes.input}
             id={groupId + '-add-switch-switch-name'}
-            inputRef={register({
+            error={errors.switchId !== undefined}
+            helperText={errors.switchId ? errors.switchId.message : ''}
+            {...register('switchId', {
               required: EMPTY_ERROR_HELPER_TEXT,
               validate: switchId => {
                 return createDuplicateValidator(Object.keys(groupData.switches))(switchId);
               },
             })}
-            error={errors.switchId !== undefined}
-            helperText={errors.switchId ? errors.switchId.message : ''}
-            name="switchId"
             label="Switch name"
             margin="normal"
             variant="outlined"
             autoFocus
-            fullWidth
-          />
+            fullWidth />
           <span />
           <TextField
             className={classes.input}
             id={groupId + '-add-switch-switch-description'}
-            inputRef={register({
+            error={errors.description !== undefined}
+            helperText={errors.description ? errors.description.message : ''}
+            {...register('description', {
               required: EMPTY_ERROR_HELPER_TEXT,
               validate: description => {
                 return createDuplicateValidator(
@@ -260,15 +260,11 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
                 )(description);
               },
             })}
-            error={errors.description !== undefined}
-            helperText={errors.description ? errors.description.message : ''}
-            name="description"
             label="Description"
             margin="normal"
             variant="outlined"
             autoFocus
-            fullWidth
-          />
+            fullWidth />
           <span />
           <div className={classes.buttons}>
             <Button

--- a/public/src/components/switchboard.tsx
+++ b/public/src/components/switchboard.tsx
@@ -205,7 +205,12 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
       switchId: string;
       description: string;
     };
-    const { register, handleSubmit, errors } = useForm<FormData>();
+    const {
+      register,
+      handleSubmit,
+
+      formState: { errors },
+    } = useForm<FormData>();
 
     const onSubmit = ({ switchId, description }: FormData): void => {
       const updatedState = cloneDeep(data);
@@ -245,7 +250,8 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
             margin="normal"
             variant="outlined"
             autoFocus
-            fullWidth />
+            fullWidth
+          />
           <span />
           <TextField
             className={classes.input}
@@ -264,7 +270,8 @@ const Switchboard: React.FC<InnerProps<SupportFrontendSwitches>> = ({
             margin="normal"
             variant="outlined"
             autoFocus
-            fullWidth />
+            fullWidth
+          />
           <span />
           <div className={classes.buttons}>
             <Button

--- a/public/src/components/tests/variants/testVariantsSplitEditor.tsx
+++ b/public/src/components/tests/variants/testVariantsSplitEditor.tsx
@@ -105,9 +105,8 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
     }
   };
 
-  const validate = (text: string): string | boolean => {
-    const percentage = Number(text);
-    if (!Number.isNaN(percentage)) {
+  const validate = (percentage: number | undefined): string | boolean => {
+    if (percentage && !Number.isNaN(percentage)) {
       const controlExists = hasControl(variants);
       if (controlExists) {
         const max = 100 / variants.length;
@@ -177,7 +176,8 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
                 helperText={errors.percentage?.message || 'Must be a number'}
                 {...register('percentage', {
                   required: EMPTY_ERROR_HELPER_TEXT,
-                  validate: validate,
+                  valueAsNumber: true,
+                  validate,
                 })}
                 onBlur={handleSubmit(onSubmit(controlProportionSettings))}
                 label="CONTROL"

--- a/public/src/components/tests/variants/testVariantsSplitEditor.tsx
+++ b/public/src/components/tests/variants/testVariantsSplitEditor.tsx
@@ -175,11 +175,11 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
               <TextField
                 error={errors.percentage !== undefined}
                 helperText={errors.percentage?.message || 'Must be a number'}
-                onBlur={handleSubmit(onSubmit(controlProportionSettings))}
                 {...register('percentage', {
                   required: EMPTY_ERROR_HELPER_TEXT,
                   validate: validate,
                 })}
+                onBlur={handleSubmit(onSubmit(controlProportionSettings))}
                 label="CONTROL"
                 InputLabelProps={{ shrink: true }}
                 variant="outlined"

--- a/public/src/components/tests/variants/testVariantsSplitEditor.tsx
+++ b/public/src/components/tests/variants/testVariantsSplitEditor.tsx
@@ -166,20 +166,18 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
           <div className={classes.variantsContainer}>
             <div>
               <TextField
-                inputRef={register({
-                  required: EMPTY_ERROR_HELPER_TEXT,
-                  validate: validate,
-                })}
                 error={errors.percentage !== undefined}
                 helperText={errors.percentage?.message || 'Must be a number'}
                 onBlur={handleSubmit(onSubmit(controlProportionSettings))}
-                name="percentage"
+                {...register('percentage', {
+                  required: EMPTY_ERROR_HELPER_TEXT,
+                  validate: validate,
+                })}
                 label="CONTROL"
                 InputLabelProps={{ shrink: true }}
                 variant="outlined"
                 fullWidth
-                disabled={isDisabled}
-              />
+                disabled={isDisabled} />
             </div>
 
             {renderVariants(controlProportionSettings.proportion)}

--- a/public/src/components/tests/variants/testVariantsSplitEditor.tsx
+++ b/public/src/components/tests/variants/testVariantsSplitEditor.tsx
@@ -56,7 +56,14 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
     percentage: controlProportionSettings ? controlProportionSettings.proportion * 100 : undefined,
   };
 
-  const { register, errors, handleSubmit, trigger, reset } = useForm<FormState>({
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    reset,
+
+    formState: { errors },
+  } = useForm<FormState>({
     mode: 'onChange',
     defaultValues,
   });
@@ -177,7 +184,8 @@ const TestVariantsSplitEditor: React.FC<TestVariantsSplitEditorProps> = ({
                 InputLabelProps={{ shrink: true }}
                 variant="outlined"
                 fullWidth
-                disabled={isDisabled} />
+                disabled={isDisabled}
+              />
             </div>
 
             {renderVariants(controlProportionSettings.proportion)}

--- a/public/src/components/tests/variants/variantCtaFieldsEditor.tsx
+++ b/public/src/components/tests/variants/variantCtaFieldsEditor.tsx
@@ -48,10 +48,10 @@ const VariantCtaFieldsEditor: React.FC<VariantCtaFieldsEditorProps> = ({
       <TextField
         error={errors.text !== undefined}
         helperText={errors.text?.message}
-        onBlur={handleSubmit(onSubmit)}
         {...register('text', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(onSubmit)}
         label="Button copy"
         margin="normal"
         variant="outlined"
@@ -62,10 +62,10 @@ const VariantCtaFieldsEditor: React.FC<VariantCtaFieldsEditorProps> = ({
       <TextField
         error={errors.baseUrl !== undefined}
         helperText={errors.baseUrl?.message}
-        onBlur={handleSubmit(onSubmit)}
         {...register('baseUrl', {
           required: EMPTY_ERROR_HELPER_TEXT,
         })}
+        onBlur={handleSubmit(onSubmit)}
         label="Button destination"
         margin="normal"
         variant="outlined"

--- a/public/src/components/tests/variants/variantCtaFieldsEditor.tsx
+++ b/public/src/components/tests/variants/variantCtaFieldsEditor.tsx
@@ -41,34 +41,30 @@ const VariantCtaFieldsEditor: React.FC<VariantCtaFieldsEditorProps> = ({
   return (
     <div>
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors.text !== undefined}
         helperText={errors.text?.message}
         onBlur={handleSubmit(onSubmit)}
-        name="text"
+        {...register('text', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Button copy"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
 
       <TextField
-        inputRef={register({
-          required: EMPTY_ERROR_HELPER_TEXT,
-        })}
         error={errors.baseUrl !== undefined}
         helperText={errors.baseUrl?.message}
         onBlur={handleSubmit(onSubmit)}
-        name="baseUrl"
+        {...register('baseUrl', {
+          required: EMPTY_ERROR_HELPER_TEXT,
+        })}
         label="Button destination"
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth
-      />
+        fullWidth />
     </div>
   );
 };

--- a/public/src/components/tests/variants/variantCtaFieldsEditor.tsx
+++ b/public/src/components/tests/variants/variantCtaFieldsEditor.tsx
@@ -27,7 +27,12 @@ const VariantCtaFieldsEditor: React.FC<VariantCtaFieldsEditorProps> = ({
     baseUrl: cta.baseUrl,
   };
 
-  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({ mode: 'onChange', defaultValues });
 
   useEffect(() => {
     const isValid = Object.keys(errors).length === 0;
@@ -51,7 +56,8 @@ const VariantCtaFieldsEditor: React.FC<VariantCtaFieldsEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
 
       <TextField
         error={errors.baseUrl !== undefined}
@@ -64,7 +70,8 @@ const VariantCtaFieldsEditor: React.FC<VariantCtaFieldsEditorProps> = ({
         margin="normal"
         variant="outlined"
         disabled={isDisabled}
-        fullWidth />
+        fullWidth
+      />
     </div>
   );
 };

--- a/public/src/components/tests/variants/variantSeparateArticleCountEditor.tsx
+++ b/public/src/components/tests/variants/variantSeparateArticleCountEditor.tsx
@@ -28,7 +28,12 @@ const VariantSeparateArticleCountEditor: React.FC<VariantSeparateArticleCountEdi
     copy: separateArticleCount?.copy ?? '',
   };
 
-  const { register, handleSubmit, errors } = useForm<FormData>({ mode: 'onChange', defaultValues });
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({ mode: 'onChange', defaultValues });
 
   const onSubmit = ({ copy }: FormData): void => {
     updateSeparateArticleCount(
@@ -60,7 +65,8 @@ const VariantSeparateArticleCountEditor: React.FC<VariantSeparateArticleCountEdi
         margin="normal"
         variant="outlined"
         disabled={isDisabled || !Boolean(separateArticleCount)}
-        fullWidth />
+        fullWidth
+      />
     </div>
   );
 };

--- a/public/src/components/tests/variants/variantSeparateArticleCountEditor.tsx
+++ b/public/src/components/tests/variants/variantSeparateArticleCountEditor.tsx
@@ -52,17 +52,15 @@ const VariantSeparateArticleCountEditor: React.FC<VariantSeparateArticleCountEdi
         label="Above"
       />
       <TextField
-        inputRef={register()}
         error={errors.copy !== undefined}
         helperText={errors.copy?.message}
         onBlur={handleSubmit(onSubmit)}
-        name="copy"
+        {...register('copy')}
         label="Article count copy"
         margin="normal"
         variant="outlined"
         disabled={isDisabled || !Boolean(separateArticleCount)}
-        fullWidth
-      />
+        fullWidth />
     </div>
   );
 };

--- a/public/src/components/tests/variants/variantSeparateArticleCountEditor.tsx
+++ b/public/src/components/tests/variants/variantSeparateArticleCountEditor.tsx
@@ -31,7 +31,6 @@ const VariantSeparateArticleCountEditor: React.FC<VariantSeparateArticleCountEdi
   const {
     register,
     handleSubmit,
-
     formState: { errors },
   } = useForm<FormData>({ mode: 'onChange', defaultValues });
 
@@ -59,8 +58,8 @@ const VariantSeparateArticleCountEditor: React.FC<VariantSeparateArticleCountEdi
       <TextField
         error={errors.copy !== undefined}
         helperText={errors.copy?.message}
-        onBlur={handleSubmit(onSubmit)}
         {...register('copy')}
+        onBlur={handleSubmit(onSubmit)}
         label="Article count copy"
         margin="normal"
         variant="outlined"


### PR DESCRIPTION
Migration guide: https://legacy.react-hook-form.com/migrate-v6-to-v7/
I've grouped similar changes by commit. The main changes are:

1. The `register` function is now used differently. Instead of `ref={register(...`, we now have to spread the register function: `{...register(...`
2. The `errors` field now lives under the `formState` object
3. Because calling `...register` gives us an `onBlur` function, we have to add our own `onBlur` after calling register, otherwise it is overridden
4. The `render` function parameters have changed, so instead of `render={data => ...`, we now use `render={({ field }) => ...`
5. Referencing field arrays has changed from e.g. `benefits[${index}].copy` to `benefits.${index}.copy`