### PR TITLE
Change bannerVariantPreview to use DesignableBannerV2 stories

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -170,7 +170,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   };
 
   const props = buildProps(variant, tickerSettingsWithData, design);
-  const storyName = 'components-marketing-designablebanner--default';
+  const storyName = 'components-marketing-designablebannerv2--with-three-tier-choice-cards';
   const storybookUrl = buildStorybookUrl(storyName, props);
 
   return (


### PR DESCRIPTION
## What does this change?

This ensures that those using RRCP can view the correct version of Designable Banner with the new 3-tier choice cards.  This will reflect the change in DCR that will occur when [SDC PR1371](https://github.com/guardian/support-dotcom-components/pull/1371) is merged.

## How to test

Run into CODE and view the banner variants via the Live Preview button or tab - they will show the new design instead of the older one.

## Have we considered potential risks?

There may be some overlap while the old design may still appear in PROD if this PR is merged before SDC PR1371

## Images

| Pointing to DesignableBanner Stories      | Pointing to DesignableBannerV2 Stories     | 
| ----------- | ---------- | 
| <img width="1897" alt="Screenshot 2025-06-04 at 17 16 59" src="https://github.com/user-attachments/assets/70fdf65f-dee6-487f-bdb6-7a475b80f0d7" /> | <img width="1903" alt="Screenshot 2025-06-04 at 17 15 42" src="https://github.com/user-attachments/assets/23a554d4-3c1c-4e6f-abbc-2f1eb6e4d482" /> | 
