### PR TITLE
Increase cache duration for GoogleGroupChecker following timeouts

### DIFF
--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -12,23 +12,10 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.{
-  Aws,
-  BigQueryService,
-  CapiService,
-  DynamoArchivedBannerDesigns,
-  DynamoArchivedChannelTests,
-  DynamoBanditData,
-  DynamoBannerDesigns,
-  DynamoCampaigns,
-  DynamoChannelTests,
-  DynamoChannelTestsAudit,
-  DynamoPermissionsCache,
-  DynamoSuperMode,
-  S3
-}
+import services.{Aws, BigQueryService, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoChannelTestsAudit, DynamoPermissionsCache, DynamoSuperMode, S3}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import java.time.Duration
 
 class AppComponents(context: Context, stage: String)
     extends BuiltInComponentsFromContext(context)
@@ -70,7 +57,8 @@ class AppComponents(context: Context, stage: String)
 
     new GoogleGroupChecker(
       impersonatedUser,
-      googleServiceAccountCredential
+      googleServiceAccountCredential,
+      Duration.ofHours(1)
     )
   }
 


### PR DESCRIPTION
## What does this change?

This increases the duration of the cache for GoogleGroupChecker from the default of 1 minute to 1 hour.  We are doing this because we have had a series of alerts recently from support-admin-console which relate to timeouts and the common item in each stack trace is the GoogleGroupChecker.  This is a strategy to see if this is what is timing out.

## How to test

Deploy to CODE and attempt to use the RRCP UI - it should authenticate as normal

## How can we measure success?

We should see a reduction in the number of timeout errors in alerts that we have been experiencing lately