### PR TITLE
Set jackson version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.13.16"
 val circeVersion = "0.14.14"
 val awsVersion = "2.31.78"
 val zioVersion = "2.1.19"
-val jacksonVersion = "2.17.2"
+val jacksonVersion = "2.17.3"
 
 lazy val scalafmtSettings = Seq(
   scalafmtFilter.withRank(KeyRanks.Invisible) := "diff-dirty",

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.13.16"
 val circeVersion = "0.14.14"
 val awsVersion = "2.31.78"
 val zioVersion = "2.1.19"
+val jacksonVersion = "2.17.2"
 
 lazy val scalafmtSettings = Seq(
   scalafmtFilter.withRank(KeyRanks.Invisible) := "diff-dirty",
@@ -48,8 +49,14 @@ libraryDependencies ++= Seq(
 
 dependencyOverrides ++= List(
   // Play still uses an old version of jackson-core which has a vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.17.3",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3",
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+  "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "io.netty" % "netty-handler" % "4.1.122.Final",
   "io.netty" % "netty-codec-http2" % "4.1.122.Final",
   // Related to Play 3.0.2-6 currently brings in a vulnerable version of commons-io


### PR DESCRIPTION
Play is still pulling in an old version of jackson with vulnerabilities.
See https://github.com/orgs/playframework/discussions/11222.
A number of our codebases are having to fix all jackson deps, e.g. https://github.com/guardian/frontend/pull/27447

Prompted by a broken scala steward PR - https://github.com/guardian/support-admin-console/pull/752