### PR TITLE
Add scalafmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 project/project
 dynamodb-local/
 project/metals.sbt
+dynamodb-local-metadata.json

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,5 @@
+version = 3.9.8
+runner.dialect = scala213
+
+maxColumn = 120
+

--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,18 @@ val circeVersion = "0.14.14"
 val awsVersion = "2.31.60"
 val zioVersion = "2.1.19"
 
+lazy val scalafmtSettings = Seq(
+  scalafmtFilter.withRank(KeyRanks.Invisible) := "diff-dirty",
+  (Test / test) := ((Test / test) dependsOn (Test / scalafmtCheckAll)).value,
+  (Test / testOnly) := ((Test / testOnly) dependsOn (Test / scalafmtCheckAll)).evaluated,
+  (Test / testQuick) := ((Test / testQuick) dependsOn (Test / scalafmtCheckAll)).evaluated,
+)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, SbtWeb, JDebPackaging, SystemdPlugin,BuildInfoPlugin)
   .settings(
     buildInfoKeys := BuildInfoSettings.buildInfoKeys,
     buildInfoPackage := "app",
+    scalafmtSettings,
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,6 @@ addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.14" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
Adds the [scalafmt plugin](https://scalameta.org/scalafmt/) and applies it to the codebase. For consistent formatting of the scala code.