### PR TITLE
Upgrade commons-beanutils to 1.11.0 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,8 @@ dependencyOverrides ++= List(
   "io.netty" % "netty-handler" % "4.1.118.Final",
   "io.netty" % "netty-codec-http2" % "4.1.100.Final",
   // Related to Play 3.0.2-6 currently brings in a vulnerable version of commons-io
-  "commons-io" % "commons-io" % "2.14.0" % Test
+  "commons-io" % "commons-io" % "2.14.0" % Test,
+  "commons-beanutils" % "commons-beanutils" % "1.11.0"
  )
 
 excludeDependencies ++= Seq(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrade [commons-beanutils to 1.11.0](https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils?p=1)  to fix the  high severity vulnerability reported [Apache Commons Improper Access Control vulnerability ](https://github.com/guardian/support-admin-console/security/dependabot/159)



## How to test
Deploy to CODE and check if everything is working
