### PR TITLE
Fix CVE-2026-54513 by upgrading Jackson to 2.21.4.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.13.18"
 val circeVersion = "0.14.15"
 val awsVersion = "2.46.13"
 val zioVersion = "2.1.26"
-val jacksonVersion = "2.21.3"
+val jacksonVersion = "2.21.4"
 
 lazy val scalafmtSettings = Seq(
   scalafmtFilter.withRank(KeyRanks.Invisible) := "diff-dirty",


### PR DESCRIPTION
Bumps `jacksonVersion` from `2.21.3` to `2.21.4` to fix CVE-2026-54513, an array subtype allowlist bypass in `BasicPolymorphicTypeValidator`.

All Jackson artifacts are pinned via `dependencyOverrides`, so `jackson-databind` and related modules are now aligned on the patched version.