### PR TITLE
Hides the hero image section and validation for now

### DIFF
--- a/public/src/components/channelManagement/studentLandingPage/utils/defaults.ts
+++ b/public/src/components/channelManagement/studentLandingPage/utils/defaults.ts
@@ -32,10 +32,13 @@ export const getDefaultInstitution = () => {
 };
 
 const DEFAULT_IMAGE: ResponsiveImage = {
-  mobileUrl: '',
-  tabletUrl: '',
-  desktopUrl: '',
-  altText: '',
+  mobileUrl:
+    'https://i.guim.co.uk/img/media/811f456e9786d119d766e55f2df821c056d415b0/0_0_2588_1276/master/2588.jpg',
+  tabletUrl:
+    'https://i.guim.co.uk/img/media/14e65d1ade49300434e31603dd5b43e25e98e6c2/0_0_1396_1632/master/1396.jpg',
+  desktopUrl:
+    'https://i.guim.co.uk/img/media/f58d5cf9b591f4ddb4ad7a4b9c7bd12ae80dd333/0_0_2295_1632/master/2295.jpg',
+  altText: 'The Guardian and Feast Apps',
 };
 
 export const getDefaultVariant = (): StudentLandingPageVariant => {

--- a/public/src/components/channelManagement/studentLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/variantEditor.tsx
@@ -9,17 +9,20 @@ import { Typography } from '@mui/material';
 import PromoCodesEditor from '../../shared/PromoCodesEditor';
 
 import { AcademicInstitutionDetailEditor } from './academicInstitutionDetails';
-import { ImageGuidance, ResponsiveImageEditor } from '../../shared/ResponsiveImageEditor';
-import { ResponsiveImage } from '../../../models/shared';
+
+// hidden until we can get the hero image sorted out in support-frontend as part of a future phase
+// import { ImageGuidance, ResponsiveImageEditor } from '../../shared/ResponsiveImageEditor';
+// import { ResponsiveImage } from '../../../models/shared';
 
 const HEADLINE_MAX_LENGTH = 65; // TODO: confirm the max length of this field
 const SUBHEADING_MAX_LENGTH = 210; // TODO: confirm the max length of this field
 
-const imageGuidance: ImageGuidance = {
-  mobileUrlGuidance: '1:1 min width of ? max width of ?',
-  tabletUrlGuidance: '1:1 min width of ? max width of ?',
-  desktopUrlGuidance: '1:1 min width of ? max width of ?',
-};
+// hidden until we can get the hero image sorted out in support-frontend as part of a future phase
+// const imageGuidance: ImageGuidance = {
+//   mobileUrlGuidance: '1:1 min width of ? max width of ?',
+//   tabletUrlGuidance: '1:1 min width of ? max width of ?',
+//   desktopUrlGuidance: '1:1 min width of ? max width of ?',
+// };
 
 const useStyles = makeStyles(({ palette, spacing }: Theme) => ({
   container: {
@@ -87,7 +90,7 @@ export const VariantEditor: React.FC<StudentLandingPageVariantEditorProps> = ({
   const [sectionValidity, setSectionValidity] = useState<VariantSectionValidity>({
     copy: false,
     institution: false,
-    image: false,
+    image: true, // change this back to false when we add the hero image bits back in.
   });
 
   const updatePromoCodes = (promoCodes: string[]): void => {
@@ -101,9 +104,10 @@ export const VariantEditor: React.FC<StudentLandingPageVariantEditorProps> = ({
     onVariantChange((current) => ({ ...current, institution }));
   };
 
-  const updateImage = (image: ResponsiveImage): void => {
-    onVariantChange((current) => ({ ...current, image }));
-  };
+  // hidden until we can get the hero image sorted out in support-frontend.
+  // const updateImage = (image: ResponsiveImage): void => {
+  //   onVariantChange((current) => ({ ...current, image }));
+  // };
 
   const {
     handleSubmit,
@@ -166,7 +170,7 @@ export const VariantEditor: React.FC<StudentLandingPageVariantEditorProps> = ({
       );
     }
     if (messages.length > 0) {
-      return messages.toString(); // TODO enhance
+      return messages.toString();
     }
     return true;
   };
@@ -251,6 +255,7 @@ export const VariantEditor: React.FC<StudentLandingPageVariantEditorProps> = ({
             }}
           />
         </div>
+        {/* hidden until we can get the hero image sorted out in support-frontend as part of a future phase
         <div className={classes.container}>
           <Typography variant={'h4'} className={classes.sectionHeader}>
             Image
@@ -268,7 +273,7 @@ export const VariantEditor: React.FC<StudentLandingPageVariantEditorProps> = ({
             onChange={updateImage}
             imageGuidance={imageGuidance}
           />
-        </div>
+        </div> */}
       </div>
       <div className={classes.container}>
         <Typography variant={'h4'} className={classes.sectionHeader}>


### PR DESCRIPTION
## What does this change?

We are not currently in a position to be able to implement the hero image in support-frontend and it is not likely to be needed in the short term, so we are hiding it in RRCP for the moment in order to enable MRR to be able to start using the  tooling in the meantime.

## How has this change been tested?

This has been deployed to CODE, created a test/variant combo and checked that the URL created behaved as expected.  Also checked that there was no impact on the existing UTS and student beans pages.

## Images

<img width="1503" height="759" alt="Screenshot 2026-04-15 at 17 26 37" src="https://github.com/user-attachments/assets/7f8684c5-28c0-4e80-9d29-c3aa4a22c482" />
