### PR TITLE
New promo tool UI - Layout, Products dropdown, PromoCampaign list and basic create PromoCampaign modal

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,7 @@ GET /healthcheck                                    controllers.Application.heal
 GET /                                               controllers.Application.index
 GET /switches                                       controllers.Application.index
 GET /amounts                                        controllers.Application.index
+GET /promo-tool                                     controllers.Application.index
 
 GET /header-tests                                   controllers.Application.index
 GET /header-tests/:name                             controllers.Application.indexWithName(name: String)

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -7,6 +7,7 @@ import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import { makeStyles } from '@mui/styles';
 import RRControlPanelLogo from './rrControlPanelLogo';
+import { getStage } from '../utils/stage';
 
 const useStyles = makeStyles({
   list: {
@@ -122,8 +123,6 @@ export default function NavDrawer(): React.ReactElement {
     const now = new Date();
     return now.getMonth() == 9 && now.getDate() == 31;
   };
-
-  const showMenuItemUnderDevelopment = false; // TODO: ensure set to false when pushing to remote!
 
   const list = (anchor: string): React.ReactElement => (
     <div
@@ -242,7 +241,7 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Apps Metering Switches" />
           </ListItem>
         </Link>
-        {showMenuItemUnderDevelopment && (
+        {getStage() !== 'PROD' && (
           <Link key="Promo Tool" to="/promo-tool" className={classes.link}>
             <ListItem className={classes.listItem} button key="Promo Tool">
               <ListItemText primary="Promo Tool" />

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -123,6 +123,8 @@ export default function NavDrawer(): React.ReactElement {
     return now.getMonth() == 9 && now.getDate() == 31;
   };
 
+  const showMenuItemUnderDevelopment = true; // TODO: set to false when pushing me to remote!
+
   const list = (anchor: string): React.ReactElement => (
     <div
       className={classes.list}
@@ -240,6 +242,13 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Apps Metering Switches" />
           </ListItem>
         </Link>
+        {showMenuItemUnderDevelopment && (
+          <Link key="Promo Tool" to="/promo-tool" className={classes.link}>
+            <ListItem className={classes.listItem} button key="Promo Tool">
+              <ListItemText primary="Promo Tool" />
+            </ListItem>
+          </Link>
+        )}
         <Link key="Default Promos" to="/default-promos" className={classes.link}>
           <ListItem className={classes.listItem} button key="Default Promos">
             <ListItemText primary="Default Promos" />

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -123,7 +123,7 @@ export default function NavDrawer(): React.ReactElement {
     return now.getMonth() == 9 && now.getDate() == 31;
   };
 
-  const showMenuItemUnderDevelopment = true; // TODO: set to false when pushing me to remote!
+  const showMenuItemUnderDevelopment = false; // TODO: ensure set to false when pushing to remote!
 
   const list = (anchor: string): React.ReactElement => (
     <div

--- a/public/src/components/promoTool/createPromoCampaignDialog.tsx
+++ b/public/src/components/promoTool/createPromoCampaignDialog.tsx
@@ -12,13 +12,6 @@ import {
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 import CloseIcon from '@mui/icons-material/Close';
-import { useForm } from 'react-hook-form';
-import {
-  createDuplicateValidator,
-  EMPTY_ERROR_HELPER_TEXT,
-  INVALID_CHARACTERS_ERROR_HELPER_TEXT,
-  VALID_CHARACTERS_REGEX,
-} from '../channelManagement/helpers/validation';
 import { Products } from './utils/promoModels';
 
 const useStyles = makeStyles(() => ({
@@ -37,9 +30,6 @@ const useStyles = makeStyles(() => ({
 
 interface FormData {
   name: string;
-  // campaignCode: String, // id? UUID? - allow them to create?  needs to be unique
-  // product: PromoProduct, // drop down of the PromoProducts.
-  // created: String // stringified today's date?
 }
 
 interface CreatePromoCampaignDialogProps {
@@ -51,36 +41,8 @@ interface CreatePromoCampaignDialogProps {
 const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
   isOpen,
   close,
-  existingNames,
-  createPromoCampaign,
 }: CreatePromoCampaignDialogProps) => {
   const classes = useStyles();
-
-  const defaultValues: FormData = {
-    // TODO: make sure these reflect our campaign fields.
-    name: '',
-    // campaignCode: String,
-    // product: PromoProduct,
-    // created: String // stringified today's date?
-    // description: '',
-  };
-
-  const {
-    register,
-    handleSubmit,
-
-    formState: { errors },
-  } = useForm<FormData>({
-    defaultValues,
-  });
-
-  const onSubmit = (vals: FormData): void => {
-    createPromoCampaign({
-      name: vals.name.toUpperCase(),
-      // description: vals.description,
-    });
-    close();
-  };
 
   return (
     <Dialog open={isOpen} onClose={close} aria-labelledby="create-test-dialog-title">
@@ -101,7 +63,6 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
           margin="dense"
           variant="outlined"
           fullWidth
-          // onChange={handleChange}
         >
           {Products.map(c => (
             <MenuItem value={c.code} key={`product-${c.code}`}>
@@ -111,16 +72,6 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
         </Select>
         <TextField
           className={classes.input}
-          error={errors.name !== undefined}
-          helperText={errors.name ? errors.name.message : ''}
-          {...register('name', {
-            required: EMPTY_ERROR_HELPER_TEXT,
-            pattern: {
-              value: VALID_CHARACTERS_REGEX,
-              message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
-            },
-            validate: createDuplicateValidator(existingNames),
-          })}
           label="Promo Campaign name"
           margin="normal"
           variant="outlined"
@@ -129,9 +80,7 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleSubmit(onSubmit)} color="primary">
-          Create Promo Campaign
-        </Button>
+        <Button color="primary">Create Promo Campaign</Button>
       </DialogActions>
     </Dialog>
   );

--- a/public/src/components/promoTool/createPromoCampaignDialog.tsx
+++ b/public/src/components/promoTool/createPromoCampaignDialog.tsx
@@ -1,19 +1,140 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  MenuItem,
+  Select,
+  TextField,
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import React from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import { useForm } from 'react-hook-form';
+import {
+  createDuplicateValidator,
+  EMPTY_ERROR_HELPER_TEXT,
+  INVALID_CHARACTERS_ERROR_HELPER_TEXT,
+  VALID_CHARACTERS_REGEX,
+} from '../channelManagement/helpers/validation';
+import { Products } from './utils/promoModels';
+
+const useStyles = makeStyles(() => ({
+  dialogHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '8px',
+  },
+  input: {
+    '& input': {
+      textTransform: 'uppercase !important',
+    },
+  },
+}));
+
+interface FormData {
+  name: string;
+  // campaignCode: String, // id? UUID? - allow them to create?  needs to be unique
+  // product: PromoProduct, // drop down of the PromoProducts.
+  // created: String // stringified today's date?
+}
 
 interface CreatePromoCampaignDialogProps {
-  //   isOpen: boolean;
-  //   close: () => void;
-  //   existingNames: string[];
-  //   existingNicknames: string[];
-  //   createCampaign: (data: FormData) => void;
+  isOpen: boolean;
+  close: () => void;
+  existingNames: string[];
+  createPromoCampaign: (data: FormData) => void;
 }
-const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({}: //   isOpen,
-//   close,
-//   existingNames,
-//   existingNicknames,
-//   createCampaign,
-CreatePromoCampaignDialogProps) => {
-  return <></>;
+const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
+  isOpen,
+  close,
+  existingNames,
+  createPromoCampaign,
+}: CreatePromoCampaignDialogProps) => {
+  const classes = useStyles();
+
+  const defaultValues: FormData = {
+    // TODO: make sure these reflect our campaign fields.
+    name: '',
+    // campaignCode: String,
+    // product: PromoProduct,
+    // created: String // stringified today's date?
+    // description: '',
+  };
+
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm<FormData>({
+    defaultValues,
+  });
+
+  const onSubmit = (vals: FormData): void => {
+    createPromoCampaign({
+      name: vals.name.toUpperCase(),
+      // description: vals.description,
+    });
+    close();
+  };
+
+  return (
+    <Dialog open={isOpen} onClose={close} aria-labelledby="create-test-dialog-title">
+      <div className={classes.dialogHeader}>
+        <DialogTitle id="create-promo-campaign-dialog-title">
+          Create a new promo campaign
+        </DialogTitle>
+        <IconButton onClick={close} aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </div>
+      <DialogContent dividers>
+        <TextField
+          className={classes.input}
+          error={errors.name !== undefined}
+          helperText={errors.name ? errors.name.message : ''}
+          {...register('name', {
+            required: EMPTY_ERROR_HELPER_TEXT,
+            pattern: {
+              value: VALID_CHARACTERS_REGEX,
+              message: INVALID_CHARACTERS_ERROR_HELPER_TEXT,
+            },
+            validate: createDuplicateValidator(existingNames),
+          })}
+          label="Promo Campaign name"
+          margin="normal"
+          variant="outlined"
+          autoFocus
+          fullWidth
+        />
+        <Select
+          labelId="promo-campaign-product-label"
+          id="promo-campaign-product"
+          label="Product"
+          value="SupporterPlus"
+          margin="dense"
+          variant="outlined"
+          fullWidth
+          // onChange={handleChange}
+        >
+          {Products.map(c => (
+            <MenuItem value={c.code} key={`product-${c.code}`}>
+              {c.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSubmit(onSubmit)} color="primary">
+          Create Promo Campaign
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
 };
 
 export default CreatePromoCampaignDialog;

--- a/public/src/components/promoTool/createPromoCampaignDialog.tsx
+++ b/public/src/components/promoTool/createPromoCampaignDialog.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface CreatePromoCampaignDialogProps {
+  //   isOpen: boolean;
+  //   close: () => void;
+  //   existingNames: string[];
+  //   existingNicknames: string[];
+  //   createCampaign: (data: FormData) => void;
+}
+const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({}: //   isOpen,
+//   close,
+//   existingNames,
+//   existingNicknames,
+//   createCampaign,
+CreatePromoCampaignDialogProps) => {
+  return <></>;
+};
+
+export default CreatePromoCampaignDialog;
+
+// TODO: carry on with this next

--- a/public/src/components/promoTool/createPromoCampaignDialog.tsx
+++ b/public/src/components/promoTool/createPromoCampaignDialog.tsx
@@ -10,7 +10,6 @@ import {
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 import CloseIcon from '@mui/icons-material/Close';
-import { promoProductNames } from './utils/promoModels';
 import { ProductSelector } from './productSelector';
 
 const useStyles = makeStyles(() => ({
@@ -54,7 +53,7 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
         </IconButton>
       </div>
       <DialogContent dividers>
-        <ProductSelector promoProductNames={promoProductNames} />
+        <ProductSelector />
         <TextField
           className={classes.input}
           label="Promo Campaign name"

--- a/public/src/components/promoTool/createPromoCampaignDialog.tsx
+++ b/public/src/components/promoTool/createPromoCampaignDialog.tsx
@@ -5,14 +5,13 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  MenuItem,
-  Select,
   TextField,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 import CloseIcon from '@mui/icons-material/Close';
-import { Products } from './utils/promoModels';
+import { promoProductNames } from './utils/promoModels';
+import { ProductSelector } from './productSelector';
 
 const useStyles = makeStyles(() => ({
   dialogHeader: {
@@ -55,21 +54,7 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
         </IconButton>
       </div>
       <DialogContent dividers>
-        <Select
-          labelId="promo-campaign-product-label"
-          id="promo-campaign-product"
-          label="Product"
-          value="SupporterPlus"
-          margin="dense"
-          variant="outlined"
-          fullWidth
-        >
-          {Products.map(c => (
-            <MenuItem value={c.code} key={`product-${c.code}`}>
-              {c.name}
-            </MenuItem>
-          ))}
-        </Select>
+        <ProductSelector promoProductNames={promoProductNames} />
         <TextField
           className={classes.input}
           label="Promo Campaign name"

--- a/public/src/components/promoTool/createPromoCampaignDialog.tsx
+++ b/public/src/components/promoTool/createPromoCampaignDialog.tsx
@@ -93,6 +93,22 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
         </IconButton>
       </div>
       <DialogContent dividers>
+        <Select
+          labelId="promo-campaign-product-label"
+          id="promo-campaign-product"
+          label="Product"
+          value="SupporterPlus"
+          margin="dense"
+          variant="outlined"
+          fullWidth
+          // onChange={handleChange}
+        >
+          {Products.map(c => (
+            <MenuItem value={c.code} key={`product-${c.code}`}>
+              {c.name}
+            </MenuItem>
+          ))}
+        </Select>
         <TextField
           className={classes.input}
           error={errors.name !== undefined}
@@ -111,22 +127,6 @@ const CreatePromoCampaignDialog: React.FC<CreatePromoCampaignDialogProps> = ({
           autoFocus
           fullWidth
         />
-        <Select
-          labelId="promo-campaign-product-label"
-          id="promo-campaign-product"
-          label="Product"
-          value="SupporterPlus"
-          margin="dense"
-          variant="outlined"
-          fullWidth
-          // onChange={handleChange}
-        >
-          {Products.map(c => (
-            <MenuItem value={c.code} key={`product-${c.code}`}>
-              {c.name}
-            </MenuItem>
-          ))}
-        </Select>
       </DialogContent>
       <DialogActions>
         <Button onClick={handleSubmit(onSubmit)} color="primary">

--- a/public/src/components/promoTool/newPromoCampaignButton.tsx
+++ b/public/src/components/promoTool/newPromoCampaignButton.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AddIcon from '@mui/icons-material/Add';
+// import { PromoCampaign } from './utils/promoModels';
+import useOpenable from '../../hooks/useOpenable';
+// import CreateCampaignDialog from '../channelManagement/campaigns/CreateCampaignDialog';
+import CreatePromoCampaignDialog from './createPromoCampaignDialog';
+
+const useStyles = makeStyles(() => ({
+  button: {
+    justifyContent: 'start',
+    height: '48px',
+  },
+  text: {
+    fontSize: '12px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+  },
+}));
+
+// interface NewPromoCampaignButtonProps {
+//   existingNames: string[]; // and existing promoCodes?
+//   createPromoCampaign: (campaign: PromoCampaign) => void;
+// }
+
+// const NewCampaignButton: React.FC<NewPromoCampaignButtonProps> = ({
+// //   existingNames,
+// //   createPromoCampaign,
+// }: NewPromoCampaignButtonProps) => {
+
+const NewPromoCampaignButton: React.FC = () => {
+  const [isOpen, open, close] = useOpenable();
+  const classes = useStyles();
+
+  console.log(isOpen, close); // TODO: to stop annoying stuff.
+
+  return (
+    <>
+      <Button className={classes.button} variant="outlined" startIcon={<AddIcon />} onClick={open}>
+        <Typography className={classes.text}>Create new promo campaign</Typography>
+      </Button>
+      <CreatePromoCampaignDialog
+      // isOpen={isOpen}
+      // close={close}
+      // existingNames={existingNames}
+      // createPromoCampaign={createPromoCampaign}
+      />
+    </>
+  );
+};
+
+export default NewPromoCampaignButton;
+
+// TODO: carry on with this

--- a/public/src/components/promoTool/newPromoCampaignButton.tsx
+++ b/public/src/components/promoTool/newPromoCampaignButton.tsx
@@ -4,7 +4,6 @@ import { makeStyles } from '@mui/styles';
 import AddIcon from '@mui/icons-material/Add';
 // import { PromoCampaign } from './utils/promoModels';
 import useOpenable from '../../hooks/useOpenable';
-// import CreateCampaignDialog from '../channelManagement/campaigns/CreateCampaignDialog';
 import CreatePromoCampaignDialog from './createPromoCampaignDialog';
 
 const useStyles = makeStyles(() => ({
@@ -34,18 +33,16 @@ const NewPromoCampaignButton: React.FC = () => {
   const [isOpen, open, close] = useOpenable();
   const classes = useStyles();
 
-  console.log(isOpen, close); // TODO: to stop annoying stuff.
-
   return (
     <>
       <Button className={classes.button} variant="outlined" startIcon={<AddIcon />} onClick={open}>
         <Typography className={classes.text}>Create new promo campaign</Typography>
       </Button>
       <CreatePromoCampaignDialog
-      // isOpen={isOpen}
-      // close={close}
-      // existingNames={existingNames}
-      // createPromoCampaign={createPromoCampaign}
+        isOpen={isOpen}
+        close={close}
+        existingNames={[]} // TODO
+        createPromoCampaign={() => {}} // TODO
       />
     </>
   );

--- a/public/src/components/promoTool/newPromoCampaignButton.tsx
+++ b/public/src/components/promoTool/newPromoCampaignButton.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import AddIcon from '@mui/icons-material/Add';
-// import { PromoCampaign } from './utils/promoModels';
 import useOpenable from '../../hooks/useOpenable';
 import CreatePromoCampaignDialog from './createPromoCampaignDialog';
 
@@ -19,23 +18,18 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-// interface NewPromoCampaignButtonProps {
-//   existingNames: string[]; // and existing promoCodes?
-//   createPromoCampaign: (campaign: PromoCampaign) => void;
-// }
-
-// const NewCampaignButton: React.FC<NewPromoCampaignButtonProps> = ({
-// //   existingNames,
-// //   createPromoCampaign,
-// }: NewPromoCampaignButtonProps) => {
-
 const NewPromoCampaignButton: React.FC = () => {
   const [isOpen, open, close] = useOpenable();
   const classes = useStyles();
 
   return (
     <>
-      <Button className={classes.button} variant="outlined" startIcon={<AddIcon />} onClick={open}>
+      <Button
+        className={classes.button}
+        variant="outlined"
+        startIcon={<AddIcon className="classes.icon" />}
+        onClick={open}
+      >
         <Typography className={classes.text}>Create new promo campaign</Typography>
       </Button>
       <CreatePromoCampaignDialog

--- a/public/src/components/promoTool/productSelector.tsx
+++ b/public/src/components/promoTool/productSelector.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import { PromoProduct } from './utils/promoModels';
 import { makeStyles } from '@mui/styles';
 import { InputLabel, MenuItem, Select } from '@mui/material';
-
-interface ProductSelectorProps {
-  promoProductNames: Record<PromoProduct, string>;
-}
+import { promoProductNames } from './utils/promoModels';
 
 const useStyles = makeStyles(() => ({
   select: {
@@ -14,7 +10,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export function ProductSelector({ promoProductNames }: ProductSelectorProps): React.ReactElement {
+export function ProductSelector(): React.ReactElement {
   const classes = useStyles();
 
   return (

--- a/public/src/components/promoTool/productSelector.tsx
+++ b/public/src/components/promoTool/productSelector.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { PromoProduct } from './utils/promoModels';
+import { makeStyles } from '@mui/styles';
+import { InputLabel, MenuItem, Select } from '@mui/material';
+
+interface ProductSelectorProps {
+  promoProductNames: Record<PromoProduct, string>;
+}
+
+interface MapableData {
+  name: string;
+  description: string;
+}
+
+const useStyles = makeStyles(() => ({
+  select: {
+    marginBottom: '8px',
+    width: '100%',
+  },
+}));
+
+export function ProductSelector({ promoProductNames }: ProductSelectorProps): React.ReactElement {
+  const classes = useStyles();
+
+  const createMapableDataStructure = () => {
+    {
+      const useableDataStructure: MapableData[] = new Array<MapableData>();
+      Object.entries(promoProductNames).forEach(([promoProductkey, promoProductvalue]) => {
+        useableDataStructure.push({ name: promoProductkey, description: promoProductvalue });
+      });
+      return useableDataStructure;
+    }
+  };
+
+  const mapableDataStructure = createMapableDataStructure();
+
+  return (
+    <>
+      <InputLabel>Select a Product</InputLabel>
+      <Select className={classes.select} value="" aria-label="Select Product">
+        {mapableDataStructure.map(product => (
+          <MenuItem value={product.name} key={product.name}>
+            {product.description}
+          </MenuItem>
+        ))}
+      </Select>
+    </>
+  );
+}
+
+export default ProductSelector;

--- a/public/src/components/promoTool/productSelector.tsx
+++ b/public/src/components/promoTool/productSelector.tsx
@@ -7,11 +7,6 @@ interface ProductSelectorProps {
   promoProductNames: Record<PromoProduct, string>;
 }
 
-interface MapableData {
-  name: string;
-  description: string;
-}
-
 const useStyles = makeStyles(() => ({
   select: {
     marginBottom: '8px',
@@ -22,25 +17,13 @@ const useStyles = makeStyles(() => ({
 export function ProductSelector({ promoProductNames }: ProductSelectorProps): React.ReactElement {
   const classes = useStyles();
 
-  const createMapableDataStructure = () => {
-    {
-      const useableDataStructure: MapableData[] = new Array<MapableData>();
-      Object.entries(promoProductNames).forEach(([promoProductkey, promoProductvalue]) => {
-        useableDataStructure.push({ name: promoProductkey, description: promoProductvalue });
-      });
-      return useableDataStructure;
-    }
-  };
-
-  const mapableDataStructure = createMapableDataStructure();
-
   return (
     <>
       <InputLabel>Select a Product</InputLabel>
       <Select className={classes.select} value="" aria-label="Select Product">
-        {mapableDataStructure.map(product => (
-          <MenuItem value={product.name} key={product.name}>
-            {product.description}
+        {Object.entries(promoProductNames).map(([code, description]) => (
+          <MenuItem value={code} key={code}>
+            {description}
           </MenuItem>
         ))}
       </Select>

--- a/public/src/components/promoTool/promoCampaignsList.tsx
+++ b/public/src/components/promoTool/promoCampaignsList.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { List, ListItem, Button, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { red } from '@mui/material/colors';
+import { PromoCampaign, PromoCampaigns } from './utils/promoModels';
+
+const useStyles = makeStyles(() => ({
+  container: {
+    marginTop: '16px',
+  },
+  list: {
+    padding: 0,
+    width: '100%',
+  },
+  listItem: {
+    margin: 0,
+    padding: 0,
+    gutter: 0,
+    width: '100%',
+  },
+  button: {
+    position: 'relative',
+    height: '50px',
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    background: 'white',
+    borderRadius: '4px',
+    padding: '0 12px',
+    marginBottom: '4px',
+  },
+  text: {
+    fontSize: '12px',
+    fontWeight: 500,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+  },
+  selected: {
+    border: `1px solid ${red[500]}`,
+
+    '&:hover': {
+      background: `${red[500]}`,
+      color: 'white',
+    },
+  },
+  unselected: {
+    background: `${red[500]}`,
+    color: 'white',
+
+    '&:hover': {
+      background: `${red[500]}`,
+      color: 'white',
+    },
+  },
+}));
+
+interface PromoCampaignsListProps {
+  promoCampaigns: PromoCampaigns;
+  promoCampaignSearch: string;
+  selectedPromoCampaign?: PromoCampaign;
+  onPromoCampaignSelected: (campaignCode: string) => void;
+}
+
+const PromoCampaignsList = ({
+  promoCampaigns,
+  promoCampaignSearch,
+  selectedPromoCampaign,
+  onPromoCampaignSelected,
+}: PromoCampaignsListProps): React.ReactElement => {
+  const classes = useStyles();
+
+  const filterPromoCampaigns = (campaignArray: PromoCampaigns) => {
+    return campaignArray.filter(c => {
+      if (!promoCampaignSearch) {
+        return true;
+      } else if (c.name && c.name.indexOf(promoCampaignSearch) >= 0) {
+        return true;
+      } else if (c.name.indexOf(promoCampaignSearch) >= 0) {
+        return true;
+      }
+      return false;
+    });
+  };
+
+  const sortPromoCampaigns = (campaignArray: PromoCampaigns) => {
+    campaignArray.sort((a, b) => {
+      const A = a.name;
+      const B = b.name;
+
+      if (A < B) {
+        return -1;
+      }
+      if (B < A) {
+        return 1;
+      }
+      return 0;
+    });
+    return campaignArray;
+  };
+
+  const sortedPromoCampaigns = sortPromoCampaigns(filterPromoCampaigns(promoCampaigns));
+
+  // TODO: test this later
+  const getStyleForSelectedPromoCampaign = (promoCampaign: PromoCampaign) => {
+    const classGroup = [classes.button];
+    if (promoCampaign.campaignCode === selectedPromoCampaign?.campaignCode) {
+      classGroup.push('classes.selected');
+    } else {
+      classGroup.push('classes.unselelected');
+    }
+    return classGroup.join(' ');
+  };
+
+  return (
+    <div className={classes.container}>
+      <List className={classes.list}>
+        {sortedPromoCampaigns.map(promoCampaign => (
+          <ListItem className={classes.listItem} key={promoCampaign.campaignCode}>
+            <Button
+              key={`${promoCampaign.name}-button`} // TODO: should this be campaignCode?
+              className={getStyleForSelectedPromoCampaign(promoCampaign)}
+              variant="outlined"
+              onClick={(): void => onPromoCampaignSelected(promoCampaign.campaignCode)}
+            >
+              <Typography className={classes.text}>{promoCampaign.name}</Typography>
+            </Button>
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  );
+};
+
+export default PromoCampaignsList;

--- a/public/src/components/promoTool/promoCampaignsList.tsx
+++ b/public/src/components/promoTool/promoCampaignsList.tsx
@@ -107,7 +107,7 @@ const PromoCampaignsList = ({
     if (promoCampaign.campaignCode === selectedPromoCampaign?.campaignCode) {
       classGroup.push('classes.selected');
     } else {
-      classGroup.push('classes.unselelected');
+      classGroup.push('classes.unselected');
     }
     return classGroup.join(' ');
   };

--- a/public/src/components/promoTool/promoCampaignsList.tsx
+++ b/public/src/components/promoTool/promoCampaignsList.tsx
@@ -1,64 +1,24 @@
 import React from 'react';
-import { List, ListItem, Button, Typography } from '@mui/material';
+import { List } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { red } from '@mui/material/colors';
 import { PromoCampaign, PromoCampaigns } from './utils/promoModels';
+import { PromoCampaignsListItem } from './promoCampaignsListItem';
 
 const useStyles = makeStyles(() => ({
   container: {
     marginTop: '16px',
+    width: '100%',
   },
   list: {
     padding: 0,
     width: '100%',
-  },
-  listItem: {
-    margin: 0,
-    padding: 0,
-    gutter: 0,
-    width: '100%',
-  },
-  button: {
-    position: 'relative',
-    height: '50px',
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    background: 'white',
-    borderRadius: '4px',
-    padding: '0 12px',
-    marginBottom: '4px',
-  },
-  text: {
-    fontSize: '12px',
-    fontWeight: 500,
-    textTransform: 'uppercase',
-    letterSpacing: '1px',
-  },
-  selected: {
-    border: `1px solid ${red[500]}`,
-
-    '&:hover': {
-      background: `${red[500]}`,
-      color: 'white',
-    },
-  },
-  unselected: {
-    background: `${red[500]}`,
-    color: 'white',
-
-    '&:hover': {
-      background: `${red[500]}`,
-      color: 'white',
-    },
   },
 }));
 
 interface PromoCampaignsListProps {
   promoCampaigns: PromoCampaigns;
   promoCampaignSearch: string;
-  selectedPromoCampaign?: PromoCampaign;
+  selectedPromoCampaign?: PromoCampaign | null;
   onPromoCampaignSelected: (campaignCode: string) => void;
 }
 
@@ -70,6 +30,7 @@ const PromoCampaignsList = ({
 }: PromoCampaignsListProps): React.ReactElement => {
   const classes = useStyles();
 
+  // TODO: need to filter by product too
   const filterPromoCampaigns = (campaignArray: PromoCampaigns) => {
     return campaignArray.filter(c => {
       if (!promoCampaignSearch) {
@@ -99,34 +60,25 @@ const PromoCampaignsList = ({
     return campaignArray;
   };
 
-  const sortedPromoCampaigns = sortPromoCampaigns(filterPromoCampaigns(promoCampaigns));
-
-  // TODO: test this later
-  const getStyleForSelectedPromoCampaign = (promoCampaign: PromoCampaign) => {
-    const classGroup = [classes.button];
-    if (promoCampaign.campaignCode === selectedPromoCampaign?.campaignCode) {
-      classGroup.push('classes.selected');
-    } else {
-      classGroup.push('classes.unselected');
-    }
-    return classGroup.join(' ');
-  };
+  const filteredAndSortedPromoCampaigns = sortPromoCampaigns(filterPromoCampaigns(promoCampaigns));
 
   return (
     <div className={classes.container}>
       <List className={classes.list}>
-        {sortedPromoCampaigns.map(promoCampaign => (
-          <ListItem className={classes.listItem} key={promoCampaign.campaignCode}>
-            <Button
-              key={`${promoCampaign.name}-button`} // TODO: should this be campaignCode?
-              className={getStyleForSelectedPromoCampaign(promoCampaign)}
-              variant="outlined"
-              onClick={(): void => onPromoCampaignSelected(promoCampaign.campaignCode)}
-            >
-              <Typography className={classes.text}>{promoCampaign.name}</Typography>
-            </Button>
-          </ListItem>
-        ))}
+        {filteredAndSortedPromoCampaigns.map(promoCampaign => {
+          const isSelected = Boolean(
+            selectedPromoCampaign &&
+              selectedPromoCampaign.campaignCode === promoCampaign.campaignCode,
+          );
+          return (
+            <PromoCampaignsListItem
+              key={promoCampaign.campaignCode}
+              promoCampaign={promoCampaign}
+              isSelected={isSelected}
+              onPromoCampaignSelected={onPromoCampaignSelected}
+            />
+          );
+        })}
       </List>
     </div>
   );

--- a/public/src/components/promoTool/promoCampaignsListItem.tsx
+++ b/public/src/components/promoTool/promoCampaignsListItem.tsx
@@ -77,8 +77,6 @@ export const PromoCampaignsListItem = ({
     textClasses.push(classes.textInverted);
   }
 
-  console.log(`The promoCode Name is: ${promoCampaign.name} and it is ${isSelected}`);
-
   return (
     <ListItem
       button={true}

--- a/public/src/components/promoTool/promoCampaignsListItem.tsx
+++ b/public/src/components/promoTool/promoCampaignsListItem.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { ListItem, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { grey } from '@mui/material/colors';
+import { PromoCampaign } from './utils/promoModels';
+import useHover from '../../hooks/useHover';
+
+const useStyles = makeStyles(() => ({
+  listItem: {
+    position: 'relative',
+    width: '100%',
+    height: '50px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    background: 'white',
+    borderRadius: '4px',
+    padding: '0 12px',
+    border: `1px solid ${grey[400]}`,
+    marginBottom: '5px',
+
+    '&:hover': {
+      background: `${grey[700]}`,
+    },
+  },
+  text: {
+    maxWidth: '190px',
+    fontSize: '12px',
+    fontWeight: 500,
+    lineHeight: '24px',
+    textTransform: 'uppercase',
+  },
+  textInverted: {
+    color: '#FFFFFF',
+  },
+  inverted: {
+    background: `${grey[700]}`,
+    border: `1px solid ${grey[700]}`,
+  },
+  whitePencil: {
+    color: 'white',
+  },
+  labelAndNameContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > * + *': {
+      marginLeft: '4px',
+    },
+  },
+}));
+
+interface Props {
+  key: string;
+  promoCampaign: PromoCampaign;
+  isSelected: boolean;
+  onPromoCampaignSelected: (promoCampaignCode: string) => void;
+}
+
+export const PromoCampaignsListItem = ({
+  key,
+  promoCampaign,
+  isSelected,
+  onPromoCampaignSelected,
+}: Props): React.ReactElement => {
+  const classes = useStyles();
+
+  const [ref, isHovered] = useHover<HTMLDivElement>();
+
+  const itemContainerClasses = [classes.listItem];
+  const shouldInvertColor = isHovered || isSelected;
+  if (shouldInvertColor) {
+    itemContainerClasses.push(classes.inverted);
+  }
+
+  const textClasses = [classes.text];
+  if (isSelected) {
+    textClasses.push(classes.textInverted);
+  }
+
+  console.log(`The promoCode Name is: ${promoCampaign.name} and it is ${isSelected}`);
+
+  return (
+    <ListItem
+      button={true}
+      className={itemContainerClasses.join(' ')}
+      key={key}
+      onClick={(): void => onPromoCampaignSelected(promoCampaign.campaignCode)}
+      ref={ref}
+    >
+      <div className={classes.labelAndNameContainer}>
+        <Typography className={textClasses.join(' ')}>{promoCampaign.name}</Typography>
+      </div>
+    </ListItem>
+  );
+};

--- a/public/src/components/promoTool/promoCampaignsListItem.tsx
+++ b/public/src/components/promoTool/promoCampaignsListItem.tsx
@@ -37,9 +37,6 @@ const useStyles = makeStyles(() => ({
     background: `${grey[700]}`,
     border: `1px solid ${grey[700]}`,
   },
-  whitePencil: {
-    color: 'white',
-  },
   labelAndNameContainer: {
     display: 'flex',
     alignItems: 'center',

--- a/public/src/components/promoTool/promoCampaignsSidebar.tsx
+++ b/public/src/components/promoTool/promoCampaignsSidebar.tsx
@@ -3,13 +3,17 @@ import { makeStyles } from '@mui/styles';
 import { MenuItem, Select, TextField } from '@mui/material';
 import PromoCampaignsList from './promoCampaignsList';
 import NewPromoCampaignButton from './newPromoCampaignButton';
-import { productTypes, PromoCampaign, PromoCampaigns } from './utils/promoModels';
+import { Products, PromoCampaign, PromoCampaigns } from './utils/promoModels';
 
 const useStyles = makeStyles(() => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
     paddingLeft: '32px',
+  },
+  headline2: {
+    color: '#555',
+    fontSize: 18,
   },
   listsContainer: {
     position: 'relative',
@@ -55,13 +59,15 @@ function PromoCampaignsSidebar({
 
   return (
     <div className={classes.root}>
-      <Select className={classes.select} value={productTypes[0]} aria-label="Select Product">
-        {productTypes.map(c => (
-          <MenuItem value={c} key={`product-${c}`}>
-            {c}
+      <h2 className={classes.headline2}>Select Product to filter Promo Campaigns</h2>
+      <Select className={classes.select} value={Products[0].code} aria-label="Select Product">
+        {Products.map(c => (
+          <MenuItem value={c.code} key={`product-${c.code}`}>
+            {c.name}
           </MenuItem>
         ))}
       </Select>
+      <h2 className={classes.headline2}>Promo Campaigns</h2>
       <div className={classes.buttonsContainer}>
         <NewPromoCampaignButton
         // existingNames={promoCampaigns.map(c => c.name)}

--- a/public/src/components/promoTool/promoCampaignsSidebar.tsx
+++ b/public/src/components/promoTool/promoCampaignsSidebar.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@mui/styles';
 import { TextField } from '@mui/material';
 import PromoCampaignsList from './promoCampaignsList';
 import NewPromoCampaignButton from './newPromoCampaignButton';
-import { promoProductNames, PromoCampaign, PromoCampaigns } from './utils/promoModels';
+import { PromoCampaign, PromoCampaigns } from './utils/promoModels';
 import { ProductSelector } from './productSelector';
 
 const useStyles = makeStyles(() => ({
@@ -62,7 +62,7 @@ function PromoCampaignsSidebar({
   return (
     <div className={classes.root}>
       <h2 className={classes.headline2}>Select Product to filter Promo Campaigns</h2>
-      <ProductSelector promoProductNames={promoProductNames} />
+      <ProductSelector />
       <h2 className={classes.headline2}>Promo Campaigns</h2>
       <div className={classes.buttonsContainer}>
         <NewPromoCampaignButton />

--- a/public/src/components/promoTool/promoCampaignsSidebar.tsx
+++ b/public/src/components/promoTool/promoCampaignsSidebar.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@mui/styles';
+import { MenuItem, Select, TextField } from '@mui/material';
+import PromoCampaignsList from './promoCampaignsList';
+import NewPromoCampaignButton from './newPromoCampaignButton';
+import { productTypes, PromoCampaign, PromoCampaigns } from './utils/promoModels';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingLeft: '32px',
+  },
+  listsContainer: {
+    position: 'relative',
+    display: 'flex',
+    marginTop: '8px',
+  },
+  searchField: {
+    marginTop: '8px',
+  },
+  select: {
+    marginBottom: '50px',
+  },
+  buttonsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '10px',
+  },
+}));
+
+interface PromoCampaignsSidebarProps {
+  promoCampaigns: PromoCampaigns;
+  selectedPromoCampaign?: PromoCampaign;
+  createPromoCampaign: (campaign: PromoCampaign) => void;
+  onPromoCampaignSelected: (campaignName: string) => void;
+}
+
+function PromoCampaignsSidebar({
+  promoCampaigns,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  createPromoCampaign,
+  selectedPromoCampaign,
+  onPromoCampaignSelected,
+}: PromoCampaignsSidebarProps): React.ReactElement {
+  const classes = useStyles();
+  const [promoCampaignSearch, setPromoCampaignSearch] = useState('');
+
+  const searchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e && e.target) {
+      setPromoCampaignSearch(e.target.value.toUpperCase());
+    }
+  };
+
+  return (
+    <div className={classes.root}>
+      <Select className={classes.select} value={productTypes[0]} aria-label="Select Product">
+        {productTypes.map(c => (
+          <MenuItem value={c} key={`product-${c}`}>
+            {c}
+          </MenuItem>
+        ))}
+      </Select>
+      <div className={classes.buttonsContainer}>
+        <NewPromoCampaignButton
+        // existingNames={promoCampaigns.map(c => c.name)}
+        // existingNicknames={promoCampaigns.map(c => c.name || '')}
+        // createCampaign={createPromoCampaign}
+        />
+        <TextField
+          className={classes.searchField}
+          label="Filter Promo Campaigns"
+          type="search"
+          variant="outlined"
+          onInput={searchInput}
+          onChange={searchInput}
+        />
+      </div>
+      <div className={classes.listsContainer}>
+        <PromoCampaignsList
+          promoCampaigns={promoCampaigns}
+          promoCampaignSearch={promoCampaignSearch}
+          selectedPromoCampaign={selectedPromoCampaign}
+          onPromoCampaignSelected={onPromoCampaignSelected}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default PromoCampaignsSidebar;

--- a/public/src/components/promoTool/promoCampaignsSidebar.tsx
+++ b/public/src/components/promoTool/promoCampaignsSidebar.tsx
@@ -69,11 +69,7 @@ function PromoCampaignsSidebar({
       </Select>
       <h2 className={classes.headline2}>Promo Campaigns</h2>
       <div className={classes.buttonsContainer}>
-        <NewPromoCampaignButton
-        // existingNames={promoCampaigns.map(c => c.name)}
-        // existingNicknames={promoCampaigns.map(c => c.name || '')}
-        // createCampaign={createPromoCampaign}
-        />
+        <NewPromoCampaignButton />
         <TextField
           className={classes.searchField}
           label="Filter Promo Campaigns"

--- a/public/src/components/promoTool/promoCampaignsSidebar.tsx
+++ b/public/src/components/promoTool/promoCampaignsSidebar.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { makeStyles } from '@mui/styles';
-import { MenuItem, Select, TextField } from '@mui/material';
+import { TextField } from '@mui/material';
 import PromoCampaignsList from './promoCampaignsList';
 import NewPromoCampaignButton from './newPromoCampaignButton';
-import { Products, PromoCampaign, PromoCampaigns } from './utils/promoModels';
+import { promoProductNames, PromoCampaign, PromoCampaigns } from './utils/promoModels';
+import { ProductSelector } from './productSelector';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -14,6 +15,7 @@ const useStyles = makeStyles(() => ({
   headline2: {
     color: '#555',
     fontSize: 18,
+    marginTop: '20px',
   },
   listsContainer: {
     position: 'relative',
@@ -60,13 +62,7 @@ function PromoCampaignsSidebar({
   return (
     <div className={classes.root}>
       <h2 className={classes.headline2}>Select Product to filter Promo Campaigns</h2>
-      <Select className={classes.select} value={Products[0].code} aria-label="Select Product">
-        {Products.map(c => (
-          <MenuItem value={c.code} key={`product-${c.code}`}>
-            {c.name}
-          </MenuItem>
-        ))}
-      </Select>
+      <ProductSelector promoProductNames={promoProductNames} />
       <h2 className={classes.headline2}>Promo Campaigns</h2>
       <div className={classes.buttonsContainer}>
         <NewPromoCampaignButton />

--- a/public/src/components/promoTool/promoCampaignsSidebar.tsx
+++ b/public/src/components/promoTool/promoCampaignsSidebar.tsx
@@ -45,10 +45,10 @@ interface PromoCampaignsSidebarProps {
 
 function PromoCampaignsSidebar({
   promoCampaigns,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  createPromoCampaign,
   selectedPromoCampaign,
   onPromoCampaignSelected,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  createPromoCampaign,
 }: PromoCampaignsSidebarProps): React.ReactElement {
   const classes = useStyles();
   const [promoCampaignSearch, setPromoCampaignSearch] = useState('');

--- a/public/src/components/promoTool/promoTool.tsx
+++ b/public/src/components/promoTool/promoTool.tsx
@@ -1,0 +1,65 @@
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material';
+import React from 'react';
+import PromoCampaignsSidebar from './promoCampaignsSidebar';
+import {
+  dummyCampaigns,
+  dummyCreatePromoCampaignFunction,
+  dummySelectedCampaign,
+  dummySelectedPromoCampaignFunction,
+} from './utils/promoModels';
+
+const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
+  viewTextContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: '-50px',
+  },
+  viewText: {
+    fontSize: typography.pxToRem(16),
+  },
+  body: {
+    display: 'flex',
+    overflow: 'hidden',
+    flexGrow: 1,
+    width: '100%',
+    height: '100%',
+  },
+  leftCol: {
+    height: '100%',
+    flexShrink: 0,
+    overflowY: 'auto',
+    background: 'white',
+    paddingTop: spacing(6),
+    paddingLeft: spacing(6),
+    paddingRight: spacing(6),
+  },
+  rightCol: {
+    flexGrow: 1,
+    display: 'flex',
+    justifyContent: 'center',
+  },
+}));
+
+const PromoTool: React.FC = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.body}>
+      {/* TODO: there should probably be a form rather than a div */}
+      <div className={classes.leftCol}>
+        <PromoCampaignsSidebar
+          promoCampaigns={dummyCampaigns}
+          selectedPromoCampaign={dummySelectedCampaign}
+          createPromoCampaign={dummyCreatePromoCampaignFunction}
+          onPromoCampaignSelected={dummySelectedPromoCampaignFunction}
+        />
+      </div>
+      <div className={classes.rightCol}>List of Promos for campaign</div>
+    </div>
+  );
+};
+
+export default PromoTool;

--- a/public/src/components/promoTool/promoTool.tsx
+++ b/public/src/components/promoTool/promoTool.tsx
@@ -1,13 +1,9 @@
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PromoCampaignsSidebar from './promoCampaignsSidebar';
-import {
-  dummyCampaigns,
-  dummyCreatePromoCampaignFunction,
-  dummySelectedCampaign,
-  dummySelectedPromoCampaignFunction,
-} from './utils/promoModels';
+import { dummyCampaigns, PromoCampaign } from './utils/promoModels';
+import { useParams } from 'react-router-dom';
 
 const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
   viewTextContainer: {
@@ -50,15 +46,42 @@ const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
 const PromoTool: React.FC = () => {
   const classes = useStyles();
 
+  const [promoCampaigns, setPromoCampaigns] = useState<PromoCampaign[]>([]);
+  const { promoCampaignCode } = useParams<{ promoCampaignCode?: string }>(); // querystring parameter
+  const [selectedPromoCampaignCode, setSelectedPromoCampaignCode] = useState<string | undefined>();
+
+  // TODO: replace
+  const dummyFetch = () => setPromoCampaigns(dummyCampaigns);
+  const onDummyCreate = (newPromoCampaign: PromoCampaign): void => {
+    // TODO: validate etc
+    setPromoCampaigns([newPromoCampaign, ...promoCampaigns]);
+  };
+
+  // set selected promoCampaign
+  useEffect(() => {
+    if (promoCampaignCode != null) {
+      setSelectedPromoCampaignCode(promoCampaignCode);
+    }
+  }, [promoCampaignCode, promoCampaigns]);
+
+  // fetch promoCampaignsList
+  useEffect(() => {
+    dummyFetch();
+  }, []);
+
+  const selectedPromoCampaign = promoCampaigns.find(
+    a => a.campaignCode === selectedPromoCampaignCode,
+  );
+
   return (
     <div className={classes.body}>
-      {/* TODO: there should probably be a form rather than a div */}
+      {/* TODO: form rather than a div? */}
       <div className={classes.leftCol}>
         <PromoCampaignsSidebar
-          promoCampaigns={dummyCampaigns}
-          selectedPromoCampaign={dummySelectedCampaign}
-          createPromoCampaign={dummyCreatePromoCampaignFunction}
-          onPromoCampaignSelected={dummySelectedPromoCampaignFunction}
+          promoCampaigns={promoCampaigns}
+          selectedPromoCampaign={selectedPromoCampaign}
+          createPromoCampaign={onDummyCreate}
+          onPromoCampaignSelected={code => setSelectedPromoCampaignCode(code)}
         />
       </div>
       <div className={classes.rightCol}>

--- a/public/src/components/promoTool/promoTool.tsx
+++ b/public/src/components/promoTool/promoTool.tsx
@@ -27,6 +27,10 @@ const useStyles = makeStyles(({ spacing, typography }: Theme) => ({
     width: '100%',
     height: '100%',
   },
+  headline2: {
+    color: '#555',
+    fontSize: 18,
+  },
   leftCol: {
     height: '100%',
     flexShrink: 0,
@@ -57,7 +61,10 @@ const PromoTool: React.FC = () => {
           onPromoCampaignSelected={dummySelectedPromoCampaignFunction}
         />
       </div>
-      <div className={classes.rightCol}>List of Promos for campaign</div>
+      <div className={classes.rightCol}>
+        {' '}
+        <h2 className={classes.headline2}>List of Promos for campaign</h2>
+      </div>
     </div>
   );
 };

--- a/public/src/components/promoTool/utils/promoModels.ts
+++ b/public/src/components/promoTool/utils/promoModels.ts
@@ -1,41 +1,85 @@
-export type PromoProduct =
-  | 'Supporter Plus'
-  | 'Three Tier'
-  | 'Digital Pack'
-  | 'Newspaper'
-  | 'Guardian Weekly'; // PromoProduct?
+import { Country } from '../../../utils/models';
 
-export const productTypes = [
-  'Supporter Plus',
-  'Three Tier',
-  'Digital Pack',
-  'Newspaper',
-  'Guardian Weekly', // TODO: notice the scala PromoProduct model for this is 'Weekly'
+export interface Product {
+  code: string;
+  name: string;
+}
+
+// applying user recognisable names to PromoProduct codes
+export const Products: Product[] = [
+  {
+    code: 'SupporterPlus',
+    name: 'Supporter Plus',
+  },
+  {
+    code: 'TierThree',
+    name: 'Tier Three',
+  },
+  {
+    code: 'DigitalPack',
+    name: 'Digital Pack',
+  },
+  {
+    code: 'Newspaper',
+    name: 'Newspaper',
+  },
+  {
+    code: 'Weekly',
+    name: 'Guardian Weekly',
+  },
 ];
 
 export interface PromoCampaign {
   campaignCode: string;
-  product: PromoProduct;
+  product: Product;
   name: string;
   created: string;
+}
+
+export interface AppliesTo {
+  productRatePlanIds: Set<string>; // TODO: where do we get these?
+  countries: Set<Country>;
+}
+
+export interface Promo {
+  promoCode: string;
+  name: string;
+  campaignCode: string;
+  appliesTo: AppliesTo;
+  startTimestamp: string;
+  endTimestamp: string;
+  description?: string;
 }
 
 export type PromoCampaigns = PromoCampaign[];
 
 /* TODO: replace these dummy variables when we have data/endpoints to call */
 export const dummySelectedCampaign: PromoCampaign = {
-  campaignCode: '1234567',
-  product: 'Three Tier',
+  campaignCode: 'C1234567',
+  product: { code: 'ThreeTier', name: 'Three Tier' },
   name: 'US Thanksgiving 2025 30% off',
   created: '2025-09-20',
 };
 export const dummySelectedCampaign2: PromoCampaign = {
-  campaignCode: '1234567',
-  product: 'Three Tier',
+  campaignCode: 'C345678',
+  product: { code: 'ThreeTier', name: 'Three Tier' },
   name: 'US New Year 2025 50% off',
   created: '2025-08-20',
 };
+export const dummyPromo1: Promo = {
+  promoCode: 'C1234567',
+  name: '',
+  campaignCode: 'P123456',
+  appliesTo: {
+    productRatePlanIds: new Set<string>(['monthly', 'annual']),
+    countries: new Set<Country>(['US', 'AU']),
+  },
+  startTimestamp: '2025-08-20',
+  endTimestamp: '2025-12-20',
+  description: 'My description here',
+};
 export const dummyCampaigns: PromoCampaigns = [dummySelectedCampaign, dummySelectedCampaign2];
+export const dummyPromos: Promo[] = [dummyPromo1];
 export const dummyCreatePromoCampaignFunction = (campaign: PromoCampaign): void => {
   console.log('dummy creation function happening for ' + campaign);
 };

--- a/public/src/components/promoTool/utils/promoModels.ts
+++ b/public/src/components/promoTool/utils/promoModels.ts
@@ -1,0 +1,45 @@
+export type PromoProduct =
+  | 'Supporter Plus'
+  | 'Three Tier'
+  | 'Digital Pack'
+  | 'Newspaper'
+  | 'Guardian Weekly'; // PromoProduct?
+
+export const productTypes = [
+  'Supporter Plus',
+  'Three Tier',
+  'Digital Pack',
+  'Newspaper',
+  'Guardian Weekly', // TODO: notice the scala PromoProduct model for this is 'Weekly'
+];
+
+export interface PromoCampaign {
+  campaignCode: string;
+  product: PromoProduct;
+  name: string;
+  created: string;
+}
+
+export type PromoCampaigns = PromoCampaign[];
+
+/* TODO: replace these dummy variables when we have data/endpoints to call */
+export const dummySelectedCampaign: PromoCampaign = {
+  campaignCode: '1234567',
+  product: 'Three Tier',
+  name: 'US Thanksgiving 2025 30% off',
+  created: '2025-09-20',
+};
+export const dummySelectedCampaign2: PromoCampaign = {
+  campaignCode: '1234567',
+  product: 'Three Tier',
+  name: 'US New Year 2025 50% off',
+  created: '2025-08-20',
+};
+export const dummyCampaigns: PromoCampaigns = [dummySelectedCampaign, dummySelectedCampaign2];
+export const dummyCreatePromoCampaignFunction = (campaign: PromoCampaign): void => {
+  console.log('dummy creation function happening for ' + campaign);
+};
+export const dummySelectedPromoCampaignFunction = (campaignName: string): void => {
+  console.log('dummy selected function happening for ' + campaignName);
+};
+/* end dummy data */

--- a/public/src/components/promoTool/utils/promoModels.ts
+++ b/public/src/components/promoTool/utils/promoModels.ts
@@ -1,37 +1,19 @@
 import { Country } from '../../../utils/models';
 
-export interface Product {
-  code: string;
-  name: string;
-}
+export type PromoProduct = 'SupporterPlus' | 'TierThree' | 'DigitalPack' | 'Newspaper' | 'Weekly';
 
 // applying user recognisable names to PromoProduct codes
-export const Products: Product[] = [
-  {
-    code: 'SupporterPlus',
-    name: 'Supporter Plus',
-  },
-  {
-    code: 'TierThree',
-    name: 'Tier Three',
-  },
-  {
-    code: 'DigitalPack',
-    name: 'Digital Pack',
-  },
-  {
-    code: 'Newspaper',
-    name: 'Newspaper',
-  },
-  {
-    code: 'Weekly',
-    name: 'Guardian Weekly',
-  },
-];
+export const promoProductNames: Record<PromoProduct, string> = {
+  SupporterPlus: 'Supporter Plus',
+  TierThree: 'Tier Three',
+  DigitalPack: 'Digital Pack',
+  Newspaper: 'Newspaper',
+  Weekly: 'Guardian Weekly',
+};
 
 export interface PromoCampaign {
   campaignCode: string;
-  product: Product;
+  product: PromoProduct;
   name: string;
   created: string;
 }
@@ -56,13 +38,13 @@ export type PromoCampaigns = PromoCampaign[];
 /* TODO: replace these dummy variables when we have data/endpoints to call */
 export const dummySelectedCampaign: PromoCampaign = {
   campaignCode: 'C1234567',
-  product: { code: 'ThreeTier', name: 'Three Tier' },
+  product: 'TierThree',
   name: 'US Thanksgiving 2025 30% off',
   created: '2025-09-20',
 };
 export const dummySelectedCampaign2: PromoCampaign = {
   campaignCode: 'C345678',
-  product: { code: 'ThreeTier', name: 'Three Tier' },
+  product: 'TierThree',
   name: 'US New Year 2025 50% off',
   created: '2025-08-20',
 };

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -42,6 +42,7 @@ import { StyledEngineProvider } from '@mui/material';
 import { LinkTrackingBuilder } from './components/linkTracking/LinkTrackingBuilder';
 import { SupportLandingPageTestsForm } from './components/channelManagement/supportLandingPage/supportLandingPage';
 import { AuditTestsDashboard } from './components/channelManagement/auditTests/auditTestsDashboard';
+import PromoTool from './components/promoTool/promoTool';
 
 declare module '@mui/styles' {
   // https://mui.com/material-ui/migration/v5-style-changes/#%E2%9C%85-add-module-augmentation-for-defaulttheme-typescript
@@ -209,6 +210,7 @@ const AppRouter = () => {
             path="/super-mode"
             element={createComponent(<SuperModeDashboard />, 'Epic Super Mode dashboard 🦸')}
           />
+          <Route path="/promo-tool" element={createComponent(<PromoTool />, 'Promo Tool')} />
           <Route
             path="/default-promos"
             element={createComponent(<DefaultPromos />, 'Default Promos')}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the project to migrate the Promo tool into RRCP this starts to create the UI for the tool.

- This creates (and hides while under development) a new Promo tool menu item and associated page component.
- The page contains a hard-coded list of Products in a drop down within a side bar which will act as a filter for the PromoCampaigns later and be filled via a service.
- It also contains a button to create a new PromoCampaign which opens a simple modal dialog (currently only containing a name textbox).  Later we will add further fields and connect it to the service to save a new PromoCampaign.
- It lists a dummy set of PromoCampaigns in the sidebar - this will be populated via a service later.
- It has a basic filter textbox which is used to filter the promoCampaigns by name.
- The basic layout of the page is mostly in place ready to add further components to show promo details associated with PromoCampaigns and a modal to create or update those Promos.
- [Trello Ticket](https://trello.com/c/a4JETnP9)
