### PR TITLE
bau default, hope and urgency ticker headline colour update

### DIFF
--- a/public/src/components/channelManagement/bannerDesigns/utils/colourThemes.ts
+++ b/public/src/components/channelManagement/bannerDesigns/utils/colourThemes.ts
@@ -65,7 +65,7 @@ export const colourThemes: { styles: ThemeStyle[] } = {
             ticker: {
               filledProgress: '#052962',
               progressBarBackground: '#D4DFE9',
-              headlineColour: '#052962',
+              headlineColour: '#000000',
               totalColour: '#052962',
               goalColour: '#000000',
             },
@@ -205,7 +205,7 @@ export const colourThemes: { styles: ThemeStyle[] } = {
             ticker: {
               filledProgress: '#0077B6',
               progressBarBackground: '#B8D6E6',
-              headlineColour: '#0077B6',
+              headlineColour: '#000000',
               totalColour: '#0077B6',
               goalColour: '#000000',
             },
@@ -380,7 +380,7 @@ export const colourThemes: { styles: ThemeStyle[] } = {
             ticker: {
               filledProgress: '#C70000',
               progressBarBackground: '#EDC5C5',
-              headlineColour: '#C70000',
+              headlineColour: '#000000',
               totalColour: '#C70000',
               goalColour: '#000000',
             },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214440007879665)
## What does this change?
This change update ticker headline colour for "business as usual: default, hope and urgency" themes.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
After:
<img width="1474" height="437" alt="bau_default" src="https://github.com/user-attachments/assets/6460313c-79d7-499a-81e8-8f3e2e9cee65" />
<img width="1043" height="436" alt="bau_hop-default" src="https://github.com/user-attachments/assets/cea46e85-6b48-43d6-a625-8daa0b29fa80" />
<img width="1049" height="428" alt="bau_urgency-default" src="https://github.com/user-attachments/assets/60126f22-26bb-4019-aec6-b6e835b8e33d" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
