### PR TITLE
ChoiceCard destination fields improvements

### DIFF
--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -2,11 +2,10 @@ import { FormControl, MenuItem, Select, Typography } from '@mui/material';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { ChoiceCardsSettings } from '../../../models/choiceCards';
-import { fetchFrontendSettings, fetchTest, FrontendSettingsType } from '../../../utils/requests';
+import { fetchFrontendSettings, FrontendSettingsType } from '../../../utils/requests';
 import { Test } from '../helpers/shared';
 import TestListTestLiveLabel from '../testListTestLiveLabel';
 import TypedRadioGroup from '../TypedRadioGroup';
-
 
 interface DestinationTestsResponse {
   tests: Test[];
@@ -18,11 +17,6 @@ interface ChoiceCardDestinationFieldsProps {
   subHeadingClassName: string;
   formMethods: UseFormReturn<ChoiceCardsSettings & { hasOneDefault: boolean }>;
   onDestinationSectionChange: () => void;
-}
-
-interface DestinationTestOption {
-  name: string;
-  status: Test['status'];
 }
 
 enum Destination {
@@ -51,21 +45,27 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   onDestinationSectionChange,
 }) => {
   const { control, getValues, setValue } = formMethods;
-  const [destinationTestOptions, setDestinationTestOptions] = useState<DestinationTestOption[]>([]);
   const [destinationVariantNames, setDestinationVariantNames] = useState<string[]>([]);
-  const[destinationTest, setDestinationTest] = useState<Test[]>([]);
+  const [destinationTests, setDestinationTests] = useState<Test[]>([]);
   const destinationListRequestId = useRef(0);
-  const destinationFetchRequestId = useRef(0);
 
   const getSafeSelectValue = (value: string | undefined, options: string[]): string =>
     value && options.includes(value) ? value : '';
 
-  const clearVariantSelection = useCallback(() => {
-    setDestinationVariantNames([]);
-    setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
-      shouldValidate: true,
-    });
-  }, [index, setValue]);
+  const clearVariantSelection = useCallback(
+    (selectedTest?: Test) => {
+      if (!selectedTest) {
+        setDestinationVariantNames([]);
+      } else {
+        const variantNames = selectedTest.variants.map((variant) => variant.name);
+        setDestinationVariantNames(variantNames);
+      }
+      setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+        shouldValidate: true,
+      });
+    },
+    [index, setValue, setDestinationVariantNames],
+  );
 
   const clearTestAndVariantSelection = useCallback(() => {
     setValue(`choiceCards.${index}.destinationTest.testName`, '', {
@@ -75,7 +75,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   }, [clearVariantSelection, index, setValue]);
 
   const fetchDestinationTest = useCallback(
-    (testName: string) => {
+    (testName: string, tests: Test[]) => {
       const trimmedTestName = testName.trim();
 
       if (!trimmedTestName) {
@@ -83,25 +83,19 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
         return;
       }
 
-      const selectedTest = destinationTest.find(test => test.name === trimmedTestName) 
-      
-      if(!selectedTest)
-      {
+      const selectedTest = tests.find((test) => test.name === trimmedTestName);
+
+      if (!selectedTest) {
         clearVariantSelection();
         return;
       }
 
       const variantNames = selectedTest.variants.map((variant) => variant.name);
-          setDestinationVariantNames(variantNames);
+      setDestinationVariantNames(variantNames);
 
-          const currentVariantName =
-            getValues(`choiceCards.${index}.destinationTest.variantName`) ?? '';
-          if (currentVariantName && !variantNames.includes(currentVariantName)) {
-            clearVariantSelection();
-          }
-
+      clearVariantSelection(selectedTest);
     },
-    [clearVariantSelection, getValues, index],
+    [clearVariantSelection],
   );
 
   const fetchDestinationTests = useCallback(
@@ -115,13 +109,9 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             return;
           }
 
-          setDestinationTest(response.tests);
-          const testOptions = response.tests.map((test) => ({
-            name: test.name,
-            status: test.status,
-          }));
-          const testNames = testOptions.map((test) => test.name);
-          setDestinationTestOptions(testOptions);
+          setDestinationTests(response.tests);
+
+          const testNames = response.tests.map((test) => test.name);
 
           const currentTestName = getValues(`choiceCards.${index}.destinationTest.testName`) ?? '';
           if (!currentTestName || !testNames.includes(currentTestName)) {
@@ -129,14 +119,12 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             return;
           }
 
-          fetchDestinationTest(currentTestName);
+          fetchDestinationTest(currentTestName, response.tests);
         })
         .catch(() => {
           if (!isCurrentRequest(destinationListRequestId, requestId)) {
             return;
           }
-
-          setDestinationTestOptions([]);
           clearTestAndVariantSelection();
         });
     },
@@ -181,19 +169,17 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
                   displayEmpty
                   value={getSafeSelectValue(
                     destinationTestNameField.value,
-                    destinationTestOptions.map((test) => test.name),
+                    destinationTests.map((test) => test.name),
                   )}
                   onChange={(e) => {
                     const selectedTestName = e.target.value;
                     destinationTestNameField.onChange(selectedTestName);
-                    fetchDestinationTest(
-                      selectedTestName,
-                    );
+                    fetchDestinationTest(selectedTestName, destinationTests);
                     onDestinationSectionChange();
                   }}
                 >
                   <MenuItem value="">Destination test name (optional)</MenuItem>
-                  {destinationTestOptions.map((test) => (
+                  {destinationTests.map((test) => (
                     <MenuItem key={test.name} value={test.name}>
                       <Typography>{test.name}</Typography>
                       <TestListTestLiveLabel

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -7,6 +7,7 @@ import { Test } from '../helpers/shared';
 import TestListTestLiveLabel from '../testListTestLiveLabel';
 import TypedRadioGroup from '../TypedRadioGroup';
 
+
 interface DestinationTestsResponse {
   tests: Test[];
 }
@@ -52,6 +53,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   const { control, getValues, setValue } = formMethods;
   const [destinationTestOptions, setDestinationTestOptions] = useState<DestinationTestOption[]>([]);
   const [destinationVariantNames, setDestinationVariantNames] = useState<string[]>([]);
+  const[destinationTest, setDestinationTest] = useState<Test[]>([]);
   const destinationListRequestId = useRef(0);
   const destinationFetchRequestId = useRef(0);
 
@@ -73,7 +75,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   }, [clearVariantSelection, index, setValue]);
 
   const fetchDestinationTest = useCallback(
-    (destination: Destination, testName: string) => {
+    (testName: string) => {
       const trimmedTestName = testName.trim();
 
       if (!trimmedTestName) {
@@ -81,16 +83,15 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
         return;
       }
 
-      const settingsType = getSettingsTypeForDestination(destination);
-      const requestId = startRequest(destinationFetchRequestId);
+      const selectedTest = destinationTest.find(test => test.name === trimmedTestName) 
+      
+      if(!selectedTest)
+      {
+        clearVariantSelection();
+        return;
+      }
 
-      fetchTest<Test>(settingsType, trimmedTestName)
-        .then((test) => {
-          if (!isCurrentRequest(destinationFetchRequestId, requestId)) {
-            return;
-          }
-
-          const variantNames = test.variants.map((variant) => variant.name);
+      const variantNames = selectedTest.variants.map((variant) => variant.name);
           setDestinationVariantNames(variantNames);
 
           const currentVariantName =
@@ -98,14 +99,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
           if (currentVariantName && !variantNames.includes(currentVariantName)) {
             clearVariantSelection();
           }
-        })
-        .catch(() => {
-          if (!isCurrentRequest(destinationFetchRequestId, requestId)) {
-            return;
-          }
 
-          clearVariantSelection();
-        });
     },
     [clearVariantSelection, getValues, index],
   );
@@ -121,6 +115,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             return;
           }
 
+          setDestinationTest(response.tests);
           const testOptions = response.tests.map((test) => ({
             name: test.name,
             status: test.status,
@@ -134,7 +129,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             return;
           }
 
-          fetchDestinationTest(destination, currentTestName);
+          fetchDestinationTest(currentTestName);
         })
         .catch(() => {
           if (!isCurrentRequest(destinationListRequestId, requestId)) {
@@ -192,7 +187,6 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
                     const selectedTestName = e.target.value;
                     destinationTestNameField.onChange(selectedTestName);
                     fetchDestinationTest(
-                      (field.value as Destination | undefined) ?? Destination.LandingPage,
                       selectedTestName,
                     );
                     onDestinationSectionChange();

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -1,0 +1,249 @@
+import { FormControl, MenuItem, Select, Typography } from '@mui/material';
+import React, { useCallback, useRef, useState } from 'react';
+import { Controller, UseFormReturn } from 'react-hook-form';
+import { ChoiceCardsSettings } from '../../../models/choiceCards';
+import { fetchFrontendSettings, fetchTest, FrontendSettingsType } from '../../../utils/requests';
+import { Test } from '../helpers/shared';
+import TestListTestLiveLabel from '../testListTestLiveLabel';
+import TypedRadioGroup from '../TypedRadioGroup';
+
+interface DestinationTestsResponse {
+  tests: Test[];
+}
+
+interface ChoiceCardDestinationFieldsProps {
+  index: number;
+  isDisabled: boolean;
+  subHeadingClassName: string;
+  formMethods: UseFormReturn<ChoiceCardsSettings & { hasOneDefault: boolean }>;
+  onDestinationSectionChange: () => void;
+}
+
+interface DestinationTestOption {
+  name: string;
+  status: Test['status'];
+}
+
+enum Destination {
+  LandingPage = 'LandingPage',
+  Checkout = 'Checkout',
+}
+
+const getSettingsTypeForDestination = (destination: Destination) =>
+  destination === Destination.LandingPage
+    ? FrontendSettingsType.SupportLandingPageTests
+    : FrontendSettingsType.OneTimeCheckout;
+
+export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsProps> = ({
+  index,
+  isDisabled,
+  subHeadingClassName,
+  formMethods,
+  onDestinationSectionChange,
+}) => {
+  const shouldInvertColor = false;
+  const { control, getValues, setValue } = formMethods;
+  const [destinationTestOptions, setDestinationTestOptions] = useState<DestinationTestOption[]>([]);
+  const [destinationVariantNames, setDestinationVariantNames] = useState<string[]>([]);
+  const destinationListRequestId = useRef(0);
+  const destinationFetchRequestId = useRef(0);
+
+  const getSafeSelectValue = (value: string | undefined, options: string[]): string =>
+    value && options.includes(value) ? value : '';
+
+  const fetchDestinationTest = useCallback(
+    (destination: Destination, testName: string) => {
+      const trimmedTestName = testName.trim();
+
+      if (!trimmedTestName) {
+        setDestinationVariantNames([]);
+        setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+          shouldValidate: true,
+        });
+        return;
+      }
+
+      const settingsType = getSettingsTypeForDestination(destination);
+
+      const requestId = destinationFetchRequestId.current + 1;
+      destinationFetchRequestId.current = requestId;
+
+      fetchTest<Test>(settingsType, trimmedTestName)
+        .then((test) => {
+          if (destinationFetchRequestId.current !== requestId) {
+            return;
+          }
+
+          const variantNames = test.variants.map((variant) => variant.name);
+          setDestinationVariantNames(variantNames);
+
+          const currentVariantName =
+            getValues(`choiceCards.${index}.destinationTest.variantName`) ?? '';
+          if (currentVariantName && !variantNames.includes(currentVariantName)) {
+            setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+              shouldValidate: true,
+            });
+          }
+        })
+        .catch(() => {
+          if (destinationFetchRequestId.current !== requestId) {
+            return;
+          }
+
+          setDestinationVariantNames([]);
+          setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+            shouldValidate: true,
+          });
+        });
+    },
+    [getValues, setValue, index],
+  );
+
+  const fetchDestinationTests = useCallback(
+    (destination: Destination) => {
+      const settingsType = getSettingsTypeForDestination(destination);
+      const requestId = destinationListRequestId.current + 1;
+      destinationListRequestId.current = requestId;
+
+      fetchFrontendSettings<DestinationTestsResponse>(settingsType)
+        .then((response) => {
+          if (destinationListRequestId.current !== requestId) {
+            return;
+          }
+
+          const testOptions = response.tests.map((test) => ({
+            name: test.name,
+            status: test.status,
+          }));
+          const testNames = testOptions.map((test) => test.name);
+          setDestinationTestOptions(testOptions);
+
+          const currentTestName = getValues(`choiceCards.${index}.destinationTest.testName`) ?? '';
+          if (!currentTestName || !testNames.includes(currentTestName)) {
+            setValue(`choiceCards.${index}.destinationTest.testName`, '', {
+              shouldValidate: true,
+            });
+            setDestinationVariantNames([]);
+            setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+              shouldValidate: true,
+            });
+            return;
+          }
+
+          fetchDestinationTest(destination, currentTestName);
+        })
+        .catch(() => {
+          if (destinationListRequestId.current !== requestId) {
+            return;
+          }
+
+          setDestinationTestOptions([]);
+          setDestinationVariantNames([]);
+          setValue(`choiceCards.${index}.destinationTest.testName`, '', {
+            shouldValidate: true,
+          });
+          setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+            shouldValidate: true,
+          });
+        });
+    },
+    [getValues, setValue, fetchDestinationTest, index],
+  );
+
+  React.useEffect(() => {
+    const destination =
+      (getValues(`choiceCards.${index}.destination`) as Destination | undefined) ??
+      Destination.LandingPage;
+    fetchDestinationTests(destination);
+  }, [fetchDestinationTests, getValues, index]);
+
+  return (
+    <Controller
+      name={`choiceCards.${index}.destination`}
+      control={control}
+      render={({ field }) => (
+        <>
+          <Typography className={subHeadingClassName}>Destination</Typography>
+          <TypedRadioGroup
+            selectedValue={(field.value as Destination | undefined) ?? Destination.LandingPage}
+            onChange={(destination) => {
+              field.onChange(destination);
+              fetchDestinationTests(destination);
+              onDestinationSectionChange();
+            }}
+            isDisabled={isDisabled}
+            labels={{
+              [Destination.LandingPage]: 'Landing page',
+              [Destination.Checkout]: 'Checkout',
+            }}
+          />
+
+          <Controller
+            name={`choiceCards.${index}.destinationTest.testName`}
+            control={control}
+            render={({ field: destinationTestNameField }) => (
+              <FormControl fullWidth margin="normal" disabled={isDisabled}>
+                <Select
+                  required={false}
+                  displayEmpty
+                  value={getSafeSelectValue(
+                    destinationTestNameField.value,
+                    destinationTestOptions.map((test) => test.name),
+                  )}
+                  onChange={(e) => {
+                    const selectedTestName = e.target.value;
+                    destinationTestNameField.onChange(selectedTestName);
+                    fetchDestinationTest(
+                      (field.value as Destination | undefined) ?? Destination.LandingPage,
+                      selectedTestName,
+                    );
+                    onDestinationSectionChange();
+                  }}
+                >
+                  <MenuItem value="">Destination test name (optional)</MenuItem>
+                  {destinationTestOptions.map((test) => (
+                    <MenuItem key={test.name} value={test.name}>
+                      <Typography>{test.name}</Typography>
+                      <TestListTestLiveLabel
+                        isLive={test.status === 'Live'}
+                        shouldInvertColor={shouldInvertColor}
+                      />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+
+          <Controller
+            name={`choiceCards.${index}.destinationTest.variantName`}
+            control={control}
+            render={({ field: destinationVariantNameField }) => (
+              <FormControl fullWidth margin="normal" disabled={isDisabled}>
+                <Select
+                  required={false}
+                  displayEmpty
+                  value={getSafeSelectValue(
+                    destinationVariantNameField.value,
+                    destinationVariantNames,
+                  )}
+                  onChange={(e) => {
+                    destinationVariantNameField.onChange(e.target.value);
+                    onDestinationSectionChange();
+                  }}
+                >
+                  <MenuItem value="">Destination variant name (optional)</MenuItem>
+                  {destinationVariantNames.map((variantName) => (
+                    <MenuItem key={variantName} value={variantName}>
+                      {variantName}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+        </>
+      )}
+    />
+  );
+};

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -1,5 +1,5 @@
 import { FormControl, MenuItem, Select, Typography } from '@mui/material';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { ChoiceCardsSettings } from '../../../models/choiceCards';
 import { fetchFrontendSettings, fetchTest, FrontendSettingsType } from '../../../utils/requests';
@@ -29,6 +29,14 @@ enum Destination {
   Checkout = 'Checkout',
 }
 
+const startRequest = (requestRef: React.MutableRefObject<number>): number => {
+  requestRef.current += 1;
+  return requestRef.current;
+};
+
+const isCurrentRequest = (requestRef: React.MutableRefObject<number>, requestId: number): boolean =>
+  requestRef.current === requestId;
+
 const getSettingsTypeForDestination = (destination: Destination) =>
   destination === Destination.LandingPage
     ? FrontendSettingsType.SupportLandingPageTests
@@ -41,7 +49,6 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   formMethods,
   onDestinationSectionChange,
 }) => {
-  const shouldInvertColor = false;
   const { control, getValues, setValue } = formMethods;
   const [destinationTestOptions, setDestinationTestOptions] = useState<DestinationTestOption[]>([]);
   const [destinationVariantNames, setDestinationVariantNames] = useState<string[]>([]);
@@ -51,26 +58,35 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   const getSafeSelectValue = (value: string | undefined, options: string[]): string =>
     value && options.includes(value) ? value : '';
 
+  const clearVariantSelection = useCallback(() => {
+    setDestinationVariantNames([]);
+    setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
+      shouldValidate: true,
+    });
+  }, [index, setValue]);
+
+  const clearTestAndVariantSelection = useCallback(() => {
+    setValue(`choiceCards.${index}.destinationTest.testName`, '', {
+      shouldValidate: true,
+    });
+    clearVariantSelection();
+  }, [clearVariantSelection, index, setValue]);
+
   const fetchDestinationTest = useCallback(
     (destination: Destination, testName: string) => {
       const trimmedTestName = testName.trim();
 
       if (!trimmedTestName) {
-        setDestinationVariantNames([]);
-        setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
-          shouldValidate: true,
-        });
+        clearVariantSelection();
         return;
       }
 
       const settingsType = getSettingsTypeForDestination(destination);
-
-      const requestId = destinationFetchRequestId.current + 1;
-      destinationFetchRequestId.current = requestId;
+      const requestId = startRequest(destinationFetchRequestId);
 
       fetchTest<Test>(settingsType, trimmedTestName)
         .then((test) => {
-          if (destinationFetchRequestId.current !== requestId) {
+          if (!isCurrentRequest(destinationFetchRequestId, requestId)) {
             return;
           }
 
@@ -80,34 +96,28 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
           const currentVariantName =
             getValues(`choiceCards.${index}.destinationTest.variantName`) ?? '';
           if (currentVariantName && !variantNames.includes(currentVariantName)) {
-            setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
-              shouldValidate: true,
-            });
+            clearVariantSelection();
           }
         })
         .catch(() => {
-          if (destinationFetchRequestId.current !== requestId) {
+          if (!isCurrentRequest(destinationFetchRequestId, requestId)) {
             return;
           }
 
-          setDestinationVariantNames([]);
-          setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
-            shouldValidate: true,
-          });
+          clearVariantSelection();
         });
     },
-    [getValues, setValue, index],
+    [clearVariantSelection, getValues, index],
   );
 
   const fetchDestinationTests = useCallback(
     (destination: Destination) => {
       const settingsType = getSettingsTypeForDestination(destination);
-      const requestId = destinationListRequestId.current + 1;
-      destinationListRequestId.current = requestId;
+      const requestId = startRequest(destinationListRequestId);
 
       fetchFrontendSettings<DestinationTestsResponse>(settingsType)
         .then((response) => {
-          if (destinationListRequestId.current !== requestId) {
+          if (!isCurrentRequest(destinationListRequestId, requestId)) {
             return;
           }
 
@@ -120,37 +130,25 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
 
           const currentTestName = getValues(`choiceCards.${index}.destinationTest.testName`) ?? '';
           if (!currentTestName || !testNames.includes(currentTestName)) {
-            setValue(`choiceCards.${index}.destinationTest.testName`, '', {
-              shouldValidate: true,
-            });
-            setDestinationVariantNames([]);
-            setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
-              shouldValidate: true,
-            });
+            clearTestAndVariantSelection();
             return;
           }
 
           fetchDestinationTest(destination, currentTestName);
         })
         .catch(() => {
-          if (destinationListRequestId.current !== requestId) {
+          if (!isCurrentRequest(destinationListRequestId, requestId)) {
             return;
           }
 
           setDestinationTestOptions([]);
-          setDestinationVariantNames([]);
-          setValue(`choiceCards.${index}.destinationTest.testName`, '', {
-            shouldValidate: true,
-          });
-          setValue(`choiceCards.${index}.destinationTest.variantName`, '', {
-            shouldValidate: true,
-          });
+          clearTestAndVariantSelection();
         });
     },
-    [getValues, setValue, fetchDestinationTest, index],
+    [clearTestAndVariantSelection, fetchDestinationTest, getValues, index],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const destination =
       (getValues(`choiceCards.${index}.destination`) as Destination | undefined) ??
       Destination.LandingPage;
@@ -206,7 +204,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
                       <Typography>{test.name}</Typography>
                       <TestListTestLiveLabel
                         isLive={test.status === 'Live'}
-                        shouldInvertColor={shouldInvertColor}
+                        shouldInvertColor={false}
                       />
                     </MenuItem>
                   ))}

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -74,7 +74,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
     clearVariantSelection();
   }, [clearVariantSelection, index, setValue]);
 
