### PR TITLE
Update AWS SDK for netty vulnerability fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.13.18"
 
 val circeVersion = "0.14.15"
-val awsVersion = "2.42.41"
+val awsVersion = "2.44.4"
 val zioVersion = "2.1.25"
 val jacksonVersion = "2.21.3"
 


### PR DESCRIPTION
We have some dependabot high severity warnings for netty dependencies:

io.netty:netty-codec-http - https://github.com/advisories/GHSA-57rv-r2g8-2cj3
io.netty:netty-codec-http2 - https://github.com/advisories/GHSA-f6hv-jmp6-3vwv
io.netty:netty-codec - https://github.com/advisories/GHSA-mj4r-2hfc-f8p6

These come via the AWS SDK, and the latest version has the fixed netty dependencies (4.1.133.Final)

To check unique versions of netty-codec* dependencies we can run:
`sbt dependencyTree | grep -oE 'io\.netty:netty-codec[^[:space:]]+' | sort -u`

<img width="852" height="92" alt="Screenshot 2026-05-12 at 13 44 36" src="https://github.com/user-attachments/assets/d1e5fac8-19ce-4096-bb0c-abdf9400fa07" />
