### PR TITLE
Restrict support landing pages to a single methodology

### DIFF
--- a/public/src/components/channelManagement/SingleMethodologyEditor.tsx
+++ b/public/src/components/channelManagement/SingleMethodologyEditor.tsx
@@ -1,0 +1,194 @@
+import {
+  Alert,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Switch,
+  TextField,
+  Theme,
+  Tooltip,
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import React from 'react';
+import { BanditAnalyticsButton } from './BanditAnalyticsButton';
+import { BanditMethodology, Methodology } from './helpers/shared';
+
+const isBandit = (methodology: Methodology): methodology is BanditMethodology =>
+  methodology.name === 'EpsilonGreedyBandit' || methodology.name === 'Roulette';
+
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  container: {
+    '& > * + *': {
+      marginTop: spacing(1),
+    },
+  },
+  methodologyContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    border: `1px solid ${palette.grey[800]}`,
+    borderRadius: '4px',
+    padding: spacing(1),
+    '& > * + *': {
+      marginLeft: spacing(2),
+      paddingLeft: spacing(2),
+      borderLeft: `1px solid ${palette.grey[400]}`,
+    },
+  },
+  sampleCountContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '14px',
+    fontWeight: 500,
+  },
+  sampleCountInput: {
+    maxWidth: '90px',
+    marginLeft: spacing(1),
+  },
+}));
+
+const defaultEpsilonGreedyBandit: Methodology = {
+  name: 'EpsilonGreedyBandit',
+  epsilon: 0.1,
+};
+
+interface MethodologySampleCountProps {
+  sampleCount?: number;
+  onChange: (sampleCount?: number) => void;
+  isDisabled: boolean;
+}
+
+const MethodologySampleCount: React.FC<MethodologySampleCountProps> = ({
+  sampleCount,
+  onChange,
+  isDisabled,
+}: MethodologySampleCountProps) => {
+  const classes = useStyles();
+
+  const onSwitchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.target.checked) {
+      onChange(24);
+    } else {
+      onChange(undefined);
+    }
+  };
+
+  return (
+    <div className={classes.sampleCountContainer}>
+      <Tooltip
+        title={
+          'Only look back this many hours. If disabled, uses all data since the start of the test.'
+        }
+      >
+        <div>
+          <div>Window</div>
+          <Switch checked={!!sampleCount} onChange={onSwitchChange} disabled={isDisabled} />
+        </div>
+      </Tooltip>
+      <TextField
+        className={classes.sampleCountInput}
+        type={'number'}
+        InputProps={{ inputProps: { min: 6, step: 1 } }}
+        value={sampleCount}
+        label={'Hours'}
+        disabled={isDisabled || !sampleCount}
+        InputLabelProps={{ shrink: true }}
+        onChange={(event) => {
+          const samples = parseInt(event.target.value);
+          onChange(samples);
+        }}
+      />
+    </div>
+  );
+};
+
+interface SingleMethodologyEditorProps {
+  methodology: Methodology;
+  testName: string;
+  channel: string;
+  onChange: (methodology: Methodology) => void;
+  isDisabled: boolean;
+}
+
+export const SingleMethodologyEditor: React.FC<SingleMethodologyEditorProps> = ({
+  methodology,
+  testName,
+  channel,
+  onChange,
+  isDisabled,
+}: SingleMethodologyEditorProps) => {
+  const classes = useStyles();
+
+  const onSelectChange = (event: SelectChangeEvent<Methodology['name']>) => {
+    const value = event.target.value as Methodology['name'];
+    if (value === 'EpsilonGreedyBandit') {
+      onChange(defaultEpsilonGreedyBandit);
+    } else if (value === 'Roulette') {
+      onChange({ name: 'Roulette' });
+    } else {
+      onChange({ name: 'ABTest' });
+    }
+  };
+
+  return (
+    <div className={classes.container}>
+      <Alert severity="info">Methodologies cannot be changed after a test has been launched</Alert>
+
+      <div className={classes.methodologyContainer}>
+        <div>
+          <Select
+            value={methodology.name}
+            disabled={isDisabled}
+            onChange={onSelectChange}
+            name="methodology-select"
+          >
+            <MenuItem value={'ABTest'} key={'ABTest'}>
+              AB test
+            </MenuItem>
+            <MenuItem value={'EpsilonGreedyBandit'} key={'EpsilonGreedyBandit'}>
+              Epsilon-greedy bandit
+            </MenuItem>
+            <MenuItem value={'Roulette'} key={'Roulette'}>
+              Roulette
+            </MenuItem>
+          </Select>
+        </div>
+        {isBandit(methodology) && (
+          <MethodologySampleCount
+            sampleCount={methodology.sampleCount}
+            onChange={(sampleCount) =>
+              onChange({
+                ...methodology,
+                sampleCount,
+              })
+            }
+            isDisabled={isDisabled}
+          />
+        )}
+        {methodology.name === 'EpsilonGreedyBandit' && (
+          <div>
+            <TextField
+              type={'number'}
+              InputProps={{ inputProps: { min: 0.1, max: 1, step: 0.1 } }}
+              value={methodology.epsilon}
+              label={'Epsilon'}
+              disabled={isDisabled}
+              onChange={(event) => {
+                const epsilon = parseFloat(event.target.value);
+                onChange({ ...methodology, epsilon });
+              }}
+            />
+          </div>
+        )}
+        {isBandit(methodology) && (
+          <div>
+            <BanditAnalyticsButton
+              testName={testName}
+              channel={channel}
+              sampleCount={methodology.sampleCount}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
@@ -9,8 +9,8 @@ import VariantSummary from '../../tests/variants/variantSummary';
 import { Methodology, RegionTargeting } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { MParticleAudienceEditor } from '../mParticleAudienceEditor';
+import { SingleMethodologyEditor } from '../SingleMethodologyEditor';
 import TestEditorTargetRegionsSelector from '../testEditorTargetRegionsSelector';
-import { TestMethodologyEditor } from '../TestMethodologyEditor';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import { getDefaultVariant } from './utils/defaults';
 import VariantEditor from './variantEditor';
@@ -96,9 +96,9 @@ const SupportLandingPageTestEditor: React.FC<ValidatedTestEditorProps<SupportLan
     }));
   };
 
