### PR TITLE
Adds logo dimensions to error message so they are aware up front

### DIFF
--- a/public/src/components/channelManagement/studentLandingPage/academicInstitutionDetails.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/academicInstitutionDetails.tsx
@@ -90,6 +90,8 @@ export const AcademicInstitutionDetailEditor: React.FC<AcademicInstituteDetailEd
   const ACRONYM_MAX_LENGTH = 4;
   const INSTITUTION_MAX_LENGTH = 150;
   const LOGO_URL_MAX_LENGTH = 150;
+  const LOGO_HELPER_TEXT =
+    'Image dimensions should be 61px wide by 27px high, with a transparent background and the foreground colour needs to be white';
 
   return (
     <div className={classes.container}>
@@ -141,7 +143,7 @@ export const AcademicInstitutionDetailEditor: React.FC<AcademicInstituteDetailEd
 
         <TextField
           {...register('logoUrl', {
-            required: EMPTY_ERROR_HELPER_TEXT,
+            required: `${EMPTY_ERROR_HELPER_TEXT} - ${LOGO_HELPER_TEXT}`,
             maxLength: LOGO_URL_MAX_LENGTH,
             validate: (name) => {
               return noHtmlValidator(name);

--- a/public/src/components/channelManagement/studentLandingPage/academicInstitutionDetails.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/academicInstitutionDetails.tsx
@@ -150,10 +150,7 @@ export const AcademicInstitutionDetailEditor: React.FC<AcademicInstituteDetailEd
             },
           })}
           error={errors.logoUrl !== undefined}
-          helperText={
-            errors?.logoUrl?.message ??
-            'Image dimensions should be 61px wide by 27px high, with a transparent background and the foreground colour needs to be white'
-          }
+          helperText={errors?.logoUrl?.message ?? LOGO_HELPER_TEXT}
           onBlur={handleSubmit(update)}
           label="Logo for Institution"
           margin="normal"


### PR DESCRIPTION
## What does this change?

A minor UI tweak to ensure that the required dimensions of the logo are explained on test load so they don't add a logo without being aware of them.

## How has this change been tested?

Run locally - a minor UI tweak

## Images

<img width="1187" height="600" alt="Screenshot 2026-05-01 at 12 23 17" src="https://github.com/user-attachments/assets/d25ef6f6-60df-449b-83b8-5485b911fef3" />