### PR TITLE
Promo codes field

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -26,6 +26,7 @@ case class BannerVariant(
     separateArticleCountSettings: Option[SeparateArticleCount],
     tickerSettings: Option[TickerSettings] = None,
     choiceCardsSettings: Option[ChoiceCardsSettings],
+    promoCodes: List[String] = Nil
 )
 
 case class BannerTestDeploySchedule(daysBetween: Int)

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -32,6 +32,7 @@ case class EpicVariant(
   cta: Option[Cta],
   secondaryCta: Option[SecondaryCta],
   separateArticleCount: Option[SeparateArticleCount],
+  promoCodes: List[String] = Nil,
   showChoiceCards: Option[Boolean],
   choiceCardsSettings: Option[ChoiceCardsSettings],
   bylineWithImage: Option[BylineWithImage],

--- a/app/models/GutterTests.scala
+++ b/app/models/GutterTests.scala
@@ -15,9 +15,10 @@ case class GutterContent(
 case class GutterVariant(
     name: String,
     content: Option[GutterContent],
+    promoCodes: List[String] = Nil
 )
 
-case class GutterTest( 
+case class GutterTest(
     name: String,
     channel: Option[Channel],
     status: Option[Status],
@@ -27,7 +28,7 @@ case class GutterTest(
     userCohort: UserCohort,
     locations: List[Region] = Nil,
     regionTargeting: Option[RegionTargeting]=None,
-    contextTargeting: PageContextTargeting = PageContextTargeting(Nil,Nil,Nil,Nil), 
+    contextTargeting: PageContextTargeting = PageContextTargeting(Nil,Nil,Nil,Nil),
     variants: List[GutterVariant],
     controlProportionSettings: Option[ControlProportionSettings] = None,
     deviceType: Option[DeviceType] = None,

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -17,6 +17,7 @@ case class HeaderVariant(
   name: String,
   content: HeaderContent,
   mobileContent: Option[HeaderContent],
+  promoCodes: List[String] = Nil
 )
 
 case class HeaderTest(

--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -25,6 +25,7 @@ import { SeparateArticleCount } from '../../../models/epic';
 import ChoiceCardsEditor from '../choiceCards/ChoiceCardsEditor';
 import { ChoiceCardsSettings } from '../../../models/choiceCards';
 import Alert from '@mui/lab/Alert';
+import PromoCodesEditor from '../choiceCards/PromoCodesEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -387,6 +388,13 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
     });
   };
 
+  const updatePromoCodes = (promoCodes: string[]): void => {
+    onVariantChange({
+      ...variant,
+      promoCodes,
+    });
+  };
+
   const designHasChoiceCards =
     designs.find(d => d.name === variant.template.designName)?.visual?.kind === 'ChoiceCards';
 
@@ -457,6 +465,12 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
             deviceType={'MOBILE'}
           />
         )}
+
+        <PromoCodesEditor
+          promoCodes={variant.promoCodes ?? []}
+          updatePromoCodes={updatePromoCodes}
+          isDisabled={!editMode}
+        />
       </div>
 
       <div className={classes.sectionContainer}>

--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -389,10 +389,10 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
   };
 
   const updatePromoCodes = (promoCodes: string[]): void => {
-    onVariantChange({
-      ...variant,
+    onVariantChange(current => ({
+      ...current,
       promoCodes,
-    });
+    }));
   };
 
   const designHasChoiceCards =

