### PR TITLE
Swap in new scaled Not For Sale image as default for new variants

### DIFF
--- a/public/src/components/channelManagement/gutterTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/gutterTests/utils/defaults.ts
@@ -7,7 +7,7 @@ export const DEFAULT_PRIMARY_CTA: Cta = {
   baseUrl: 'https://support.theguardian.com/contribute',
 };
 
-export const DEFAULT_IMAGE_URL = 'https://uploads.guim.co.uk/2025/01/22/not_for_sale.svg';
+export const DEFAULT_IMAGE_URL = 'https://uploads.guim.co.uk/2025/06/12/not_for_sale_bg_scaled.svg';
 export const DEFAULT_IMAGE_ALT = 'Not for Sale';
 
 const DEV_AND_CODE_DEFAULT_VARIANT: GutterVariant = {


### PR DESCRIPTION
## What does this change?

Following issues with trying new images in the Gutter Ask we are applying a couple of fixes to dotcom-rendering that will help: [PR14056](https://github.com/guardian/dotcom-rendering/pull/14056).  As part of that , a fix was needed to the original Not For Sale svg to add background-colour and scale it so that it has margin within the svg itself rather than applied via padding to the containing div.

This swaps out the new SVG image URL as the default that will then appear in any new variants unless changed.

## How to test

Run into CODE and create a new variant - this URL should appear.  If you use a web preview, note that until the DCR fix above has been applied, the text in the image will appear much smaller - see screenshots below (this is temporary).

## Images

### before DCR fix applied
<img width="1114" alt="Gutter-image-scaled-no-fix" src="https://github.com/user-attachments/assets/5a97a756-0467-40f9-876e-f9a42efd9d57" />

### after DCR fix has been applied
<img width="1118" alt="gutter-image-scaled-with-fix" src="https://github.com/user-attachments/assets/581c6fa5-e945-45db-828b-fa2bc08a2bc1" />




