### PR TITLE
Override plexus-utils to 3.6.1 to fix vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,9 @@ dependencyOverrides ++= List(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   // Related to Play 3.0.2-6 currently brings in a vulnerable version of commons-io
   "commons-io" % "commons-io" % "2.22.0" % Test,
-  "commons-beanutils" % "commons-beanutils" % "1.11.0"
+  "commons-beanutils" % "commons-beanutils" % "1.11.0",
+  // Play-test brings in a vulnerable version of plexus-utils - https://github.com/advisories/GHSA-4368-p58w-2w5w
+  "org.codehaus.plexus" % "plexus-utils" % "3.6.1"
 )
 
 excludeDependencies ++= Seq(


### PR DESCRIPTION
Add dependency override for `org.codehaus.plexus:plexus-utils` to version 3.6.1 to fix the Directory Traversal vulnerability. The vulnerable version was being introduced transitively via `play-test_2.13 3.0.10`. This follows the existing pattern in build.sbt for handling similar transitive dependency vulnerabilities (jackson, commons-io).