### PR TITLE
Fix banner preview - update storybook module name

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerVariantPreview.tsx
@@ -171,7 +171,7 @@ const BannerVariantPreview: React.FC<BannerVariantPreviewProps> = ({
   };
 
   const props = buildProps(variant, tickerSettingsWithData, design);
-  const storyName = 'components-marketing-designablebannerv2--default';
+  const storyName = 'components-marketing-designablebanner--default';
   const storybookUrl = buildStorybookUrl(storyName, props);
 
   return (


### PR DESCRIPTION
## What does this change?

Now that the DesignableBannerV2 story has been renamed, change the name of the module used for live-preview so that it picks up the correct story.

## How to test

Deploy to CODE and open live-preview for a banner - you should see the banner rather than an error.