### PR TITLE
destination variant name display fix

### DIFF
--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -75,7 +75,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   }, [clearVariantSelection, index, setValue]);
 
   const setDestinationTest = useCallback(
-    (testName: string, tests: Test[]) => {
+    (testName: string, tests: Test[], variantName?: string) => {
       const trimmedTestName = testName.trim();
 
       if (!trimmedTestName) {
@@ -92,8 +92,11 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
 
       const variantNames = selectedTest.variants.map((variant) => variant.name);
       setDestinationVariantNames(variantNames);
-
-      clearVariantSelection(selectedTest);
+      const isValidVariant = !!variantName?.trim() && variantNames.includes(variantName.trim());
+      if (!isValidVariant) {
+        clearVariantSelection(selectedTest);
+        return;
+      }
     },
     [clearVariantSelection],
   );
@@ -118,8 +121,10 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             clearTestAndVariantSelection();
             return;
           }
+          const currentVariantName =
+            getValues(`choiceCards.${index}.destinationTest.variantName`) ?? '';
 
-          setDestinationTest(currentTestName, response.tests);
+          setDestinationTest(currentTestName, response.tests, currentVariantName);
         })
         .catch(() => {
           if (!isCurrentRequest(destinationListRequestId, requestId)) {

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -92,7 +92,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
 
       const variantNames = selectedTest.variants.map((variant) => variant.name);
       setDestinationVariantNames(variantNames);
-      const isValidVariant = !!variantName?.trim() && variantNames.includes(variantName.trim());
+      const isValidVariant = !!variantName && variantNames.includes(variantName);
       if (!isValidVariant) {
         clearVariantSelection(selectedTest);
         return;
@@ -124,7 +124,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
           const currentVariantName =
             getValues(`choiceCards.${index}.destinationTest.variantName`) ?? '';
 
-          setDestinationTest(currentTestName, response.tests, currentVariantName);
+          setDestinationTest(currentTestName, response.tests, currentVariantName.trim());
         })
         .catch(() => {
           if (!isCurrentRequest(destinationListRequestId, requestId)) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This change fixes displaying of Variant Name, if it was selected
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE, verified that the correct destination variant name is displayed after test is saved
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1074" height="455" alt="Screenshot 2026-06-05 at 13 26 40" src="https://github.com/user-attachments/assets/ac0326e7-0f9f-427f-af32-638c02fce3d3" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
