### PR TITLE
Optional scheduler added to channel tests

### DIFF
--- a/app/models/BannerTests.scala
+++ b/app/models/BannerTests.scala
@@ -53,7 +53,8 @@ case class BannerTest(
     deploySchedule: Option[BannerTestDeploySchedule] = None,
     methodologies: List[Methodology] = defaultMethodologies,
     frontsOnly: Option[Boolean] = None,
-    mParticleAudience: Option[Int] = None
+    mParticleAudience: Option[Int] = None,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[BannerTest] {
 
   override def withChannel(channel: Channel): BannerTest =

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -3,7 +3,7 @@ package models
 import io.circe.Decoder.Result
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.{deriveDecoder, deriveEnumerationDecoder, deriveEnumerationEncoder}
+import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder, deriveDecoder, deriveEnumerationDecoder, deriveEnumerationEncoder}
 
 sealed trait Status
 
@@ -19,6 +19,17 @@ object Status {
   implicit val statusDecoder: Decoder[Status] = deriveEnumerationDecoder[Status]
 }
 
+case class Scheduler(
+    start: Option[String] = None, // ISO date "YYYY-MM-DD", inclusive
+    end: Option[String] = None // ISO date "YYYY-MM-DD", inclusive
+)
+
+object Scheduler {
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val schedulerDecoder: Decoder[Scheduler] = deriveConfiguredDecoder[Scheduler]
+  implicit val schedulerEncoder: Encoder[Scheduler] = deriveConfiguredEncoder[Scheduler]
+}
+
 trait ChannelTest[T] {
   val name: String
   val channel: Option[Channel] // optional only for the migration
@@ -27,6 +38,7 @@ trait ChannelTest[T] {
   val priority: Option[Int] // 0 is top priority
   val campaignName: Option[String]
   val methodologies: List[Methodology]
+  val scheduler: Option[Scheduler]
 
   def withChannel(channel: Channel): T
   def withPriority(priority: Int): T

--- a/app/models/ChannelTest.scala
+++ b/app/models/ChannelTest.scala
@@ -20,8 +20,8 @@ object Status {
 }
 
 case class Scheduler(
-    start: Option[String] = None, // ISO date "YYYY-MM-DD", inclusive
-    end: Option[String] = None // ISO date "YYYY-MM-DD", inclusive
+    start: Option[String] = None, // ISO datetime "YYYY-MM-DDTHH:MM" in UTC, inclusive
+    end: Option[String] = None // ISO datetime "YYYY-MM-DDTHH:MM" in UTC, inclusive
 )
 
 object Scheduler {

--- a/app/models/CheckoutNudgeTest.scala
+++ b/app/models/CheckoutNudgeTest.scala
@@ -70,7 +70,8 @@ case class CheckoutNudgeTest(
     nudgeFromProduct: Product,
     variants: List[CheckoutNudgeVariant],
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-    methodologies: List[Methodology] = defaultMethodologies
+    methodologies: List[Methodology] = defaultMethodologies,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[CheckoutNudgeTest] {
 
   override def withChannel(channel: Channel): CheckoutNudgeTest =

--- a/app/models/EpicTest.scala
+++ b/app/models/EpicTest.scala
@@ -67,7 +67,8 @@ case class EpicTest(
     signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
     consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
     methodologies: List[Methodology] = defaultMethodologies,
-    mParticleAudience: Option[Int] = None
+    mParticleAudience: Option[Int] = None,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[EpicTest] {
 
   override def withChannel(channel: Channel): EpicTest = this.copy(channel = Some(channel))

--- a/app/models/GutterTests.scala
+++ b/app/models/GutterTests.scala
@@ -35,7 +35,8 @@ case class GutterTest(
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
     signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
     consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
-    methodologies: List[Methodology] = defaultMethodologies
+    methodologies: List[Methodology] = defaultMethodologies,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[GutterTest] {
 
   override def withChannel(channel: Channel): GutterTest =

--- a/app/models/HeaderTests.scala
+++ b/app/models/HeaderTests.scala
@@ -37,7 +37,8 @@ case class HeaderTest(
     signedInStatus: Option[SignedInStatus] = Some(SignedInStatus.All),
     consentStatus: Option[ConsentStatus] = Some(ConsentStatus.All),
     methodologies: List[Methodology] = defaultMethodologies,
-    mParticleAudience: Option[Int] = None
+    mParticleAudience: Option[Int] = None,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[HeaderTest] {
 
   override def withChannel(channel: Channel): HeaderTest = this.copy(channel = Some(channel))

--- a/app/models/OneTimeCheckoutTest.scala
+++ b/app/models/OneTimeCheckoutTest.scala
@@ -32,9 +32,9 @@ case class OneTimeCheckoutTest(
     variants: List[OneTimeCheckoutVariant],
     methodologies: List[Methodology] = defaultMethodologies,
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-    mParticleAudience: Option[Int] = None,
-    scheduler: Option[Scheduler] = None
+    mParticleAudience: Option[Int] = None
 ) extends ChannelTest[OneTimeCheckoutTest] {
+  override val scheduler: Option[Scheduler] = None
 
   override def withChannel(channel: Channel): OneTimeCheckoutTest =
     this.copy(channel = Some(channel))

--- a/app/models/OneTimeCheckoutTest.scala
+++ b/app/models/OneTimeCheckoutTest.scala
@@ -32,7 +32,8 @@ case class OneTimeCheckoutTest(
     variants: List[OneTimeCheckoutVariant],
     methodologies: List[Methodology] = defaultMethodologies,
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-    mParticleAudience: Option[Int] = None
+    mParticleAudience: Option[Int] = None,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[OneTimeCheckoutTest] {
 
   override def withChannel(channel: Channel): OneTimeCheckoutTest =

--- a/app/models/StudentLandingPageTest.scala
+++ b/app/models/StudentLandingPageTest.scala
@@ -37,9 +37,9 @@ case class StudentLandingPageTest(
     countryGroupId: Region,
     variants: List[StudentLandingPageVariant],
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-    methodologies: List[Methodology] = defaultMethodologies,
-    scheduler: Option[Scheduler] = None
+    methodologies: List[Methodology] = defaultMethodologies
 ) extends ChannelTest[StudentLandingPageTest] {
+  override val scheduler: Option[Scheduler] = None
 
   override def withChannel(channel: Channel): StudentLandingPageTest =
     this.copy(channel = Some(channel))

--- a/app/models/StudentLandingPageTest.scala
+++ b/app/models/StudentLandingPageTest.scala
@@ -37,7 +37,8 @@ case class StudentLandingPageTest(
     countryGroupId: Region,
     variants: List[StudentLandingPageVariant],
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
-    methodologies: List[Methodology] = defaultMethodologies
+    methodologies: List[Methodology] = defaultMethodologies,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[StudentLandingPageTest] {
 
   override def withChannel(channel: Channel): StudentLandingPageTest =

--- a/app/models/SupportLandingPageTest.scala
+++ b/app/models/SupportLandingPageTest.scala
@@ -65,7 +65,8 @@ case class SupportLandingPageTest(
     variants: List[SupportLandingPageVariant],
     campaignName: Option[String] = Some("NOT_IN_CAMPAIGN"),
     methodologies: List[Methodology] = defaultMethodologies,
-    mParticleAudience: Option[Int] = None
+    mParticleAudience: Option[Int] = None,
+    scheduler: Option[Scheduler] = None
 ) extends ChannelTest[SupportLandingPageTest] {
 
   override def withChannel(channel: Channel): SupportLandingPageTest =

--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -28,6 +28,7 @@ import {
 } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { ARTICLE_COUNT_TEMPLATE } from '../helpers/validation';
+import ScheduleEditor from '../scheduleEditor';
 import TestEditorArticleCountEditor, {
   DEFAULT_ARTICLES_VIEWED_SETTINGS,
 } from '../testEditorArticleCountEditor';
@@ -440,6 +441,17 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
           frontsOnly={test.frontsOnly}
           onFrontsOnlyChange={onFrontsOnlyChange}
           isDisabled={!userHasTestLocked}
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Schedule
+        </Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/checkoutNudge/checkoutNudgeTestEditor.tsx
+++ b/public/src/components/channelManagement/checkoutNudge/checkoutNudgeTestEditor.tsx
@@ -12,6 +12,7 @@ import VariantsEditor from '../../tests/variants/variantsEditor';
 import VariantSummary from '../../tests/variants/variantSummary';
 import { RegionTargeting } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
+import ScheduleEditor from '../scheduleEditor';
 import TestEditorTargetRegionsSelector from '../testEditorTargetRegionsSelector';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import {
@@ -246,6 +247,17 @@ const CheckoutNudgeTestEditor: React.FC<ValidatedTestEditorProps<CheckoutNudgeTe
           regionTargeting={test.regionTargeting}
           onRegionTargetingUpdate={onTargetingChange}
           isDisabled={!userHasTestLocked}
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Schedule
+        </Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/epicTests/testEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/testEditor.tsx
@@ -23,6 +23,7 @@ import {
 } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { ARTICLE_COUNT_TEMPLATE, COUNTRY_NAME_TEMPLATE } from '../helpers/validation';
+import ScheduleEditor from '../scheduleEditor';
 import TestEditorArticleCountEditor, {
   DEFAULT_ARTICLES_VIEWED_SETTINGS,
 } from '../testEditorArticleCountEditor';
@@ -480,6 +481,17 @@ export const getEpicTestEditor = (
             />
           </div>
         )}
+
+        <div className={classes.sectionContainer}>
+          <Typography variant={'h3'} className={classes.sectionHeader}>
+            Schedule
+          </Typography>
+          <ScheduleEditor
+            scheduler={test.scheduler}
+            disabled={!userHasTestLocked}
+            onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+          />
+        </div>
       </div>
     );
   };

--- a/public/src/components/channelManagement/gutterTests/gutterTestEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterTestEditor.tsx
@@ -16,6 +16,7 @@ import {
   UserCohort,
 } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
+import ScheduleEditor from '../scheduleEditor';
 import TestEditorContextTargeting from '../testEditorContextTargeting';
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
@@ -261,6 +262,17 @@ const GutterTestEditor: React.FC<ValidatedTestEditorProps<GutterTest>> = ({
           onSignedInStatusChange={onSignedInStatusChange}
           showConsentStatusSelector={false}
           onConsentStatusChange={onConsentChange} // can't remove but hidden anyway
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Schedule
+        </Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -15,6 +15,7 @@ import {
 } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { MParticleAudienceEditor } from '../mParticleAudienceEditor';
+import ScheduleEditor from '../scheduleEditor';
 import TestEditorTargetAudienceSelector from '../testEditorTargetAudienceSelector';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import HeaderTestVariantEditor from './headerTestVariantEditor';
@@ -247,6 +248,17 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
               mParticleAudience,
             }));
           }}
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Schedule
+        </Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -40,6 +40,11 @@ export type Methodology = { testName?: string } & (
 );
 export type BanditMethodology = Exclude<Methodology, { name: 'ABTest' }>;
 
+export interface Scheduler {
+  start?: string; // ISO date "YYYY-MM-DD", inclusive
+  end?: string; // ISO date "YYYY-MM-DD", inclusive
+}
+
 export interface Test {
   name: string;
   nickname?: string;
@@ -57,6 +62,7 @@ export interface Test {
   signedInStatus?: SignedInStatus;
   consentStatus?: ConsentStatus;
   methodologies: Methodology[];
+  scheduler?: Scheduler;
 }
 
 export interface EpicEditorConfig {

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -41,8 +41,8 @@ export type Methodology = { testName?: string } & (
 export type BanditMethodology = Exclude<Methodology, { name: 'ABTest' }>;
 
 export interface Scheduler {
-  start?: string; // ISO date "YYYY-MM-DD", inclusive
-  end?: string; // ISO date "YYYY-MM-DD", inclusive
+  start?: string; // ISO datetime "YYYY-MM-DDTHH:MM" in UTC, inclusive
+  end?: string; // ISO datetime "YYYY-MM-DDTHH:MM" in UTC, inclusive
 }
 
 export interface Test {

--- a/public/src/components/channelManagement/helpers/utilities.test.ts
+++ b/public/src/components/channelManagement/helpers/utilities.test.ts
@@ -1,4 +1,4 @@
-import { buildChartData } from './utilities';
+import { buildChartData, isWithinSchedule, parseSchedulerUtc } from './utilities';
 
 describe('buildChartData', () => {
   it('formats timestamps in 24-hour format', () => {
@@ -49,5 +49,62 @@ describe('buildChartData', () => {
         B: null,
       },
     ]);
+  });
+});
+
+describe('parseSchedulerUtc', () => {
+  it('returns null for undefined', () => {
+    expect(parseSchedulerUtc(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseSchedulerUtc('')).toBeNull();
+  });
+
+  it('returns null for an invalid date string', () => {
+    expect(parseSchedulerUtc('not-a-date')).toBeNull();
+  });
+
+  it('parses a valid YYYY-MM-DDTHH:MM string as UTC', () => {
+    const result = parseSchedulerUtc('2026-07-15T14:30');
+    expect(result).not.toBeNull();
+    expect(result?.toISOString()).toBe('2026-07-15T14:30:00.000Z');
+  });
+});
+
+describe('isWithinSchedule', () => {
+  const PAST = '2020-01-01T00:00';
+  const FUTURE = '2099-12-31T23:59';
+
+  it('returns true when no start or end is set', () => {
+    expect(isWithinSchedule({})).toBe(true);
+  });
+
+  it('returns true when only start is set and now is after start', () => {
+    expect(isWithinSchedule({ start: PAST })).toBe(true);
+  });
+
+  it('returns false when only start is set and now is before start', () => {
+    expect(isWithinSchedule({ start: FUTURE })).toBe(false);
+  });
+
+  it('returns true when only end is set and now is before end', () => {
+    expect(isWithinSchedule({ end: FUTURE })).toBe(true);
+  });
+
+  it('returns false when only end is set and now is after end', () => {
+    expect(isWithinSchedule({ end: PAST })).toBe(false);
+  });
+
+  it('returns true when now is within start and end', () => {
+    expect(isWithinSchedule({ start: PAST, end: FUTURE })).toBe(true);
+  });
+
+  it('returns false when now is before start', () => {
+    expect(isWithinSchedule({ start: FUTURE, end: FUTURE })).toBe(false);
+  });
+
+  it('returns false when now is after end', () => {
+    expect(isWithinSchedule({ start: PAST, end: PAST })).toBe(false);
   });
 });

--- a/public/src/components/channelManagement/helpers/utilities.tsx
+++ b/public/src/components/channelManagement/helpers/utilities.tsx
@@ -106,3 +106,29 @@ function formatToUtcString(date: Date): string {
     pad(date.getUTCMinutes())
   );
 }
+
+// Parses a "YYYY-MM-DDTHH:MM" UTC string into a Date. Returns null if empty/invalid.
+export const parseSchedulerUtc = (value?: string): Date | null => {
+  if (!value) {
+    return null;
+  }
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
+    return null;
+  }
+  const d = new Date(`${value}:00Z`);
+  return isNaN(d.getTime()) ? null : d;
+};
+
+// Returns true if the current time falls within the scheduler's start/end range.
+export const isWithinSchedule = (scheduler: { start?: string; end?: string }): boolean => {
+  const now = new Date();
+  const start = parseSchedulerUtc(scheduler.start);
+  const end = parseSchedulerUtc(scheduler.end);
+  if (start && now < start) {
+    return false;
+  }
+  if (end && now > end) {
+    return false;
+  }
+  return true;
+};

--- a/public/src/components/channelManagement/helpers/utilities.tsx
+++ b/public/src/components/channelManagement/helpers/utilities.tsx
@@ -1,6 +1,7 @@
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { Typography } from '@mui/material';
+import { isValid, parseISO } from 'date-fns';
 import React from 'react';
 
 export const renderVisibilityIcons = (isOn: boolean): React.ReactNode => {
@@ -112,11 +113,8 @@ export const parseSchedulerUtc = (value?: string): Date | null => {
   if (!value) {
     return null;
   }
-  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
-    return null;
-  }
-  const d = new Date(`${value}:00Z`);
-  return isNaN(d.getTime()) ? null : d;
+  const d = parseISO(value.endsWith('Z') ? value : `${value}Z`);
+  return isValid(d) ? d : null;
 };
 
 // Returns true if the current time falls within the scheduler's start/end range.

--- a/public/src/components/channelManagement/oneTimeCheckout/oneTimeCheckoutTestEditor.tsx
+++ b/public/src/components/channelManagement/oneTimeCheckout/oneTimeCheckoutTestEditor.tsx
@@ -7,6 +7,7 @@ import VariantSummary from '../../tests/variants/variantSummary';
 import { RegionTargeting } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { MParticleAudienceEditor } from '../mParticleAudienceEditor';
+import ScheduleEditor from '../scheduleEditor';
 import TestEditorTargetRegionsSelector from '../testEditorTargetRegionsSelector';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import { getDefaultVariant } from './utils/defaults';
@@ -176,6 +177,17 @@ const OneTimeCheckoutTestEditor: React.FC<ValidatedTestEditorProps<OneTimeChecko
               mParticleAudience,
             }));
           }}
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Schedule
+        </Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/oneTimeCheckout/oneTimeCheckoutTestEditor.tsx
+++ b/public/src/components/channelManagement/oneTimeCheckout/oneTimeCheckoutTestEditor.tsx
@@ -7,7 +7,6 @@ import VariantSummary from '../../tests/variants/variantSummary';
 import { RegionTargeting } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { MParticleAudienceEditor } from '../mParticleAudienceEditor';
-import ScheduleEditor from '../scheduleEditor';
 import TestEditorTargetRegionsSelector from '../testEditorTargetRegionsSelector';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import { getDefaultVariant } from './utils/defaults';
@@ -177,17 +176,6 @@ const OneTimeCheckoutTestEditor: React.FC<ValidatedTestEditorProps<OneTimeChecko
               mParticleAudience,
             }));
           }}
-        />
-      </div>
-
-      <div className={classes.sectionContainer}>
-        <Typography variant={'h3'} className={classes.sectionHeader}>
-          Schedule
-        </Typography>
-        <ScheduleEditor
-          scheduler={test.scheduler}
-          disabled={!userHasTestLocked}
-          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/scheduleEditor.tsx
+++ b/public/src/components/channelManagement/scheduleEditor.tsx
@@ -50,15 +50,15 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ scheduler, disabled, on
       <Typography variant="subtitle2">
         Test scheduler{' '}
         <small>
-          (Start and end dates are inclusive. Leave blank to go live immediately. Note: schedule has
-          no effect on draft tests.)
+          (Start and end times are inclusive and in UTC. Leave blank to go live immediately. Note:
+          schedule has no effect on draft tests.)
         </small>
       </Typography>
       <div className={classes.dateRange}>
         <TextField
           className={classes.field}
-          label="Start Date"
-          type="date"
+          label="Start Date (UTC)"
+          type="datetime-local"
           value={scheduler?.start ?? ''}
           onChange={handleStartChange}
           variant="outlined"
@@ -68,8 +68,8 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ scheduler, disabled, on
         />
         <TextField
           className={classes.field}
-          label="End Date"
-          type="date"
+          label="End Date (UTC)"
+          type="datetime-local"
           value={scheduler?.end ?? ''}
           onChange={handleEndChange}
           variant="outlined"

--- a/public/src/components/channelManagement/scheduleEditor.tsx
+++ b/public/src/components/channelManagement/scheduleEditor.tsx
@@ -1,0 +1,85 @@
+import { TextField, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import React from 'react';
+import { Scheduler } from './helpers/shared';
+
+const useStyles = makeStyles(({ spacing }: Theme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacing(1),
+  },
+  dateRange: {
+    display: 'flex',
+    gap: spacing(2),
+  },
+  field: {
+    flex: '1 0 200px',
+  },
+}));
+
+interface ScheduleEditorProps {
+  scheduler?: Scheduler;
+  disabled: boolean;
+  onChange: (scheduler?: Scheduler) => void;
+}
+
+const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ scheduler, disabled, onChange }) => {
+  const classes = useStyles();
+
+  const handleStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const start = e.target.value || undefined;
+    if (!start && !scheduler?.end) {
+      onChange(undefined);
+    } else {
+      onChange({ ...scheduler, start });
+    }
+  };
+
+  const handleEndChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const end = e.target.value || undefined;
+    if (!end && !scheduler?.start) {
+      onChange(undefined);
+    } else {
+      onChange({ ...scheduler, end });
+    }
+  };
+
+  return (
+    <div className={classes.container}>
+      <Typography variant="subtitle2">
+        Test scheduler{' '}
+        <small>
+          (Start and end dates are inclusive. Leave blank to go live immediately. Note: schedule has
+          no effect on draft tests.)
+        </small>
+      </Typography>
+      <div className={classes.dateRange}>
+        <TextField
+          className={classes.field}
+          label="Start Date"
+          type="date"
+          value={scheduler?.start ?? ''}
+          onChange={handleStartChange}
+          variant="outlined"
+          size="small"
+          disabled={disabled}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          className={classes.field}
+          label="End Date"
+          type="date"
+          value={scheduler?.end ?? ''}
+          onChange={handleEndChange}
+          variant="outlined"
+          size="small"
+          disabled={disabled}
+          InputLabelProps={{ shrink: true }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleEditor;

--- a/public/src/components/channelManagement/studentLandingPage/studentLandingPageTestEditor.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/studentLandingPageTestEditor.tsx
@@ -6,6 +6,7 @@ import {
   StudentLandingPageVariant,
 } from '../../../models/studentLandingPage';
 import { Region } from '../../../utils/models';
+import ScheduleEditor from '../scheduleEditor';
 import TypedRadioGroup from '../TypedRadioGroup';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import { StudentLandingPageLinkBuilder } from './studentLandingPageLinkBuilder';
@@ -181,6 +182,15 @@ export const StudentLandingPageTestEditor: React.FC<
             }}
           />
         </div>
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography className={classes.sectionHeader}>Schedule</Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+        />
       </div>
     </>
   );

--- a/public/src/components/channelManagement/studentLandingPage/studentLandingPageTestEditor.tsx
+++ b/public/src/components/channelManagement/studentLandingPage/studentLandingPageTestEditor.tsx
@@ -6,7 +6,6 @@ import {
   StudentLandingPageVariant,
 } from '../../../models/studentLandingPage';
 import { Region } from '../../../utils/models';
-import ScheduleEditor from '../scheduleEditor';
 import TypedRadioGroup from '../TypedRadioGroup';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
 import { StudentLandingPageLinkBuilder } from './studentLandingPageLinkBuilder';
@@ -182,15 +181,6 @@ export const StudentLandingPageTestEditor: React.FC<
             }}
           />
         </div>
