### PR TITLE
Open student landing page tooling to PROD

### DIFF
--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -194,17 +194,15 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="Landing Page" />
           </ListItemButton>
         </Link>
-        {getStage() != 'PROD' && (
-          <Link
-            key="Student Landing Page Offers"
-            to="/student-landing-page-tests"
-            className={classes.link}
-          >
-            <ListItemButton className={classes.listItem} key="Student Landing Page Offers">
-              <ListItemText primary="Student Landing Page Offers" />
-            </ListItemButton>
-          </Link>
-        )}
+        <Link
+          key="Student Landing Page Offers"
+          to="/student-landing-page-tests"
+          className={classes.link}
+        >
+          <ListItemButton className={classes.listItem} key="Student Landing Page Offers">
+            <ListItemText primary="Student Landing Page Offers" />
+          </ListItemButton>
+        </Link>
         <Link key="Checkout Nudge" to="/checkout-nudge-tests" className={classes.link}>
           <ListItemButton className={classes.listItem} key="Checkout Nudge">
             <ListItemText primary="Checkout Nudge" />


### PR DESCRIPTION
## What does this change?

Unhides the menu item by removing the stage restriction so MRR can start tooling student landing pages (not student beans) pages in PROD.

## How has this change been tested?

Pretty hard to test until it's in main.