### PR TITLE
Fix links to audit page

### DIFF
--- a/public/src/components/channelManagement/testsForm.tsx
+++ b/public/src/components/channelManagement/testsForm.tsx
@@ -183,7 +183,7 @@ export const TestsForm = <T extends Test>(
     const onTestAudit = (testName: string, channel?: string): void => {
       const redirectPathname = window.location.pathname.replace(
         window.location.pathname,
-        `audit-tests/${channel}/${testName}`,
+        `/audit-tests/${channel}/${testName}`,
       );
       window.location.href = redirectPathname; // Redirect to the audit page
     };


### PR DESCRIPTION
The audit link at the top of the channel test tools is currently broken.
Without the leading slash, the new path keeps the first part of the current path, e.g. it incorrectly becomes
`/epic-tests/audit-tests/Epic/MY_TEST`
instead of
`/audit-tests/Epic/MY_TEST`

This is only an issue if the user has nagivated to a specific test using the url, e.g.
`/epic-tests/MY_TEST`