### PR TITLE
Point live-preview to default story for DesignableBannerV2

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -170,7 +170,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   };
 
   const props = buildProps(variant, tickerSettingsWithData, design);
-  const storyName = 'components-marketing-designablebannerv2--with-three-tier-choice-cards';
+  const storyName = 'components-marketing-designablebannerv2--default';
   const storybookUrl = buildStorybookUrl(storyName, props);
 
   return (

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -11,6 +11,7 @@ import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
 import { ArticleCounts } from '../epicTests/variantPreview';
 import { SeparateArticleCount } from '../../../models/epic';
 import { buildStorybookUrl } from '../helpers/dcrStorybook';
+import Alert from "@mui/lab/Alert";
 
 // Mock prices data
 interface ProductPriceData {
@@ -188,6 +189,10 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
           <div>
             <div className={classes.hint} onClick={toggleDrawer(false)}>
               <Typography>Click anywhere outside the banner to close</Typography>
+              <Alert severity="info">
+                The Live Preview does not support choice cards. Please use the Web Preview to view choice
+                cards.
+              </Alert>
             </div>
             <div>
               <iframe className={classes.iframe} src={storybookUrl}></iframe>

--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -11,7 +11,7 @@ import { BannerDesign, BannerDesignProps } from '../../../models/bannerDesign';
 import { ArticleCounts } from '../epicTests/variantPreview';
 import { SeparateArticleCount } from '../../../models/epic';
 import { buildStorybookUrl } from '../helpers/dcrStorybook';
-import Alert from "@mui/lab/Alert";
+import Alert from '@mui/lab/Alert';
 
 // Mock prices data
 interface ProductPriceData {
@@ -190,8 +190,8 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
             <div className={classes.hint} onClick={toggleDrawer(false)}>
               <Typography>Click anywhere outside the banner to close</Typography>
               <Alert severity="info">
-                The Live Preview does not support choice cards. Please use the Web Preview to view choice
-                cards.
+                The Live Preview does not support choice cards. Please use the Web Preview to view
+                choice cards.
               </Alert>
             </div>
             <div>


### PR DESCRIPTION
## What does this change?

This hopes to fix an issue with live-preview (only) where it is displaying choice cards where the banner does not contain choice cards.

It was noticed that the live-preview was pointing to a story with some configuration that included choice cards rather than a completely unconfigured default story (added in [DCR PR14083](https://github.com/guardian/dotcom-rendering/pull/14083)).

## How to test

Deploy to CODE and check live-preview for a banner variant containing no choice cards.

**Note** - this also adds an alert to the live-preview about the fact that choice cards are no longer supported in live-preview following [PR738](https://github.com/guardian/support-admin-console/pull/738) to enable custom configuration of benefits in choice cards.

## Screenshots

### Before - where the choice cards were peeping in at the bottom of banners where they were not configured at all.

<img width="1507" alt="Screenshot 2025-06-13 at 11 06 10" src="https://github.com/user-attachments/assets/5109e898-2455-4612-ab08-83761b3e3ba2" />

### After - no choice cards peeping out.

<img width="1493" alt="Screenshot 2025-06-13 at 16 06 03" src="https://github.com/user-attachments/assets/abf36df7-2716-49ad-9477-eb2cb9fc70d5" />

### Before - no warning message about choice cards being unsupported - just not showing

<img width="1495" alt="Screenshot 2025-06-13 at 16 06 57" src="https://github.com/user-attachments/assets/d736f1be-5665-4cc7-868e-fcd0166e43b6" />

### After - with warning message that choice cards are unsupported in live-preview

<img width="1505" alt="Screenshot 2025-06-13 at 16 06 22" src="https://github.com/user-attachments/assets/187817bf-857c-450a-b45d-1cf68647db2b" />