### PR TITLE
Precision suppression of the problematic lint issue to unblock PRs

### DIFF
--- a/public/src/components/channelExclusions/useExclusionRuleHandlers.ts
+++ b/public/src/components/channelExclusions/useExclusionRuleHandlers.ts
@@ -55,6 +55,7 @@ export const useExclusionRuleHandlers = ({
   const { watch, reset, setValue } = useForm<ExclusionRuleFormValues>({
     defaultValues: { rule },
   });
+  // eslint-disable-next-line react-hooks/incompatible-library -- temporary suppression
   const formRule = watch('rule');
 
   useEffect(() => {


### PR DESCRIPTION
## What does this change?

This particular lint rule, introduced when upgrading eslint to v9 and using @guardian/eslint-config rules is blocking the build of other PRs.

I have disabled it at the line level only in order not to cause problems with other PRs that are picking up and handling the other linting suppressions.  This will need to be tackled properly in future PRs such as [PR1131](https://github.com/guardian/support-admin-console/pull/1131)

## How has this change been tested?

Ran linting before and after adding the line suppression - the build on push will also be a good indicator.