### PR TITLE
Remove hover colour inputs and hover from models

### DIFF
--- a/app/models/BannerDesign.scala
+++ b/app/models/BannerDesign.scala
@@ -93,7 +93,6 @@ case class CtaStateDesign(
 
 case class CtaDesign(
     default: CtaStateDesign,
-    hover: CtaStateDesign
 )
 
 case class TickerDesign(

--- a/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
+++ b/public/src/components/channelManagement/bannerDesigns/CtaColoursEditor.tsx
@@ -79,35 +79,6 @@ export const CtaColoursEditor: React.FC<Props> = ({
             onValidationChange={onValidationChange}
           />
         </div>
-
-        <div className={classes.stateContainer}>
-          <div className={classes.stateLabel}>Hover</div>
-
-          <ColourInput
-            colour={cta.hover.text}
-            name={`${name}.text`}
-            label="Text Colour"
-            isDisabled={isDisabled}
-            onChange={colour => onChange({ ...cta, hover: { ...cta.hover, text: colour } })}
-            onValidationChange={onValidationChange}
-          />
-          <ColourInput
-            colour={cta.hover.background}
-            name={`${name}.background`}
-            label="Background Colour"
-            isDisabled={isDisabled}
-            onChange={colour => onChange({ ...cta, hover: { ...cta.hover, background: colour } })}
-            onValidationChange={onValidationChange}
-          />
-          <OptionalColourInput
-            colour={cta.hover.border}
-            name={`${name}.border`}
-            label="Border Colour"
-            isDisabled={isDisabled}
-            onChange={colour => onChange({ ...cta, hover: { ...cta.hover, border: colour } })}
-            onValidationChange={onValidationChange}
-          />
-        </div>
       </div>
     </div>
   );

--- a/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/defaults.ts
@@ -53,20 +53,11 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
         text: stringToHexColour('FFFFFF'),
         background: stringToHexColour('0077B6'),
       },
-      hover: {
-        text: stringToHexColour('FFFFFF'),
-        background: stringToHexColour('004E7C'),
-      },
     },
     secondaryCta: {
       default: {
         text: stringToHexColour('004E7C'),
         background: stringToHexColour('F1F8FC'),
-        border: stringToHexColour('004E7C'),
-      },
-      hover: {
-        text: stringToHexColour('004E7C'),
-        background: stringToHexColour('E5E5E5'),
         border: stringToHexColour('004E7C'),
       },
     },
@@ -75,10 +66,6 @@ export const createDefaultBannerDesign = (name: string): BannerDesign => ({
         text: stringToHexColour('052962'),
         background: stringToHexColour('F1F8FC'),
         border: stringToHexColour('052962'),
-      },
-      hover: {
-        text: stringToHexColour('052962'),
-        background: stringToHexColour('E5E5E5'),
       },
     },
     ticker: {

--- a/public/src/models/bannerDesign.ts
+++ b/public/src/models/bannerDesign.ts
@@ -27,7 +27,6 @@ interface CtaStateDesign {
 }
 export interface CtaDesign {
   default: CtaStateDesign;
-  hover: CtaStateDesign;
 }
 
 export interface TickerDesign {


### PR DESCRIPTION
## What does this change?

Removes the hover colour pickers from the Banner Design UI and removes hover from the models.
These are no longer required as we are using automated hover colour selection in dotcom-rendering. 

## How to test

Deploy to CODE and open a design - note that the colour pickers no longer exist for hover.
Update a colour and save the design.

## How can we measure success?

This removes hover colours which reduces the complexity of the code.

## Have we considered potential risks?

Further investigation needs to happen before deploying to PROD - will it break existing designs?

## Images

| Before      | After      |
| ----------- | ---------- |
| <img width="654" height="559" alt="Screenshot 2025-07-24 at 17 37 01" src="https://github.com/user-attachments/assets/790918e7-7881-4053-b67c-300fd7b11b5f" /> | <img width="585" height="463" alt="Screenshot 2025-07-24 at 17 40 23" src="https://github.com/user-attachments/assets/41b56d07-55df-4705-8c85-f62c3591d41f" /> |





