### PR TITLE
Migrate to Zio v2

### DIFF
--- a/app/controllers/AmountsController.scala
+++ b/app/controllers/AmountsController.scala
@@ -4,10 +4,9 @@ import com.gu.googleauth.AuthAction
 import models.AmountsTests
 import models.AmountsTests._
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class AmountsController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class AmountsController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[AmountsTests](authAction, components, stage, filename = "configured-amounts-v3.json", runtime) {
 }

--- a/app/controllers/AppsMeteringSwitchesController.scala
+++ b/app/controllers/AppsMeteringSwitchesController.scala
@@ -4,10 +4,9 @@ import com.gu.googleauth.AuthAction
 import models.AppsMeteringSwitches
 import models.AppsMeteringSwitches._
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class AppsMeteringSwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class AppsMeteringSwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[AppsMeteringSwitches](authAction, components, stage, filename = "apps-metering-switches.json", runtime) {
 }

--- a/app/controllers/BanditDataController.scala
+++ b/app/controllers/BanditDataController.scala
@@ -23,7 +23,7 @@ class BanditDataController(
     runtime.unsafeRunToFuture {
       f.catchAll(error => {
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       })
     }
 

--- a/app/controllers/CampaignsController.scala
+++ b/app/controllers/CampaignsController.scala
@@ -29,7 +29,7 @@ class CampaignsController(
     runtime.unsafeRunToFuture {
       f.catchAll(error => {
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       })
     }
 
@@ -49,7 +49,7 @@ class CampaignsController(
         .map(_ => Ok("created"))
         .catchSome { case DynamoDuplicateNameError(error) =>
           logger.warn(s"Failed to create '${campaign.name}' because name already exists: ${error.getMessage}")
-          IO.succeed(BadRequest(s"Cannot create campaign '${campaign.name}' because it already exists. Please use a different name"))
+          ZIO.succeed(BadRequest(s"Cannot create campaign '${campaign.name}' because it already exists. Please use a different name"))
         }
     }
   }

--- a/app/controllers/CampaignsController.scala
+++ b/app/controllers/CampaignsController.scala
@@ -11,7 +11,7 @@ import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.{DynamoCampaigns, DynamoChannelTests}
 import utils.Circe.noNulls
-import zio.{IO, ZEnv, ZIO}
+import zio.{Unsafe, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -19,19 +19,19 @@ class CampaignsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoChannelTests: DynamoChannelTests,
   dynamoCampaigns: DynamoCampaigns
 )(implicit ec: ExecutionContext)
   extends AbstractController(components) with Circe with LazyLogging{
 
-  private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
-    runtime.unsafeRunToFuture {
+  private def run(f: => ZIO[Any, Throwable, Result]): Future[Result] =
+    Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
       f.catchAll(error => {
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
         ZIO.succeed(InternalServerError(error.getMessage))
       })
-    }
+    }}
 
   def get(): Action[AnyContent] = authAction.async { request =>
     run {

--- a/app/controllers/ChannelSwitchesController.scala
+++ b/app/controllers/ChannelSwitchesController.scala
@@ -3,10 +3,9 @@ package controllers
 import com.gu.googleauth.AuthAction
 import models.ChannelSwitches
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class ChannelSwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class ChannelSwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[ChannelSwitches](authAction, components, stage, filename = "channel-switches.json", runtime) {
 }

--- a/app/controllers/ChannelTestsAuditController.scala
+++ b/app/controllers/ChannelTestsAuditController.scala
@@ -6,7 +6,7 @@ import io.circe.syntax.EncoderOps
 import play.api.mvc.{AbstractController, Action, ActionBuilder, AnyContent, ControllerComponents, Result}
 import services.DynamoChannelTestsAudit
 import utils.Circe.noNulls
-import zio.{IO, ZEnv, ZIO}
+import zio.{Unsafe, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -14,17 +14,17 @@ class ChannelTestsAuditController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamo: DynamoChannelTestsAudit
 )(implicit ec: ExecutionContext) extends AbstractController(components) with LazyLogging {
 
-  private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
-    runtime.unsafeRunToFuture {
+  private def run(f: => ZIO[Any, Throwable, Result]): Future[Result] =
+    Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
       f.catchAll(error => {
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
         ZIO.succeed(InternalServerError(error.getMessage))
       })
-    }
+    }}
 
   def getAuditsForChannelTest(channel: String, testName: String): Action[AnyContent] = authAction.async { request =>
     run {

--- a/app/controllers/ChannelTestsAuditController.scala
+++ b/app/controllers/ChannelTestsAuditController.scala
@@ -22,7 +22,7 @@ class ChannelTestsAuditController(
     runtime.unsafeRunToFuture {
       f.catchAll(error => {
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       })
     }
 

--- a/app/controllers/DefaultPromosController.scala
+++ b/app/controllers/DefaultPromosController.scala
@@ -1,13 +1,11 @@
 package controllers
 
 import com.gu.googleauth.AuthAction
-import models.{AppsMeteringSwitches, DefaultPromos}
-import models.AppsMeteringSwitches._
+import models.DefaultPromos
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class DefaultPromosController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class DefaultPromosController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[DefaultPromos](authAction, components, stage, filename = "default-promos.json", runtime) {
 }

--- a/app/controllers/HeaderTestsController.scala
+++ b/app/controllers/HeaderTestsController.scala
@@ -6,7 +6,6 @@ import models.{Channel, HeaderTest}
 import models.HeaderTest._
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -18,7 +17,7 @@ class HeaderTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/S3ObjectController.scala
+++ b/app/controllers/S3ObjectController.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{AbstractController, ActionBuilder, AnyContent, ControllerCo
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
 import utils.Circe.noNulls
-import zio.blocking.Blocking
+
 import zio.{IO, ZEnv, ZIO}
 import com.typesafe.scalalogging.LazyLogging
 
@@ -39,7 +39,7 @@ abstract class S3ObjectController[T : Decoder : Encoder](
     runtime.unsafeRunToFuture {
       f.catchAll { error =>
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       }
     }
 

--- a/app/controllers/S3ObjectController.scala
+++ b/app/controllers/S3ObjectController.scala
@@ -9,8 +9,7 @@ import play.api.mvc.{AbstractController, ActionBuilder, AnyContent, ControllerCo
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
 import utils.Circe.noNulls
-
-import zio.{IO, ZEnv, ZIO}
+import zio.{Unsafe, ZIO}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -25,7 +24,7 @@ abstract class S3ObjectController[T : Decoder : Encoder](
   components: ControllerComponents,
   stage: String,
   filename: String,
-  val runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
+  val runtime: zio.Runtime[Any])(implicit ec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
 
   private val dataObjectSettings = S3ObjectSettings(
     bucket = "support-admin-console",
@@ -35,13 +34,13 @@ abstract class S3ObjectController[T : Decoder : Encoder](
   )
   private val s3Client = services.S3
 
-  protected def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
-    runtime.unsafeRunToFuture {
+  protected def run(f: => ZIO[Any, Throwable, Result]): Future[Result] =
+    Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
       f.catchAll { error =>
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
         ZIO.succeed(InternalServerError(error.getMessage))
       }
-    }
+    }}
 
   /**
     * Returns current version of the object in s3 as json, with the version id.

--- a/app/controllers/S3ObjectsController.scala
+++ b/app/controllers/S3ObjectsController.scala
@@ -7,8 +7,7 @@ import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
-
-import zio.{IO, ZEnv, ZIO}
+import zio.{Unsafe, ZIO}
 import S3ObjectsController.extractFilename
 import com.typesafe.scalalogging.LazyLogging
 import utils.Circe.noNulls
@@ -35,17 +34,17 @@ abstract class S3ObjectsController[T : Decoder : Encoder](
   stage: String,
   path: String,
   nameGenerator: T => String,
-  runtime: zio.Runtime[ZEnv]
+  runtime: zio.Runtime[Any]
 )(implicit ec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
 
   val s3Client = services.S3
 
-  private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
-    runtime.unsafeRunToFuture {
+  private def run(f: => ZIO[Any, Throwable, Result]): Future[Result] =
+    Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
       f.catchAll { error =>
         ZIO.succeed(InternalServerError(error.getMessage))
       }
-    }
+    }}
 
   private def buildObjectSettings(name: String) = S3ObjectSettings(
     bucket = "support-admin-console",

--- a/app/controllers/S3ObjectsController.scala
+++ b/app/controllers/S3ObjectsController.scala
@@ -7,7 +7,7 @@ import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.S3Client.S3ObjectSettings
 import services.{S3Json, VersionedS3Data}
-import zio.blocking.Blocking
+
 import zio.{IO, ZEnv, ZIO}
 import S3ObjectsController.extractFilename
 import com.typesafe.scalalogging.LazyLogging
@@ -43,7 +43,7 @@ abstract class S3ObjectsController[T : Decoder : Encoder](
   private def run(f: => ZIO[ZEnv, Throwable, Result]): Future[Result] =
     runtime.unsafeRunToFuture {
       f.catchAll { error =>
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       }
     }
 

--- a/app/controllers/SuperModeController.scala
+++ b/app/controllers/SuperModeController.scala
@@ -24,7 +24,7 @@ class SuperModeController(
     runtime.unsafeRunToFuture {
       f.catchAll(error => {
         logger.error(s"Returning InternalServerError to client: ${error.getMessage}", error)
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       })
     }
 

--- a/app/controllers/SupportLandingPageController.scala
+++ b/app/controllers/SupportLandingPageController.scala
@@ -7,7 +7,6 @@ import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.UserPermissions.Permission
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit, DynamoPermissionsCache}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -19,7 +18,7 @@ class SupportLandingPageController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit,

--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -3,10 +3,9 @@ package controllers
 import com.gu.googleauth.AuthAction
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import models.SupportFrontendSwitches.{SupportFrontendSwitches, SupportFrontendSwitchesDecoder, SupportFrontendSwitchesEncoder}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class SwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class SwitchesController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[SupportFrontendSwitches](authAction, components, stage, filename = "switches_v2.json", runtime) {
 }

--- a/app/controllers/banner/BannerDeployController.scala
+++ b/app/controllers/banner/BannerDeployController.scala
@@ -5,10 +5,9 @@ import controllers.S3ObjectController
 import io.circe.generic.auto._
 import models.BannerDeploys
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class BannerDeployController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class BannerDeployController(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel1.json", runtime) {
 }

--- a/app/controllers/banner/BannerDeployController2.scala
+++ b/app/controllers/banner/BannerDeployController2.scala
@@ -5,10 +5,9 @@ import controllers.S3ObjectController
 import io.circe.generic.auto._
 import models.BannerDeploys
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
-class BannerDeployController2(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[ZEnv])(implicit ec: ExecutionContext)
+class BannerDeployController2(authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent], components: ControllerComponents, stage: String, runtime: zio.Runtime[Any])(implicit ec: ExecutionContext)
   extends S3ObjectController[BannerDeploys](authAction, components, stage, filename = "banner-deploy/channel2.json", runtime) {
 }

--- a/app/controllers/banner/BannerDesignsController.scala
+++ b/app/controllers/banner/BannerDesignsController.scala
@@ -51,7 +51,7 @@ class BannerDesignsController(
         logger.error(
           s"Returning InternalServerError to client: ${error.getMessage}",
           error)
-        IO.succeed(InternalServerError(error.getMessage))
+        ZIO.succeed(InternalServerError(error.getMessage))
       })
     }
 
@@ -91,7 +91,7 @@ class BannerDesignsController(
           case DynamoNoLockError(error) =>
             logger.warn(
               s"Failed to save '${design.name}' because user ${request.user.email} does not have it locked: ${error.getMessage}")
-            IO.succeed(Conflict(
+            ZIO.succeed(Conflict(
               s"You do not currently have design '${design.name}' open for edit"))
         }
     }
@@ -108,7 +108,7 @@ class BannerDesignsController(
           case DynamoDuplicateNameError(error) =>
             logger.warn(
               s"Failed to create '${design.name}' because name already exists: ${error.getMessage}")
-            IO.succeed(BadRequest(
+            ZIO.succeed(BadRequest(
               s"Cannot create design '${design.name}' because it already exists. Please use a different name"))
         }
     }
@@ -124,7 +124,7 @@ class BannerDesignsController(
           case DynamoNoLockError(error) =>
             logger.warn(
               s"Failed to lock '$designName' because it is already locked: ${error.getMessage}")
-            IO.succeed(Conflict(
+            ZIO.succeed(Conflict(
               s"Design '$designName' is already locked for edit by another user"))
         }
     }
@@ -140,7 +140,7 @@ class BannerDesignsController(
           case DynamoNoLockError(error) =>
             logger.warn(
               s"Failed to unlock '$designName' because user ${request.user.email} does not have it locked: ${error.getMessage}")
-            IO.succeed(Conflict(
+            ZIO.succeed(Conflict(
               s"You do not currently have design '$designName' open for edit"))
         }
     }

--- a/app/controllers/banner/BannerTestsController.scala
+++ b/app/controllers/banner/BannerTestsController.scala
@@ -8,7 +8,6 @@ import models.BannerTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class BannerTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/banner/BannerTestsController2.scala
+++ b/app/controllers/banner/BannerTestsController2.scala
@@ -8,7 +8,6 @@ import models.BannerTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class BannerTestsController2(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/epic/AMPEpicTestsController.scala
+++ b/app/controllers/epic/AMPEpicTestsController.scala
@@ -8,7 +8,6 @@ import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class AMPEpicTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/epic/AppleNewsEpicTestsController.scala
+++ b/app/controllers/epic/AppleNewsEpicTestsController.scala
@@ -8,7 +8,6 @@ import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class AppleNewsEpicTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/epic/EpicTestsController.scala
+++ b/app/controllers/epic/EpicTestsController.scala
@@ -8,7 +8,6 @@ import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class EpicTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/epic/LiveblogEpicTestsController.scala
+++ b/app/controllers/epic/LiveblogEpicTestsController.scala
@@ -8,7 +8,6 @@ import models.EpicTest._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class LiveblogEpicTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/controllers/gutter/GutterLiveblogTestsController.scala
+++ b/app/controllers/gutter/GutterLiveblogTestsController.scala
@@ -8,7 +8,6 @@ import models.GutterTest._
 import play.api.libs.circe.Circe
 import play.api.mvc.{ActionBuilder, AnyContent, ControllerComponents}
 import services.{DynamoArchivedChannelTests, DynamoChannelTests, DynamoChannelTestsAudit}
-import zio.ZEnv
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +19,7 @@ class GutterLiveblogTestsController(
   authAction: ActionBuilder[AuthAction.UserIdentityRequest, AnyContent],
   components: ControllerComponents,
   stage: String,
-  runtime: zio.Runtime[ZEnv],
+  runtime: zio.Runtime[Any],
   dynamoTests: DynamoChannelTests,
   dynamoArchivedTests: DynamoArchivedChannelTests,
   dynamoTestsAudit: DynamoChannelTestsAudit

--- a/app/services/BigQueryService.scala
+++ b/app/services/BigQueryService.scala
@@ -6,7 +6,7 @@ import com.google.cloud.RetryOption
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, FieldValueList, JobInfo, QueryJobConfiguration, TableResult}
 import com.typesafe.scalalogging.LazyLogging
 import models.BigQueryResult
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 
 import java.io.ByteArrayInputStream
 import scala.jdk.CollectionConverters._
@@ -37,7 +37,7 @@ class BigQueryService(bigQuery: BigQuery) extends LazyLogging {
     """
   }
 
-  def runQuery(queryString: String): ZIO[ZEnv, BigQueryError, TableResult] =
+  def runQuery(queryString: String): ZIO[Any, BigQueryError, TableResult] =
     attemptBlocking {
       val queryConfig = QueryJobConfiguration
         .newBuilder(queryString)
@@ -79,7 +79,7 @@ class BigQueryService(bigQuery: BigQuery) extends LazyLogging {
     result.getValues.asScala.map(toBigQueryResult).toList
   }
 
-  def getLTV3Data(testName: String, channel: String, stage: String): ZIO[ZEnv, BigQueryError, List[BigQueryResult]] = {
+  def getLTV3Data(testName: String, channel: String, stage: String): ZIO[Any, BigQueryError, List[BigQueryResult]] = {
 
     val query = buildQuery(testName, channel, stage)
     logger.info(s"Query: $query");

--- a/app/services/BigQueryService.scala
+++ b/app/services/BigQueryService.scala
@@ -6,11 +6,11 @@ import com.google.cloud.RetryOption
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, FieldValueList, JobInfo, QueryJobConfiguration, TableResult}
 import com.typesafe.scalalogging.LazyLogging
 import models.BigQueryResult
-import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
 
 import java.io.ByteArrayInputStream
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
 
 
 case class BigQueryError(message: String) extends Throwable
@@ -38,7 +38,7 @@ class BigQueryService(bigQuery: BigQuery) extends LazyLogging {
   }
 
   def runQuery(queryString: String): ZIO[ZEnv, BigQueryError, TableResult] =
-    effectBlocking {
+    attemptBlocking {
       val queryConfig = QueryJobConfiguration
         .newBuilder(queryString)
         .setUseLegacySql(false)

--- a/app/services/DynamoArchivedBannerDesigns.scala
+++ b/app/services/DynamoArchivedBannerDesigns.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.StrictLogging
 import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoPutError}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ConditionalCheckFailedException, PutItemRequest}
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 
 import java.text.SimpleDateFormat
 import java.util
@@ -14,7 +14,7 @@ class DynamoArchivedBannerDesigns(stage: String, client: DynamoDbClient) extends
 
   protected val tableName = s"support-admin-console-archived-banner-designs-$stage"
 
-  def putRaw(item: java.util.Map[String, AttributeValue]): ZIO[ZEnv, DynamoError, Unit] = {
+  def putRaw(item: java.util.Map[String, AttributeValue]): ZIO[Any, DynamoError, Unit] = {
     // Add date attribute, which is the sort key. We first have to build a mutable Map, otherwise the Java Map throws when we insert
     val mutableItem = new util.HashMap(item)
     val date = new SimpleDateFormat("yyyy-MM-dd").format(new Date())

--- a/app/services/DynamoArchivedBannerDesigns.scala
+++ b/app/services/DynamoArchivedBannerDesigns.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.StrictLogging
 import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoPutError}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ConditionalCheckFailedException, PutItemRequest}
-import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
 
 import java.text.SimpleDateFormat

--- a/app/services/DynamoArchivedChannelTests.scala
+++ b/app/services/DynamoArchivedChannelTests.scala
@@ -4,13 +4,13 @@ import com.typesafe.scalalogging.StrictLogging
 import models.DynamoErrors._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model._
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 
 class DynamoArchivedChannelTests(stage: String, client: DynamoDbClient) extends DynamoService(stage, client) with StrictLogging {
 
   protected val tableName = s"support-admin-console-archived-channel-tests-$stage"
 
-  def putAllRaw(items: List[java.util.Map[String, AttributeValue]]): ZIO[ZEnv, DynamoPutError, Unit] = {
+  def putAllRaw(items: List[java.util.Map[String, AttributeValue]]): ZIO[Any, DynamoPutError, Unit] = {
     val writeRequests = items.map(item => WriteRequest.builder.putRequest(
       PutRequest
         .builder

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, QueryRequest}
 import utils.Circe.dynamoMapToJson
 import io.circe.generic.auto._
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 
 import scala.jdk.CollectionConverters._
 import zio.ZIO.attemptBlocking
@@ -44,7 +44,7 @@ class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogg
   // No DEV table for bandit data
   private val tableName = s"support-bandit-${if (stage == "PROD") "PROD" else "CODE"}"
 
-  private def query(testName: String, channel: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] = {
+  private def query(testName: String, channel: String): ZIO[Any, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] = {
     attemptBlocking {
       client.query(
         QueryRequest
@@ -99,7 +99,7 @@ class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogg
       .toList
   }
 
-  def getDataForTest(testName: String, channel: String, sampleCount: Option[Int]): ZIO[ZEnv, DynamoError, BanditData] =
+  def getDataForTest(testName: String, channel: String, sampleCount: Option[Int]): ZIO[Any, DynamoError, BanditData] =
     query(testName, channel)
       .map { results =>
         results.asScala

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -7,10 +7,10 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, QueryRequest}
 import utils.Circe.dynamoMapToJson
 import io.circe.generic.auto._
-import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
 
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
 
 /**
  * Models for data received from DynamoDb
@@ -45,7 +45,7 @@ class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogg
   private val tableName = s"support-bandit-${if (stage == "PROD") "PROD" else "CODE"}"
 
   private def query(testName: String, channel: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] = {
-    effectBlocking {
+    attemptBlocking {
       client.query(
         QueryRequest
           .builder()

--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -9,11 +9,11 @@ import models.BannerDesign
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model._
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
-import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
 
 import java.time.OffsetDateTime
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
 
 class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     extends DynamoService(stage, client)
@@ -32,7 +32,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     */
   private def get(designName: String)
     : ZIO[ZEnv, DynamoGetError, java.util.Map[String, AttributeValue]] =
-    effectBlocking {
+    attemptBlocking {
       val query = QueryRequest.builder
         .tableName(tableName)
         .keyConditionExpression("#name = :name")
@@ -63,7 +63,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     : ZIO[ZEnv,
           DynamoGetError,
           java.util.List[java.util.Map[String, AttributeValue]]] =
-    effectBlocking {
+    attemptBlocking {
       client
         .scan(
           ScanRequest
@@ -76,7 +76,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
 
   private def update(
       updateRequest: UpdateItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
+    attemptBlocking {
       val result = client.updateItem(updateRequest)
       logger.info(s"UpdateItemResponse: $result")
       ()
@@ -86,7 +86,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     }
 
   private def delete(deleteRequest: DeleteItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
+    attemptBlocking {
       val result = client.deleteItem(deleteRequest)
       logger.info(s"DeleteItemResponse: $result")
       ()

--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -9,7 +9,7 @@ import models.BannerDesign
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model._
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 
 import java.time.OffsetDateTime
 import scala.jdk.CollectionConverters._
@@ -31,7 +31,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     * Attempts to retrieve a banner design from dynamodb. Fails if the banner design does not exist.
     */
   private def get(designName: String)
-    : ZIO[ZEnv, DynamoGetError, java.util.Map[String, AttributeValue]] =
+    : ZIO[Any, DynamoGetError, java.util.Map[String, AttributeValue]] =
     attemptBlocking {
       val query = QueryRequest.builder
         .tableName(tableName)
@@ -60,7 +60,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
       .mapError(error => DynamoGetError(error))
 
   private def getAll()
-    : ZIO[ZEnv,
+    : ZIO[Any,
           DynamoGetError,
           java.util.List[java.util.Map[String, AttributeValue]]] =
     attemptBlocking {
@@ -75,7 +75,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     }.mapError(DynamoGetError)
 
   private def update(
-      updateRequest: UpdateItemRequest): ZIO[ZEnv, DynamoError, Unit] =
+      updateRequest: UpdateItemRequest): ZIO[Any, DynamoError, Unit] =
     attemptBlocking {
       val result = client.updateItem(updateRequest)
       logger.info(s"UpdateItemResponse: $result")
@@ -85,7 +85,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
       case other                                => DynamoPutError(other)
     }
 
-  private def delete(deleteRequest: DeleteItemRequest): ZIO[ZEnv, DynamoError, Unit] =
+  private def delete(deleteRequest: DeleteItemRequest): ZIO[Any, DynamoError, Unit] =
     attemptBlocking {
       val result = client.deleteItem(deleteRequest)
       logger.info(s"DeleteItemResponse: $result")
@@ -96,7 +96,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     }
 
   def getBannerDesign(
-      designName: String): ZIO[ZEnv, DynamoGetError, BannerDesign] =
+      designName: String): ZIO[Any, DynamoGetError, BannerDesign] =
     get(designName)
       .map(item => dynamoMapToJson(item).as[BannerDesign])
       .flatMap {
@@ -104,7 +104,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
         case Left(error)         => ZIO.fail(DynamoGetError(error))
       }
 
-  def getAllBannerDesigns(): ZIO[ZEnv, DynamoGetError, List[BannerDesign]] =
+  def getAllBannerDesigns(): ZIO[Any, DynamoGetError, List[BannerDesign]] =
     getAll().map(
       results =>
         results.asScala
@@ -133,7 +133,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
   }
 
   def createBannerDesign(
-      bannerDesign: BannerDesign): ZIO[ZEnv, DynamoError, Unit] = {
+      bannerDesign: BannerDesign): ZIO[Any, DynamoError, Unit] = {
     val item = jsonToDynamo(bannerDesign.asJson).m()
     val request = PutItemRequest.builder
       .tableName(tableName)
@@ -146,7 +146,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
   }
 
   def updateBannerDesign(bannerDesign: BannerDesign,
-                         email: String): ZIO[ZEnv, DynamoError, Unit] = {
+                         email: String): ZIO[Any, DynamoError, Unit] = {
     val item = jsonToDynamo(bannerDesign.asJson).m().asScala.toMap -
       "lockStatus" - // Unlock by removing lockStatus
       "name" - // key field"
@@ -173,7 +173,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
 
   def lockBannerDesign(designName: String,
                        email: String,
-                       force: Boolean): ZIO[ZEnv, DynamoError, Unit] = {
+                       force: Boolean): ZIO[Any, DynamoError, Unit] = {
     val lockStatus = LockStatus(
       locked = true,
       email = Some(email),
@@ -202,7 +202,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
 
   // Removes the lockStatus attribute if the user currently has it locked
   def unlockBannerDesign(designName: String,
-                         email: String): ZIO[ZEnv, DynamoError, Unit] = {
+                         email: String): ZIO[Any, DynamoError, Unit] = {
     val request = UpdateItemRequest.builder
       .tableName(tableName)
       .key(buildKey(designName))
@@ -216,7 +216,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
     update(request)
   }
 
-  def deleteBannerDesign(designName: String): ZIO[ZEnv, DynamoError, Unit] = {
+  def deleteBannerDesign(designName: String): ZIO[Any, DynamoError, Unit] = {
     val request = DeleteItemRequest.builder
       .tableName(tableName)
       .key(buildKey(designName))
@@ -228,7 +228,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
   def updateStatus(
       designName: String,
       status: BannerDesignStatus
-  ): ZIO[ZEnv, DynamoError, Unit] = {
+  ): ZIO[Any, DynamoError, Unit] = {
     val updateRequest = UpdateItemRequest.builder
       .tableName(tableName)
       .key(buildKey(designName))
@@ -249,7 +249,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
   }
 
   // Does not decode the Dynamodb data
-  def getRawDesign(designName: String): ZIO[ZEnv, DynamoGetError,java.util.Map[String, AttributeValue]] = {
+  def getRawDesign(designName: String): ZIO[Any, DynamoGetError,java.util.Map[String, AttributeValue]] = {
     get(designName)
   }
 

--- a/app/services/DynamoCampaigns.scala
+++ b/app/services/DynamoCampaigns.scala
@@ -6,7 +6,7 @@ import models.DynamoErrors._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ConditionalCheckFailedException, PutItemRequest, ScanRequest}
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 import io.circe.syntax._
 
 import scala.jdk.CollectionConverters._
@@ -17,7 +17,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
 
   private val tableName = s"support-admin-console-campaigns-$stage"
 
-  private def getAll(): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
+  private def getAll(): ZIO[Any, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
     attemptBlocking {
       client.scan(
         ScanRequest
@@ -27,7 +27,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
       ).items()
     }.mapError(DynamoGetError)
 
-  private def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
+  private def put(putRequest: PutItemRequest): ZIO[Any, DynamoError, Unit] =
     attemptBlocking {
       val result = client.putItem(putRequest)
       logger.info(s"PutItemResponse: $result")
@@ -37,7 +37,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
       case other => DynamoPutError(other)
     }
 
-  def getAllCampaigns(): ZIO[ZEnv, DynamoGetError, List[Campaign]] =
+  def getAllCampaigns(): ZIO[Any, DynamoGetError, List[Campaign]] =
     getAll().map(results =>
       results.asScala
         .map(item => dynamoMapToJson(item).as[Campaign])
@@ -51,7 +51,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
         .sortBy(_.name)
     )
 
-  def createCampaign(campaign: Campaign): ZIO[ZEnv, DynamoError, Unit] = {
+  def createCampaign(campaign: Campaign): ZIO[Any, DynamoError, Unit] = {
     val item = jsonToDynamo(campaign.asJson).m()
     val request = PutItemRequest
       .builder
@@ -64,7 +64,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
     put(request)
   }
 
-  def updateCampaign(campaign: Campaign): ZIO[ZEnv, DynamoError, Unit] = {
+  def updateCampaign(campaign: Campaign): ZIO[Any, DynamoError, Unit] = {
     val item = jsonToDynamo(campaign.asJson).m()
     val request = PutItemRequest
       .builder

--- a/app/services/DynamoCampaigns.scala
+++ b/app/services/DynamoCampaigns.scala
@@ -6,11 +6,11 @@ import models.DynamoErrors._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ConditionalCheckFailedException, PutItemRequest, ScanRequest}
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
-import zio.blocking.effectBlocking
 import zio.{ZEnv, ZIO}
 import io.circe.syntax._
 
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
 
 
 class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLogging {
@@ -18,7 +18,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
   private val tableName = s"support-admin-console-campaigns-$stage"
 
   private def getAll(): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
-    effectBlocking {
+    attemptBlocking {
       client.scan(
         ScanRequest
           .builder()
@@ -28,7 +28,7 @@ class DynamoCampaigns(stage: String, client: DynamoDbClient) extends StrictLoggi
     }.mapError(DynamoGetError)
 
   private def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
+    attemptBlocking {
       val result = client.putItem(putRequest)
       logger.info(s"PutItemResponse: $result")
       ()

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -9,13 +9,13 @@ import models._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model._
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
-import zio.blocking.effectBlocking
 import zio.duration.durationInt
 import zio.stream.ZStream
 import zio.{ZEnv, ZIO}
 
 import java.time.OffsetDateTime
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
 
 
 class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoService(stage, client) with StrictLogging {
@@ -33,7 +33,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
     * Attempts to retrieve a test from dynamodb. Fails if the test does not exist.
     */
   private def get(testName: String, channel: Channel): ZIO[ZEnv, DynamoGetError, java.util.Map[String, AttributeValue]] =
-    effectBlocking {
+    attemptBlocking {
       val query = QueryRequest
         .builder
         .tableName(tableName)
@@ -59,7 +59,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
     )
 
   private def getAll(channel: Channel): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
-    effectBlocking {
+    attemptBlocking {
       client.query(
         QueryRequest
           .builder
@@ -78,7 +78,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
     }.mapError(DynamoGetError)
 
   private def getAllInCampaign(campaignName: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
-    effectBlocking {
+    attemptBlocking {
       client.query(
         QueryRequest
           .builder
@@ -93,7 +93,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
     }.mapError(DynamoGetError)
 
   private def update(updateRequest: UpdateItemRequest): ZIO[ZEnv, DynamoError, Unit] =
-    effectBlocking {
+    attemptBlocking {
       val result = client.updateItem(updateRequest)
       logger.info(s"UpdateItemResponse: $result")
       ()
@@ -134,7 +134,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient) extends DynamoSe
       .requestItems(Map(tableName -> keysAndAttributes).asJava)
       .build()
 
-    effectBlocking {
+    attemptBlocking {
       client.batchGetItem(request)
         .responses().asScala.get(tableName).map(_.asScala.toList).getOrElse(Nil)
     }.mapError(DynamoGetError)

--- a/app/services/DynamoChannelTestsAudit.scala
+++ b/app/services/DynamoChannelTestsAudit.scala
@@ -11,10 +11,10 @@ import zio.{ZEnv, ZIO}
 import models.DynamoErrors._
 import DynamoChannelTestsAudit.{ChannelTestAudit, getTimeToLive}
 import utils.Circe.{dynamoMapToJson, jsonToDynamo}
-import zio.blocking.effectBlocking
 
 import java.time.OffsetDateTime
 import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
+import zio.ZIO.attemptBlocking
 
 object DynamoChannelTestsAudit {
   // The model that we write to the audit table
@@ -37,7 +37,7 @@ class DynamoChannelTestsAudit(stage: String, client: DynamoDbClient) extends Dyn
   protected val tableName = s"support-admin-console-channel-tests-audit-$stage"
 
   private def getAuditsFromDynamo(channelAndName: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
-    effectBlocking {
+    attemptBlocking {
       client.query(
         QueryRequest
           .builder

--- a/app/services/DynamoPermissionsCache.scala
+++ b/app/services/DynamoPermissionsCache.scala
@@ -10,8 +10,7 @@ import services.UserPermissions.{PagePermission, UserPermissions, decoder}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ScanRequest}
 import utils.Circe.dynamoMapToJson
-import zio.duration.durationInt
-import zio.{Schedule, ZEnv, ZIO}
+import zio._
 
 import scala.jdk.CollectionConverters._
 import java.util.concurrent.atomic.AtomicReference
@@ -40,7 +39,7 @@ object UserPermissions {
 class DynamoPermissionsCache(
   stage: String,
   client: DynamoDbClient,
-  runtime: zio.Runtime[ZEnv]
+  runtime: zio.Runtime[Any]
 ) extends DynamoService(stage, client) with StrictLogging {
   type Email = String
 
@@ -48,7 +47,7 @@ class DynamoPermissionsCache(
 
   private val permissionsCache = new AtomicReference[Map[Email, UserPermissions]](Map.empty)
 
-  private def getAll: ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
+  private def getAll: ZIO[Any, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
     attemptBlocking {
       client
         .scan(
@@ -60,7 +59,7 @@ class DynamoPermissionsCache(
         .items()
     }.mapError(DynamoGetError)
 
-  private def fetchPermissions(): ZIO[ZEnv, DynamoGetError, Map[Email, UserPermissions]] =
+  private def fetchPermissions(): ZIO[Any, DynamoGetError, Map[Email, UserPermissions]] =
     getAll.map(
       results =>
         results.asScala
@@ -82,11 +81,11 @@ class DynamoPermissionsCache(
   }
 
   // Poll every minute in the background
-  runtime.unsafeRunAsync {
+  Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
     fetchPermissions()
       .map(updatePermissions)
       .repeat(Schedule.fixed(1.minute))
-  }
+  }}
 
   def getPermissionsForUser(email: Email): Option[List[PagePermission]] = {
     permissionsCache.get().get(email).map(_.permissions)

--- a/app/services/DynamoService.scala
+++ b/app/services/DynamoService.scala
@@ -4,9 +4,9 @@ import com.typesafe.scalalogging.StrictLogging
 import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoPutError}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{BatchWriteItemRequest, ConditionalCheckFailedException, PutItemRequest, ReturnConsumedCapacity, TransactWriteItem, TransactWriteItemsRequest, WriteRequest}
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 import zio.stream.ZStream
-import zio.duration.durationInt
+import zio._
 
 import scala.jdk.CollectionConverters._
 import zio.ZIO.attemptBlocking
@@ -16,7 +16,7 @@ abstract class DynamoService(stage: String, client: DynamoDbClient)
     extends StrictLogging {
   protected val tableName: String
 
-  protected def put(putRequest: PutItemRequest): ZIO[ZEnv, DynamoError, Unit] =
+  protected def put(putRequest: PutItemRequest): ZIO[Any, DynamoError, Unit] =
     attemptBlocking {
       val result = client.putItem(putRequest)
       logger.info(s"PutItemResponse: $result")
@@ -28,7 +28,7 @@ abstract class DynamoService(stage: String, client: DynamoDbClient)
 
   // Sends a batch of write requests, and returns any unprocessed items
   protected def putAll(writeRequests: List[WriteRequest])
-    : ZIO[ZEnv, DynamoPutError, List[WriteRequest]] =
+    : ZIO[Any, DynamoPutError, List[WriteRequest]] =
     attemptBlocking {
       val batchWriteRequest =
         BatchWriteItemRequest.builder
@@ -58,10 +58,10 @@ abstract class DynamoService(stage: String, client: DynamoDbClient)
   protected val BATCH_SIZE = 25
 
   protected def putAllBatched(
-      writeRequests: List[WriteRequest]): ZIO[ZEnv, DynamoPutError, Unit] = {
+      writeRequests: List[WriteRequest]): ZIO[Any, DynamoPutError, Unit] = {
     val batches = writeRequests.grouped(BATCH_SIZE).toList
     ZStream(()).forever
-      .fixed(2.seconds) // wait 2 seconds between batches
+      .schedule(Schedule.spaced(2.seconds)) // wait 2 seconds between batches
       .timeoutFail(DynamoPutError(
         new Throwable("Timed out writing batches to dynamodb")))(1.minute)
       .runFoldWhileZIO(batches)(_.nonEmpty) {
@@ -82,11 +82,11 @@ abstract class DynamoService(stage: String, client: DynamoDbClient)
     * It uses a zio stream to do this, pausing between batches to avoid any throttling and timing out after 1 minute.
     */
   protected def putAllBatchedTransaction(
-      items: List[TransactWriteItem]): ZIO[ZEnv, DynamoPutError, Unit] = {
+      items: List[TransactWriteItem]): ZIO[Any, DynamoPutError, Unit] = {
     val batches = items.grouped(BATCH_SIZE).toList
     ZStream
       .fromIterable(batches)
-      .fixed(2.seconds) // wait 2 seconds between batches
+      .schedule(Schedule.spaced(2.seconds)) // wait 2 seconds between batches
       .timeoutFail(DynamoPutError(
         new Throwable("Timed out writing batches to dynamodb")))(1.minute)
       .mapZIO(putAllTransaction)
@@ -95,7 +95,7 @@ abstract class DynamoService(stage: String, client: DynamoDbClient)
   }
 
   private def putAllTransaction(
-      items: List[TransactWriteItem]): ZIO[ZEnv, DynamoPutError, Unit] =
+      items: List[TransactWriteItem]): ZIO[Any, DynamoPutError, Unit] =
     attemptBlocking {
       val request = TransactWriteItemsRequest.builder
         .transactItems(items.asJava)

--- a/app/services/DynamoSuperMode.scala
+++ b/app/services/DynamoSuperMode.scala
@@ -7,7 +7,7 @@ import models.SuperModeRow._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, QueryRequest}
 import utils.Circe.dynamoMapToJson
-import zio.{ZEnv, ZIO}
+import zio.ZIO
 
 import java.text.SimpleDateFormat
 import java.time.Instant
@@ -22,7 +22,7 @@ class DynamoSuperMode(client: DynamoDbClient) extends StrictLogging {
   private val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
   private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
 
-  private def get(endDate: String, endTimestamp: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
+  private def get(endDate: String, endTimestamp: String): ZIO[Any, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
     attemptBlocking {
       client.query(
         QueryRequest
@@ -38,7 +38,7 @@ class DynamoSuperMode(client: DynamoDbClient) extends StrictLogging {
       ).items()
     }.mapError(DynamoGetError)
 
-  private def getRowsForDate(date: String, endTimestamp: String): ZIO[ZEnv, DynamoGetError, List[SuperModeRow]] =
+  private def getRowsForDate(date: String, endTimestamp: String): ZIO[Any, DynamoGetError, List[SuperModeRow]] =
     get(date, endTimestamp).map(results =>
       results.asScala
         .map(item => dynamoMapToJson(item).as[SuperModeRow])
@@ -52,7 +52,7 @@ class DynamoSuperMode(client: DynamoDbClient) extends StrictLogging {
         .sortBy(_.endTimestamp)
     )
 
-  def getCurrentSuperModeRows(): ZIO[ZEnv, DynamoGetError, List[SuperModeRow]] = {
+  def getCurrentSuperModeRows(): ZIO[Any, DynamoGetError, List[SuperModeRow]] = {
     /**
      * Articles that are currently in super mode will have an endTimestamp later than now.
      * Because the index partition key is endDate, we have to make 2 queries for today and tomorrow

--- a/app/services/DynamoSuperMode.scala
+++ b/app/services/DynamoSuperMode.scala
@@ -8,13 +8,13 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, QueryRequest}
 import utils.Circe.dynamoMapToJson
 import zio.{ZEnv, ZIO}
-import zio.blocking.effectBlocking
 
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
 
 class DynamoSuperMode(client: DynamoDbClient) extends StrictLogging {
   private val tableName = s"super-mode-calculator-PROD"
@@ -23,7 +23,7 @@ class DynamoSuperMode(client: DynamoDbClient) extends StrictLogging {
   private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
 
   private def get(endDate: String, endTimestamp: String): ZIO[ZEnv, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =
-    effectBlocking {
+    attemptBlocking {
       client.query(
         QueryRequest
           .builder()

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -8,11 +8,12 @@ import services.S3Client._
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, ListObjectsRequest, ObjectCannedACL, PutObjectRequest}
 import zio._
-import zio.blocking.effectBlocking
 import software.amazon.awssdk.services.s3.{S3Client => AwsS3Client}
 import utils.Circe.noNulls
 
 import scala.jdk.CollectionConverters._
+import zio.ZIO.attemptBlocking
+import zio.managed._
 
 
 case class VersionedS3Data[T](value: T, version: String)
@@ -67,9 +68,9 @@ object S3 extends S3Client with StrictLogging {
       .build
 
     ZManaged
-      .fromAutoCloseable(effectBlocking(s3Client.getObject(request)))
+      .fromAutoCloseable(attemptBlocking(s3Client.getObject(request)))
       .use { s3Object =>
-        Task {
+        ZIO.attempt {
           VersionedS3Data(
             value = scala.io.Source.fromInputStream(s3Object).mkString,
             version = s3Object.response().versionId()
@@ -89,7 +90,7 @@ object S3 extends S3Client with StrictLogging {
       .key(objectSettings.key)
       .build
 
-    effectBlocking(s3Client.headObject(request))
+    attemptBlocking(s3Client.headObject(request))
       .mapError(e => {
         logger.error(s"Error getting object metadata for $objectSettings: ${e.getMessage}", e)
         S3GetObjectError(e)
@@ -99,13 +100,13 @@ object S3 extends S3Client with StrictLogging {
           createOrUpdate(data.value)(objectSettings)
         } else {
           logger.warn(s"Cannot update S3 object $objectSettings because provided version (${data.version}) does not match latest version (${response.versionId()})")
-          IO.fail(S3VersionMatchError)
+          ZIO.fail(S3VersionMatchError)
         }
       })
   }
 
   def createOrUpdate(data: String): S3Action[Unit] = { objectSettings =>
-      UIO.effectTotal {
+      ZIO.succeed {
         val request = PutObjectRequest.builder
           .bucket(objectSettings.bucket)
           .key(objectSettings.key)
@@ -122,7 +123,7 @@ object S3 extends S3Client with StrictLogging {
           .build()
 
       }.flatMap { request =>
-        effectBlocking {
+        attemptBlocking {
           s3Client.putObject(request, RequestBody.fromString(data))
         }.unit
       }
@@ -133,7 +134,7 @@ object S3 extends S3Client with StrictLogging {
   }
 
   def listKeys: S3Action[List[String]] = { objectSettings =>
-    effectBlocking {
+    attemptBlocking {
       val request = ListObjectsRequest
         .builder
         .bucket(objectSettings.bucket)
@@ -158,7 +159,7 @@ object S3Json extends StrictLogging {
   def getFromJson[T : Decoder](s3: S3Client): S3ObjectSettings => ZIO[ZEnv,Throwable,VersionedS3Data[T]] = { objectSettings =>
     s3.get(objectSettings).flatMap { raw =>
 
-      IO.fromEither(decode[T](raw.value))
+      ZIO.fromEither(decode[T](raw.value))
         .map(decoded => raw.copy(value = decoded))
         .mapError { error =>
           logger.error(s"Error decoding json from S3 ($objectSettings): ${error.getMessage}", error)

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.13.16"
 
 val circeVersion = "0.14.14"
 val awsVersion = "2.31.60"
-val zioVersion = "1.0.18"
+val zioVersion = "2.1.19"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, SbtWeb, JDebPackaging, SystemdPlugin,BuildInfoPlugin)
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,5 +11,3 @@ addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.14" artifacts (Artifact("jdeb", "jar", "jar"))
-
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.14" artifacts (Artifact("jdeb", "jar", "jar"))
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -119,7 +119,7 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
     var mockStore: Option[RawVersionedS3Data] = None
 
     def get: S3Action[RawVersionedS3Data] = { _ =>
-      IO.succeed {
+      ZIO.succeed {
         VersionedS3Data[String](
           expectedJson,
           "v1"
@@ -128,10 +128,10 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
     }
     def update(data: RawVersionedS3Data): S3Action[Unit] = _ => {
       mockStore = Some(data)
-      IO.succeed(())
+      ZIO.succeed(())
     }
-    def createOrUpdate(data: String): S3Action[Unit] = _ => IO.succeed(())
-    def listKeys: S3Action[List[String]] = _ => IO.succeed(Nil)
+    def createOrUpdate(data: String): S3Action[Unit] = _ => ZIO.succeed(())
+    def listKeys: S3Action[List[String]] = _ => ZIO.succeed(Nil)
   }
 
   it should "decode from json" in {

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -136,7 +136,6 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   it should "decode from json" in {
     val result = Await.result(
-//      runtime.unsafeRunToFuture {
       Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
         S3Json.getFromJson[SupportFrontendSwitches](dummyS3Client).apply(objectSettings)
       }},

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -7,7 +7,7 @@ import services.S3Client.{RawVersionedS3Data, S3Action, S3ObjectSettings}
 import models.SupportFrontendSwitches.{SupportFrontendSwitches, Switch, SwitchGroup}
 import models._
 import org.scalatest.matchers.should.Matchers
-import zio.IO
+import zio.{Unsafe, ZIO}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -136,9 +136,10 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   it should "decode from json" in {
     val result = Await.result(
-      runtime.unsafeRunToFuture {
+//      runtime.unsafeRunToFuture {
+      Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
         S3Json.getFromJson[SupportFrontendSwitches](dummyS3Client).apply(objectSettings)
-      },
+      }},
       1.second
     )
 
@@ -158,7 +159,7 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
     } yield json
 
     val jsonFromClient: RawVersionedS3Data = Await.result(
-      runtime.unsafeRunToFuture(program),
+      Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture(program) },
       1.second
     )
 


### PR DESCRIPTION
Scala steward tried and failed to do this here: https://github.com/guardian/support-admin-console/pull/752

It's quite a significant migration:
https://zio.dev/guides/migrate/zio-2.x-migration-guide/

The main changes are:
- `ZEnv` has been removed and can simply be replaced with `Any` (see https://zio.dev/guides/migrate/zio-2.x-migration-guide/#elimination-of-default-services-from-the-zio-environment)
- The new `Unsafe` type replaces the uses of `runtime.unsafeRun` (see https://zio.dev/guides/migrate/zio-2.x-migration-guide/#unsafe-marker)
- `effectBlocking` becomes `attemptBlocking`
- Small `ZStream` API changes - e.g. `fixed` becomes `schedule`
- `ZManaged` replaced by `Scope` type (see https://zio.dev/guides/migrate/zio-2.x-migration-guide/#immediate-migration)