### PR TITLE
Enforce article count restriction for mParticle audience targeting of signed-out users in banner tests

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { Alert, Typography } from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
 import {
   BannerContent,
@@ -155,7 +155,19 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   };
 
   const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
-    onTestChange((current) => ({ ...current, signedInStatus }));
+    onTestChange((current) => {
+      const updatedTest = { ...current, signedInStatus };
+      if (current.mParticleAudience !== undefined && signedInStatus !== 'SignedIn') {
+        const minViews = current.articlesViewedSettings?.minViews ?? 0;
+        if (!current.articlesViewedSettings || minViews < 5) {
+          const enforced = current.articlesViewedSettings
+            ? { ...current.articlesViewedSettings, minViews: 5 }
+            : DEFAULT_ARTICLES_VIEWED_SETTINGS;
+          return { ...updatedTest, articlesViewedSettings: enforced };
+        }
+      }
+      return updatedTest;
+    });
   };
 
   const onConsentStatusChange = (consentStatus: ConsentStatus): void => {
@@ -165,7 +177,8 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   const onArticlesViewedSettingsChange = (
     updatedArticlesViewedSettings?: ArticlesViewedSettings,
   ): void => {
-    updateTest((current) => ({
+    // Bypass updateTest to avoid re-calculation, go directly to onTestChange
+    onTestChange((current) => ({
       ...current,
       articlesViewedSettings: updatedArticlesViewedSettings,
     }));
@@ -186,7 +199,19 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   };
 
   const onMParticleAudienceChange = (mParticleAudience?: number): void => {
-    onTestChange((current) => ({ ...current, mParticleAudience }));
+    onTestChange((current) => {
+      const updatedTest = { ...current, mParticleAudience };
+      if (mParticleAudience !== undefined && current.signedInStatus !== 'SignedIn') {
+        const minViews = current.articlesViewedSettings?.minViews ?? 0;
+        if (!current.articlesViewedSettings || minViews < 5) {
+          const enforced = current.articlesViewedSettings
+            ? { ...current.articlesViewedSettings, minViews: 5 }
+            : DEFAULT_ARTICLES_VIEWED_SETTINGS;
+          return { ...updatedTest, articlesViewedSettings: enforced };
+        }
+      }
+      return updatedTest;
+    });
   };
 
   // Memoize callbacks by variant name to prevent infinite render loops
@@ -203,6 +228,22 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
     setValidationStatusRef.current = setValidationStatusForField;
     onVariantsChangeRef.current = onVariantsChange;
   });
+
+  // Validate mParticle audience constraint: if mParticle audience is set and can target signed-out users,
+  // then article count must have minViews >= 5
+  useEffect(() => {
+    const requiresArticleCount =
+      test.mParticleAudience !== undefined && test.signedInStatus !== 'SignedIn';
+    const isValid =
+      !requiresArticleCount ||
+      (test.articlesViewedSettings !== undefined && test.articlesViewedSettings.minViews >= 5);
+    setValidationStatusForField('mParticleAudience', isValid);
+  }, [
+    test.mParticleAudience,
+    test.signedInStatus,
+    test.articlesViewedSettings,
+    setValidationStatusForField,
+  ]);
 
   const getValidationCallback = (variantName: string): ((isValid: boolean) => void) => {
     if (!validationCallbacksRef.current.has(variantName)) {
@@ -380,6 +421,10 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
             mParticleAudience: test.mParticleAudience,
             onMParticleAudienceChange: onMParticleAudienceChange,
           }}
+          mParticleAudienceValidation={
+            !(test.mParticleAudience !== undefined && test.signedInStatus !== 'SignedIn') ||
+            (test.articlesViewedSettings !== undefined && test.articlesViewedSettings.minViews >= 5)
+          }
         />
       </div>
 
@@ -387,6 +432,12 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Article count
         </Typography>
+
+        {test.mParticleAudience !== undefined && test.signedInStatus !== 'SignedIn' && (
+          <Alert severity="info" style={{ marginBottom: '16px' }}>
+            mParticle audience targeting of signed-out users requires minimum article count ≥ 5.
+          </Alert>
+        )}
 
         <TestEditorArticleCountEditor
           articlesViewedSettings={test.articlesViewedSettings}

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -155,19 +155,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   };
 
   const onSignedInStatusChange = (signedInStatus: SignedInStatus): void => {
-    onTestChange((current) => {
-      const updatedTest = { ...current, signedInStatus };
-      if (current.mParticleAudience !== undefined && signedInStatus !== 'SignedIn') {
-        const minViews = current.articlesViewedSettings?.minViews ?? 0;
-        if (!current.articlesViewedSettings || minViews < 5) {
-          const enforced = current.articlesViewedSettings
-            ? { ...current.articlesViewedSettings, minViews: 5 }
-            : DEFAULT_ARTICLES_VIEWED_SETTINGS;
-          return { ...updatedTest, articlesViewedSettings: enforced };
-        }
-      }
-      return updatedTest;
-    });
+    onTestChange((current) => ({ ...current, signedInStatus }));
   };
 
   const onConsentStatusChange = (consentStatus: ConsentStatus): void => {
@@ -199,19 +187,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
   };
 
   const onMParticleAudienceChange = (mParticleAudience?: number): void => {
-    onTestChange((current) => {
-      const updatedTest = { ...current, mParticleAudience };
-      if (mParticleAudience !== undefined && current.signedInStatus !== 'SignedIn') {
-        const minViews = current.articlesViewedSettings?.minViews ?? 0;
-        if (!current.articlesViewedSettings || minViews < 5) {
-          const enforced = current.articlesViewedSettings
-            ? { ...current.articlesViewedSettings, minViews: 5 }
-            : DEFAULT_ARTICLES_VIEWED_SETTINGS;
-          return { ...updatedTest, articlesViewedSettings: enforced };
-        }
-      }
-      return updatedTest;
-    });
+    onTestChange((current) => ({ ...current, mParticleAudience }));
   };
 
   // Memoize callbacks by variant name to prevent infinite render loops

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -60,6 +60,7 @@ interface TestEditorTargetAudienceSelectorProps {
     mParticleAudience?: number;
     onMParticleAudienceChange: (mParticleAudience?: number) => void;
   };
+  mParticleAudienceValidation?: boolean;
 }
 const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelectorProps> = ({
   regionTargeting,
@@ -80,6 +81,7 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   showConsentStatusSelector,
   platform,
   mParticleAudienceEditor,
+  mParticleAudienceValidation,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
 
@@ -181,6 +183,11 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
               mParticleAudience={mParticleAudienceEditor.mParticleAudience}
               onChange={mParticleAudienceEditor.onMParticleAudienceChange}
             />
+            {mParticleAudienceValidation === false && (
+              <Typography style={{ color: 'red', marginTop: '8px', fontSize: '14px' }}>
+                mParticle audience targeting of signed-out users requires minimum article count ≥ 5.
+              </Typography>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
When a banner test targets an mParticle audience and can target signed-out users, it must have a minimum article count of 5 views. This prevents excessive mParticle traffic for low-engagement browsers.

Changes:
- Auto-enforce `articlesViewedSettings` with `minViews=5` when mParticle audience is set and `signedInStatus !== 'SignedIn'`
- Add validation to block saving if article count is manually reduced below 5 when the constraint applies
- Display error message below mParticle audience ID field when constraint is violated
- Display informational note in Article count section when constraint is active
- Fix bug where "Do not target by user's article count" wouldn't persist due to template-based re-calculation