### PR TITLE
show exclusions page on prod

### DIFF
--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -254,13 +254,11 @@ export default function NavDrawer(): React.ReactElement {
             <ListItemText primary="App Meter Switches" />
           </ListItemButton>
         </Link>
-        {getStage() != 'PROD' && (
-          <Link key="Channel Exclusions" to="/exclusions" className={classes.link}>
-            <ListItemButton className={classes.listItem} key="Channel Exclusions">
-              <ListItemText primary="Channel Exclusions" />
-            </ListItemButton>
-          </Link>
-        )}
+        <Link key="Channel Exclusions" to="/exclusions" className={classes.link}>
+          <ListItemButton className={classes.listItem} key="Channel Exclusions">
+            <ListItemText primary="Channel Exclusions" />
+          </ListItemButton>
+        </Link>
         <Link key="Test Audits" to="/audit-tests" className={classes.link}>
           <ListItemButton className={classes.listItem} key="Test Audits">
             <ListItemText primary="Test Audits" />


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213735979039323)
## What does this change?
This change removes the constraint of hiding "Exclusions" page in PROD environment
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE environment, verified that the page is visible
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
