### PR TITLE
Separate preview params from force params for web preview URLs

### DIFF
--- a/public/src/components/channelManagement/checkoutNudge/checkoutNudgeTestEditor.tsx
+++ b/public/src/components/channelManagement/checkoutNudge/checkoutNudgeTestEditor.tsx
@@ -89,7 +89,7 @@ const CheckoutNudgeTestEditor: React.FC<ValidatedTestEditorProps<CheckoutNudgeTe
     queryParams.append('product', product);
     queryParams.append('ratePlan', ratePlan);
 
-    return `${supportHost}/${path}?${queryParams.toString()}&force-checkout-nudge=${
+    return `${supportHost}/${path}?${queryParams.toString()}&preview-checkout-nudge=${
       test.name
     }:${variantName}`;
   };

--- a/public/src/components/channelManagement/oneTimeCheckout/oneTimeCheckoutTestEditor.tsx
+++ b/public/src/components/channelManagement/oneTimeCheckout/oneTimeCheckoutTestEditor.tsx
@@ -51,7 +51,7 @@ const OneTimeCheckoutTestEditor: React.FC<ValidatedTestEditorProps<OneTimeChecko
   const getWebPreviewUrl = (variantName: string): string => {
     const stage = getStage();
     const supportHost = `https://support.${stage !== 'PROD' ? 'code.dev-' : ''}theguardian.com`;
-    return `${supportHost}/one-time-checkout?force-one-time-checkout=${test.name}:${variantName}`;
+    return `${supportHost}/one-time-checkout?preview-one-time-checkout=${test.name}:${variantName}`;
   };
 
   // Memoize callbacks by variant name to prevent infinite render loops

--- a/public/src/components/channelManagement/supportLandingPage/urlGenerator.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/urlGenerator.tsx
@@ -70,7 +70,7 @@ const getPreviewUrl = ({
   const channelName = 'landing-page';
   const params = new URLSearchParams();
 
-  params.set(`force-${channelName}`, `${testName}:${variant.name}`);
+  params.set(`preview-${channelName}`, `${testName}:${variant.name}`);
 
   const builder: UrlBuilder = {
     withParams: (newParams: Record<string, string>) => {

--- a/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
+++ b/public/src/components/tests/variants/variantSummaryWebPreviewButton.tsx
@@ -38,7 +38,7 @@ const getPreviewUrl = (
 ): string => {
   const stage = getStage();
   const channelName = getChannelName(testType, articleType);
-  const queryString = `?force-${channelName}=${testName}:${variantName}`;
+  const queryString = `?preview-${channelName}=${testName}:${variantName}`;
 
   if (testType === 'LANDING_PAGE') {
     // link to the support site landing page


### PR DESCRIPTION
Replace `force-*` with `preview-*` URL params in all web preview locations (variant summary button, one-time checkout, checkout nudge, and landing page URL generator). This separates the admin preview feature from the real-user variant routing mechanism, enabling the backend to allow draft/expired tests in preview mode while keeping `force-*` for joined-up journeys.