### PR TITLE
Sales Tax Api : Enable Tax Exclusive Promotions

### DIFF
--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -115,7 +115,9 @@ object ProductCatalog {
 
   case class SupporterPlusRatePlans(
       Annual: RatePlan,
-      Monthly: RatePlan
+      AnnualTaxExclusive: RatePlan,
+      Monthly: RatePlan,
+      MonthlyTaxExclusive: RatePlan
   ) extends ProductRatePlans
 
   case class TierThreeRatePlans(

--- a/app/models/promos/ProductCatalog.scala
+++ b/app/models/promos/ProductCatalog.scala
@@ -129,7 +129,9 @@ object ProductCatalog {
 
   case class DigitalSubscriptionRatePlans(
       Monthly: RatePlan,
+      MonthlyTaxExclusive: RatePlan,
       Annual: RatePlan,
+      AnnualTaxExclusive: RatePlan,
       Quarterly: RatePlan
   ) extends ProductRatePlans
 


### PR DESCRIPTION
## What does this change?
Enables TaxExclusive Promotions to be applied to the following products->
- Supporter Plus
- Digital Plus

Requires [Support-FrontEnd Tax Exclusive PR](https://github.com/guardian/support-frontend/pull/8084)

Note: Currently this should be limited to Canada (GBP is always active within Zuora for accounting purposes)



## How has this change been tested?
1. Build, deploy to CODE
2. Setup CANADIAN-ONLY Promotion on S+ & Digital+
https://support.code.dev-gutools.co.uk/switches
4. Add #promoCode=TAX_EXCLUSIVE_SP or #promoCode=TAX_EXCLUSIVE_DP
https://support.code.dev-theguardian.com/ca/checkout?promoCode=TAX_EXCLUSIVE_SP&product=SupporterPlus&ratePlan=MonthlyTaxExclusive



## Images

Example Promotions
|S+|D+|
|----|----|
|<img width="537" height="1171" alt="image" src="https://github.com/user-attachments/assets/e60fa1c1-3b6c-4e52-847b-40a9287245bf" />|<img width="537" height="1171" alt="image" src="https://github.com/user-attachments/assets/850dc494-9bb9-4a4c-9d04-440797c0e7a0" />|




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215506815395861