### PR TITLE
A fix for subheading copy and addition to logo helper text

### DIFF
--- a/public/src/components/channelManagement/studentLandingPage/academicInstitutionDetails.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/academicInstitutionDetails.tsx
@@ -150,7 +150,7 @@ export const AcademicInstitutionDetailEditor: React.FC<AcademicInstituteDetailEd
           error={errors.logoUrl !== undefined}
           helperText={
             errors?.logoUrl?.message ??
-            'Image dimensions should be 61 wide by 27 high, with a transparent background and the foreground colour needs to be white'
+            'Image dimensions should be 61px wide by 27px high, with a transparent background and the foreground colour needs to be white'
           }
           onBlur={handleSubmit(update)}
           label="Logo for Institution"

--- a/public/src/components/channelManagement/studentLandingPage/utils/defaults.ts
+++ b/public/src/components/channelManagement/studentLandingPage/utils/defaults.ts
@@ -46,7 +46,7 @@ export const getDefaultVariant = (): StudentLandingPageVariant => {
     name: 'offer',
     heading: 'Subscribe to fearless, independent and inspiring journalism',
     subheading:
-      'For a limited time, students with a valid ??? email address can unlock the premium experience of Guardian journalism, including unmetered app access, free for two years.',
+      'For a limited time, students with a valid ??? email address can unlock the premium experience of Guardian journalism, including unmetered app access',
     institution: getDefaultInstitution(),
     promoCodes: [],
     image: DEFAULT_IMAGE,


### PR DESCRIPTION
## What does this change?

On creating the PROD UTS test/variant combo, it became obvious that the default copy for the subheading contained an unnecessary element.  The last part of the copy is actually dependent upon the discount code being in the parameters and so should not be hard coded into the subheading.

It was also noticed that the unit of measurement for the logo helper text was missing.

## How has this change been tested?

Deploy to CODE and create a new test to check the changes.

## Images

| Before | After |
|-------|-------|
| <img width="1493" height="792" alt="Screenshot 2026-04-22 at 11 51 57" src="https://github.com/user-attachments/assets/08db4638-e9c2-40b6-ab05-bfbd3313b631" /> |<img width="1490" height="793" alt="Screenshot 2026-04-22 at 12 14 09" src="https://github.com/user-attachments/assets/73b34bf8-3ca1-460e-b27c-75b838f26d50" /> |
