### PR TITLE
date validation added to the test scheduler

### DIFF
--- a/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
+++ b/public/src/components/channelManagement/bannerTests/bannerTestEditor.tsx
@@ -452,6 +452,7 @@ const BannerTestEditor: React.FC<ValidatedTestEditorProps<BannerTest>> = ({
           scheduler={test.scheduler}
           disabled={!userHasTestLocked}
           onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+          onValidationChange={(isValid) => setValidationStatusForField('schedule', isValid)}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/checkoutNudge/checkoutNudgeTestEditor.tsx
+++ b/public/src/components/channelManagement/checkoutNudge/checkoutNudgeTestEditor.tsx
@@ -258,6 +258,7 @@ const CheckoutNudgeTestEditor: React.FC<ValidatedTestEditorProps<CheckoutNudgeTe
           scheduler={test.scheduler}
           disabled={!userHasTestLocked}
           onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+          onValidationChange={(isValid) => setValidationStatusForField('schedule', isValid)}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/epicTests/testEditor.tsx
+++ b/public/src/components/channelManagement/epicTests/testEditor.tsx
@@ -490,6 +490,7 @@ export const getEpicTestEditor = (
             scheduler={test.scheduler}
             disabled={!userHasTestLocked}
             onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+            onValidationChange={(isValid) => setValidationStatusForField('schedule', isValid)}
           />
         </div>
       </div>

--- a/public/src/components/channelManagement/gutterTests/gutterTestEditor.tsx
+++ b/public/src/components/channelManagement/gutterTests/gutterTestEditor.tsx
@@ -273,6 +273,7 @@ const GutterTestEditor: React.FC<ValidatedTestEditorProps<GutterTest>> = ({
           scheduler={test.scheduler}
           disabled={!userHasTestLocked}
           onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+          onValidationChange={(isValid) => setValidationStatusForField('schedule', isValid)}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
+++ b/public/src/components/channelManagement/headerTests/headerTestEditor.tsx
@@ -259,6 +259,7 @@ const HeaderTestEditor: React.FC<ValidatedTestEditorProps<HeaderTest>> = ({
           scheduler={test.scheduler}
           disabled={!userHasTestLocked}
           onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+          onValidationChange={(isValid) => setValidationStatusForField('schedule', isValid)}
         />
       </div>
     </div>

--- a/public/src/components/channelManagement/scheduleEditor.tsx
+++ b/public/src/components/channelManagement/scheduleEditor.tsx
@@ -2,6 +2,7 @@ import { TextField, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 import { Scheduler } from './helpers/shared';
+import { parseSchedulerUtc } from './helpers/utilities';
 
 const useStyles = makeStyles(({ spacing }: Theme) => ({
   container: {
@@ -22,10 +23,24 @@ interface ScheduleEditorProps {
   scheduler?: Scheduler;
   disabled: boolean;
   onChange: (scheduler?: Scheduler) => void;
+  onValidationChange?: (isValid: boolean) => void;
 }
 
-const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ scheduler, disabled, onChange }) => {
+const ScheduleEditor: React.FC<ScheduleEditorProps> = ({
+  scheduler,
+  disabled,
+  onChange,
+  onValidationChange,
+}) => {
   const classes = useStyles();
+
+  const startDate = React.useMemo(() => parseSchedulerUtc(scheduler?.start), [scheduler?.start]);
+  const endDate = React.useMemo(() => parseSchedulerUtc(scheduler?.end), [scheduler?.end]);
+  const hasInvalidRange = Boolean(startDate && endDate && endDate < startDate);
+
+  React.useEffect(() => {
+    onValidationChange?.(!hasInvalidRange);
+  }, [hasInvalidRange, onValidationChange]);
 
   const handleStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const start = e.target.value || undefined;
@@ -64,6 +79,7 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ scheduler, disabled, on
           variant="outlined"
           size="small"
           disabled={disabled}
+          error={hasInvalidRange}
           InputLabelProps={{ shrink: true }}
         />
         <TextField
@@ -75,6 +91,8 @@ const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ scheduler, disabled, on
           variant="outlined"
           size="small"
           disabled={disabled}
+          error={hasInvalidRange}
+          helperText={hasInvalidRange ? 'End date must be after the start date' : ' '}
           InputLabelProps={{ shrink: true }}
         />
       </div>

--- a/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
+++ b/public/src/components/channelManagement/supportLandingPage/supportLandingPageTestEditor.tsx
@@ -206,6 +206,7 @@ const SupportLandingPageTestEditor: React.FC<ValidatedTestEditorProps<SupportLan
           scheduler={test.scheduler}
           disabled={!userHasTestLocked}
           onChange={(scheduler) => onTestChange((current) => ({ ...current, scheduler }))}
+          onValidationChange={(isValid) => setValidationStatusForField('schedule', isValid)}
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1216519378200925)
## What does this change?
This change refactors Tests Scheduler component to validate end and start date - start date should not be in front of the end date.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE and tests that error message is visible when end date is before start date and test is not allowed to be saved in this case.
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1083" height="203" alt="Screenshot 2026-07-15 at 11 13 59" src="https://github.com/user-attachments/assets/50b8db19-d6cd-4124-9723-7c746d233e96" />
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