-      </div>
-
-      <div className={classes.sectionContainer}>
-        <Typography className={classes.sectionHeader}>Schedule</Typography>
-        <ScheduleEditor
-          scheduler={test.scheduler}
-          disabled={!userHasTestLocked}
-          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
-        />
       </div>
     </>
   );

--- a/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
@@ -9,6 +9,7 @@ import VariantSummary from '../../tests/variants/variantSummary';
 import { Methodology, RegionTargeting } from '../helpers/shared';
 import { useStyles } from '../helpers/testEditorStyles';
 import { MParticleAudienceEditor } from '../mParticleAudienceEditor';
+import ScheduleEditor from '../scheduleEditor';
 import { SingleMethodologyEditor } from '../SingleMethodologyEditor';
 import TestEditorTargetRegionsSelector from '../testEditorTargetRegionsSelector';
 import { ValidatedTestEditorProps } from '../validatedTestEditor';
@@ -194,6 +195,17 @@ const SupportLandingPageTestEditor: React.FC<ValidatedTestEditorProps<SupportLan
               mParticleAudience,
             }));
           }}
+        />
+      </div>
+
+      <div className={classes.sectionContainer}>
+        <Typography variant={'h3'} className={classes.sectionHeader}>
+          Schedule
+        </Typography>
+        <ScheduleEditor
+          scheduler={test.scheduler}
+          disabled={!userHasTestLocked}
+          onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/testListSchedulerLabel.tsx
+++ b/public/src/components/channelManagement/testListSchedulerLabel.tsx
@@ -1,0 +1,60 @@
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import { Tooltip } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required by jsx: "react" in tsconfig.json
+import React from 'react';
+import { Scheduler } from './helpers/shared';
+
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: '1px',
+    lineHeight: 0,
+  },
+  iconWhite: {
+    color: '#ffffff',
+  },
+  iconBlack: {
+    color: '#000000',
+  },
+}));
+
+interface TestListSchedulerLabelProps {
+  scheduler: Scheduler;
+  shouldInvertColor: boolean;
+}
+
+const TestListSchedulerLabel = ({
+  scheduler,
+  shouldInvertColor,
+}: TestListSchedulerLabelProps): JSX.Element => {
+  const classes = useStyles();
+
+  const iconClass = shouldInvertColor ? classes.iconWhite : classes.iconBlack;
+
+  const lines: string[] = [];
+  if (scheduler.start) {
+    lines.push(`Start: ${scheduler.start} UTC`);
+  }
+  if (scheduler.end) {
+    lines.push(`End: ${scheduler.end} UTC`);
+  }
+
+  return (
+    <Tooltip
+      title={
+        <>
+          {lines.map((line, i) => (
+            <div key={i}>{line}</div>
+          ))}
+        </>
+      }
+      arrow
+    >
+      <div className={classes.container}>
+        <ScheduleIcon className={iconClass} sx={{ fontSize: 16 }} />
+      </div>
+    </Tooltip>
+  );
+};
+
+export default TestListSchedulerLabel;

