### PR TITLE
Update heading, subheading copy max length following design advice

### DIFF
--- a/public/src/components/channelManagement/studentLandingPage/variantEditor.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/variantEditor.tsx
@@ -14,8 +14,8 @@ import { AcademicInstitutionDetailEditor } from './academicInstitutionDetails';
 // import { ImageGuidance, ResponsiveImageEditor } from '../../shared/ResponsiveImageEditor';
 // import { ResponsiveImage } from '../../../models/shared';
 
-const HEADLINE_MAX_LENGTH = 65; // TODO: confirm the max length of this field
-const SUBHEADING_MAX_LENGTH = 210; // TODO: confirm the max length of this field
+const HEADLINE_MAX_LENGTH = 75;
+const SUBHEADING_MAX_LENGTH = 230;
 
 // hidden until we can get the hero image sorted out in support-frontend as part of a future phase
 // const imageGuidance: ImageGuidance = {


### PR DESCRIPTION
## What does this change?

This sets the heading copy field max length to 75 and the subheading copy field max length to 230.
The subheading copy length at 230 allows for the hard coded section at the end of the subheading which is added based on the existence and length of the promo code which takes the likely max length of the subheading to 250 characters altogether.

## How has this change been tested?

Run locally and added more copy (see image below).

## Images

<img width="1146" height="306" alt="Screenshot 2026-04-22 at 15 52 10" src="https://github.com/user-attachments/assets/67d47dcc-1a8e-4b23-a723-fbe8b69d6f55" />