### PR TITLE
Added web preview flag to variant summary buttons

### DIFF
--- a/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
+++ b/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
@@ -38,7 +38,7 @@ const getPreviewUrl = (
 ): string => {
   const stage = getStage();
   const channelName = getChannelName(testType, articleType);
-  const queryString = `?force-${channelName}=${testName}:${variantName}`;
+  const queryString = `?force-${channelName}=${testName}:${variantName}&rrcp=1`;
 
   if (testType === 'LANDING_PAGE') {
     // link to the support site landing page


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This change adds additional rrcp=1 search param to the "Web preview" button url to indicate that the page was loaded from rrcp as a web preview.
Sometimes when users tried to preview banners through clicking "web preview", they saw CMP consent dialog instead which could be confusing. This change suppresses CMP for "web preview".
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE env
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