--- a/public/src/components/channelManagement/choiceCards/PromoCodesEditor.tsx
+++ b/public/src/components/channelManagement/choiceCards/PromoCodesEditor.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@mui/styles';
+import { TextField, Theme } from '@mui/material';
+import { parsePromoInput } from '../../../utils/parsePromoInput';
+
+interface PromoCodesEditorProps {
+  promoCodes: string[];
+  updatePromoCodes: (promoCodes: string[]) => void;
+  isDisabled: boolean;
+  maxPromoCodes?: number;
+}
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(1),
+    },
+  },
+  fieldContainer: {
+    marginBottom: spacing(1),
+  },
+  helperText: {
+    marginTop: spacing(1),
+  },
+}));
+
+const PromoCodesEditor: React.FC<PromoCodesEditorProps> = ({
+  promoCodes,
+  updatePromoCodes,
+  isDisabled,
+}) => {
+  const classes = useStyles();
+  const [promoCodesString, setPromoCodesString] = useState<string>(promoCodes.join(', '));
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    setPromoCodesString(inputValue);
+    updatePromoCodes(parsePromoInput(inputValue));
+  };
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.fieldContainer}>
+        <TextField
+          label="Promo Codes (comma separated)"
+          fullWidth
+          value={promoCodesString}
+          onChange={handleChange}
+          disabled={isDisabled}
+          placeholder="e.g. PROMO1, PROMO2, PROMO3"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PromoCodesEditor;

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -41,6 +41,7 @@ import { EpicVariant, SeparateArticleCount } from '../../../models/epic';
 import { AppleNewsChoiceCards } from './appleChoiceCardsEditor';
 import EpicTestNewsletter from './newsletterSignUp';
 import { ChoiceCardsSettings } from '../../../models/choiceCards';
