### PR TITLE
DEV env removed

### DIFF
--- a/app/services/DynamoBanditData.scala
+++ b/app/services/DynamoBanditData.scala
@@ -45,8 +45,7 @@ object BanditData {
 }
 
 class DynamoBanditData(stage: String, client: DynamoDbClient) extends StrictLogging {
-  // No DEV table for bandit data
-  private val tableName = s"support-bandit-${if (stage == "PROD") "PROD" else "CODE"}"
+  private val tableName = s"support-bandit-${stage}"
 
   private def query(
       testName: String,

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -16,6 +16,8 @@ class AppLoader extends ApplicationLoader with StrictLogging {
   override def load(context: Context): Application = {
     new LogbackLoggerConfigurator().configure(context.environment)
 
+    val isDev = context.environment.mode == Mode.Dev
+
     def addConfigToContext(identity: AppIdentity): Try[Context] = Try {
       val loadedConfig = ConfigurationLoader.load(identity) {
         case AwsIdentity(app, stack, stage, _) => SSMConfigurationLocation(s"/$app/$stage", Aws.region.id())
@@ -30,12 +32,12 @@ class AppLoader extends ApplicationLoader with StrictLogging {
 
     val application: Try[Application] = for {
       identity <-
-        if (context.environment.mode == Mode.Dev) Success(DevIdentity("admin-console"))
+        if (isDev) Success(DevIdentity("admin-console"))
         else AppIdentity.whoAmI(defaultAppName = "admin-console", Aws.credentialsProvider.build())
       newContext <- addConfigToContext(identity)
       stage = identity match {
         case AwsIdentity(_, _, s, _) => s
-        case _                       => "DEV"
+        case _                       => "CODE"
       }
       application <- Try(new AppComponents(newContext, stage).application)
     } yield application

--- a/public/src/components/bookmarklets/Bookmarklets.tsx
+++ b/public/src/components/bookmarklets/Bookmarklets.tsx
@@ -62,8 +62,8 @@ const Bookmarklets: React.FC = () => {
       <ol>
         <li>
           Just drag each button below in the grid below to your Chrome bookmarks bar. Then go to{' '}
-          <a href="https://www.theguardian.com">theguardian.com</a> (DEV, CODE, or PROD) and click
-          the one you want.
+          <a href="https://www.theguardian.com">theguardian.com</a> (CODE, or PROD) and click the
+          one you want.
         </li>
         <li>
           If that doesn’t work or you want to import all of them at the same time, download the

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -12,7 +12,7 @@ export const DEFAULT_SECONDARY_CTA: Cta = {
   baseUrl: 'https://support.theguardian.com/contribute',
 };
 
-const DEV_AND_CODE_DEFAULT_VARIANT: BannerVariant = {
+const CODE_DEFAULT_VARIANT: BannerVariant = {
   name: 'CONTROL',
   template: { designName: 'TEST_NOT_SELECTED' },
   bannerContent: {
@@ -37,8 +37,8 @@ const PROD_DEFAULT_VARIANT: BannerVariant = {
 
 export const getDefaultVariant = (): BannerVariant => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_VARIANT;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_VARIANT;
   }
   return PROD_DEFAULT_VARIANT;
 };
@@ -48,14 +48,14 @@ export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryCodes: [],
 };
 
-const DEV_AND_CODE_DEFAULT_BANNER_TEST: BannerTest = {
+const CODE_DEFAULT_BANNER_TEST: BannerTest = {
   name: 'TEST',
   nickname: 'TEST',
   status: 'Draft',
   userCohort: UserCohort.AllNonSupporters,
   locations: [],
   regionTargeting: DEFAULT_REGION_TARGETING,
-  variants: [DEV_AND_CODE_DEFAULT_VARIANT],
+  variants: [CODE_DEFAULT_VARIANT],
   articlesViewedSettings: undefined,
   contextTargeting: { tagIds: [], sectionIds: [], excludedTagIds: [], excludedSectionIds: [] },
   methodologies: [{ name: 'ABTest' }],
@@ -76,8 +76,8 @@ const PROD_DEFAULT_BANNER: BannerTest = {
 
 export const getDefaultTest = (): BannerTest => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_BANNER_TEST;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_BANNER_TEST;
   }
   return PROD_DEFAULT_BANNER;
 };

--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -18,7 +18,7 @@ export const DEFAULT_SECONDARY_CTA: Cta = {
   baseUrl: '',
 };
 
-const DEV_AND_CODE_DEFAULT_VARIANT: EpicVariant = {
+const CODE_DEFAULT_VARIANT: EpicVariant = {
   name: 'CONTROL',
   paragraphs: [
     "… we have a small favour to ask. You've read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; millions are flocking to the Guardian for quality news every day. We believe everyone deserves access to factual information, and analysis that has authority and integrity. That’s why, unlike many others, we made a choice: to keep Guardian reporting open for all, regardless of where they live or what they can afford to pay.",
@@ -49,8 +49,8 @@ const PROD_DEFAULT_VARIANT: EpicVariant = {
 
 export const getDefaultVariant = (): EpicVariant => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_VARIANT;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_VARIANT;
   }
   return PROD_DEFAULT_VARIANT;
 };
@@ -60,7 +60,7 @@ export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryCodes: [],
 };
 
-const DEV_AND_CODE_DEFAULT_TEST: EpicTest = {
+const CODE_DEFAULT_TEST: EpicTest = {
   name: 'TEST',
   nickname: 'TEST',
   status: 'Draft',
@@ -74,7 +74,7 @@ const DEV_AND_CODE_DEFAULT_TEST: EpicTest = {
   maxViews: DEFAULT_MAX_EPIC_VIEWS,
   userCohort: UserCohort.AllNonSupporters, // matches the default in dotcom
   hasCountryName: false,
-  variants: [DEV_AND_CODE_DEFAULT_VARIANT],
+  variants: [CODE_DEFAULT_VARIANT],
   highPriority: false, // has been removed from form, but might be used in future
   useLocalViewLog: false,
   methodologies: [{ name: 'ABTest' }],
@@ -102,8 +102,8 @@ const PROD_DEFAULT_TEST: EpicTest = {
 
 export const getDefaultTest = (): EpicTest => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_TEST;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_TEST;
   }
   return PROD_DEFAULT_TEST;
 };

--- a/public/src/components/channelManagement/gutterTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/gutterTests/utils/defaults.ts
@@ -10,7 +10,7 @@ export const DEFAULT_PRIMARY_CTA: Cta = {
 export const DEFAULT_IMAGE_URL = 'https://uploads.guim.co.uk/2025/06/12/not_for_sale_bg_scaled.svg';
 export const DEFAULT_IMAGE_ALT = 'Not for Sale';
 
-const DEV_AND_CODE_DEFAULT_VARIANT: GutterVariant = {
+const CODE_DEFAULT_VARIANT: GutterVariant = {
   content: {
     image: {
       mainUrl: DEFAULT_IMAGE_URL,
@@ -40,8 +40,8 @@ const PROD_DEFAULT_VARIANT: GutterVariant = {
 
 export const getDefaultVariant = (): GutterVariant => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_VARIANT;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_VARIANT;
   }
   return PROD_DEFAULT_VARIANT;
 };
@@ -51,14 +51,14 @@ export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryCodes: [],
 };
 
-const DEV_AND_CODE_DEFAULT_GUTTER_TEST: GutterTest = {
+const CODE_DEFAULT_GUTTER_TEST: GutterTest = {
   name: 'TEST',
   nickname: 'TEST',
   status: 'Draft',
   userCohort: UserCohort.AllNonSupporters,
   locations: [],
   regionTargeting: DEFAULT_REGION_TARGETING,
-  variants: [DEV_AND_CODE_DEFAULT_VARIANT],
+  variants: [CODE_DEFAULT_VARIANT],
   contextTargeting: { tagIds: [], sectionIds: [], excludedTagIds: [], excludedSectionIds: [] },
   methodologies: [{ name: 'ABTest' }],
   campaignName: '',
@@ -81,8 +81,8 @@ const PROD_DEFAULT_GUTTER_TEST: GutterTest = {
 
 export const getDefaultTest = (): GutterTest => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_GUTTER_TEST;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_GUTTER_TEST;
   }
   return PROD_DEFAULT_GUTTER_TEST;
 };

--- a/public/src/components/channelManagement/headerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/headerTests/utils/defaults.ts
@@ -12,7 +12,7 @@ export const DEFAULT_SECONDARY_CTA: Cta = {
   baseUrl: 'https://support.theguardian.com/contribute',
 };
 
-const DEV_AND_CODE_DEFAULT_VARIANT: HeaderVariant = {
+const CODE_DEFAULT_VARIANT: HeaderVariant = {
   name: 'CONTROL',
   content: {
     heading: 'Support the Guardian',
@@ -32,8 +32,8 @@ const PROD_DEFAULT_VARIANT: HeaderVariant = {
 
 export const getDefaultVariant = (): HeaderVariant => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_VARIANT;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_VARIANT;
   }
   return PROD_DEFAULT_VARIANT;
 };
@@ -43,7 +43,7 @@ export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryCodes: [],
 };
 
-const DEV_AND_CODE_DEFAULT_BANNER_TEST: HeaderTest = {
+const CODE_DEFAULT_BANNER_TEST: HeaderTest = {
   name: '',
   nickname: '',
   status: 'Draft',
@@ -67,8 +67,8 @@ const PROD_DEFAULT_BANNER: HeaderTest = {
 
 export const getDefaultTest = (): HeaderTest => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_BANNER_TEST;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_BANNER_TEST;
   }
   return PROD_DEFAULT_BANNER;
 };

--- a/public/src/components/channelManagement/supportLandingPage/utils/defaults.ts
+++ b/public/src/components/channelManagement/supportLandingPage/utils/defaults.ts
@@ -80,7 +80,7 @@ const defaultProducts = {
   },
 };
 
-const DEV_AND_CODE_DEFAULT_VARIANT: SupportLandingPageVariant = {
+const CODE_DEFAULT_VARIANT: SupportLandingPageVariant = {
   name: 'CONTROL',
   copy: {
     heading: 'Support fearless, independent journalism',
@@ -102,8 +102,8 @@ const PROD_DEFAULT_VARIANT: SupportLandingPageVariant = {
 
 export const getDefaultVariant = (): SupportLandingPageVariant => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_VARIANT;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_VARIANT;
   }
   return PROD_DEFAULT_VARIANT;
 };
@@ -113,13 +113,13 @@ export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryCodes: [],
 };
 
-const DEV_AND_CODE_DEFAULT_LANDING_PAGE_TEST: SupportLandingPageTest = {
+const CODE_DEFAULT_LANDING_PAGE_TEST: SupportLandingPageTest = {
   name: 'TEST',
   nickname: 'TEST',
   status: 'Draft',
   locations: [],
   regionTargeting: DEFAULT_REGION_TARGETING,
-  variants: [DEV_AND_CODE_DEFAULT_VARIANT],
+  variants: [CODE_DEFAULT_VARIANT],
   methodologies: [{ name: 'ABTest' }],
 };
 
@@ -135,8 +135,8 @@ const PROD_DEFAULT_LANDING_PAGE: SupportLandingPageTest = {
 
 export const getDefaultTest = (): SupportLandingPageTest => {
   const stage = getStage();
-  if (stage === 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_DEFAULT_LANDING_PAGE_TEST;
+  if (stage === 'CODE') {
+    return CODE_DEFAULT_LANDING_PAGE_TEST;
   }
   return PROD_DEFAULT_LANDING_PAGE;
 };

--- a/public/src/main.tsx
+++ b/public/src/main.tsx
@@ -56,7 +56,7 @@ interface PagePermission {
   permission: 'Read' | 'Write';
 }
 
-type Stage = 'DEV' | 'CODE' | 'PROD';
+type Stage = 'CODE' | 'PROD';
 declare global {
   interface Window {
     guardian: {

--- a/public/src/utils/stage.ts
+++ b/public/src/utils/stage.ts
@@ -1,4 +1,4 @@
-export type Stage = 'DEV' | 'CODE' | 'PROD';
+export type Stage = 'CODE' | 'PROD';
 
 export const getStage = (): Stage => {
   return window.guardian.stage;

--- a/public/src/utils/theme.ts
+++ b/public/src/utils/theme.ts
@@ -3,7 +3,7 @@ import purple from '@mui/material/colors/purple';
 import { createTheme, Theme } from '@mui/material/styles';
 import { getStage } from './stage';
 
-const DEV_AND_CODE_THEME = createTheme({
+const CODE_THEME = createTheme({
   palette: {
     primary: {
       main: purple[500],
@@ -18,8 +18,8 @@ const PROD_THEME = createTheme({});
 
 export const getTheme = (): Theme => {
   const stage = getStage();
-  if (stage == 'DEV' || stage === 'CODE') {
-    return DEV_AND_CODE_THEME;
+  if (stage === 'CODE') {
+    return CODE_THEME;
   }
   return PROD_THEME;
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213310019687781)
## What does this change?
This change removes the DEV environment stage from the application codebase.  Local development continues to work as before without requiring a separate DEV stage.
After this change, only two stages exist:
- `CODE` - staging environment in AWS
- `PROD` - production environment in AWS

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
