### PR TITLE
Fix paragraphs in RichTextEditor if html disabled

### DIFF
--- a/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
+++ b/public/src/components/channelManagement/richTextEditor/richTextEditor.tsx
@@ -525,9 +525,12 @@ const RichTextEditor: React.FC<RichTextEditorProps<string[]>> = ({
   const getEditorContent = useCallback(() => {
     const view = manager.view;
     const { state } = view;
-    const text = state.doc.textContent;
     const html = view.dom.innerHTML;
-    return { html, text };
+    const textParagraphs: string[] = [];
+    state.doc.forEach((node) => {
+      textParagraphs.push(node.textContent);
+    });
+    return { html, textParagraphs };
   }, [manager]);
 
   const hooks = useMemo(() => {
@@ -537,9 +540,9 @@ const RichTextEditor: React.FC<RichTextEditorProps<string[]>> = ({
 
     const setupHandler = () => {
       const handleSaveShortcut = () => {
-        const { html, text } = getEditorContent();
+        const { html, textParagraphs } = getEditorContent();
         if (!enableHtml) {
-          updateCopy(text.split('\n'));
+          updateCopy(textParagraphs);
         } else {
           updateCopy(paragraphsToArray(html));
         }


### PR DESCRIPTION
In the Apple News epic tool there is a bug that prevents newlines. I'm not sure exactly when this stopped working, it's probably related to a remirror upgrade.
Newlines are not saved, and if you edit an existing text field that contains newlines it will actually remove them and save as a single line.


It relates to the fact that `enableHtml` is false for the Apple News epic tool.
In the past `doc.textContent` must have contained newline characters, but this is now not the case.
The solution is to process each node to build the `string[]` when `enableHtml` is false.

I will also add a ticket to add tests for the RichTextEditor - ideally we'd spot regressions like this.