-  const onMethodologyChange = (methodologies: Methodology[]): void => {
-    setValidationStatusForField('methodologies', methodologies.length > 0);
-    onTestChange((current) => ({ ...current, methodologies }));
+  const onMethodologyChange = (methodology: Methodology): void => {
+    setValidationStatusForField('methodologies', true);
+    onTestChange((current) => ({ ...current, methodologies: [methodology] }));
   };
 
   const renderVariantEditor = (variant: SupportLandingPageVariant): React.ReactElement => (
@@ -161,8 +161,8 @@ const SupportLandingPageTestEditor: React.FC<ValidatedTestEditorProps<SupportLan
         <Typography variant={'h3'} className={classes.sectionHeader}>
           Experiment Methodology
         </Typography>
-        <TestMethodologyEditor
-          methodologies={test.methodologies}
+        <SingleMethodologyEditor
+          methodology={test.methodologies[0] ?? { name: 'ABTest' }}
           testName={test.name}
           channel={test.channel ?? ''}
           isDisabled={!userHasTestLocked || test.status === 'Live'}


### PR DESCRIPTION
## What does this change?
Adds a new [SingleMethodologyEditor](cci:1://file:///Users/admin.juarez.mota/code/support-admin-console/public/src/components/channelManagement/SingleMethodologyEditor.tsx:112:0-194:2) component that manages exactly one methodology, and updates the [SupportLandingPageTestEditor](cci:1://file:///Users/admin.juarez.mota/code/support-admin-console/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx:17:0-200:2) to use it.

- Landing page tests can now only have **one** methodology (ABTest, EpsilonGreedyBandit, or Roulette)
- No audience percentage splitting, no add/remove buttons, no `testName` override
- Bandit analytics button still works using the test's main `name`

## What was left unchanged?
- Other test editors (banner, epic, header, gutter, etc.) continue to use [TestMethodologyEditor](cci:1://file:///Users/admin.juarez.mota/code/support-admin-console/public/src/components/channelManagement/TestMethodologyEditor.tsx:261:0-335:2) with multi-methodology support
- Shared [Methodology](cci:2://file:///Users/admin.juarez.mota/code/support-frontend/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts:108:0-108:66) type keeps `testName?: string` for dotcom-rendering compatibility
- Backend Scala models remain `List[Methodology]` for DynamoDB backward compatibility
- [StudentLandingPageTestEditor](cci:1://file:///Users/admin.juarez.mota/code/support-admin-console/public/src/components/channelManagement/studentLandingPage/studentLandingPageTestEditor.tsx:67:0-186:2) unchanged (already had no methodology UI)

This aligns `support-admin-console` with `support-frontend` PR [#8061](https://github.com/guardian/support-frontend/pull/8061), where only the first methodology is used.