### PR TITLE
Revert "build(deps): bump @remirror/react-ui from 1.0.1 to 1.0.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mui/x-data-grid": "8.27.0",
     "@remirror/pm": "3.0.1",
     "@remirror/react": "3.0.1",
-    "@remirror/react-ui": "1.0.3",
+    "@remirror/react-ui": "1.0.1",
     "@types/lodash": "4.17.24",
     "date-fns": "4.1.0",
     "immutability-helper": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@remirror/react-ui':
-        specifier: 1.0.3
-        version: 1.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.1
+        version: 1.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: 4.17.24
         version: 4.17.24
@@ -334,18 +334,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6':
-    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+  '@babel/plugin-transform-modules-commonjs@7.27.1':
+    resolution: {integrity: sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -503,23 +499,11 @@ packages:
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
-
   '@floating-ui/dom@1.7.4':
     resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
 
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
-
   '@floating-ui/react-dom@2.1.6':
     resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/react-dom@2.1.8':
-    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -532,9 +516,6 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@guardian/eslint-config@14.0.1':
     resolution: {integrity: sha512-obYXmA5pYwHHr+5FpPZZ3+lMiBxZd5ang2touY7osC/ObC3NslO/Sk4VXpwVkbpFOJzG3Ili4+n5mX9WSxe/iw==}
@@ -1123,11 +1104,6 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/core@3.0.2':
-    resolution: {integrity: sha512-M38zWJ9VfDZIDtU76odiPMiDsITHjnZD1EGiYS4AbyH50kmj0w/0I8Jd35phmXdB8Vwl3+z6eql54qEkV477oA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/dom@3.0.1':
     resolution: {integrity: sha512-WijRZ3oviQYLmxtp0b+mVD14i5LA3lJHzyx3GW+mf5e0/i3YC+I9fd7k8jXuMVMEM5jgGq8q7s4Gj6cvrQj6yw==}
     peerDependencies:
@@ -1148,30 +1124,15 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-blockquote@3.0.2':
-    resolution: {integrity: sha512-+lLFLJ24krmAgC/CaHrsMkfqNALpNo9qLGYYwA4xxDadEm+sAU0KDHee+dpV92xQ6xfgQO6OOhzjet/S3B+M+A==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-bold@3.0.1':
     resolution: {integrity: sha512-jvjbC8qBQPMu8X6WETvOa3GJbu9SasXGjWI6PQA6xL4iklmEgGTqL88f4Y7tK/0IsEFDT0WRqt7VeU6sYR9I5g==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-bold@3.0.2':
-    resolution: {integrity: sha512-Ls50mPBtGJMbvE4FfcMSOxGglXaEntYIhDGKls5MVqdVnzAfyhCKPIkZTOuf3rfKPvtIMsXvo5dKvyDIpPV91w==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-callout@3.0.1':
     resolution: {integrity: sha512-w03YtdTzrQ+EVabJPuixlPvzuRoW8swEt4uSAEFQwCM0pmWWbi5tobLI82WnlVo5Nz4tIPceFEYdjTELba8Ydw==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-callout@3.0.2':
-    resolution: {integrity: sha512-t8UpInA3rgw1GD3t8mMhXNNr9fq7PokQa10CPoPU/PJnjXalP1Pt+z8DUKGLjTaD/iBMH85+wrb5K1RBU4pZig==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-code-block@3.0.1':
     resolution: {integrity: sha512-Odpbxuu5tp9k1sS0SRRuWMQ6pV6Rm26CkD/rOtSRNiPNJfmjRA8xGkJVzgqbd40pH3UaOfxl9+bAwX9WL54lWQ==}
@@ -1182,24 +1143,10 @@ packages:
       prettier:
         optional: true
 
-  '@remirror/extension-code-block@3.0.2':
-    resolution: {integrity: sha512-hVSqsVhHrWTXuk6eI/mEIuGJsThxEtc5M30SlXsbwChlzgEYJzg3MNeZM8sX81F2s/BwOhb057xLdVCWSdZSSw==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-      prettier: ^3.2.0
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-
   '@remirror/extension-code@3.0.1':
     resolution: {integrity: sha512-7WmPS9w1K7vxnq3DVJEBXLQLvI3VJvfodkF0Tbrc7zFjkHCT3KTXtCxwFv/gqn8YX7QoOZPASxoigVyRV+mT3w==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-code@3.0.2':
-    resolution: {integrity: sha512-05foCVffhtGTVoyP5wNGYI803ujLqvmEqn73L1PJk/qVxubMYHyakKcIRgPxAKrdHv68fyuyOJ+M1bjMuL8hfw==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-collaboration@3.0.1':
     resolution: {integrity: sha512-0D6ww5YTvhXZzzyM4SOkb4E+IYGxaUHqV1E5LXOu9s3E10VLFIFiA11/vqgOSlvh3d08f5gniqI7D25AzKa5xQ==}
@@ -1211,11 +1158,6 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-columns@3.0.2':
-    resolution: {integrity: sha512-E/Reb7wGbZSyakYeMJ4puWfrq73d8AQCaVdBh3OrsquSLcxdNXmJyXcMRb+Hfrn+2lyaS8oMvFIk+y/HurpfMw==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-diff@3.0.1':
     resolution: {integrity: sha512-oG6n5mzoh9SBPV2ZonuwMSQFERbcqfilMrr5Ffn9J1pMsx+adaZE/oy16+4Y7YAi1U0+dkKGe5Bi4cIR515hhw==}
     peerDependencies:
@@ -1225,11 +1167,6 @@ packages:
     resolution: {integrity: sha512-fN1lnxbltVZlR27aLRsQsg2YZHtMukz8hZP6ks2/+8zPTMYxWcVc1SCEhdcWpAc836h5Vsf8YlHUEawlUuhooQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-doc@3.0.2':
-    resolution: {integrity: sha512-/UU5wJtYlz4I3xft9WMhgyxifDjVL5HiusEScyfiezEuFaWEqujJC5RfoqggF+ATZ1Yd6gvvJFAL5rljwZ0FkQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-drop-cursor@3.0.1':
     resolution: {integrity: sha512-E+C7Il2XT2g+apbJQ9Z9r0V2ahLqG5sqnHwF3o3OFt0Ll8WUuKig9g33eysynj0rHvCO8VlXmQUozsBc3NA93w==}
@@ -1246,11 +1183,6 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-emoji@3.0.2':
-    resolution: {integrity: sha512-itTqNf0NF9ncI3f5q+hkLTSPpmaKGrWGJFrbexZtik9SfbPlkb+TXFS+svM74ZNu4VYqUJrp5BocsFpG9pCG5A==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-entity-reference@3.0.1':
     resolution: {integrity: sha512-xE8ndLJrwmRvdqLXvq9LVkTbx6tkqitUT/VytFLpH+mDm7Uko5faVN0D/LWR39KKaoEGQB8CpBuFZGF8BjNsSw==}
     peerDependencies:
@@ -1266,20 +1198,10 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-events@3.0.2':
-    resolution: {integrity: sha512-d+5tJMa7VtSbovNLRdqNyMrPdRolMKM7/l0ByTjouTbMB5QDd93gSIp+buD12y343lqyBYl69rDIK3HJQODSgg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-find@1.0.1':
     resolution: {integrity: sha512-q5ftpVf7zRezEadLNumSQ8c6fs7mbLTMX845qyPeBKO4cHoAEDcEnEHIpPGdUH16MmwcXKsannHFgwzO3nU0PA==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-find@1.0.2':
-    resolution: {integrity: sha512-m0rHkbPNpCI2OAatWmvq7xaUbiWZmYiYig46BrvhVxgoT+r3W15kOne7SA9NbI3a+s7TAL28XJhn524mHfIEsA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-font-family@3.0.1':
     resolution: {integrity: sha512-f5cwcB6yAsxkBApgFKPQ+qRnBN9T+8aNh5Loz+Ffzs3kKEGa/+7SD4U3GEZb83mTvLUHUHOutmz3M4QYnIDfUQ==}
@@ -1291,20 +1213,10 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-font-size@3.0.2':
-    resolution: {integrity: sha512-EWu02TeIi1Cep2bgpkND5HOqTmHlNsV3JhvhjOeQXfScZPGUHOig4/aMFi1nXcD/E63ZYoJlVawGC2+/bnsuQQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-gap-cursor@3.0.1':
     resolution: {integrity: sha512-yyWPy5oSw88b0jezDxf30oivccjV1aaGZ70EqEFW7+7MCe9t2k9lZZmbRbkZYwPjT7WrnHgMcN3XtxsNemI2rA==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-gap-cursor@3.0.2':
-    resolution: {integrity: sha512-gTxLugLj+GWtKpm2vFQsT8nJxfx3lFppZsb6rKGRrVNy3JHi9A+lZyJ+EmQmdplypDIYm1G7nfT7moIwK88dpA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-hard-break@3.0.1':
     resolution: {integrity: sha512-KDc4CXiNYhHu+aaAbImkZrzPzn2wo1ZSU4rgwUHL0HFdILwLs0TxTXmpAWX+jF4jkK1PKXrnuyMDMunVdJEajA==}
@@ -1316,30 +1228,15 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-heading@3.0.2':
-    resolution: {integrity: sha512-+eB1u/QLdX/+LGk9/Jjrma778wYni38yth+aFkouJo5DtFdC0dOd1pyEFWBOsp6fzYbG4gh6mGfjYrQwaVBt2w==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-history@3.0.1':
     resolution: {integrity: sha512-WZX8nEsPabCjA0cVR+V01OBOJpeJL7BFHXnVZ84e/a95ByWSYVWg8hFHPF5nOdQV0BUIwH/jp19X2uMikt6UXg==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-history@3.0.2':
-    resolution: {integrity: sha512-CzrbK/+bmKQdge6wSsOBTQhtktre/Q4JH5bnqUtMaFyz6SYyRFsZjIhaKoJhsCt9mKzXHTCnxZfIsfT7F8sQhQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-horizontal-rule@3.0.1':
     resolution: {integrity: sha512-ebNWzGWTZkx3NGjs4zVRMzP1ISOGF4RP0BkcV169IRIfpB+MqDdvc8P8pf8wvjABiJ5oGMEGCEZMFQWfckbIFA==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-horizontal-rule@3.0.2':
-    resolution: {integrity: sha512-WuKN4xssGN2jFtSYf/8sGIWInBRGfX9Rc5OXzvbIm6lzjqErgqpH9X03QDkGOR0SQKcVSZq4et44kyyynjwZwg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-image@3.0.1':
     resolution: {integrity: sha512-KuFoaSYwVRb4VdDxiVDKfRFDPakdiS5VPguF7wfcvXF7Y/lsv8qzy5Cnz/lrzwY1VycKEt3ZecKY1bnEt0Mt7A==}
@@ -1351,11 +1248,6 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-italic@3.0.2':
-    resolution: {integrity: sha512-VcGoFww3PEx+JdAKfLRfBGdqQC9QcM80QQzl9jqok8Qo1dLJTLVEYY4DBBtaSCfFOorCVNt2LZ+0w+cRWGC3DQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-link@3.0.1':
     resolution: {integrity: sha512-uTbLN+FWaCAioaVSg3ppsFPUnmIh4/maNBhnLcMasliNItdQdDy1nC5WeSk2lRD2I0HWCphQ9DFFqiG5ZLNuiQ==}
     peerDependencies:
@@ -1365,11 +1257,6 @@ packages:
     resolution: {integrity: sha512-x3lIanZgk0wLTNJ+vEIgvYCho35imgXzVxILMLhOK3HNKPS+JLSRdF0aZg35F7P3vrJJ9M0gaueVWT2NMt1nvQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-list@3.0.2':
-    resolution: {integrity: sha512-xz1ewNdbMdwn2vZDtTYKmAKyDVXD4R4sMEho7iY9dmdlF47Wc/nIos7/9ihS+zrlomdmw5o+zXry355x0rzFXA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-markdown@3.0.1':
     resolution: {integrity: sha512-vOGh6+mwn5yIQdGNGulXPk4i/ynyfi4XDfWDxN+rpFQ95oHoxk6XD6DEqxH2X7Z4/3osbf7ooZ2ZEgNDv9qVrw==}
@@ -1385,79 +1272,35 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-mention-atom@3.0.2':
-    resolution: {integrity: sha512-/C//SGkvK59FmmWnGIVB6PVkwTVRco4QeUj1xf3OWAufMSI3l2AcEULu1/K9XPLi8ZSPFq5e46W//gcZZAls7w==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-mention@3.0.1':
     resolution: {integrity: sha512-ZYq5qmbZl6mBhz2tvo/Yxq1+SoVQdmW/RhPociVoQrcS2GnlP6j10O3+39r2chHlBLwTFSLMFLP7X1dsTnhRJQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-mention@3.0.2':
-    resolution: {integrity: sha512-BPlUHGoGbDqh+H1ZycJdP/WjvRn2yffR1pc5jUiLtajN8Z6E/slAB4wHsT/n8pnRk1EOwnCrapYD/i3AK1PaFg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-node-formatting@3.0.1':
     resolution: {integrity: sha512-UY7hyau+BAgJjhBnEojiY1rW4t3q+sPB2lmfpBpoT2b8kXInDpT2ECm3kVZ7T0Luuuh5cJVjjzP2qd8flPm+SQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-node-formatting@3.0.2':
-    resolution: {integrity: sha512-t+mrqmJELSj/CVL5p854TuhaxFqU9VyGColNk28KGSyXyoiUxlWj0lwdxpq5KaLxo/o6VdHIfVbTqLLb4cypDg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-paragraph@3.0.1':
     resolution: {integrity: sha512-NIF1o/fHOML0JUNeuqwtk5pcqMCLKqpqra4EnnGUdD2IpKrYuh5UFJu4o7jCBUSdl2Nj99yEgSWSOVgzN4afHQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-paragraph@3.0.2':
-    resolution: {integrity: sha512-m3LzbJASQmMu5HM25VjmeLjDNhS/fkGtCIivnkdQGtIf9tnUmXaclcJ9AN51kh5m8Sqx/YGpvbW5b1HIik+PlA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-placeholder@3.0.1':
     resolution: {integrity: sha512-rwfGRV2ikhqfLHUMscPHISGzmbRSL2sqngtZYENBhKaHW4fg399k6Mx/W/VdTBRsGAjDlbsrF4Qs4ofj5h6Dpw==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-placeholder@3.0.2':
-    resolution: {integrity: sha512-BsdF0PSLw2JLtGIwedqqvOt8WPaRJRHlfR5uT4eJNfZ7M6UIoa7SV4I3kxE8+eqPe6sofXeRh5+pvRuvdVveiA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-positioner@3.0.1':
     resolution: {integrity: sha512-sCUY2YGqHJOnx9Pwx61tOunAgc9FkYV6O/aKM0ccjJNfCTykgAhZX9yWcOkSPsL5KRmaMeMXOXSFB7VdwFY6rQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-positioner@3.0.2':
-    resolution: {integrity: sha512-5MXXhifGMeQ/OFw7lK9dbvbUr+pOElqdc/TvvYLmOLn+Or/Z91vtGA249WXI3oWsoKwrVitFFz1OaBnLFpuGdQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-react-component@3.0.1':
     resolution: {integrity: sha512-gSingq8+DRrr5h6pMowlRv1duN2kRGQ7RqZ3EgI3oYWKaCrc2fX3sha33yMk5+lUPRRrbfCRmHY1UwXDlcCkKg==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-      '@types/react': ^16.14.0 || ^17 || ^18
-      '@types/react-dom': ^16.9.0 || ^17 || ^18
-      react: ^16.14.0 || ^17 || ^18
-      react-dom: ^16.14.0 || ^17 || ^18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@remirror/extension-react-component@3.0.3':
-    resolution: {integrity: sha512-nu9nM3tCQdhvVMyAhBDfA3Ciwcz8GN+q0ABmaMWkMCfhFlsE59ymbsrGQaV+xnyQvpKdXr89ZgHP+k6dKjG8FQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
       '@types/react': ^16.14.0 || ^17 || ^18
       '@types/react-dom': ^16.9.0 || ^17 || ^18
       react: ^16.14.0 || ^17 || ^18
@@ -1478,40 +1321,20 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-strike@3.0.2':
-    resolution: {integrity: sha512-aSdlGxXnoPD7dMhCElY7jGamVoAz6VEQMn++CTGEG8tYXO/sovy47X0tZrvPQ8mcO/mq4JeSAS8KkwcZ28IpRg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-sub@3.0.1':
     resolution: {integrity: sha512-QSnOeG6vsdAHQ3XyGTtnXr1dISLcawmClnn2BA2wqaY+og9XsfuqKTcCCPlNW8ZKHnQa6noY7GPF8L3Kns5rQQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-sub@3.0.2':
-    resolution: {integrity: sha512-vZoMvdVpVFH34lnRQBD1qKJbJeUwe48hFRJOi0i7u+l3JMVTHGuaus022ccL3FhYAhV10c1iABpGkF2fgvc2lQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-sup@3.0.1':
     resolution: {integrity: sha512-PC2k9T1GVqsN4IaHulBNpvksIZ3nLXmOHIgZPn+AhhC1QkSNVz7Uvf4fKVxADNCyQqjEg6gS+OVJHJdLcDed7g==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-sup@3.0.2':
-    resolution: {integrity: sha512-Rk3fjMpEhkTzA3pJWPuLQd6H2oU19vqeTn2PRR7v4ZcW+/5IwXyTjUNkmbhby4UjxKc7iPzsOup0mbxsmC1KJQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-tables@3.0.1':
     resolution: {integrity: sha512-1CfwUp1Z986CPPSsxBBW/PXdH3uqnOGhZ+UaczBG5tBPOdXtplMc7zcCdGjBVZTRWu19zkBoJa0Dl4IB+jQ8qg==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-tables@3.0.2':
-    resolution: {integrity: sha512-IVuvQRz2lDmpID/PhG01nZqJ7nxoBx4NcJRG1MsdiBhzdlReWndERIDZ6nXhaY9snsGIpNzX43OYbb/90NKjUQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-text-case@3.0.1':
     resolution: {integrity: sha512-yRyGvCxdrUh6cVVBDxyaYRoy+pJ7aiftPRFmtfWhRc43+33srNjm9+koIxmSwhh2teEF3ctpiMqoCBedIhyBRw==}
@@ -1523,11 +1346,6 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-text-color@3.0.2':
-    resolution: {integrity: sha512-B90ZJnyzDxlwfYGpjJkOnWOfpiTUPbcjWLU+IaNNIMjlXnSH4Lg7Wsqj1+JxWko2wPNbsC5lgDEql0dKyPNxeg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-text-highlight@3.0.1':
     resolution: {integrity: sha512-GqLPIoNQUSbZ0Fkf3gVmCfncWLH2mQLhq2fEORa7L1bBEYas8yLukeeILVSu5+6QRxc+bYcufXn81O1RaywO9g==}
     peerDependencies:
@@ -1537,11 +1355,6 @@ packages:
     resolution: {integrity: sha512-r6qJ2ttv5HH46MbMJeCQ/M3ON5z3/Y11zKtlpsdZaJUCNTr2eynPui0QYB6o0nspF5tpy8fFc83AgbuSwKnCcQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-text@3.0.2':
-    resolution: {integrity: sha512-VtdYnT2oF2cBj1f0SF7lIkoGlrXzwCUqjC8bh8Ppi9mzkcnz+DrEjSpyN4BYsw4WUWStIUIR2jxFgENhZ3trmg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/extension-trailing-node@3.0.1':
     resolution: {integrity: sha512-/6XwCGECyKIsmsS0IalBMrrXBsviUU6ZK0r1QqH3gqksJyo+dTrF9xW1KXobwDoANQcPm/wtJGj52TCYqZ2fNA==}
@@ -1553,20 +1366,10 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/extension-underline@3.0.2':
-    resolution: {integrity: sha512-FJwjnRYKk8VmfbU/zcE0PVPsaqA6ZYrDMsIIBbywhLU5c9MP/EGw6K1Ps4hPFhmyHgc6IZNE8hLR4Ej7ZbYagQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/extension-whitespace@3.0.1':
     resolution: {integrity: sha512-rljEa4/kFrHXdS4J5GlzZgtAPZQTUoUBqAxySBuoTcFCmh+V86UYxHK7Ki7CsFqiSHeBq3212FtVQLPupTOgvg==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-
-  '@remirror/extension-whitespace@3.0.2':
-    resolution: {integrity: sha512-uVV8t7YKecIEUjou1GRhBgDr3Pwah598LkT9NIEOuYG3BjdtQdJgh1K1gAzBA1og72BWfzEPFFjvYbfaBsQHAw==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
 
   '@remirror/icons@3.0.0':
     resolution: {integrity: sha512-NOgd0ENWWlUOb8xH7xz3qpcW+OCVt0oxF2Lde1hOg/x67LyUbybofe6SwXpdx3TN8bdgSU5CzlNPeugGsGMdwg==}
@@ -1582,11 +1385,6 @@ packages:
     peerDependencies:
       '@remirror/pm': ^3.0.0
 
-  '@remirror/preset-core@3.0.2':
-    resolution: {integrity: sha512-VYRGiudl8bE/DVO2YBx/kE0rWKNWG9qQwZbK63x8TXZY19eS5P97G87MGxAAoxv90U+IZbrIfOy1K6aVW4KeGA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-
   '@remirror/preset-formatting@3.0.1':
     resolution: {integrity: sha512-tJPVI4eS6SSUJCDIO2rSUEN71gK+0JwdfJaImdAlY4lcm8h2foPZ1sFn9naqkfNUQFn5BinnE5j+zM95AG2sKQ==}
     peerDependencies:
@@ -1596,20 +1394,6 @@ packages:
     resolution: {integrity: sha512-6uFjOa1nPIQEFHrcwh43aVtLYyP85jIQNUvcfM/KRqqZ4CuEp+jy9T5hCbl6Lz+DKoJexOaik6l5u7u0ADgdwQ==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-      '@types/react': ^16.14.0 || ^17 || ^18
-      '@types/react-dom': ^16.9.0 || ^17 || ^18
-      react: ^16.14.0 || ^17 || ^18
-      react-dom: ^16.14.0 || ^17 || ^18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@remirror/preset-react@3.0.3':
-    resolution: {integrity: sha512-VdwnUuAz1UIXWaExXyggfuuSYIn9V2lMMyhTPdpjnEBwjpAgnfpxFRmwfbdWTCTq3BPFFTZp48Lz+1fw2fuwWg==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
       '@types/react': ^16.14.0 || ^17 || ^18
       '@types/react-dom': ^16.9.0 || ^17 || ^18
       react: ^16.14.0 || ^17 || ^18
@@ -1639,38 +1423,10 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@remirror/react-components@3.0.3':
-    resolution: {integrity: sha512-PymiL2E9hnE77J7OMg8vr0J7giFG1U1dWxB9J1dGbc7RPUlQpeBDp6xTrz1HiW5AQEs/D1EwKG6T5HOY7rDrww==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-      '@types/react': ^16.14.0 || ^17 || ^18
-      '@types/react-dom': ^16.9.0 || ^17 || ^18
-      react: ^16.14.0 || ^17 || ^18
-      react-dom: ^16.14.0 || ^17 || ^18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@remirror/react-core@3.0.1':
     resolution: {integrity: sha512-x5g6EMl1+lfYBUWaiYD50FYjMskKU3AeS/UHbp41t6rFv1jUVpJlV4gTSN9OB/OfBsgp4cCmSgqzDxX9s2e3Aw==}
     peerDependencies:
       '@remirror/pm': ^3.0.0
-      '@types/react': ^16.14.0 || ^17 || ^18
-      '@types/react-dom': ^16.9.0 || ^17 || ^18
-      react: ^16.14.0 || ^17 || ^18
-      react-dom: ^16.14.0 || ^17 || ^18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@remirror/react-core@3.0.3':
-    resolution: {integrity: sha512-N8bgKcbGO4G/ViKWNFRsYoo9wBr4i5Pd0j4KxUb2bPAs9XdoDM0/4IyP8Vf5d4kjmB0iKXaHtmL+mvZSq6v1TQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
       '@types/react': ^16.14.0 || ^17 || ^18
       '@types/react-dom': ^16.9.0 || ^17 || ^18
       react: ^16.14.0 || ^17 || ^18
@@ -1699,24 +1455,6 @@ packages:
       react-dom:
         optional: true
 
-  '@remirror/react-hooks@3.0.3':
-    resolution: {integrity: sha512-Cf7qXF9H+QgA2tRngV5jfJhQ6SWEEC6G7/3JLGQOx2q6Wh/KAlAEol6hZfmJGM27ZR1H1IwKFQoUTHy7Dz0QtQ==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
-      '@types/react': ^16.14.0 || ^17 || ^18
-      '@types/react-dom': ^16.9.0 || ^17 || ^18
-      react: ^16.14.0 || ^17 || ^18
-      react-dom: ^16.14.0 || ^17 || ^18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   '@remirror/react-renderer@3.0.1':
     resolution: {integrity: sha512-OtAuuo5frLPYC51Q3i25p07Okze2fR+5ceVotfkJoj30fndjQjesGeox2z3EVGPVb8EGzEaBi+GYxltVgOCEKw==}
     peerDependencies:
@@ -1726,19 +1464,10 @@ packages:
       '@types/react':
         optional: true
 
-  '@remirror/react-renderer@3.0.2':
-    resolution: {integrity: sha512-jmu7nwXfHR+WhNpvY3EsLbFcYIYwnvmR3554JNYteiE+OOVwDAOlK/ijOuNgCGKvoLi8+Srr4nFaBXQm7CboGQ==}
+  '@remirror/react-ui@1.0.1':
+    resolution: {integrity: sha512-T+Q6TZbDNR6lyUTIXVCU3L6l6EgdNzSH+QLaZ/Mr5a2C3IK1J5kCXddvpucdE+XGLYarzHpinrnRmFXsjbn1Ww==}
     peerDependencies:
-      '@types/react': ^16.14.0 || ^17 || ^18
-      react: ^16.14.0 || ^17 || ^18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@remirror/react-ui@1.0.3':
-    resolution: {integrity: sha512-jiOvi5GcBKgRV/EF+/TtoUbzZavRBkSwqcweQk8dA7uh8+RIx8jhQlOYobEJQQBaS4MfO8IrFcLdHJMtuuLQCA==}
-    peerDependencies:
-      '@remirror/pm': ^3.0.1
+      '@remirror/pm': ^3.0.0
       '@types/react': ^16.14.0 || ^17 || ^18
       '@types/react-dom': ^16.9.0 || ^17 || ^18
       react: ^16.14.0 || ^17 || ^18
@@ -2624,10 +2353,6 @@ packages:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.9:
-    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
-    engines: {node: '>= 0.4'}
-
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -3042,10 +2767,6 @@ packages:
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
-    engines: {node: '>= 0.4'}
-
-  es-abstract@1.24.2:
-    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -4895,10 +4616,6 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
-  safe-array-concat@1.1.4:
-    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
-    engines: {node: '>=0.4'}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -5589,10 +5306,6 @@ packages:
     resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
-    engines: {node: '>= 0.4'}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -5650,8 +5363,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@1.10.3:
-    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
   yargs-parser@21.1.1:
@@ -5861,7 +5574,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -5870,8 +5583,6 @@ snapshots:
       - supports-color
 
   '@babel/runtime@7.28.6': {}
-
-  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5944,7 +5655,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -5975,7 +5686,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -6001,7 +5712,7 @@ snapshots:
 
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.4.0
       '@emotion/react': 11.14.0(@types/react@18.3.12)(react@18.3.1)
@@ -6082,19 +5793,10 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/core@1.7.5':
-    dependencies:
-      '@floating-ui/utils': 0.2.11
-
   '@floating-ui/dom@1.7.4':
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
-
-  '@floating-ui/dom@1.7.6':
-    dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
 
   '@floating-ui/react-dom@2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -6102,23 +5804,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@floating-ui/react@0.24.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.10': {}
-
-  '@floating-ui/utils@0.2.11': {}
 
   '@guardian/eslint-config@14.0.1(@typescript-eslint/utils@8.57.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -6566,7 +6260,7 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.29.0)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -6626,7 +6320,7 @@ snapshots:
 
   '@mui/private-theming@5.17.1(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@mui/utils': 5.17.1(@types/react@18.3.12)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
@@ -6644,7 +6338,7 @@ snapshots:
 
   '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       csstype: 3.2.3
@@ -6679,7 +6373,7 @@ snapshots:
 
   '@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@mui/private-theming': 5.17.1(@types/react@18.3.12)(react@18.3.1)
       '@mui/styled-engine': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.12)
@@ -6938,7 +6632,7 @@ snapshots:
 
   '@remirror/core-utils@3.0.0(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core-constants': 3.0.0
       '@remirror/core-helpers': 4.0.0
       '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
@@ -6956,23 +6650,7 @@ snapshots:
 
   '@remirror/core@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core-constants': 3.0.0
-      '@remirror/core-helpers': 4.0.0
-      '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/core-utils': 3.0.0(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/icons': 3.0.0
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      nanoevents: 5.1.13
-      tiny-warning: 1.0.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/core@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core-constants': 3.0.0
       '@remirror/core-helpers': 4.0.0
       '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
@@ -6988,7 +6666,7 @@ snapshots:
 
   '@remirror/dom@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/pm': 3.0.1
       '@remirror/preset-core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
@@ -6999,7 +6677,7 @@ snapshots:
 
   '@remirror/extension-annotation@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-positioner': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
@@ -7011,7 +6689,7 @@ snapshots:
 
   '@remirror/extension-bidi@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7023,20 +6701,8 @@ snapshots:
 
   '@remirror/extension-blockquote@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-blockquote@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7047,18 +6713,8 @@ snapshots:
 
   '@remirror/extension-bold@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-bold@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7067,20 +6723,8 @@ snapshots:
 
   '@remirror/extension-callout@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-callout@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7091,26 +6735,9 @@ snapshots:
 
   '@remirror/extension-code-block@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(prettier@3.8.3)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-positioner': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-      '@types/refractor': 3.4.1
-      refractor: 3.6.0
-    optionalDependencies:
-      prettier: 3.8.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-code-block@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)(prettier@3.8.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7125,18 +6752,8 @@ snapshots:
 
   '@remirror/extension-code@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-code@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7145,7 +6762,7 @@ snapshots:
 
   '@remirror/extension-collaboration@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7155,18 +6772,8 @@ snapshots:
 
   '@remirror/extension-columns@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-columns@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7175,7 +6782,7 @@ snapshots:
 
   '@remirror/extension-diff@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7185,18 +6792,8 @@ snapshots:
 
   '@remirror/extension-doc@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-doc@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7205,7 +6802,7 @@ snapshots:
 
   '@remirror/extension-drop-cursor@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7215,7 +6812,7 @@ snapshots:
 
   '@remirror/extension-embed@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7228,27 +6825,9 @@ snapshots:
 
   '@remirror/extension-emoji@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@ocavue/svgmoji-cjs': 0.1.1
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-      emojibase: 6.1.0
-      emojibase-data: 6.2.0(emojibase@6.1.0)
-      emojibase-regex: 6.0.1
-      escape-string-regexp: 4.0.0
-      svgmoji: 3.2.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-emoji@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@ocavue/svgmoji-cjs': 0.1.1
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7264,7 +6843,7 @@ snapshots:
 
   '@remirror/extension-entity-reference@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-positioner': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
@@ -7276,7 +6855,7 @@ snapshots:
 
   '@remirror/extension-epic-mode@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7286,18 +6865,8 @@ snapshots:
 
   '@remirror/extension-events@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-events@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7315,20 +6884,9 @@ snapshots:
       - '@types/node'
       - jsdom
 
-  '@remirror/extension-find@1.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/pm': 3.0.1
-      '@types/string.prototype.matchall': 4.0.4
-      escape-string-regexp: 4.0.0
-      string.prototype.matchall: 4.0.12
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
   '@remirror/extension-font-family@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7338,19 +6896,8 @@ snapshots:
 
   '@remirror/extension-font-size@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      round: 2.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-font-size@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       round: 2.0.1
@@ -7360,18 +6907,8 @@ snapshots:
 
   '@remirror/extension-gap-cursor@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-gap-cursor@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7380,7 +6917,7 @@ snapshots:
 
   '@remirror/extension-hard-break@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7390,18 +6927,8 @@ snapshots:
 
   '@remirror/extension-heading@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-heading@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7410,18 +6937,8 @@ snapshots:
 
   '@remirror/extension-history@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-history@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7430,18 +6947,8 @@ snapshots:
 
   '@remirror/extension-horizontal-rule@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-horizontal-rule@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7450,7 +6957,7 @@ snapshots:
 
   '@remirror/extension-image@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7463,18 +6970,8 @@ snapshots:
 
   '@remirror/extension-italic@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-italic@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7483,7 +6980,7 @@ snapshots:
 
   '@remirror/extension-link@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
@@ -7495,7 +6992,7 @@ snapshots:
 
   '@remirror/extension-list@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
@@ -7506,22 +7003,9 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/extension-list@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/extension-markdown@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7536,22 +7020,9 @@ snapshots:
 
   '@remirror/extension-mention-atom@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-mention-atom@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7562,7 +7033,7 @@ snapshots:
 
   '@remirror/extension-mention@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
@@ -7572,32 +7043,10 @@ snapshots:
       - '@types/node'
       - jsdom
 
-  '@remirror/extension-mention@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      escape-string-regexp: 4.0.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
   '@remirror/extension-node-formatting@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-node-formatting@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7606,18 +7055,8 @@ snapshots:
 
   '@remirror/extension-paragraph@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-paragraph@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7636,37 +7075,11 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/extension-placeholder@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/extension-positioner@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-      nanoevents: 5.1.13
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-positioner@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7696,29 +7109,9 @@ snapshots:
       - '@types/node'
       - jsdom
 
-  '@remirror/extension-react-component@3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/core-constants': 3.0.0
-      '@remirror/core-helpers': 4.0.0
-      '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/core-utils': 3.0.0(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      nanoevents: 5.1.13
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
   '@remirror/extension-shortcuts@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7727,18 +7120,8 @@ snapshots:
 
   '@remirror/extension-strike@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-strike@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7747,18 +7130,8 @@ snapshots:
 
   '@remirror/extension-sub@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-sub@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7767,18 +7140,8 @@ snapshots:
 
   '@remirror/extension-sup@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-sup@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7787,7 +7150,7 @@ snapshots:
 
   '@remirror/extension-tables@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-positioner': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
@@ -7799,23 +7162,9 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/extension-tables@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/extension-text-case@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7825,21 +7174,8 @@ snapshots:
 
   '@remirror/extension-text-color@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-      color2k: 2.0.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/extension-text-color@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
@@ -7851,7 +7187,7 @@ snapshots:
 
   '@remirror/extension-text-highlight@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-text-color': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
@@ -7863,18 +7199,8 @@ snapshots:
 
   '@remirror/extension-text@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-text@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7883,7 +7209,7 @@ snapshots:
 
   '@remirror/extension-trailing-node@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
@@ -7893,18 +7219,8 @@ snapshots:
 
   '@remirror/extension-underline@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-underline@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7913,18 +7229,8 @@ snapshots:
 
   '@remirror/extension-whitespace@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-
-  '@remirror/extension-whitespace@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
     transitivePeerDependencies:
@@ -7933,12 +7239,12 @@ snapshots:
 
   '@remirror/icons@3.0.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core-helpers': 4.0.0
 
   '@remirror/messages@3.0.0(@remirror/pm@3.0.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core-helpers': 4.0.0
       '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
     transitivePeerDependencies:
@@ -7968,7 +7274,7 @@ snapshots:
 
   '@remirror/preset-core@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-doc': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-events': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
@@ -7983,26 +7289,9 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/preset-core@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-doc': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-gap-cursor': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-history': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-paragraph': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-text': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/pm': 3.0.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/preset-formatting@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-bold': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-columns': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
@@ -8042,27 +7331,9 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/preset-react@3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-placeholder': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-react-component': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/react-utils': 3.0.0(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/preset-wysiwyg@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(prettier@3.8.3)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-bidi': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/extension-blockquote': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
@@ -8121,35 +7392,6 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/react-components@3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/react': 0.24.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/icons': 3.0.0
-      '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/react-core': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/react-hooks': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/react-utils': 3.0.0(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-      '@seznam/compose-react-refs': 1.0.6
-      '@types/react-color': 3.0.13(@types/react@18.3.12)
-      create-context-state: 2.0.3(@types/react@18.3.12)(react@18.3.1)
-      match-sorter: 6.3.4
-      multishift: 2.0.10(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
-      react: 18.3.1
-      react-color: 2.19.3(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/react-core@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -8160,32 +7402,6 @@ snapshots:
       '@remirror/preset-core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/preset-react': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@remirror/react-renderer': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react@18.3.12)(react@18.3.1)
-      '@remirror/react-utils': 3.0.0(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
-      '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
-      '@seznam/compose-react-refs': 1.0.6
-      fast-deep-equal: 3.1.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      resize-observer-polyfill: 1.5.1
-      tiny-warning: 1.0.3
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
-  '@remirror/react-core@3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-react-component': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/preset-core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/preset-react': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/react-renderer': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react@18.3.12)(react@18.3.1)
       '@remirror/react-utils': 3.0.0(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
       '@seznam/compose-react-refs': 1.0.6
@@ -8230,34 +7446,6 @@ snapshots:
       - jsdom
       - supports-color
 
-  '@remirror/react-hooks@3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/core-constants': 3.0.0
-      '@remirror/core-helpers': 4.0.0
-      '@remirror/extension-emoji': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-events': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-history': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-mention': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-mention-atom': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/pm': 3.0.1
-      '@remirror/react-core': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/react-utils': 3.0.0(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
-      multishift: 2.0.10(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1)
-      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.12)(react@18.3.1)
-      use-previous: 1.2.0(@types/react@18.3.12)(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jsdom
-      - supports-color
-
   '@remirror/react-renderer@3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -8270,54 +7458,42 @@ snapshots:
       - '@types/node'
       - jsdom
 
-  '@remirror/react-renderer@3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react@18.3.12)(react@18.3.1)':
+  '@remirror/react-ui@1.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.12
-    transitivePeerDependencies:
-      - '@remirror/pm'
-      - '@types/node'
-      - jsdom
-
-  '@remirror/react-ui@1.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@emotion/react': 11.14.0(@types/react@18.3.12)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/material': 5.15.14(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
-      '@remirror/core': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-blockquote': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-bold': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-callout': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-code': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-code-block': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)(prettier@3.8.3)
-      '@remirror/extension-columns': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-find': 1.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-font-size': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-heading': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-history': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-horizontal-rule': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-italic': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-list': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-node-formatting': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-positioner': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-strike': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-sub': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-sup': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-tables': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-text-color': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-underline': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
-      '@remirror/extension-whitespace': 3.0.2(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-blockquote': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-bold': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-callout': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-code': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-code-block': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(prettier@3.8.3)
+      '@remirror/extension-columns': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-find': 1.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-font-size': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-heading': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-history': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-horizontal-rule': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-italic': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-list': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-node-formatting': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-positioner': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-strike': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-sub': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-sup': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-tables': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-text-color': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-underline': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
+      '@remirror/extension-whitespace': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)
       '@remirror/icons': 3.0.0
       '@remirror/messages': 3.0.0(@remirror/pm@3.0.1)
       '@remirror/pm': 3.0.1
-      '@remirror/react-components': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/react-core': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@remirror/react-hooks': 3.0.3(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@remirror/react-components': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@remirror/react-core': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@remirror/react-hooks': 3.0.1(@remirror/pm@3.0.1)(@types/node@25.9.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@remirror/theme': 3.0.0(@remirror/pm@3.0.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8367,7 +7543,7 @@ snapshots:
 
   '@remirror/theme@3.0.0(@remirror/pm@3.0.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@linaria/core': 4.2.10
       '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
       color2k: 2.0.3
@@ -8410,12 +7586,12 @@ snapshots:
 
   '@svgmoji/blob@3.2.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@svgmoji/core': 3.2.0
 
   '@svgmoji/core@3.2.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       emojibase: 5.2.0
       emojibase-regex: 5.1.3
       idb-keyval: 5.1.5
@@ -8424,17 +7600,17 @@ snapshots:
 
   '@svgmoji/noto@3.2.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@svgmoji/core': 3.2.0
 
   '@svgmoji/openmoji@3.2.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@svgmoji/core': 3.2.0
 
   '@svgmoji/twemoji@3.2.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@svgmoji/core': 3.2.0
 
   '@tybys/wasm-util@0.10.1':
@@ -8992,7 +8168,7 @@ snapshots:
 
   a11y-status@2.0.2:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@types/throttle-debounce': 2.1.0
       throttle-debounce: 3.0.1
 
@@ -9100,9 +8276,9 @@ snapshots:
 
   array.prototype.flat@1.3.3:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.2
+      es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.3:
@@ -9123,9 +8299,9 @@ snapshots:
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.2
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
@@ -9183,7 +8359,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
@@ -9293,13 +8469,6 @@ snapshots:
       function-bind: 1.1.2
 
   call-bind@1.0.8:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -9444,11 +8613,11 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.3
+      yaml: 1.10.2
 
   create-context-state@2.0.3(@types/react@18.3.12)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.12
@@ -9478,7 +8647,7 @@ snapshots:
 
   css-vendor@2.0.8:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       is-in-browser: 1.1.3
 
   cssesc@3.0.0: {}
@@ -9610,7 +8779,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
   dom-walk@0.1.2: {}
@@ -9714,63 +8883,6 @@ snapshots:
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.19
-
-  es-abstract@1.24.2:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      arraybuffer.prototype.slice: 1.0.4
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      data-view-buffer: 1.0.2
-      data-view-byte-length: 1.0.2
-      data-view-byte-offset: 1.0.1
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.8
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      get-symbol-description: 1.1.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.3
-      internal-slot: 1.1.0
-      is-array-buffer: 3.0.5
-      is-callable: 1.2.7
-      is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
-      is-regex: 1.2.1
-      is-set: 2.0.3
-      is-shared-array-buffer: 1.0.4
-      is-string: 1.1.1
-      is-typed-array: 1.1.15
-      is-weakref: 1.1.1
-      math-intrinsics: 1.1.0
-      object-inspect: 1.13.4
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      own-keys: 1.0.1
-      regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.4
-      safe-push-apply: 1.0.0
-      safe-regex-test: 1.1.0
-      set-proto: 1.0.0
-      stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.10
-      string.prototype.trimend: 1.0.9
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.3
-      typed-array-byte-length: 1.0.3
-      typed-array-byte-offset: 1.0.4
-      typed-array-length: 1.0.7
-      unbox-primitive: 1.1.0
-      which-typed-array: 1.1.20
 
   es-define-property@1.0.1: {}
 
@@ -10179,11 +9291,11 @@ snapshots:
 
   function.prototype.name@1.1.8:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.3
+      hasown: 2.0.2
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -10206,7 +9318,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.2
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
@@ -10437,7 +9549,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.3
+      hasown: 2.0.2
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
@@ -10457,7 +9569,7 @@ snapshots:
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -10602,7 +9714,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.19
 
   is-weakmap@2.0.2: {}
 
@@ -11185,7 +10297,7 @@ snapshots:
 
   match-sorter@6.3.4:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       remove-accents: 0.5.0
 
   material-colors@1.2.6: {}
@@ -11271,7 +10383,7 @@ snapshots:
 
   multishift@2.0.10(@remirror/pm@3.0.1)(@types/react@18.3.12)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core-helpers': 4.0.0
       '@remirror/core-types': 3.0.0(@remirror/pm@3.0.1)
       '@seznam/compose-react-refs': 1.0.6
@@ -11325,7 +10437,7 @@ snapshots:
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -11629,7 +10741,7 @@ snapshots:
 
   prosemirror-resizable-view@3.0.0(@remirror/pm@3.0.1)(@types/node@25.9.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@remirror/core-helpers': 4.0.0
       '@remirror/core-utils': 3.0.0(@remirror/pm@3.0.1)(@types/node@25.9.1)
       prosemirror-model: 1.25.4
@@ -11875,9 +10987,9 @@ snapshots:
 
   reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.24.2
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -11892,7 +11004,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -12032,14 +11144,6 @@ snapshots:
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
-  safe-array-concat@1.1.4:
-    dependencies:
-      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
@@ -12300,10 +11404,10 @@ snapshots:
 
   string.prototype.matchall@4.0.12:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.2
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -12321,24 +11425,24 @@ snapshots:
 
   string.prototype.trim@1.2.10:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.2
+      es-abstract: 1.24.1
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   string.prototype.trimstart@1.0.8:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
@@ -12384,7 +11488,7 @@ snapshots:
 
   svgmoji@3.2.0:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
       '@svgmoji/blob': 3.2.0
       '@svgmoji/core': 3.2.0
       '@svgmoji/noto': 3.2.0
@@ -12549,7 +11653,7 @@ snapshots:
 
   typed-array-byte-length@1.0.3:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -12558,7 +11662,7 @@ snapshots:
   typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -12567,7 +11671,7 @@ snapshots:
 
   typed-array-length@1.0.7:
     dependencies:
-      call-bind: 1.0.9
+      call-bind: 1.0.8
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
@@ -12882,7 +11986,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.19
 
   which-collection@1.0.2:
     dependencies:
@@ -12895,16 +11999,6 @@ snapshots:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-
-  which-typed-array@1.1.20:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1
@@ -12952,7 +12046,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@1.10.3: {}
+  yaml@1.10.2: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
Reverts guardian/support-admin-console#1164

The error occurs when editing a test and a variant is expanded:
`useRemirrorContext was called outside of the `remirror` context. It can only be used within an active remirror context created by the `<Remirror />`.`
