### PR TITLE
Return 404 if item not found in DynamoDB

### DIFF
--- a/app/controllers/promos/PromosController.scala
+++ b/app/controllers/promos/PromosController.scala
@@ -3,7 +3,7 @@ package controllers.promos
 import actions.{AuthAndPermissionActions, PermissionAction}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax._
-import models.DynamoErrors.{DynamoDuplicateNameError, DynamoNoLockError}
+import models.DynamoErrors.{DynamoDuplicateNameError, DynamoGetError, DynamoNoLockError, DynamoNotFoundError}
 import models.promos.Promo
 import play.api.libs.circe.Circe
 import play.api.mvc.{AbstractController, Action, ActionBuilder, AnyContent, ControllerComponents, Result}
@@ -67,6 +67,7 @@ class PromosController(
           ).asJson
           Ok(noNulls(response))
         }
+        .catchSome { case DynamoGetError(_: DynamoNotFoundError) => ZIO.succeed(NotFound(s"Promo $promoCode not found")) }
     }
   }
 

--- a/app/controllers/promos/PromosController.scala
+++ b/app/controllers/promos/PromosController.scala
@@ -3,7 +3,7 @@ package controllers.promos
 import actions.{AuthAndPermissionActions, PermissionAction}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax._
-import models.DynamoErrors.{DynamoDuplicateNameError, DynamoGetError, DynamoNoLockError, DynamoNotFoundError}
+import models.DynamoErrors.{DynamoDuplicateNameError, DynamoNoLockError, DynamoNotFoundError}
 import models.promos.Promo
 import play.api.libs.circe.Circe
 import play.api.mvc.{AbstractController, Action, ActionBuilder, AnyContent, ControllerComponents, Result}
@@ -67,7 +67,7 @@ class PromosController(
           ).asJson
           Ok(noNulls(response))
         }
-        .catchSome { case DynamoGetError(_: DynamoNotFoundError) => ZIO.succeed(NotFound(s"Promo $promoCode not found")) }
+        .catchSome { case DynamoNotFoundError(_) => ZIO.succeed(NotFound(s"Promo $promoCode not found")) }
     }
   }
 

--- a/app/models/DynamoErrors.scala
+++ b/app/models/DynamoErrors.scala
@@ -11,6 +11,9 @@ object DynamoErrors {
   case class DynamoGetError(error: Throwable) extends DynamoError {
     override def getMessage = s"Error reading from Dynamo: ${error.getMessage}"
   }
+  case class DynamoNotFoundError(key: String) extends DynamoError {
+    override def getMessage = s"Item not found: $key"
+  }
   case class DynamoDuplicateNameError(error: Throwable) extends DynamoError {
     override def getMessage = s"Error writing to Dynamo: ${error.getMessage}"
   }

--- a/app/services/DynamoBannerDesigns.scala
+++ b/app/services/DynamoBannerDesigns.scala
@@ -58,7 +58,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
       case other                                => DynamoPutError(other)
     }
 
-  def getBannerDesign(designName: String): ZIO[Any, DynamoGetError, BannerDesign] =
+  def getBannerDesign(designName: String): ZIO[Any, DynamoError, BannerDesign] =
     get(buildQuery(designName))
       .map(item => dynamoMapToJson(item).as[BannerDesign])
       .flatMap {
@@ -210,7 +210,7 @@ class DynamoBannerDesigns(stage: String, client: DynamoDbClient)
   }
 
   // Does not decode the Dynamodb data
-  def getRawDesign(designName: String): ZIO[Any, DynamoGetError, java.util.Map[String, AttributeValue]] =
+  def getRawDesign(designName: String): ZIO[Any, DynamoError, java.util.Map[String, AttributeValue]] =
     get(buildQuery(designName))
 
 }

--- a/app/services/DynamoChannelTests.scala
+++ b/app/services/DynamoChannelTests.scala
@@ -99,7 +99,7 @@ class DynamoChannelTests(stage: String, client: DynamoDbClient)
       case other                                => DynamoPutError(other)
     }
 
