### PR TITLE
Prevent npm version prefix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-prefix=''
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@types/material-ui": "0.21.18",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "concurrently": "^10.0.3",
+    "concurrently": "10.0.3",
     "css-loader": "7.1.4",
     "eslint": "9.39.4",
     "eslint-plugin-prettier": "5.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
         specifier: 18.3.1
         version: 18.3.1
       concurrently:
-        specifier: ^10.0.3
+        specifier: 10.0.3
         version: 10.0.3
       css-loader:
         specifier: 7.1.4


### PR DESCRIPTION
We do not want the range prefix on our dependency versions.
This PR uses the `save-prefix` setting to prevent this when running `pnpm add`
https://pnpm.io/settings#saveprefix