### PR TITLE
lint fix

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1778,7 +1778,7 @@
   },
   "public/src/components/drawer.tsx": {
     "import/order": {
-      "count": 7
+      "count": 6
     }
   },
   "public/src/components/indexPage.tsx": {

--- a/public/src/components/drawer.tsx
+++ b/public/src/components/drawer.tsx
@@ -6,7 +6,6 @@ import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import { makeStyles } from '@mui/styles';
 import RRControlPanelLogo from './rrControlPanelLogo';
-import { getStage } from '../utils/stage';
 import ListItemButton from '@mui/material/ListItemButton';
 
 const useStyles = makeStyles({


### PR DESCRIPTION
## What does this change?

On merging the previous [PR](https://github.com/guardian/support-admin-console/pull/1119), the new lint changes resulted a build failure that did not appear on pushing the PR previously - this fixes that and updates the suppression file

## How has this change been tested?

Run linting locally