-  def getTest[T <: ChannelTest[T]: Decoder](testName: String, channel: Channel): ZIO[Any, DynamoGetError, T] =
+  def getTest[T <: ChannelTest[T]: Decoder](testName: String, channel: Channel): ZIO[Any, DynamoError, T] =
     get(buildQuery(testName, channel))
       .map(item => dynamoMapToJson(item).as[T])
       .flatMap {

--- a/app/services/DynamoService.scala
+++ b/app/services/DynamoService.scala
@@ -27,19 +27,18 @@ abstract class DynamoService(stage: String, client: DynamoDbClient) extends Stri
   protected val tableName: String
 
   // Attempts to retrieve an item. Fails if the item does not exist.
-  protected def get(query: QueryRequest): ZIO[Any, DynamoGetError, java.util.Map[String, AttributeValue]] =
+  protected def get(query: QueryRequest): ZIO[Any, DynamoError, java.util.Map[String, AttributeValue]] =
     attemptBlocking {
       client
         .query(query)
         .items
         .asScala
         .headOption
-
-    }.flatMap {
-      case Some(item) => ZIO.succeed(item)
-      case None       =>
-        ZIO.fail(DynamoNotFoundError(query.keyConditionExpression()))
-    }.mapError(error => DynamoGetError(error))
+    }.mapError(DynamoGetError(_))
+      .flatMap {
+        case Some(item) => ZIO.succeed(item)
+        case None       => ZIO.fail(DynamoNotFoundError(query.keyConditionExpression()))
+      }
 
   // Performs a full scan of the table
   protected def getAll(): ZIO[Any, DynamoGetError, java.util.List[java.util.Map[String, AttributeValue]]] =

--- a/app/services/DynamoService.scala
+++ b/app/services/DynamoService.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.typesafe.scalalogging.StrictLogging
-import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoGetError, DynamoPutError}
+import models.DynamoErrors.{DynamoDuplicateNameError, DynamoError, DynamoGetError, DynamoNotFoundError, DynamoPutError}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{
   AttributeValue,
@@ -38,7 +38,7 @@ abstract class DynamoService(stage: String, client: DynamoDbClient) extends Stri
     }.flatMap {
       case Some(item) => ZIO.succeed(item)
       case None       =>
-        ZIO.fail(DynamoGetError(new Exception(s"Item does not exist: ${query.keyConditionExpression()}")))
+        ZIO.fail(DynamoNotFoundError(query.keyConditionExpression()))
     }.mapError(error => DynamoGetError(error))
 
   // Performs a full scan of the table

--- a/app/services/promos/DynamoPromoCampaigns.scala
+++ b/app/services/promos/DynamoPromoCampaigns.scala
@@ -38,7 +38,7 @@ class DynamoPromoCampaigns(stage: String, client: DynamoDbClient)
       )
       .build()
 
-  def getPromoCampaign(campaignCode: String): ZIO[Any, DynamoGetError, PromoCampaign] =
+  def getPromoCampaign(campaignCode: String): ZIO[Any, DynamoError, PromoCampaign] =
     get(buildQuery(campaignCode))
       .map(item => dynamoMapToJson(item).as[PromoCampaign])
       .flatMap {

--- a/app/services/promos/DynamoPromos.scala
+++ b/app/services/promos/DynamoPromos.scala
@@ -39,7 +39,7 @@ class DynamoPromos(stage: String, client: DynamoDbClient) extends DynamoService(
       )
       .build()
 
-  def getPromo(promoCode: String): ZIO[Any, DynamoGetError, Promo] =
+  def getPromo(promoCode: String): ZIO[Any, DynamoError, Promo] =
     get(buildQuery(promoCode))
       .map(item => dynamoMapToJson(item).as[Promo])
       .flatMap {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1217032428374914)
## What does this change?
This change updated code to return 404 instead of 500 when promo code is not found

When a promo code doesn't exist in DynamoDB, the GET /promo/:promoCode endpoint was returning a 500 and logging a spurious InternalServerError alert. This was caused by the not-found case falling through to the generic error handler in run().

Side effect: other services that use DynamoService.get (DynamoBannerDesigns, DynamoChannelTests, DynamoPromoCampaigns) are functionally unchanged (still 500 on not-found) but their not-found log messages are now cleaner — single-wrapped instead of double-wrapped.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE env
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1094" height="383" alt="Screenshot 2026-07-31 at 15 27 09" src="https://github.com/user-attachments/assets/9c9b6c5d-1498-4f09-91ed-16cdab7a5574" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
