### PR TITLE
Make default choice card error scarier

### DIFF
--- a/public/src/components/channelManagement/choiceCards/ChoiceCardsEditor.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardsEditor.tsx
@@ -164,7 +164,7 @@ const ChoiceCardsEditor: React.FC<ChoiceCardsEditorProps> = ({
       {choiceCardsSelection === 'CustomChoiceCards' && (
         <>
           {formMethods.formState.errors?.hasOneDefault && (
-            <Alert severity="info">{formMethods.formState.errors.hasOneDefault.message}</Alert>
+            <Alert severity="error">{formMethods.formState.errors.hasOneDefault.message}</Alert>
           )}
           {fields.map((choiceCard, idx) => (
             <div className={classes.choiceCardContainer} key={choiceCard.id}>


### PR DESCRIPTION

I forgot to push this commit to https://github.com/guardian/support-admin-console/pull/748
Makes the error red -
<img width="606" alt="Screenshot 2025-06-19 at 13 36 14" src="https://github.com/user-attachments/assets/08e1dd1c-7684-40da-9ee1-bfd83009d5d1" />
