### PR TITLE
Tweak to add AWS_PROFILE to script that runs updatePermissions in README

### DIFF
--- a/scripts/updatePermissions/README.md
+++ b/scripts/updatePermissions/README.md
@@ -7,6 +7,7 @@ We do not yet have a tool for maintaining these permissions, so for now we can u
 ### Usage:
 From this directory, run:
 ```
+AWS_PROFILE=membership \
 Stage=DEV \
 PermissionLevel=Write \
 PermissionName=support-landing-page-tests \


### PR DESCRIPTION
## What does this change?

Updates the README to ensures that the appropriate AWS Profile is being used when running the updatePermissions script locally.
