### PR TITLE
Product catalog service

### DIFF
--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -1,0 +1,57 @@
+package models.promos
+
+case class Pricing(
+  aud: Option[Double] = None,
+  cad: Option[Double] = None,
+  eur: Option[Double] = None,
+  gbp: Option[Double] = None,
+  nzd: Option[Double] = None,
+  usd: Option[Double] = None
+)
+
+case class Charge(id: String)
+case class Charges(items: Map[String, Charge])
+
+case class RatePlan(
+  billingPeriod: String,
+  charges: Charges,
+  id: String,
+  pricing: Pricing,
+  termLengthInMonths: Int,
+  termType: String
+)
+
+case class GuardianWeeklyDomestic(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)
+
+case class GuardianWeeklyRestOfWorld(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)
+
+case class HomeDelivery(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)
+
+case class NationalDelivery(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)
+
+case class SubscriptionCard(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)
+
+case class SupporterPlus(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)
+
+case class TierThree(
+  customerFacingName: String,
+  ratePlans: Map[String, RatePlan]
+)

--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -5,6 +5,43 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import ProductCatalog._
 
+/**
+ * Example JSON from the product catalog, excluding fields that we do not care about here:
+ *
+ * {
+ *  "SupporterPlus": {
+ *     "customerFacingName": "All-access digital",
+ *     "ratePlans": {
+ *       "Monthly": {
+ *         "id": "8ad08cbd8586721c01858804e3275376",
+ *         "pricing": {
+ *           "USD": 15,
+ *           "NZD": 20,
+ *           "EUR": 12,
+ *           "GBP": 12,
+ *           "CAD": 15,
+ *           "AUD": 20
+ *         },
+ *         "billingPeriod": "Month"
+ *       },
+ *       "Annual": {
+ *         "id": "8ad08e1a8586721801858805663f6fab",
+ *         "pricing": {
+ *           "USD": 150,
+ *           "NZD": 200,
+ *           "EUR": 120,
+ *           "GBP": 120,
+ *           "CAD": 150,
+ *           "AUD": 200
+ *         },
+ *         "billingPeriod": "Annual"
+ *       }
+ *     }
+ *   },
+ *   ...
+ * }
+ */
+
 case class ProductCatalog(
   GuardianWeeklyDomestic: ProductDetails[GuardianWeeklyRatePlans],
   GuardianWeeklyRestOfWorld: ProductDetails[GuardianWeeklyRatePlans],

--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -99,14 +99,17 @@ object ProductCatalog {
   )
 
   case class TierThreeRatePlans(
-    Annual: RatePlan,
-    Monthly: RatePlan,
-    Quarterly: RatePlan
+    DomesticMonthly: RatePlan,
+    DomesticAnnual: RatePlan,
+    RestOfWorldMonthly: RatePlan,
+    RestOfWorldAnnual: RatePlan
   )
   case class TierThree(
     customerFacingName: String,
     ratePlans: TierThreeRatePlans
   )
+
+  import io.circe.generic.auto._
 
   implicit val encoder: Encoder[ProductCatalog] = deriveEncoder[ProductCatalog]
   implicit val decoder: Decoder[ProductCatalog] = deriveDecoder[ProductCatalog]

--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -31,6 +31,7 @@ object ProductCatalog {
     id: String,
     pricing: Pricing
   )
+
   sealed trait BillingPeriod
   object BillingPeriod {
     case object Month extends BillingPeriod

--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -1,57 +1,113 @@
 package models.promos
 
-case class Pricing(
-  aud: Option[Double] = None,
-  cad: Option[Double] = None,
-  eur: Option[Double] = None,
-  gbp: Option[Double] = None,
-  nzd: Option[Double] = None,
-  usd: Option[Double] = None
+import io.circe.generic.extras.Configuration
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import ProductCatalog._
+
+case class ProductCatalog(
+  GuardianWeeklyDomestic: GuardianWeeklyDomestic,
+  GuardianWeeklyRestOfWorld: GuardianWeeklyRestOfWorld,
+  HomeDelivery: HomeDelivery,
+  SubscriptionCard: SubscriptionCard,
+  NationalDelivery: NationalDelivery,
+  SupporterPlus: SupporterPlus,
+  TierThree: TierThree
 )
 
-case class Charge(id: String)
-case class Charges(items: Map[String, Charge])
+object ProductCatalog {
+  // All currencies here are optional, and the product catalog will define which are available for a given rate plan
+  case class Pricing(
+    AUD: Option[Double] = None,
+    CAD: Option[Double] = None,
+    EUR: Option[Double] = None,
+    GBP: Option[Double] = None,
+    NZD: Option[Double] = None,
+    USD: Option[Double] = None
+  )
 
-case class RatePlan(
-  billingPeriod: String,
-  charges: Charges,
-  id: String,
-  pricing: Pricing,
-  termLengthInMonths: Int,
-  termType: String
-)
+  case class RatePlan(
+    billingPeriod: BillingPeriod,
+    id: String,
+    pricing: Pricing
+  )
+  sealed trait BillingPeriod
+  object BillingPeriod {
+    case object Month extends BillingPeriod
+    case object Annual extends BillingPeriod
+    case object Quarter extends BillingPeriod
 
-case class GuardianWeeklyDomestic(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+    import io.circe.generic.extras.semiauto._
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
+    implicit val encoder: Encoder[BillingPeriod] = deriveEnumerationEncoder[BillingPeriod]
+    implicit val decoder: Decoder[BillingPeriod] = deriveEnumerationDecoder[BillingPeriod]
+  }
 
-case class GuardianWeeklyRestOfWorld(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+  case class GuardianWeeklyRatePlans(
+    Annual: RatePlan,
+    Monthly: RatePlan,
+    Quarterly: RatePlan
+  )
 
-case class HomeDelivery(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+  case class GuardianWeeklyDomestic(
+    customerFacingName: String,
+    ratePlans: GuardianWeeklyRatePlans
+  )
 
-case class NationalDelivery(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+  case class GuardianWeeklyRestOfWorld(
+    customerFacingName: String,
+    ratePlans: GuardianWeeklyRatePlans
+  )
 
-case class SubscriptionCard(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+  case class HomeDeliveryAndSubscriptionCardRatePlans(
+    EverydayPlus: RatePlan,
+    SaturdayPlus: RatePlan,
+    WeekendPlus: RatePlan,
+    SixdayPlus: RatePlan,
+    // The only non-"Plus" rate plan is Sunday (Observer)
+    Sunday: RatePlan
+  )
 
-case class SupporterPlus(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+  case class HomeDelivery(
+    customerFacingName: String,
+    ratePlans: HomeDeliveryAndSubscriptionCardRatePlans
+  )
 
-case class TierThree(
-  customerFacingName: String,
-  ratePlans: Map[String, RatePlan]
-)
+  case class SubscriptionCard(
+    customerFacingName: String,
+    ratePlans: HomeDeliveryAndSubscriptionCardRatePlans
+  )
+
+  case class NationalDeliveryRatePlans(
+    EverydayPlus: RatePlan,
+    SixdayPlus: RatePlan,
+    WeekendPlus: RatePlan
+  )
+
+  case class NationalDelivery(
+    customerFacingName: String,
+    ratePlans: NationalDeliveryRatePlans
+  )
+
+  case class SupporterPlusRatePlans(
+    Annual: RatePlan,
+    Monthly: RatePlan,
+  )
+  case class SupporterPlus(
+    customerFacingName: String,
+    ratePlans: SupporterPlusRatePlans
+  )
+
+  case class TierThreeRatePlans(
+    Annual: RatePlan,
+    Monthly: RatePlan,
+    Quarterly: RatePlan
+  )
+  case class TierThree(
+    customerFacingName: String,
+    ratePlans: TierThreeRatePlans
+  )
+
+  implicit val encoder: Encoder[ProductCatalog] = deriveEncoder[ProductCatalog]
+  implicit val decoder: Decoder[ProductCatalog] = deriveDecoder[ProductCatalog]
+}

--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -49,7 +49,8 @@ case class ProductCatalog(
   SubscriptionCard: ProductDetails[HomeDeliveryAndSubscriptionCardRatePlans],
   NationalDelivery: ProductDetails[NationalDeliveryRatePlans],
   SupporterPlus: ProductDetails[SupporterPlusRatePlans],
-  TierThree: ProductDetails[TierThreeRatePlans]
+  TierThree: ProductDetails[TierThreeRatePlans],
+  DigitalSubscription: ProductDetails[DigitalSubscriptionRatePlans]
 )
 
 object ProductCatalog {
@@ -114,6 +115,12 @@ object ProductCatalog {
     DomesticAnnual: RatePlan,
     RestOfWorldMonthly: RatePlan,
     RestOfWorldAnnual: RatePlan
+  ) extends ProductRatePlans
+
+  case class DigitalSubscriptionRatePlans(
+    Monthly: RatePlan,
+    Annual: RatePlan,
+    Quarterly: RatePlan
   ) extends ProductRatePlans
 
   trait ProductDetails[R <: ProductRatePlans] {

--- a/app/services/ProductCatalogCache.scala
+++ b/app/services/ProductCatalogCache.scala
@@ -1,0 +1,48 @@
+package services
+
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.parser.decode
+import models.promos.ProductCatalog
+import play.api.libs.ws.WSClient
+import zio._
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.ExecutionContext
+
+class ProductCatalogCache(
+  runtime: zio.Runtime[Any],
+  wsClient: WSClient
+)(implicit val ec: ExecutionContext) extends StrictLogging {
+
+  private val url = "https://product-catalog.guardianapis.com/product-catalog.json"
+  private val catalogCache = new AtomicReference[Option[ProductCatalog]](None)
+
+  private def fetchCatalog(): ZIO[Any, Throwable, ProductCatalog] =
+    ZIO.fromFuture { implicit ec =>
+      wsClient
+        .url(url)
+        .get()
+        .map { response =>
+          decode[ProductCatalog](response.body)
+        }
+    }.flatMap {
+      case Right(catalog) => ZIO.succeed(catalog)
+      case Left(error)    => ZIO.fail(new Exception(error.getMessage))
+    }
+
+  private def updateCatalog(catalog: ProductCatalog) = {
+    catalogCache.set(Some(catalog))
+    ZIO.succeed(())
+  }
+
+  // Poll every 5 minutes in the background
+  Unsafe.unsafe { implicit unsafe =>
+    runtime.unsafe.runToFuture {
+      fetchCatalog()
+        .map(updateCatalog)
+        .repeat(Schedule.fixed(5.minutes))
+    }
+  }
+
+  def getCatalog: Option[ProductCatalog] = catalogCache.get()
+}

--- a/app/services/ProductCatalogCache.scala
+++ b/app/services/ProductCatalogCache.scala
@@ -40,6 +40,10 @@ class ProductCatalogCache(
     runtime.unsafe.runToFuture {
       fetchCatalog()
         .map(updateCatalog)
+        .catchAll(error => {
+          logger.error(s"Error fetching product catalog: ${error.getMessage}")
+          ZIO.succeed(()) // allow it to repeat
+        })
         .repeat(Schedule.fixed(5.minutes))
     }
   }

--- a/app/services/ProductCatalogCache.scala
+++ b/app/services/ProductCatalogCache.scala
@@ -10,11 +10,14 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext
 
 class ProductCatalogCache(
+  stage: String,
   runtime: zio.Runtime[Any],
   wsClient: WSClient
 )(implicit val ec: ExecutionContext) extends StrictLogging {
-
-  private val url = "https://product-catalog.guardianapis.com/product-catalog.json"
+  private val url = {
+    if (stage == "PROD") "https://product-catalog.guardianapis.com/product-catalog.json"
+    else "https://product-catalog.code.dev-guardianapis.com/product-catalog.json"
+  }
   private val catalogCache = new AtomicReference[Option[ProductCatalog]](None)
 
   private def fetchCatalog(): ZIO[Any, Throwable, ProductCatalog] =

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -104,7 +104,7 @@ class AppComponents(context: Context, stage: String)
   val bigQueryClientConfig = configuration.get[String]("gcp-wif-credentials-config")
   val bigQueryService: BigQueryService = BigQueryService(stage, bigQueryClientConfig)
 
-  val productCatalogCache = new ProductCatalogCache(runtime, wsClient)
+  val productCatalogCache = new ProductCatalogCache(stage, runtime, wsClient)
 
   override lazy val router: Router = new Routes(
     httpErrorHandler,

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -12,9 +12,10 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.AnyContent
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import router.Routes
-import services.{Aws, BigQueryService, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoChannelTestsAudit, DynamoPermissionsCache, DynamoSuperMode, S3}
+import services.{Aws, BigQueryService, CapiService, DynamoArchivedBannerDesigns, DynamoArchivedChannelTests, DynamoBanditData, DynamoBannerDesigns, DynamoCampaigns, DynamoChannelTests, DynamoChannelTestsAudit, DynamoPermissionsCache, DynamoSuperMode, ProductCatalogCache, S3}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+
 import java.time.Duration
 
 class AppComponents(context: Context, stage: String)
@@ -102,6 +103,8 @@ class AppComponents(context: Context, stage: String)
 
   val bigQueryClientConfig = configuration.get[String]("gcp-wif-credentials-config")
   val bigQueryService: BigQueryService = BigQueryService(stage, bigQueryClientConfig)
+
+  val productCatalogCache = new ProductCatalogCache(runtime, wsClient)
 
   override lazy val router: Router = new Routes(
     httpErrorHandler,


### PR DESCRIPTION
This is in preparation for the new promos tool in the RRCP.

When creating a promo the user must define which product rate plans it should apply to.
We use the product catalog to find out which rate plans are available for each product. We store the selected rate plan IDs in the table.

This PR adds scala models for the parts of the product catalog that are relevant.
It also adds a `ProductCatalogCache`, which polls the product catalog API every 5 mins.
This data will eventually be used by the client to know which rate plans are available.

I think there's a case for _not_ defining a server-side model, and passing the entire JSON blob as-is to the client. This would work. But validating and refining the data server-side is more in keeping with the design of this app, and it enables us to catch and log any data issues more formally.