### PR TITLE
Fix SAC compile warnings

### DIFF
--- a/app/models/Amounts.scala
+++ b/app/models/Amounts.scala
@@ -29,11 +29,13 @@ object AmountsTestTargeting {
   case class Region(targetingType: String = "Region", region: RegionEnum) extends AmountsTestTargeting
   case class Country(targetingType: String = "Country", countries: List[String]) extends AmountsTestTargeting
 
-  import io.circe.generic.extras.auto._
+  import io.circe.generic.extras.semiauto._
   implicit val customConfig: Configuration = Configuration.default.withDiscriminator("targetingType")
 
-  implicit val amountsTestTargetingDecoder = Decoder[AmountsTestTargeting]
-  implicit val amountsTestTargetingEncoder = Encoder[AmountsTestTargeting]
+  implicit val amountsTestTargetingDecoder: Decoder[AmountsTestTargeting] =
+    deriveConfiguredDecoder[AmountsTestTargeting]
+  implicit val amountsTestTargetingEncoder: Encoder[AmountsTestTargeting] =
+    deriveConfiguredEncoder[AmountsTestTargeting]
 }
 
 case class AmountsTest(
@@ -53,6 +55,6 @@ object AmountsTests {
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
 
-  implicit val decoder = Decoder[AmountsTests]
-  implicit val encoder = Encoder[AmountsTests]
+  implicit val decoder: Decoder[AmountsTests] = Decoder.decodeList[AmountsTest]
+  implicit val encoder: Encoder[AmountsTests] = Encoder.encodeList[AmountsTest]
 }

--- a/app/models/AppsMeteringSwitches.scala
+++ b/app/models/AppsMeteringSwitches.scala
@@ -1,6 +1,6 @@
 package models
 
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 
 case class AppsMeteringSwitches(
@@ -10,6 +10,6 @@ case class AppsMeteringSwitches(
 )
 
 object AppsMeteringSwitches {
-  implicit val decoder = Decoder[AppsMeteringSwitches]
-  implicit val encoder = Encoder[AppsMeteringSwitches]
+  implicit val decoder: Decoder[AppsMeteringSwitches] = deriveDecoder[AppsMeteringSwitches]
+  implicit val encoder: Encoder[AppsMeteringSwitches] = deriveEncoder[AppsMeteringSwitches]
 }

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -2,7 +2,7 @@ package models
 
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.Configuration
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
 sealed trait BannerDesignStatus
 
@@ -108,7 +108,7 @@ case class TickerDesign(
 
 object TickerDesign {
   import io.circe.generic.auto._
-  implicit val encoder: Encoder[TickerDesign] = Encoder[TickerDesign]
+  implicit val encoder: Encoder[TickerDesign] = deriveEncoder[TickerDesign]
 
   // Modify the Decoder to use existing values for the new fields
   private val normalDecoder: Decoder[TickerDesign] = deriveDecoder[TickerDesign]

--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -2,7 +2,7 @@ package models
 
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+import io.circe.generic.semiauto.deriveDecoder
 
 sealed trait BannerDesignStatus
 
@@ -11,9 +11,10 @@ object BannerDesignStatus {
 
   case object Draft extends BannerDesignStatus
 
+  import io.circe.generic.extras.semiauto._
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val statusEncoder = deriveEnumerationEncoder[BannerDesignStatus]
-  implicit val statusDecoder = deriveEnumerationDecoder[BannerDesignStatus]
+  implicit val statusEncoder: Encoder[BannerDesignStatus] = deriveEnumerationEncoder[BannerDesignStatus]
+  implicit val statusDecoder: Decoder[BannerDesignStatus] = deriveEnumerationDecoder[BannerDesignStatus]
 }
 
 case class HeaderImage(
@@ -29,6 +30,7 @@ object FontSize {
   case object medium extends FontSize
   case object large extends FontSize
 
+  import io.circe.generic.extras.semiauto._
   implicit val decoder: Decoder[FontSize] = deriveEnumerationDecoder[FontSize]
   implicit val encoder: Encoder[FontSize] = deriveEnumerationEncoder[FontSize]
 }
@@ -58,8 +60,9 @@ object BannerDesignVisual {
   import io.circe.generic.extras.auto._
   implicit val customConfig: Configuration = Configuration.default.withDiscriminator("kind")
 
-  implicit val encoder = Encoder[BannerDesignVisual]
-  implicit val decoder = Decoder[BannerDesignVisual]
+  import io.circe.generic.extras.semiauto._
+  implicit val encoder: Encoder[BannerDesignVisual] = deriveConfiguredEncoder[BannerDesignVisual]
+  implicit val decoder: Decoder[BannerDesignVisual] = deriveConfiguredDecoder[BannerDesignVisual]
 }
 
 case class HexColour(
@@ -105,11 +108,11 @@ case class TickerDesign(
 
 object TickerDesign {
   import io.circe.generic.auto._
-  implicit val encoder = Encoder[TickerDesign]
+  implicit val encoder: Encoder[TickerDesign] = Encoder[TickerDesign]
 
   // Modify the Decoder to use existing values for the new fields
-  val normalDecoder = Decoder[TickerDesign]
-  implicit val decoder = normalDecoder.map(design => {
+  private val normalDecoder: Decoder[TickerDesign] = deriveDecoder[TickerDesign]
+  implicit val decoder: Decoder[TickerDesign] = normalDecoder.map(design => {
     val headlineColour = design.headlineColour.getOrElse(design.text)
     val totalColour = design.totalColour.getOrElse(design.text)
     val goalColour = design.goalColour.getOrElse(design.text)

--- a/app/models/Campaigns.scala
+++ b/app/models/Campaigns.scala
@@ -1,7 +1,7 @@
 package models
 
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
 case class Campaign(
@@ -14,14 +14,14 @@ case class Campaign(
 
 object Campaigns {
   type Campaigns = List[Campaign]
-
+  import io.circe.generic.extras.auto._
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val decoder = Decoder[Campaigns]
-  implicit val encoder = Encoder[Campaigns]
+  implicit val decoder: Decoder[Campaigns] = Decoder.decodeList[Campaign]
+  implicit val encoder: Encoder[Campaigns] = Encoder.encodeList[Campaign]
 }
 
 object Campaign {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val decoder = Decoder[Campaign]
-  implicit val encoder = Encoder[Campaign]
+  implicit val decoder: Decoder[Campaign] = deriveConfiguredDecoder[Campaign]
+  implicit val encoder: Encoder[Campaign] = deriveConfiguredEncoder[Campaign]
 }

--- a/app/models/Channel.scala
+++ b/app/models/Channel.scala
@@ -1,5 +1,6 @@
 package models
 
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 
@@ -17,6 +18,6 @@ object Channel {
   case object SupportLandingPage extends Channel
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val statusEncoder = deriveEnumerationEncoder[Channel]
-  implicit val statusDecoder = deriveEnumerationDecoder[Channel]
+  implicit val statusEncoder: Encoder[Channel] = deriveEnumerationEncoder[Channel]
+  implicit val statusDecoder: Decoder[Channel] = deriveEnumerationDecoder[Channel]
 }

--- a/app/models/ChannelSwitches.scala
+++ b/app/models/ChannelSwitches.scala
@@ -1,7 +1,7 @@
 package models
 
 import io.circe.{Decoder, Encoder}
-import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.generic.extras.Configuration
 
 case class ChannelSwitches(
@@ -18,6 +18,6 @@ case class ChannelSwitches(
 
 object ChannelSwitches {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val decoder = Decoder[ChannelSwitches]
-  implicit val encoder = Encoder[ChannelSwitches]
+  implicit val decoder: Decoder[ChannelSwitches] = deriveConfiguredDecoder[ChannelSwitches]
+  implicit val encoder: Encoder[ChannelSwitches] = deriveConfiguredEncoder[ChannelSwitches]
 }

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -15,8 +15,8 @@ object Status {
   case object Archived extends Status
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val statusEncoder = deriveEnumerationEncoder[Status]
-  implicit val statusDecoder = deriveEnumerationDecoder[Status]
+  implicit val statusEncoder: Encoder[Status] = deriveEnumerationEncoder[Status]
+  implicit val statusDecoder: Decoder[Status] = deriveEnumerationDecoder[Status]
 }
 
 trait ChannelTest[T] {
@@ -35,7 +35,7 @@ trait ChannelTest[T] {
 object ChannelTest {
   import Channel._
 
-  implicit def channelTestDecoder = new Decoder[ChannelTest[_]] {
+  implicit def channelTestDecoder: Decoder[ChannelTest[_]] = new Decoder[ChannelTest[_]] {
     override def apply(c: HCursor): Result[ChannelTest[_]] = {
       c.downField("channel").as[Channel].flatMap {
         case Header             => HeaderTest.headerTestDecoder(c)
@@ -47,7 +47,7 @@ object ChannelTest {
     }
   }
 
-  implicit def channelTestEncoder = new Encoder[ChannelTest[_]] {
+  implicit def channelTestEncoder: Encoder[ChannelTest[_]] = new Encoder[ChannelTest[_]] {
     override def apply(test: ChannelTest[_]): Json = test match {
       case header: HeaderTest                  => HeaderTest.headerTestEncoder(header)
       case banner: BannerTest                  => BannerTest.bannerTestEncoder(banner)

--- a/app/models/ChoiceCardsSettings.scala
+++ b/app/models/ChoiceCardsSettings.scala
@@ -4,7 +4,12 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.auto._
 import ChoiceCardsSettings._
-import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+import io.circe.generic.extras.semiauto.{
+  deriveConfiguredDecoder,
+  deriveConfiguredEncoder,
+  deriveEnumerationDecoder,
+  deriveEnumerationEncoder
+}
 
 case class ChoiceCardsSettings(choiceCards: List[ChoiceCard])
 
@@ -17,8 +22,8 @@ object ChoiceCardsSettings {
     object Annual extends RatePlan
 
     implicit val customConfig: Configuration = Configuration.default.withDefaults
-    implicit val ratePlanEncoder = deriveEnumerationEncoder[RatePlan]
-    implicit val ratePlanDecoder = deriveEnumerationDecoder[RatePlan]
+    implicit val ratePlanEncoder: Encoder[RatePlan] = deriveEnumerationEncoder[RatePlan]
+    implicit val ratePlanDecoder: Decoder[RatePlan] = deriveEnumerationDecoder[RatePlan]
   }
 
   sealed trait Product {
@@ -39,10 +44,9 @@ object ChoiceCardsSettings {
         supportTier: String = "OneOff"
     ) extends Product
 
-    import io.circe.generic.extras.auto._
     implicit val customConfig: Configuration = Configuration.default.withDiscriminator("supportTier")
-    implicit val productDecoder = Decoder[Product]
-    implicit val productEncoder = Encoder[Product]
+    implicit val productDecoder: Decoder[Product] = deriveConfiguredDecoder[Product]
+    implicit val productEncoder: Encoder[Product] = deriveConfiguredEncoder[Product]
   }
 
   case class Pill(copy: String)
@@ -56,6 +60,7 @@ object ChoiceCardsSettings {
       isDefault: Boolean
   )
 
-  implicit val choiceCardsSettingsDecoder = Decoder[ChoiceCardsSettings]
-  implicit val choiceCardsSettingsEncoder = Encoder[ChoiceCardsSettings]
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val choiceCardsSettingsDecoder: Decoder[ChoiceCardsSettings] = deriveConfiguredDecoder[ChoiceCardsSettings]
+  implicit val choiceCardsSettingsEncoder: Encoder[ChoiceCardsSettings] = deriveConfiguredEncoder[ChoiceCardsSettings]
 }

--- a/app/models/Cta.scala
+++ b/app/models/Cta.scala
@@ -1,9 +1,15 @@
 package models
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
 case class Cta(text: String, baseUrl: String)
+
+object Cta {
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val secondaryCtaDecoder: Decoder[Cta] = deriveConfiguredDecoder[Cta]
+  implicit val secondaryCtaEncoder: Encoder[Cta] = deriveConfiguredEncoder[Cta]
+}
 
 sealed trait SecondaryCta
 
@@ -19,6 +25,6 @@ case class ContributionsReminderSecondaryCta(
 object SecondaryCta {
   implicit val customConfig: Configuration = Configuration.default.withDiscriminator("type")
 
-  implicit val secondaryCtaDecoder = Decoder[SecondaryCta]
-  implicit val secondaryCtaEncoder = Encoder[SecondaryCta]
+  implicit val secondaryCtaDecoder: Decoder[SecondaryCta] = deriveConfiguredDecoder[SecondaryCta]
+  implicit val secondaryCtaEncoder: Encoder[SecondaryCta] = deriveConfiguredEncoder[SecondaryCta]
 }

--- a/app/models/DefaultPromos.scala
+++ b/app/models/DefaultPromos.scala
@@ -1,6 +1,6 @@
 package models
 
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 
 case class DefaultPromos(
@@ -12,6 +12,6 @@ case class DefaultPromos(
 )
 
 object DefaultPromos {
-  implicit val decoder = Decoder[DefaultPromos]
-  implicit val encoder = Encoder[DefaultPromos]
+  implicit val decoder: Decoder[DefaultPromos] = deriveDecoder[DefaultPromos]
+  implicit val encoder: Encoder[DefaultPromos] = deriveEncoder[DefaultPromos]
 }

--- a/app/models/Methodology.scala
+++ b/app/models/Methodology.scala
@@ -1,7 +1,7 @@
 package models
 
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.auto._
+import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
 sealed trait Methodology {
@@ -31,6 +31,6 @@ case object Methodology {
 
   implicit val customConfig: Configuration = Configuration.default.withDiscriminator("name")
 
-  implicit val methodologyDecoder = Decoder[Methodology]
-  implicit val methodologyEncoder = Encoder[Methodology]
+  implicit val methodologyDecoder: Decoder[Methodology] = deriveConfiguredDecoder[Methodology]
+  implicit val methodologyEncoder: Encoder[Methodology] = deriveConfiguredEncoder[Methodology]
 }

--- a/app/models/SuperMode.scala
+++ b/app/models/SuperMode.scala
@@ -1,7 +1,7 @@
 package models
 
 import io.circe.{Decoder, Encoder}
-import io.circe.generic.auto._
+import io.circe.generic.semiauto._
 
 case class SuperModeRow(
     url: String,
@@ -15,6 +15,6 @@ case class SuperModeRow(
 )
 
 object SuperModeRow {
-  implicit val encoder = Encoder[SuperModeRow]
-  implicit val decoder = Decoder[SuperModeRow]
+  implicit val encoder: Encoder[SuperModeRow] = deriveEncoder[SuperModeRow]
+  implicit val decoder: Decoder[SuperModeRow] = deriveDecoder[SuperModeRow]
 }

--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -3,7 +3,7 @@ package models
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.generic.extras.auto._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 
 sealed trait SwitchState
 case object On extends SwitchState
@@ -20,6 +20,14 @@ object SupportFrontendSwitches {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val stateDecoder: Decoder[SwitchState] = deriveEnumerationDecoder[SwitchState]
   implicit val stateEncoder: Encoder[SwitchState] = deriveEnumerationEncoder[SwitchState]
-  implicit val SupportFrontendSwitchesDecoder: Decoder[SupportFrontendSwitches] = Decoder[SupportFrontendSwitches]
-  implicit val SupportFrontendSwitchesEncoder: Encoder[SupportFrontendSwitches] = Encoder[SupportFrontendSwitches]
+  import io.circe.generic.extras.semiauto._
+
+  implicit val switchDecoder: Decoder[Switch] = deriveConfiguredDecoder[Switch]
+  implicit val switchEncoder: Encoder[Switch] = deriveConfiguredEncoder[Switch]
+  implicit val switchGroupDecoder: Decoder[SwitchGroup] = deriveConfiguredDecoder[SwitchGroup]
+  implicit val switchGroupEncoder: Encoder[SwitchGroup] = deriveConfiguredEncoder[SwitchGroup]
+  implicit val SupportFrontendSwitchesDecoder: Decoder[SupportFrontendSwitches] =
+    Decoder.decodeMap[GroupName, SwitchGroup](KeyDecoder.decodeKeyString, switchGroupDecoder)
+  implicit val SupportFrontendSwitchesEncoder: Encoder[SupportFrontendSwitches] =
+    Encoder.encodeMap[GroupName, SwitchGroup](KeyEncoder.encodeKeyString, switchGroupEncoder)
 }

--- a/app/models/SupportFrontendSwitches.scala
+++ b/app/models/SupportFrontendSwitches.scala
@@ -1,8 +1,8 @@
 package models
 
 import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto._
 import io.circe.generic.extras.auto._
-import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 import io.circe.{Decoder, Encoder}
 
 sealed trait SwitchState
@@ -20,6 +20,6 @@ object SupportFrontendSwitches {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val stateDecoder: Decoder[SwitchState] = deriveEnumerationDecoder[SwitchState]
   implicit val stateEncoder: Encoder[SwitchState] = deriveEnumerationEncoder[SwitchState]
-  implicit val SupportFrontendSwitchesDecoder = Decoder[SupportFrontendSwitches]
-  implicit val SupportFrontendSwitchesEncoder = Encoder[SupportFrontendSwitches]
+  implicit val SupportFrontendSwitchesDecoder: Decoder[SupportFrontendSwitches] = Decoder[SupportFrontendSwitches]
+  implicit val SupportFrontendSwitchesEncoder: Encoder[SupportFrontendSwitches] = Encoder[SupportFrontendSwitches]
 }

--- a/app/models/Ticker.scala
+++ b/app/models/Ticker.scala
@@ -1,4 +1,5 @@
 package models
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 
@@ -9,8 +10,8 @@ object TickerName {
   case object global extends TickerName
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults
-  implicit val encoder = deriveEnumerationEncoder[TickerName]
-  implicit val decoder = deriveEnumerationDecoder[TickerName]
+  implicit val encoder: Encoder[TickerName] = deriveEnumerationEncoder[TickerName]
+  implicit val decoder: Decoder[TickerName] = deriveEnumerationDecoder[TickerName]
 }
 
 case class TickerCopy(

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -23,8 +23,8 @@ case class VariantSample(
 )
 case class TestSample(testName: String, variants: List[VariantSample], timestamp: String)
 object TestSample {
-  implicit val decoder = Decoder[TestSample]
-  implicit val encoder = Encoder[TestSample]
+  implicit val decoder: Decoder[TestSample] = Decoder[TestSample]
+  implicit val encoder: Encoder[TestSample] = Encoder[TestSample]
 }
 
 /** Models for data returned to the client
@@ -39,8 +39,8 @@ case class VariantSummary(variantName: String, mean: Double, views: Double)
 
 case class BanditData(variantSummaries: List[VariantSummary], samples: List[EnrichedTestSampleData])
 object BanditData {
-  implicit val decoder = Decoder[BanditData]
-  implicit val encoder = Encoder[BanditData]
+  implicit val decoder: Decoder[BanditData] = Decoder[BanditData]
+  implicit val encoder: Encoder[BanditData] = Encoder[BanditData]
 }
 
 class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogging {

--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, QueryRequest}
 import utils.Circe.dynamoMapToJson
 import io.circe.generic.auto._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import zio.ZIO
 
 import scala.jdk.CollectionConverters._
@@ -23,8 +24,8 @@ case class VariantSample(
 )
 case class TestSample(testName: String, variants: List[VariantSample], timestamp: String)
 object TestSample {
-  implicit val decoder: Decoder[TestSample] = Decoder[TestSample]
-  implicit val encoder: Encoder[TestSample] = Encoder[TestSample]
+  implicit val decoder: Decoder[TestSample] = deriveDecoder[TestSample]
+  implicit val encoder: Encoder[TestSample] = deriveEncoder[TestSample]
 }
 
 /** Models for data returned to the client
@@ -39,8 +40,8 @@ case class VariantSummary(variantName: String, mean: Double, views: Double)
 
 case class BanditData(variantSummaries: List[VariantSummary], samples: List[EnrichedTestSampleData])
 object BanditData {
-  implicit val decoder: Decoder[BanditData] = Decoder[BanditData]
-  implicit val encoder: Encoder[BanditData] = Encoder[BanditData]
+  implicit val decoder: Decoder[BanditData] = deriveDecoder[BanditData]
+  implicit val encoder: Encoder[BanditData] = deriveEncoder[BanditData]
 }
 
 class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogging {

--- a/app/services/DynamoChannelTestsAudit.scala
+++ b/app/services/DynamoChannelTestsAudit.scala
@@ -26,8 +26,8 @@ object DynamoChannelTestsAudit {
       item: T // The new state of the item being changed
   )
 
-  implicit def encoder[T: Encoder: Decoder] = deriveEncoder[ChannelTestAudit[T]]
-  implicit def decoder[T: Encoder: Decoder] = deriveDecoder[ChannelTestAudit[T]]
+  implicit def encoder[T: Encoder: Decoder]: Encoder[ChannelTestAudit[T]] = deriveEncoder[ChannelTestAudit[T]]
+  implicit def decoder[T: Encoder: Decoder]: Decoder[ChannelTestAudit[T]] = deriveDecoder[ChannelTestAudit[T]]
 
   private val RetentionPeriodInYears = 1
   def getTimeToLive(timestamp: OffsetDateTime): OffsetDateTime = timestamp.plusYears(RetentionPeriodInYears)

--- a/app/services/DynamoPermissionsCache.scala
+++ b/app/services/DynamoPermissionsCache.scala
@@ -6,7 +6,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 import io.circe.generic.auto._
 import models.DynamoErrors.DynamoGetError
-import services.UserPermissions.{PagePermission, UserPermissions, decoder}
+import services.UserPermissions._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ScanRequest}
 import utils.Circe.dynamoMapToJson
@@ -29,8 +29,8 @@ object UserPermissions {
   case class PagePermission(name: String, permission: Permission)
   case class UserPermissions(email: String, permissions: List[PagePermission])
 
-  implicit val encoder = Encoder[UserPermissions]
-  implicit val decoder = Decoder[UserPermissions]
+  implicit val encoder: Encoder[UserPermissions] = Encoder[UserPermissions]
+  implicit val decoder: Decoder[UserPermissions] = Decoder[UserPermissions]
 }
 
 /** Polls the user permissions DynamoDb table and caches all permissions in memory

--- a/app/services/DynamoPermissionsCache.scala
+++ b/app/services/DynamoPermissionsCache.scala
@@ -5,6 +5,7 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
 import io.circe.generic.auto._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import models.DynamoErrors.DynamoGetError
 import services.UserPermissions._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
@@ -29,8 +30,8 @@ object UserPermissions {
   case class PagePermission(name: String, permission: Permission)
   case class UserPermissions(email: String, permissions: List[PagePermission])
 
-  implicit val encoder: Encoder[UserPermissions] = Encoder[UserPermissions]
-  implicit val decoder: Decoder[UserPermissions] = Decoder[UserPermissions]
+  implicit val encoder: Encoder[UserPermissions] = deriveEncoder[UserPermissions]
+  implicit val decoder: Decoder[UserPermissions] = deriveDecoder[UserPermissions]
 }
 
 /** Polls the user permissions DynamoDb table and caches all permissions in memory

--- a/app/services/DynamoPermissionsCache.scala
+++ b/app/services/DynamoPermissionsCache.scala
@@ -75,7 +75,7 @@ class DynamoPermissionsCache(
 
   private def updatePermissions(permissions: Map[Email, UserPermissions]) = {
     permissionsCache.set(permissions)
-    ZIO.succeed()
+    ZIO.succeed(())
   }
 
   // Poll every minute in the background

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -25,7 +25,7 @@ class AppLoader extends ApplicationLoader with StrictLogging {
           ) // assume conf is available locally
       }
 
-      context.copy(initialConfiguration = context.initialConfiguration ++ Configuration(loadedConfig))
+      context.copy(initialConfiguration = context.initialConfiguration.withFallback(Configuration(loadedConfig)))
     }
 
     val application: Try[Application] = for {

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -25,7 +25,7 @@ class AppLoader extends ApplicationLoader with StrictLogging {
           ) // assume conf is available locally
       }
 
-      context.copy(initialConfiguration = context.initialConfiguration.withFallback(Configuration(loadedConfig)))
+      context.copy(initialConfiguration = context.initialConfiguration ++ Configuration(loadedConfig))
     }
 
     val application: Try[Application] = for {

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -25,7 +25,7 @@ class AppLoader extends ApplicationLoader with StrictLogging {
           ) // assume conf is available locally
       }
 
-      context.copy(initialConfiguration = context.initialConfiguration ++ Configuration(loadedConfig))
+      context.copy(initialConfiguration = Configuration(loadedConfig).withFallback(context.initialConfiguration))
     }
 
     val application: Try[Application] = for {

--- a/conf/routes
+++ b/conf/routes
@@ -216,7 +216,7 @@ GET   /frontend/channel-switches                       controllers.ChannelSwitch
 POST  /frontend/channel-switches/update                controllers.ChannelSwitchesController.set
 
 # ----- campaigns ----- #
-GET   /frontend/campaigns                              controllers.CampaignsController.get
+GET   /frontend/campaigns                              controllers.CampaignsController.get()
 POST  /frontend/campaigns/create                       controllers.CampaignsController.createCampaign
 POST  /frontend/campaigns/update                       controllers.CampaignsController.updateCampaign
 GET   /frontend/campaign/:campaignName/tests           controllers.CampaignsController.getTests(campaignName: String)

--- a/test/services/S3JsonSpec.scala
+++ b/test/services/S3JsonSpec.scala
@@ -100,8 +100,8 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
       "campaignSwitches" -> SwitchGroup(
         description = "Campaign switches",
         switches = Map(
-          "enableCampaign"-> Switch("Enable contributions campaign", On),
-          "forceAll"-> Switch("Force all users into the campaign", On)
+          "enableCampaign" -> Switch("Enable contributions campaign", On),
+          "forceAll" -> Switch("Force all users into the campaign", On)
         )
       )
     ),
@@ -136,9 +136,11 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   it should "decode from json" in {
     val result = Await.result(
-      Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture {
-        S3Json.getFromJson[SupportFrontendSwitches](dummyS3Client).apply(objectSettings)
-      }},
+      Unsafe.unsafe { implicit unsafe =>
+        runtime.unsafe.runToFuture {
+          S3Json.getFromJson[SupportFrontendSwitches](dummyS3Client).apply(objectSettings)
+        }
+      },
       1.second
     )
 
@@ -152,6 +154,7 @@ class S3JsonSpec extends AnyFlatSpec with Matchers with EitherValues {
     import diffson.jsonpatch.lcsdiff._
     import io.circe.parser._
 
+    import SupportFrontendSwitches.SupportFrontendSwitchesEncoder
     val program = for {
       _ <- S3Json.updateAsJson[SupportFrontendSwitches](expectedDecoded)(dummyS3Client).apply(objectSettings)
       json <- dummyS3Client.get(objectSettings)


### PR DESCRIPTION
## What does this change?

This PR fixes most of the SAC compliation warnings.

Most of the warnings were about "Implicit definition should have explicit type", related to [Circe Decoders and Encoders](https://circe.github.io/circe/codec.html)

Simply adding the types however caused it to throw NullPointerException at runtime. E.g. changing
`implicit val decoder = Decoder[AppsMeteringSwitches]`
to
`implicit val decoder: Decoder[AppsMeteringSwitches] = Decoder[AppsMeteringSwitches]`
leads to the runtime error:
```
[sbt] Caused by: java.lang.NullPointerException: null
[sbt] 	at io.circe.Parser.finishDecode(Parser.scala:31)
```

Instead, the solution is to switch from [automatic](https://circe.github.io/circe/codecs/auto-derivation.html) to [semiautomatic](https://circe.github.io/circe/codecs/semiauto-derivation.html) derivation. E.g.

`implicit val decoder: Decoder[AppsMeteringSwitches] = deriveDecoder[AppsMeteringSwitches]`


## How to test

Test in CODE by deploying the branch and looking for any errors

