### PR TITLE
New promotion property to capture introductory prices

### DIFF
--- a/app/models/promos/Promo.scala
+++ b/app/models/promos/Promo.scala
@@ -25,7 +25,8 @@ case class Promo(
     description: Option[String],
     lockStatus: Option[LockStatus],
     discount: Option[DiscountDetails],
-    landingPage: Option[PromoLandingPage]
+    landingPage: Option[PromoLandingPage],
+    isIntroductoryPricing: Option[Boolean]
 )
 
 object Promo {

--- a/public/src/components/promoTool/promoEditor.tsx
+++ b/public/src/components/promoTool/promoEditor.tsx
@@ -189,6 +189,15 @@ const PromoEditor = ({
     });
   };
 
+  const handleIsIntroductoryPromotionChange = () => {
+    if (isEditing && editedPromo) {
+      setEditedPromo({
+        ...editedPromo,
+        isIntroductoryPricing: !editedPromo.isIntroductoryPricing,
+      });
+    }
+  };
+
   const handlePromotionHasLandingPageChange = () => {
     if (isEditing && editedPromo) {
       setEditedPromo({
@@ -339,6 +348,16 @@ const PromoEditor = ({
             />
           </Grid>
         </Grid>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={editedPromo?.isIntroductoryPricing ?? false}
+              onChange={handleIsIntroductoryPromotionChange}
+              disabled={!isEditing}
+            />
+          }
+          label="Introductory Price (will not display price comparison on the product page)"
+        />
       </div>
 
       {allRatePlans.length > 0 && (

--- a/public/src/components/promoTool/promoEditor.tsx
+++ b/public/src/components/promoTool/promoEditor.tsx
@@ -189,11 +189,16 @@ const PromoEditor = ({
     });
   };
 
-  const handleIsIntroductoryPromotionChange = () => {
+  const handleIsIntroductoryPricingChange = () => {
     if (isEditing && editedPromo) {
-      setEditedPromo({
-        ...editedPromo,
-        isIntroductoryPricing: !editedPromo.isIntroductoryPricing,
+      setEditedPromo((curr) => {
+        if (!curr) {
+          return null;
+        }
+        return {
+          ...curr,
+          isIntroductoryPricing: !curr.isIntroductoryPricing,
+        };
       });
     }
   };
@@ -352,7 +357,7 @@ const PromoEditor = ({
           control={
             <Checkbox
               checked={editedPromo?.isIntroductoryPricing ?? false}
-              onChange={handleIsIntroductoryPromotionChange}
+              onChange={handleIsIntroductoryPricingChange}
               disabled={!isEditing}
             />
           }

--- a/public/src/components/promoTool/utils/promoModels.ts
+++ b/public/src/components/promoTool/utils/promoModels.ts
@@ -66,6 +66,7 @@ export interface Promo {
   description?: string;
   lockStatus?: LockStatus;
   landingPage?: LandingPage;
+  isIntroductoryPricing?: boolean;
 }
 
 export type PromoCampaigns = PromoCampaign[];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds a boolean flag to the Promo interface to indicate whether a promotion should display both the previous and new price (strikthrough) or only the new lower price. The flag is surfaced in the promo editor as a checkbox.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
Running support-admin-console locally, enabled the flag via UI, and then checked on AWS dynamodb the updated entry. 

## Screenshot
<img width="1239" height="734" alt="Screenshot 2026-07-15 at 15 28 35" src="https://github.com/user-attachments/assets/5ddbda3a-abdd-421e-b5dc-191d0a24074d" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216427013678097