### PR TITLE
Improve choice cards destination

### DIFF
--- a/app/models/ChoiceCardsSettings.scala
+++ b/app/models/ChoiceCardsSettings.scala
@@ -49,6 +49,16 @@ object ChoiceCardsSettings {
     implicit val productEncoder: Encoder[Product] = deriveConfiguredEncoder[Product]
   }
 
+  sealed trait Destination
+  object Destination {
+    case object LandingPage extends Destination
+    case object Checkout extends Destination
+
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
+    implicit val encoder: Encoder[Destination] = deriveEnumerationEncoder[Destination]
+    implicit val decoder: Decoder[Destination] = deriveEnumerationDecoder[Destination]
+  }
+
   case class Pill(copy: String)
 
   case class ChoiceCard(
@@ -58,7 +68,7 @@ object ChoiceCardsSettings {
       benefits: List[ProductBenefit],
       pill: Option[Pill],
       isDefault: Boolean,
-      destinationUrl: Option[String]
+      destination: Option[Destination]
   )
 
   implicit val customConfig: Configuration = Configuration.default.withDefaults

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardEditor.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardEditor.tsx
@@ -22,7 +22,8 @@ import { makeStyles } from '@mui/styles';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
 import { RichTextEditorSingleLine, RteMenuConstraints } from '../richTextEditor/richTextEditor';
-import { EMPTY_ERROR_HELPER_TEXT, optionalUrlValidator } from '../helpers/validation';
+import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
+import TypedRadioGroup from '../TypedRadioGroup';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -33,7 +34,7 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
       marginLeft: spacing(2),
     },
   },
-  benefitsHeading: {
+  subHeading: {
     fontWeight: 700,
   },
   benefitContainer: {
@@ -45,6 +46,9 @@ const useStyles = makeStyles(({ spacing }: Theme) => ({
   },
   deleteButton: {
     margin: `${spacing(2)} 0 ${spacing(1)} ${spacing(1)}`,
+  },
+  addButton: {
+    marginBottom: spacing(2),
   },
 }));
 
@@ -256,7 +260,7 @@ export const ChoiceCardEditor: React.FC<ChoiceCardEditorProps> = ({
         />
 
         <div>
-          <label className={classes.benefitsHeading}>Benefits</label>
+          <label className={classes.subHeading}>Benefits</label>
           {benefits.map((benefit, benefitIndex) => (
             <div className={classes.benefitContainer} key={benefit.id}>
               <Controller
@@ -299,34 +303,31 @@ export const ChoiceCardEditor: React.FC<ChoiceCardEditorProps> = ({
             disabled={isDisabled || benefits.length >= 8}
             variant="outlined"
             size="medium"
+            className={classes.addButton}
           >
             <AddIcon />
           </Button>
         </div>
 
         <Controller
-          name={`choiceCards.${index}.destinationUrl`}
+          name={`choiceCards.${index}.destination`}
           control={control}
-          rules={{
-            validate: (value?: string | null) => optionalUrlValidator(value),
-          }}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              required={false}
-              label="Destination URL (optional)"
-              variant="filled"
-              fullWidth
-              margin="normal"
-              disabled={isDisabled}
-              error={!!fieldState.error}
-              helperText={fieldState.error?.message}
-              onChange={e => {
-                const trimmedValue = e.target.value.trim();
-                field.onChange(trimmedValue);
-                handleCardChange();
-              }}
-            />
+          render={({ field }) => (
+            <>
+              <label className={classes.subHeading}>Destination</label>
+              <TypedRadioGroup
+                selectedValue={field.value ?? 'LandingPage'}
+                onChange={destination => {
+                  field.onChange(destination);
+                  handleCardChange();
+                }}
+                isDisabled={isDisabled}
+                labels={{
+                  LandingPage: 'Landing page',
+                  Checkout: 'Checkout',
+                }}
+              />
+            </>
           )}
         />
       </AccordionDetails>

--- a/public/src/components/channelManagement/helpers/validation.tsx
+++ b/public/src/components/channelManagement/helpers/validation.tsx
@@ -94,18 +94,3 @@ export const copyLengthValidator = (maxLength: number) => (
   }
   return undefined;
 };
-
-export const optionalUrlValidator = (value?: string | null): string | undefined => {
-  const trimmedValue = (value && value.trim()) ?? '';
-
-  if (!trimmedValue) {
-    return undefined;
-  }
-
-  try {
-    new URL(trimmedValue);
-    return undefined;
-  } catch {
-    return 'Please enter a valid URL';
-  }
-};

--- a/public/src/models/choiceCards.ts
+++ b/public/src/models/choiceCards.ts
@@ -11,6 +11,8 @@ export type Product =
       supportTier: 'OneOff';
     };
 
+type Destination = 'LandingPage' | 'Checkout';
+
 export interface ChoiceCard {
   product: Product;
   label: string;
@@ -20,7 +22,7 @@ export interface ChoiceCard {
     copy: string; // e.g. "Recommended", will be overridden if a promo applies
   };
   isDefault: boolean;
-  destinationUrl?: string | null;
+  destination?: Destination;
 }
 
 export interface ChoiceCardsSettings {


### PR DESCRIPTION
A while back we added a `destinationUrl` field to the `ChoiceCard` model.
The idea was to let MRR configure a custom url per choice.
However, all they really need is a choice between landing page or checkout.
The url query params are the same regardless, e.g. `product=SupporterPlus&ratePlan=Monthly`.

Currently the client (DCR) uses either the primary cta url, or the relevant choice card `destinationUrl` if it's configured.
We can simplify things by just configuring the choice of `'LandingPage' | 'Checkout'` per choice card, and let DCR work out the url from that.

This will require a model change in SDC, and an update to DCR to use the new field.
There are currently no live tests that use the `destinationUrl`, because of a tracking bug in the client.

The new UI in the tool:
<img width="306" height="144" alt="Screenshot 2025-10-03 at 14 23 05" src="https://github.com/user-attachments/assets/ef20cab1-727c-4961-aaa9-09714c8a2556" />

