### PR TITLE
Add frontIds field to channel exclusion rules for network fronts

### DIFF
--- a/app/models/ChannelExclusions.scala
+++ b/app/models/ChannelExclusions.scala
@@ -19,6 +19,8 @@ case class ExclusionRule(
     name: String = "",
     sectionIds: Option[List[String]] = None, // suppress if the page's sectionId matches any entry
     tagIds: Option[List[String]] = None, // suppress if the page has any of these tag IDs
+    frontIds: Option[List[String]] =
+      None, // suppress if the page is one of these network fronts (uk, us, au, europe, international)
     dateRange: Option[DateRange] = None, // ISO date "YYYY-MM-DD", inclusive
     contentTypes: Option[List[String]] = None // e.g. ["Article"], ["Front"]; absent = all content types
 )

--- a/public/src/components/channelExclusions/ExclusionRule.tsx
+++ b/public/src/components/channelExclusions/ExclusionRule.tsx
@@ -4,6 +4,9 @@ import {
   AccordionDetails,
   AccordionSummary,
   Alert,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
   TextField,
   Theme,
   Typography,
@@ -17,6 +20,14 @@ import ContentTypesSelector from './ContentTypesSelector';
 import RuleHeader from './RuleHeader';
 import { useExclusionRuleHandlers } from './useExclusionRuleHandlers';
 import { ChannelKey } from './util';
+
+const NETWORK_FRONTS = [
+  { id: 'uk', name: 'UK' },
+  { id: 'us', name: 'US' },
+  { id: 'au', name: 'Australia' },
+  { id: 'europe', name: 'Europe' },
+  { id: 'international', name: 'International' },
+];
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   accordion: {
@@ -129,8 +140,8 @@ const ExclusionRule: React.FC<ExclusionRuleProps> = ({
               onUpdateRule={handleUpdateRuleWithIndex}
             />
             <Alert severity="info" className={classes.fullRowField}>
-              Pages for this exclusion are determined by Section IDs <strong>OR</strong> Tag IDs. If
-              either list matches, the rule exclusion will apply.
+              Pages for this exclusion are determined by Section IDs <strong>OR</strong> Tag IDs
+              <strong> OR</strong> Front IDs. If any list matches, the rule exclusion will apply.
             </Alert>
             <div className={classes.fullRowField}>
               <Typography variant="subtitle2" sx={{ mb: 1 }}>
@@ -164,6 +175,42 @@ const ExclusionRule: React.FC<ExclusionRuleProps> = ({
                   onUpdate={(ids) => handleRuleChange({ ...formRule, tagIds: ids })}
                   disabled={!isRuleInEditMode}
                 />
+              )}
+            </div>
+            <div className={classes.fullRowField}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Network Fronts
+              </Typography>
+              {!isRuleInEditMode && (!formRule.frontIds || formRule.frontIds.length === 0) ? (
+                <Typography variant="body2" color="textSecondary">
+                  No network fronts selected
+                </Typography>
+              ) : (
+                <FormGroup row>
+                  {NETWORK_FRONTS.map((front) => (
+                    <FormControlLabel
+                      key={front.id}
+                      control={
+                        <Checkbox
+                          checked={formRule.frontIds?.includes(front.id) ?? false}
+                          onChange={(e) => {
+                            const currentIds = formRule.frontIds ?? [];
+                            const updatedIds = e.target.checked
+                              ? [...currentIds, front.id]
+                              : currentIds.filter((id) => id !== front.id);
+                            handleRuleChange({
+                              ...formRule,
+                              frontIds: updatedIds.length > 0 ? updatedIds : undefined,
+                            });
+                          }}
+                          disabled={!isRuleInEditMode}
+                          size="small"
+                        />
+                      }
+                      label={front.name}
+                    />
+                  ))}
+                </FormGroup>
               )}
             </div>
           </div>

--- a/public/src/models/exclusions.ts
+++ b/public/src/models/exclusions.ts
@@ -7,6 +7,7 @@ export interface ExclusionRule {
   name: string;
   sectionIds?: string[];
   tagIds?: string[];
+  frontIds?: string[];
   dateRange?: DateRange;
   contentTypes?: Array<'Fronts' | 'Articles'>;
 }


### PR DESCRIPTION
Adds `frontIds` field to [ExclusionRule](cci:1://file:///Users/admin.juarez.mota/code/support-admin-console/public/src/components/channelExclusions/ExclusionRule.tsx:66:0-269:2) (Scala + TS models) and a checkbox selector for the 5 network fronts (uk, us, au, europe, international) in the exclusion rule UI. Exclusion matching uses OR logic with existing section and tag IDs.

### Screenshot

<img width="709" height="539" alt="image" src="https://github.com/user-attachments/assets/7009e722-53d8-4678-aa13-f88128ec7281" />
