### PR TITLE
Fixes some build warnings related to old sbt syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,13 +78,13 @@ Test / testQuick := { (Test / testQuick).dependsOn(startDynamoDBLocal).evaluated
 Test / test := { (Test / test).dependsOn(startDynamoDBLocal).value }
 Test / testOptions += { dynamoDBLocalTestCleanup.value }
 
-sources in (Compile, doc) := Seq.empty
+Compile / doc / sources := Seq.empty
 
-publishArtifact in (Compile, packageDoc) := false
+Compile / packageDoc / publishArtifact := false
 
 pipelineStages := Seq(digest)
 
-riffRaffPackageType := (packageBin in Debian).value
+riffRaffPackageType := (Debian / packageBin).value
 riffRaffManifestProjectName := "support:admin-console"
 riffRaffPackageName := "admin-console"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
@@ -98,4 +98,4 @@ riffRaffArtifactResources += (
   "cfn/AdminConsole-CODE.template.json"
 )
 
-javaOptions in run ++= Seq("-Xms2G", "-Xmx2G", "-Xss4M")
+run / javaOptions ++= Seq("-Xms2G", "-Xmx2G", "-Xss4M")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates remaining old syntax in the build.sbt file which was causing some build warnings. 

### Warnings seen:

Seen in [build](https://github.com/guardian/support-admin-console/actions/runs/18008755401/job/51235401827?pr=778) 

/home/runner/work/support-admin-console/support-admin-console/build.sbt:81: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
sources in (Compile, doc) := Seq.empty
        ^
/home/runner/work/support-admin-console/support-admin-console/build.sbt:83: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
publishArtifact in (Compile, packageDoc) := false
                ^
/home/runner/work/support-admin-console/support-admin-console/build.sbt:87: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
riffRaffPackageType := (packageBin in Debian).value
                                   ^
/home/runner/work/support-admin-console/support-admin-console/build.sbt:101: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
javaOptions in run ++= Seq("-Xms2G", "-Xmx2G", "-Xss4M")

based on the [document mentioned in the warning](https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash)

## How to test

- It compiles and runs, on push the build works and does not display any warnings
- Deploys to CODE successfully