### PR TITLE
Fix 'days between deploys' field

### DIFF
--- a/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/deployScheduleEditor.tsx
@@ -29,7 +29,7 @@ const DeployScheduleEditor: React.FC<DeployScheduleEditorProps> = ({
   const classes = useStyles();
 
   const defaultValues: BannerTestDeploySchedule = {
-    daysBetween: 1,
+    daysBetween: deploySchedule?.daysBetween ?? 1,
   };
   const {
     register,


### PR DESCRIPTION
Currently the banner tool does correctly save the value that the user enters in this field.
But - it always displays "1" instead of the actual value from the table.

<img width="372" alt="Screenshot 2025-07-01 at 11 30 04" src="https://github.com/user-attachments/assets/d0776bcb-4cd7-49f2-b9d9-ce1071c5bea4" />
