### PR TITLE
Better validation of default choice card

### DIFF
--- a/public/src/components/channelManagement/bannerTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/variantEditor.tsx
@@ -488,6 +488,9 @@ const VariantEditor: React.FC<VariantEditorProps> = ({
             choiceCardsSettings={variant.choiceCardsSettings}
             updateChoiceCardsSettings={updateChoiceCardsSettings}
             isDisabled={!editMode}
+            onValidationChange={(isValid): void =>
+              setValidationStatusForField('choiceCardsSettings', isValid)
+            }
           />
         )}
       </div>

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardEditor.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardEditor.tsx
@@ -75,7 +75,7 @@ interface ChoiceCardEditorProps {
   onChange: (choiceCard: ChoiceCard) => void;
   isDisabled: boolean;
   index: number;
-  formMethods: UseFormReturn<ChoiceCardsSettings>;
+  formMethods: UseFormReturn<ChoiceCardsSettings & { hasOneDefault: boolean }>;
 }
 export const ChoiceCardEditor: React.FC<ChoiceCardEditorProps> = ({
   choiceCard,

--- a/public/src/components/channelManagement/epicTests/variantEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/variantEditor.tsx
@@ -465,6 +465,7 @@ const VariantEditor: React.FC<EpicTestVariantEditorProps> = ({
                 choiceCardsSettings={variant.choiceCardsSettings}
                 updateChoiceCardsSettings={updateChoiceCardsSettings}
                 isDisabled={!editMode}
+                onValidationChange={onValidationChange}
               />
             </div>
           )}


### PR DESCRIPTION
When configuring custom choice cards, a single card should be the default selected card (`isDefault` field). Currently there's a warning if no card has isDefault set, but it's not very obvious and has already caused confusion.

This PR:
- Makes the need for a single default choice card clearer in the UI
- Adds it to the react-hook-form validation state
- Wires it up to the parent component's validation, with a `onValidationChange` callback. This means the user cannot save changes until the error is fixed

No default choice card error:
<img width="606" alt="Screenshot 2025-06-19 at 13 36 14" src="https://github.com/user-attachments/assets/4324ac99-71ef-4802-93dd-bfc72bcd79de" />

More than 1 default choice card error:
<img width="606" alt="Screenshot 2025-06-19 at 13 36 34" src="https://github.com/user-attachments/assets/ca498b43-b2a0-4818-a983-826e60968b2b" />

1 default choice card:

<img width="606" alt="Screenshot 2025-06-19 at 13 36 43" src="https://github.com/user-attachments/assets/c780d70d-24ab-43a3-8f44-4109ef2b4029" />

