### PR TITLE
get LP tests for destination for recurring products

### DIFF
--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -101,6 +101,14 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
     [clearVariantSelection],
   );
 
+  const getDestination = useCallback(
+    (destination: Destination): Destination => {
+      const isRecurringProduct = getValues(`choiceCards.${index}.product`).supportTier !== 'OneOff';
+      return isRecurringProduct ? Destination.LandingPage : destination;
+    },
+    [getValues, index],
+  );
+
   const fetchDestinationTests = useCallback(
     (destination: Destination) => {
       const settingsType = getSettingsTypeForDestination(destination);
@@ -137,11 +145,11 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
   );
 
   useEffect(() => {
-    const destination =
+    const rawDestination =
       (getValues(`choiceCards.${index}.destination`) as Destination | undefined) ??
       Destination.LandingPage;
-    fetchDestinationTests(destination);
-  }, [fetchDestinationTests, getValues, index]);
+    fetchDestinationTests(getDestination(rawDestination));
+  }, [fetchDestinationTests, getDestination, getValues, index]);
 
   return (
     <Controller
@@ -154,7 +162,7 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
             selectedValue={(field.value as Destination | undefined) ?? Destination.LandingPage}
             onChange={(destination) => {
               field.onChange(destination);
-              fetchDestinationTests(destination);
+              fetchDestinationTests(getDestination(destination));
               onDestinationSectionChange();
             }}
             isDisabled={isDisabled}

--- a/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
+++ b/public/src/components/channelManagement/choiceCards/ChoiceCardDestinationFields.tsx
@@ -101,9 +101,14 @@ export const ChoiceCardDestinationFields: React.FC<ChoiceCardDestinationFieldsPr
     [clearVariantSelection],
   );
 
+  //
   const getDestination = useCallback(
     (destination: Destination): Destination => {
       const isRecurringProduct = getValues(`choiceCards.${index}.product`).supportTier !== 'OneOff';
+      // For recurring products, both destinations use Landing Page tests. When the landing page
+      // is skipped (i.e. the banner CTA goes directly to checkout), the test journey must
+      // continue on the checkout page — so the Checkout destination is used to carry the test
+      // variant through to checkout.
       return isRecurringProduct ? Destination.LandingPage : destination;
     },
     [getValues, index],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This change updates destinationTests options for recurring products in Choice cards (all products except OneOff products)
Previously if "checkout" destination was selected, tests for One-time-checkout were shown up in destinationTests options. But it is not correct for recurring products.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE and verified that correct tests are shown up for correct products.
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1104" height="709" alt="Screenshot 2026-07-01 at 07 16 20" src="https://github.com/user-attachments/assets/25d01bce-d5ec-4ff6-ab79-b3d42f7cf724" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
