### PR TITLE
Add backend promos models

### DIFF
--- a/app/models/promos/Promo.scala
+++ b/app/models/promos/Promo.scala
@@ -1,0 +1,19 @@
+package models.promos
+
+import com.gu.i18n.Country
+
+case class AppliesTo(
+  productRatePlanIds: Set[String],
+  countries: Set[Country]
+)
+
+case class Promo(
+  promoCode: String,
+  name: String,
+  campaignCode: String,
+  appliesTo: AppliesTo,
+  startTimestamp: String,
+  endTimestamp: String,
+  description: Option[String],
+  // TODO - landing page config for print products
+)

--- a/app/models/promos/PromoCampaign.scala
+++ b/app/models/promos/PromoCampaign.scala
@@ -1,0 +1,8 @@
+package models.promos
+
+case class PromoCampaign(
+  campaignCode: String,
+  product: PromoProduct,
+  name: String,
+  created: String
+)

--- a/app/models/promos/PromoProduct.scala
+++ b/app/models/promos/PromoProduct.scala
@@ -1,0 +1,8 @@
+package models.promos
+
+sealed trait PromoProduct
+case object SupporterPlus extends PromoProduct
+case object TierThree extends PromoProduct
+case object DigitalPack extends PromoProduct
+case object Newspaper extends PromoProduct
+case object Weekly extends PromoProduct

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ libraryDependencies ++= Seq(
   ws,
   "dev.zio" %% "zio" % zioVersion,
   "dev.zio" %% "zio-streams" % zioVersion,
+  "com.gu" %% "support-internationalisation" % "0.16",
   "org.scalatest" %% "scalatest" % "3.2.19" % "test",
   "org.gnieh" %% "diffson-circe" % "4.6.0" % "test"
 )


### PR DESCRIPTION
We're migrating the promos tool to the RRCP.

This is a much simplified form of the models from the old repo: https://github.com/guardian/memsub-promotions/blob/main/app/com/gu/memsub/promo/Promotion.scala