+import PromoCodesEditor from '../choiceCards/PromoCodesEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const getUseStyles = (shouldAddPadding: boolean) => {
@@ -222,6 +223,9 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
   };
   const updateNewsletterSignup = (updateNewsletterSignup?: NewsletterSignup): void => {
     onVariantChange({ ...variant, newsletterSignup: updateNewsletterSignup });
+  };
+  const updatePromoCodes = (promoCodes: string[]): void => {
+    onVariantChange({ ...variant, promoCodes });
   };
 
   const getParagraphsHelperText = () => {
@@ -442,6 +446,12 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
               />
             </div>
           </div>
+
+          <PromoCodesEditor
+            promoCodes={variant.promoCodes ?? []}
+            updatePromoCodes={updatePromoCodes}
+            isDisabled={!editMode}
+          />
 
           {allowVariantChoiceCards && (
             <div className={classes.sectionContainer}>

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -225,7 +225,7 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
     onVariantChange(current => ({ ...current, newsletterSignup: updateNewsletterSignup }));
   };
   const updatePromoCodes = (promoCodes: string[]): void => {
-    onVariantChange({ ...variant, promoCodes });
+    onVariantChange(current => ({ ...current, promoCodes }));
   };
 
   const getParagraphsHelperText = () => {

--- a/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
@@ -279,7 +279,7 @@ const GutterVariantEditor: React.FC<GutterVariantEditorProps> = ({
         <PromoCodesEditor
           promoCodes={variant.promoCodes ?? []}
           updatePromoCodes={promoCodes => {
-            onVariantChange({ ...variant, promoCodes });
+            onVariantChange(current => ({ ...current, promoCodes }));
           }}
           isDisabled={!editMode}
         />

--- a/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterVariantEditor.tsx
@@ -14,6 +14,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { getRteCopyLength, RichTextEditor } from '../richTextEditor/richTextEditor';
 import { ImageEditorToggle } from '../imageEditor';
 import { DEFAULT_IMAGE_URL, DEFAULT_IMAGE_ALT } from './utils/defaults';
+import PromoCodesEditor from '../choiceCards/PromoCodesEditor';
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -274,6 +275,13 @@ const GutterVariantEditor: React.FC<GutterVariantEditorProps> = ({
             setValidationStatusForField('mainContent', isValid)
           }
           editMode={editMode}
+        />
+        <PromoCodesEditor
+          promoCodes={variant.promoCodes ?? []}
+          updatePromoCodes={promoCodes => {
+            onVariantChange({ ...variant, promoCodes });
+          }}
+          isDisabled={!editMode}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -9,6 +9,7 @@ import { templateValidatorForPlatform } from '../helpers/validation';
 import { Cta } from '../helpers/shared';
 import { HeaderContent, HeaderVariant } from '../../../models/header';
 import useValidation from '../hooks/useValidation';
+import PromoCodesEditor from '../choiceCards/PromoCodesEditor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
@@ -278,6 +279,14 @@ const HeaderTestVariantEditor: React.FC<HeaderTestVariantEditorProps> = ({
           deviceType={'MOBILE'}
         />
       )}
+
+      <PromoCodesEditor
+        promoCodes={variant.promoCodes ?? []}
+        updatePromoCodes={promoCodes => {
+          onVariantChange({ ...variant, promoCodes });
+        }}
+        isDisabled={!editMode}
+      />
     </div>
   );
 };

--- a/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestVariantEditor.tsx
@@ -283,7 +283,7 @@ const HeaderTestVariantEditor: React.FC<HeaderTestVariantEditorProps> = ({
       <PromoCodesEditor
         promoCodes={variant.promoCodes ?? []}
         updatePromoCodes={promoCodes => {
-          onVariantChange({ ...variant, promoCodes });
+          onVariantChange(current => ({ ...current, promoCodes }));
         }}
         isDisabled={!editMode}
       />

--- a/public/src/models/banner.ts
+++ b/public/src/models/banner.ts
@@ -36,6 +36,7 @@ export interface BannerVariant extends Variant {
   separateArticleCountSettings?: SeparateArticleCount;
   tickerSettings?: TickerSettings;
   choiceCardsSettings?: ChoiceCardsSettings;
+  promoCodes?: string[];
 }
 
 export interface BannerTestDeploySchedule {

--- a/public/src/models/epic.ts
+++ b/public/src/models/epic.ts
@@ -33,6 +33,7 @@ export interface EpicVariant extends Variant {
   cta?: Cta;
   secondaryCta?: SecondaryCta;
   separateArticleCount?: SeparateArticleCount;
+  promoCodes?: string[];
   showChoiceCards?: boolean;
   choiceCardsSettings?: ChoiceCardsSettings;
   defaultChoiceCardFrequency?: ContributionFrequency; // deprecated, use choiceCardSettings

--- a/public/src/models/gutter.ts
+++ b/public/src/models/gutter.ts
@@ -19,6 +19,7 @@ export interface GutterContent {
 
 export interface GutterVariant extends Variant {
   content: GutterContent;
+  promoCodes?: string[];
 }
 
 export interface GutterTest extends Test {

--- a/public/src/models/header.ts
+++ b/public/src/models/header.ts
@@ -21,6 +21,7 @@ export interface HeaderVariant extends Variant {
   name: string;
   content: HeaderContent;
   mobileContent?: HeaderContent;
+  promoCodes?: string[];
 }
 
 export interface HeaderTest extends Test {


### PR DESCRIPTION
Currently Marketing have to add a `promoCode=` parameter to the CTA url if they want to add a promo.
This PR adds a `promoCodes` field to the epic/banner/header/gutter variant models. This allows Marketing to configure promo codes that should be added to the CTA url, and reflected in the choice cards if applicable.

For now it's a simple text field that takes a comma-separated list of codes. This is consistent with the UX of the existing "Default promos" tool in the RRCP. Perhaps one day we can improve on this by making the RRCP fetch promo codes from the promos table.

<img width="474" alt="Screenshot 2025-06-10 at 13 46 54" src="https://github.com/user-attachments/assets/8ff1b54c-c188-4193-88b8-3123d31e1f2f" />

Clicking into the field -
<img width="474" alt="Screenshot 2025-06-10 at 13 46 56" src="https://github.com/user-attachments/assets/588e4a1d-88b9-432e-85e2-efa8a8bef239" />

SDC PR: https://github.com/guardian/support-dotcom-components/pull/1373
DCR PR: https://github.com/guardian/dotcom-rendering/pull/14071