### PR TITLE
Fix validation of LP products

### DIFF
--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -85,5 +85,12 @@ export const templateValidatorForPlatform = (platform: TestPlatform) => (
 export const noHtmlValidator = (s: string): string | undefined =>
   /<\/?[a-z][\s\S]*>/i.test(s) ? 'HTML is not allowed' : undefined;
 
-export const copyLengthValidator = (maxLength: number) => (copy: string): string | undefined =>
-  copy.length > maxLength ? `Max length is ${maxLength}` : undefined;
+// If copy is defined then enforce maxLength requirement
+export const copyLengthValidator = (maxLength: number) => (
+  copy: string | undefined,
+): string | undefined => {
+  if (copy) {
+    return copy.length > maxLength ? `Max length is ${maxLength}` : undefined;
+  }
+  return undefined;
+};


### PR DESCRIPTION
Currently we get errors in the console when editing product config in the Landing Page tool.
This is because when the `label` field is undefined, it's still trying to do the copy length validation:
<img width="392" alt="Screenshot 2025-05-28 at 09 02 50" src="https://github.com/user-attachments/assets/1c23084b-6782-472d-9c3b-4662a7265a19" />
This PR fixes this by changing the `copyLengthValidator` function to handle the case where the `copy` field is undefined.