--- a/public/src/components/channelManagement/testListSchedulerLabel.tsx
+++ b/public/src/components/channelManagement/testListSchedulerLabel.tsx
@@ -4,32 +4,43 @@ import { makeStyles } from '@mui/styles';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required by jsx: "react" in tsconfig.json
 import React from 'react';
 import { Scheduler } from './helpers/shared';
+import { isWithinSchedule } from './helpers/utilities';
 
 const useStyles = makeStyles(() => ({
   container: {
     padding: '1px',
     lineHeight: 0,
   },
+  iconActive: {
+    color: '#F2453D',
+  },
+  iconInactive: {
+    color: '#9e9e9e',
+  },
   iconWhite: {
     color: '#ffffff',
-  },
-  iconBlack: {
-    color: '#000000',
   },
 }));
 
 interface TestListSchedulerLabelProps {
   scheduler: Scheduler;
+  isLive: boolean;
   shouldInvertColor: boolean;
 }
 
 const TestListSchedulerLabel = ({
   scheduler,
+  isLive,
   shouldInvertColor,
 }: TestListSchedulerLabelProps): JSX.Element => {
   const classes = useStyles();
 
-  const iconClass = shouldInvertColor ? classes.iconWhite : classes.iconBlack;
+  const isActive = isLive && isWithinSchedule(scheduler);
+  const iconClass = shouldInvertColor
+    ? classes.iconWhite
+    : isActive
+      ? classes.iconActive
+      : classes.iconInactive;
 
   const lines: string[] = [];
   if (scheduler.start) {

--- a/public/src/components/channelManagement/testListSchedulerLabel.tsx
+++ b/public/src/components/channelManagement/testListSchedulerLabel.tsx
@@ -1,7 +1,6 @@
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import { Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required by jsx: "react" in tsconfig.json
 import React from 'react';
 import { Scheduler } from './helpers/shared';
 import { isWithinSchedule } from './helpers/utilities';
@@ -28,7 +27,7 @@ interface TestListSchedulerLabelProps {
   shouldInvertColor: boolean;
 }
 
-const TestListSchedulerLabel = ({
+const TestListSchedulerLabel: React.FC<TestListSchedulerLabelProps> = ({
   scheduler,
   isLive,
   shouldInvertColor,

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import useHover from '../../hooks/useHover';
 import { Test } from './helpers/shared';
 import TestListBanditIcon from './testListBanditIcon';
+import TestListSchedulerLabel from './testListSchedulerLabel';
 import TestListTestArticleCountLabel from './testListTestArticleCountLabel';
 import TestListTestLiveLabel from './testListTestLiveLabel';
 import TestListTestName from './testListTestName';
@@ -105,6 +106,12 @@ const TestListTest: React.FC<TestListTestProps> = ({
           isLive={test.status === 'Live'}
           shouldInvertColor={shouldInvertColor}
         />
+        {test.scheduler && (
+          <TestListSchedulerLabel
+            scheduler={test.scheduler}
+            shouldInvertColor={shouldInvertColor}
+          />
+        )}
         <TestListTestName
           name={test.name}
           nickname={test.nickname}

--- a/public/src/components/channelManagement/testListTest.tsx
+++ b/public/src/components/channelManagement/testListTest.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles(({ palette }: Theme) => ({
   liveInverted: {
     background: `${red[500]}`,
   },
+
   draft: {
     border: `1px solid ${palette.grey[700]}`,
 
@@ -109,6 +110,7 @@ const TestListTest: React.FC<TestListTestProps> = ({
         {test.scheduler && (
           <TestListSchedulerLabel
             scheduler={test.scheduler}
+            isLive={test.status === 'Live'}
             shouldInvertColor={shouldInvertColor}
           />
         )}

--- a/public/src/components/channelManagement/testListTestArticleCountLabel.tsx
+++ b/public/src/components/channelManagement/testListTestArticleCountLabel.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required by jsx: "react" in tsconfig.json
 import React from 'react';
 
 const useStyles = makeStyles(() => ({
@@ -16,7 +15,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const TestListTestArticleCountLabel = (): JSX.Element => {
+const TestListTestArticleCountLabel: React.FC = (): JSX.Element => {
   const classes = useStyles();
   return (
     <div className={classes.container}>

--- a/public/src/components/channelManagement/testSchedulerStatusBanner.tsx
+++ b/public/src/components/channelManagement/testSchedulerStatusBanner.tsx
@@ -1,0 +1,163 @@
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import { Theme, Typography, useTheme } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
+import React from 'react';
+import { Scheduler, Status } from './helpers/shared';
+
+const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
+  containerLive: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing(1),
+    padding: spacing(1.5),
+    borderRadius: '4px',
+    border: `1px solid ${palette.primary.main}`,
+    backgroundColor: alpha(palette.primary.main, 0.1),
+    marginBottom: spacing(2),
+  },
+  containerOffline: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing(1),
+    padding: spacing(1.5),
+    borderRadius: '4px',
+    border: `1px solid ${palette.grey[700]}`,
+    backgroundColor: palette.grey[200],
+    marginBottom: spacing(2),
+  },
+  iconRow: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    flexShrink: 0,
+  },
+  details: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacing(0.5),
+  },
+  titleTextLive: {
+    fontSize: '16px',
+    color: palette.grey[700],
+  },
+  titleTextOffline: {
+    fontSize: '16px',
+    color: palette.grey[700],
+  },
+  statusLive: {
+    fontWeight: 600,
+    fontSize: '16px',
+    color: palette.grey[700],
+  },
+  statusOffline: {
+    fontWeight: 600,
+    fontSize: '16px',
+    color: palette.grey[700],
+  },
+  scheduleTimeText: {
+    fontSize: '16px',
+    color: palette.grey[600],
+  },
+  reasonText: {
+    fontSize: '16px',
+    color: palette.grey[600],
+  },
+}));
+
+const parseUtc = (value?: string): Date | null => {
+  if (!value) {
+    return null;
+  }
+  const d = new Date(`${value}:00Z`);
+  return isNaN(d.getTime()) ? null : d;
+};
+
+const formatUtc = (value: string): string => `${value} UTC`;
+
+const isWithinSchedule = (scheduler: Scheduler): boolean => {
+  const now = new Date();
+  const start = parseUtc(scheduler.start);
+  const end = parseUtc(scheduler.end);
+  if (start && now < start) {
+    return false;
+  }
+  if (end && now > end) {
+    return false;
+  }
+  return true;
+};
+
+interface TestSchedulerStatusBannerProps {
+  scheduler: Scheduler;
+  status: Status;
+}
+
+const TestSchedulerStatusBanner: React.FC<TestSchedulerStatusBannerProps> = ({
+  scheduler,
+  status,
+}) => {
+  const classes = useStyles();
+
+  const theme = useTheme();
+  const isLive = status === 'Live';
+  const withinSchedule = isWithinSchedule(scheduler);
+  const liveOnSite = isLive && withinSchedule;
+
+  const containerClass = liveOnSite ? classes.containerLive : classes.containerOffline;
+  const statusClass = liveOnSite ? classes.statusLive : classes.statusOffline;
+  const titleClass = liveOnSite ? classes.titleTextLive : classes.titleTextOffline;
+  const iconColor = liveOnSite ? theme.palette.primary.main : '#616161';
+
+  const statusLabel = liveOnSite
+    ? 'Test is currently live on site'
+    : 'Test is currently not live on site';
+
+  let reason: string | null = null;
+  if (!isLive) {
+    reason = '(Test is in Draft status.)';
+  } else if (!withinSchedule) {
+    const now = new Date();
+    const start = parseUtc(scheduler.start);
+    const end = parseUtc(scheduler.end);
+    if (start && now < start) {
+      reason = `(Scheduled to start at ${formatUtc(scheduler.start!)}.)`;
+    } else if (end && now > end) {
+      reason = `(Schedule ended at ${formatUtc(scheduler.end!)}.)`;
+    }
+  }
+
+  return (
+    <div className={containerClass}>
+      <div className={classes.iconRow}>
+        <ScheduleIcon sx={{ fontSize: 40, color: iconColor }} />
+      </div>
+      <div className={classes.details}>
+        <Typography className={titleClass}>
+          Scheduler configured.{' '}
+          {scheduler.start && (
+            <Typography component="span" className={classes.scheduleTimeText}>
+              Start time: {formatUtc(scheduler.start)}
+            </Typography>
+          )}
+          {scheduler.start && scheduler.end && <Typography component="span"> </Typography>}
+          {scheduler.end && (
+            <Typography component="span" className={classes.scheduleTimeText}>
+              End time: {formatUtc(scheduler.end)}
+            </Typography>
+          )}
+        </Typography>
+        <Typography className={statusClass}>
+          {statusLabel}
+          {reason && (
+            <Typography component="span" className={classes.reasonText}>
+              {' '}
+              {reason}
+            </Typography>
+          )}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export default TestSchedulerStatusBanner;

--- a/public/src/components/channelManagement/testSchedulerStatusBanner.tsx
+++ b/public/src/components/channelManagement/testSchedulerStatusBanner.tsx
@@ -4,6 +4,7 @@ import { alpha } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 import { Scheduler, Status } from './helpers/shared';
+import { isWithinSchedule, parseSchedulerUtc } from './helpers/utilities';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   containerLive: {
@@ -64,28 +65,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
   },
 }));
 
-const parseUtc = (value?: string): Date | null => {
-  if (!value) {
-    return null;
-  }
-  const d = new Date(`${value}:00Z`);
-  return isNaN(d.getTime()) ? null : d;
-};
-
 const formatUtc = (value: string): string => `${value} UTC`;
-
-const isWithinSchedule = (scheduler: Scheduler): boolean => {
-  const now = new Date();
-  const start = parseUtc(scheduler.start);
-  const end = parseUtc(scheduler.end);
-  if (start && now < start) {
-    return false;
-  }
-  if (end && now > end) {
-    return false;
-  }
-  return true;
-};
 
 interface TestSchedulerStatusBannerProps {
   scheduler: Scheduler;
@@ -117,8 +97,8 @@ const TestSchedulerStatusBanner: React.FC<TestSchedulerStatusBannerProps> = ({
     reason = '(Test is in Draft status.)';
   } else if (!withinSchedule) {
     const now = new Date();
-    const start = parseUtc(scheduler.start);
-    const end = parseUtc(scheduler.end);
+    const start = parseSchedulerUtc(scheduler.start);
+    const end = parseSchedulerUtc(scheduler.end);
     if (start && now < start) {
       reason = `(Scheduled to start at ${formatUtc(scheduler.start!)}.)`;
     } else if (end && now > end) {
@@ -159,5 +139,5 @@ const TestSchedulerStatusBanner: React.FC<TestSchedulerStatusBannerProps> = ({
     </div>
   );
 };
-
-export default TestSchedulerStatusBanner;
+// Rerender banner only when test is saved
+export default React.memo(TestSchedulerStatusBanner, () => true);

--- a/public/src/components/channelManagement/validatedTestEditor.tsx
+++ b/public/src/components/channelManagement/validatedTestEditor.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react';
 import { Test } from './helpers/shared';
 import useValidation from './hooks/useValidation';
 import StickyTopBar from './stickyTopBar/stickyTopBar';
+import TestSchedulerStatusBanner from './testSchedulerStatusBanner';
 import { TestEditorProps } from './testsForm';
 
 const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
@@ -109,6 +110,9 @@ export const ValidatedTestEditor = <T extends Test>(
         />
 
         <div className={classes.scrollableContainer}>
+          {test.scheduler && (
+            <TestSchedulerStatusBanner scheduler={test.scheduler} status={test.status} />
+          )}
           <TestEditor
             test={test}
             userHasTestLocked={userHasTestLocked}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1215974875812105)
## What does this change?
This change adds optional Scheduler fields with optional start and end properties to channel tests. Also a new React component ScheduleEditor was created to manage this field changes in client side.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE env
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="1124" height="694" alt="Screenshot 2026-06-29 at 16 18 29" src="https://github.com/user-attachments/assets/01a13f4f-00ee-48cd-8ae7-ab382cf3268c" />

**Live Test Scheduled Active**

<img width="1502" height="688" alt="live-scheduled-active" src="https://github.com/user-attachments/assets/e5774b1d-0856-44ae-bc14-b605b1db7fab" />

**Live Test Scheduled expired**

<img width="1088" height="198" alt="live-scheduled-expired" src="https://github.com/user-attachments/assets/52ad8c91-9ae5-4b16-b12f-7f98af09a9c9" />

**Live Test Scheduled not started**

<img width="1094" height="210" alt="live-scheduled-notstarted" src="https://github.com/user-attachments/assets/89b870da-c5e1-4f37-821f-efbc8ad24e4a" />

**Draft Test Scheduled**

<img width="1093" height="223" alt="draft-scheduled" src="https://github.com/user-attachments/assets/10b12442-700e-401f-ab1b-8591b624ba99" />

**Side list indicator: Live scheduled test (active)**

<img width="318" height="56" alt="sidebar-indicator-scheduled-live-active" src="https://github.com/user-attachments/assets/06cf437c-3497-4b10-a846-23ecce124554" />

**Side list indicator: Live scheduled test (inactive)**

<img width="306" height="59" alt="sidebar-indicator-scheduled-live-inactive" src="https://github.com/user-attachments/assets/3c759976-f752-40b9-9de2-bc1ccb575e5b" />
## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
