### PR TITLE
Make audit page scrollable

### DIFF
--- a/public/src/components/channelManagement/auditTests/auditTestsDashboard.tsx
+++ b/public/src/components/channelManagement/auditTests/auditTestsDashboard.tsx
@@ -15,7 +15,10 @@ import { AuditDataRow, AuditTestsTable } from './auditTestsTable';
 import { useParams } from 'react-router-dom';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
-  container: {
+  mainContainer: {
+    overflow: 'scroll',
+  },
+  searchContainer: {
     margin: '50px',
     display: 'flex',
     gap: spacing(5),
@@ -36,7 +39,6 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
     width: '300px',
   },
   tableContainer: {
-    width: '100%',
     margin: spacing(7),
   },
 }));
@@ -76,8 +78,8 @@ export const AuditTestsDashboard: React.FC = () => {
   }, [testName, channel]);
 
   return (
-    <div>
-      <div className={classes.container}>
+    <div className={classes.mainContainer}>
+      <div className={classes.searchContainer}>
         <div>
           <div className={classes.sectionContainer}>
             <Typography className={classes.heading}>Test Name</Typography>


### PR DESCRIPTION
Currently the table on the audit page disappears off the bottom and right of the page, which means you cannot see the full list:
<img width="1145" alt="Screenshot 2025-07-10 at 09 25 48" src="https://github.com/user-attachments/assets/e8cc6df1-734c-4298-862c-85ab084e9cb2" />

This PR fixes that:
<img width="1145" alt="Screenshot 2025-07-10 at 09 25 57" src="https://github.com/user-attachments/assets/2e2abdae-55c3-4bed-bcb6-90ce5859ea10" />
