### PR TITLE
Update grpc-netty-shaded

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,8 @@ dependencyOverrides ++= List(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "io.netty" % "netty-handler" % "4.2.4.Final",
   "io.netty" % "netty-codec-http2" % "4.2.4.Final",
+  // google-cloud-bigquery pulls in a vulnerable version of grpc-netty-shaded
+  "io.grpc" % "grpc-netty-shaded" % "1.75.0",
   // Related to Play 3.0.2-6 currently brings in a vulnerable version of commons-io
   "commons-io" % "commons-io" % "2.20.0" % Test,
   "commons-beanutils" % "commons-beanutils" % "1.11.0"


### PR DESCRIPTION
Dependabot has flagged this dependency: https://github.com/guardian/support-admin-console/security/dependabot/174
Upgrading google-cloud-bigquery will not help as it still uses a vulnerable version.
For now we have to override the version.