-  const fetchDestinationTest = useCallback(
+  const setDestinationTest = useCallback(
     (testName: string, tests: Test[]) => {
       const trimmedTestName = testName.trim();
 
@@ -119,7 +119,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             return;
           }
 
-          fetchDestinationTest(currentTestName, response.tests);
+          setDestinationTest(currentTestName, response.tests);
         })
         .catch(() => {
           if (!isCurrentRequest(destinationListRequestId, requestId)) {
@@ -128,7 +128,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
           clearTestAndVariantSelection();
         });
     },
-    [clearTestAndVariantSelection, fetchDestinationTest, getValues, index],
+    [clearTestAndVariantSelection, setDestinationTest, getValues, index],
   );
 
   useEffect(() => {
@@ -174,7 +174,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
                   onChange={(e) => {
                     const selectedTestName = e.target.value;
                     destinationTestNameField.onChange(selectedTestName);
-                    fetchDestinationTest(selectedTestName, destinationTests);
+                    setDestinationTest(selectedTestName, destinationTests);
                     onDestinationSectionChange();
                   }}
                 >

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardEditor.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardEditor.tsx
@@ -23,7 +23,7 @@ import { Controller, useFieldArray, UseFormReturn } from 'react-hook-form';
 import { ChoiceCard, ChoiceCardsSettings, Product } from '../../../models/choiceCards';
 import { EMPTY_ERROR_HELPER_TEXT } from '../helpers/validation';
 import { RichTextEditorSingleLine, RteMenuConstraints } from '../richTextEditor/richTextEditor';
-import TypedRadioGroup from '../TypedRadioGroup';
+import { ChoiceCardDestinationFields } from './ChoiceCardDestinationFields';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -314,66 +314,12 @@ export const ChoiceCardEditor: React.FC<ChoiceCardEditorProps> = ({
           </Button>
         </div>
 
-        <Controller
-          name={`choiceCards.${index}.destination`}
-          control={control}
-          render={({ field }) => (
-            <>
-              <Typography className={classes.subHeading}>Destination</Typography>
-              <TypedRadioGroup
-                selectedValue={field.value ?? 'LandingPage'}
-                onChange={(destination) => {
-                  field.onChange(destination);
-                  handleCardChange();
-                }}
-                isDisabled={isDisabled}
-                labels={{
-                  LandingPage: 'Landing page',
-                  Checkout: 'Checkout',
-                }}
-              />
-
-              <Controller
-                name={`choiceCards.${index}.destinationTest.testName`}
-                control={control}
-                render={({ field: destinationTestNameField }) => (
-                  <TextField
-                    required={false}
-                    label="Destination test name (optional)"
-                    variant="filled"
-                    fullWidth
-                    margin="normal"
-                    disabled={isDisabled}
-                    value={destinationTestNameField.value ?? ''}
-                    onChange={(e) => {
-                      destinationTestNameField.onChange(e.target.value);
-                      handleCardChange();
-                    }}
-                  />
-                )}
-              />
-
-              <Controller
-                name={`choiceCards.${index}.destinationTest.variantName`}
-                control={control}
-                render={({ field: destinationVariantNameField }) => (
-                  <TextField
-                    required={false}
-                    label="Destination variant name (optional)"
-                    variant="filled"
-                    fullWidth
-                    margin="normal"
-                    disabled={isDisabled}
-                    value={destinationVariantNameField.value ?? ''}
-                    onChange={(e) => {
-                      destinationVariantNameField.onChange(e.target.value);
-                      handleCardChange();
-                    }}
-                  />
-                )}
-              />
-            </>
-          )}
+        <ChoiceCardDestinationFields
+          index={index}
+          isDisabled={isDisabled}
+          subHeadingClassName={classes.subHeading}
+          formMethods={formMethods}
+          onDestinationSectionChange={handleCardChange}
         />
       </AccordionDetails>
     </Accordion>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1215013136667319)
## What does this change?
This change switches Destination Test Name and Destination Variant Name fields to dropdowns instead of TextFields in order to make the process of assigning the correct destination of the CTA button in choice cards easier and less prone to errors
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE env and verified that fields work as expected
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1503" height="732" alt="Screenshot 2026-05-27 at 14 54 30" src="https://github.com/user-attachments/assets/66e0d5fe-d944-4bfd-b697-7fd3d8207ada" />
<img width="825" height="266" alt="Screenshot 2026-05-27 at 14 54 43" src="https://github.com/user-attachments/assets/5a302c7a-42c3-4e14-9b22-dfaeac4d92eb" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
