### PR TITLE
Enable choice cards config in banner tool

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -25,6 +25,7 @@ case class BannerVariant(
     separateArticleCount: Option[Boolean],
     separateArticleCountSettings: Option[SeparateArticleCount],
     tickerSettings: Option[TickerSettings] = None,
+    choiceCardsSettings: Option[ChoiceCardsSettings],
 )
 
 case class BannerTestDeploySchedule(daysBetween: Int)

--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -22,6 +22,8 @@ import TickerEditor from '../tickerEditor';
 import { BannerDesign } from '../../../models/bannerDesign';
 import VariantSeparateArticleCountEditor from '../../tests/variants/variantSeparateArticleCountEditor';
 import { SeparateArticleCount } from '../../../models/epic';
+import ChoiceCardsEditor from '../choiceCards/ChoiceCardsEditor';
+import { ChoiceCardsSettings } from '../../../models/choiceCards';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -373,6 +375,19 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
       separateArticleCountSettings: updatedSeparateArticleCountSettings,
     });
   };
+
+  const updateChoiceCardsSettings = (
+    showChoiceCards: boolean, // unused for banners, as this comes from the banner design
+    choiceCardsSettings?: ChoiceCardsSettings,
+  ): void => {
+    onVariantChange({
+      ...variant,
+      choiceCardsSettings,
+    });
+  };
+
+  const design = designs.find(d => d.name === variant.template.designName);
+
   return (
     <div className={classes.container}>
       <div className={classes.sectionContainer}>
@@ -406,6 +421,22 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
           editMode={editMode}
           deviceType={variant.mobileBannerContent === undefined ? 'ALL' : 'NOT_MOBILE'}
         />
+
+        {design?.visual?.kind === 'ChoiceCards' && (
+          <div className={classes.sectionContainer}>
+            <Typography className={classes.sectionHeader} variant="h4">
+              Choice Cards
+            </Typography>
+
+            <ChoiceCardsEditor
+              showChoiceCards={true}
+              allowNoChoiceCards={false}
+              choiceCardsSettings={variant.choiceCardsSettings}
+              updateChoiceCardsSettings={updateChoiceCardsSettings}
+              isDisabled={!editMode}
+            />
+          </div>
+        )}
 
         <RadioGroup
           value={variant.mobileBannerContent !== undefined ? 'enabled' : 'disabled'}

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardsEditor.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardsEditor.tsx
@@ -48,6 +48,7 @@ const getChoiceCardsSelection = (
 
 interface ChoiceCardsEditorProps {
   showChoiceCards: boolean;
+  allowNoChoiceCards: boolean;
   choiceCardsSettings?: ChoiceCardsSettings;
   updateChoiceCardsSettings: (
     showChoiceCards: boolean,
@@ -60,6 +61,7 @@ const ChoiceCardsEditor: React.FC<ChoiceCardsEditorProps> = ({
   showChoiceCards,
   choiceCardsSettings,
   updateChoiceCardsSettings,
+  allowNoChoiceCards,
   isDisabled,
 }: ChoiceCardsEditorProps) => {
   const classes = useStyles();
@@ -101,13 +103,15 @@ const ChoiceCardsEditor: React.FC<ChoiceCardsEditorProps> = ({
   return (
     <div className={classes.container}>
       <RadioGroup value={choiceCardsSelection} onChange={onRadioGroupChange}>
-        <FormControlLabel
-          value="NoChoiceCards"
-          key="NoChoiceCards"
-          control={<Radio />}
-          label="No choice cards"
-          disabled={isDisabled}
-        />
+        {allowNoChoiceCards && (
+          <FormControlLabel
+            value="NoChoiceCards"
+            key="NoChoiceCards"
+            control={<Radio />}
+            label="No choice cards"
+            disabled={isDisabled}
+          />
+        )}
         <FormControlLabel
           value="DefaultChoiceCards"
           key="DefaultChoiceCards"

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -451,6 +451,7 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
 
               <ChoiceCardsEditor
                 showChoiceCards={variant.showChoiceCards ?? false}
+                allowNoChoiceCards={true}
                 choiceCardsSettings={variant.choiceCardsSettings}
                 updateChoiceCardsSettings={updateChoiceCardsSettings}
                 isDisabled={!editMode}

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -14,6 +14,7 @@ import {
 import { Region } from '../utils/models';
 import { ControlProportionSettings } from '../components/channelManagement/helpers/controlProportionSettings';
 import { SeparateArticleCount } from './epic';
+import { ChoiceCardsSettings } from './choiceCards';
 
 export interface BannerUi {
   designName: string;
@@ -34,6 +35,7 @@ export interface BannerVariant extends Variant {
   separateArticleCount?: boolean;
   separateArticleCountSettings?: SeparateArticleCount;
   tickerSettings?: TickerSettings;
+  choiceCardsSettings?: ChoiceCardsSettings;
 }
 
 export interface BannerTestDeploySchedule {


### PR DESCRIPTION
A previous PR enabled Marketing to configure the choice cards in the epic tool:
https://github.com/guardian/support-admin-console/pull/733

This means it overrides the "default" settings, which are hardcoded in SDC.

This PR does the same for the banner tool.
The difference here is that choice cards are enabled in the banner from the _banner design tool_.
So, whereas the epic variant model has a boolean for enabling choice cards, banner variants get this from the associated banner design.
This means that the banner variant editor only displays the choice cards settings component if the banner design has choice cards enabled.