### PR TITLE
remirror empty value fix and console warning for multiselect fix

### DIFF
--- a/public/src/components/channelManagement/MutliSelectTagEditor.tsx
+++ b/public/src/components/channelManagement/MutliSelectTagEditor.tsx
@@ -70,6 +70,7 @@ const MultiselectAutocomplete: React.FC<MultiselectAutocompleteProps> = ({
         disabled={disabled}
         options={options}
         getOptionLabel={(option) => option.label}
+        isOptionEqualToValue={(option, value) => option.value === value.value}
         value={tagIds?.map<Option>((tag) => ({ label: tag, value: tag }))}
         inputValue={inputValue}
         componentsProps={{

--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -484,7 +484,8 @@ const paragraphsToArray = (html: string): string[] => {
 
   const paragraphs = elements.filter((p) => p.tagName === 'P');
 
-  return paragraphs.map((p) => p.innerHTML);
+  // When a paragraph contains only a <br> (ProseMirror trailing break), treat it as empty
+  return paragraphs.map((p) => (p.textContent === '' ? '' : p.innerHTML));
 };
 
 // Component function


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1215499216707078)
## What does this change?
This change fixes the bug with <br> tag instead of empty string in RichTextEditor component.
Also it fixes the console warning from MUI (see screenshot)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE. Fields that use RichTextEditor were updated to empty string and the saves data was verified
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
**BEFORE**
<img width="1404" height="634" alt="Screenshot 2026-06-08 at 15 49 55" src="https://github.com/user-attachments/assets/0fa598e8-924b-4b73-a201-04b612b7d928" />
<img width="471" height="349" alt="Screenshot 2026-06-12 at 09 53 25" src="https://github.com/user-attachments/assets/4a5abe1d-76e3-4742-a99a-47ce906feb0e" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
