### PR TITLE
Add contributions-only countries targeting to RegionTargeting

### DIFF
--- a/app/models/RegionTargeting.scala
+++ b/app/models/RegionTargeting.scala
@@ -1,6 +1,23 @@
 package models
 
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{deriveEnumerationDecoder, deriveEnumerationEncoder}
+import io.circe.{Decoder, Encoder}
+
+sealed trait ContributionsOnlyCountriesTargeting
+
+object ContributionsOnlyCountriesTargeting {
+  case object Include extends ContributionsOnlyCountriesTargeting
+  case object Exclude extends ContributionsOnlyCountriesTargeting
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+  implicit val decoder: Decoder[ContributionsOnlyCountriesTargeting] =
+    deriveEnumerationDecoder[ContributionsOnlyCountriesTargeting]
+  implicit val encoder: Encoder[ContributionsOnlyCountriesTargeting] =
+    deriveEnumerationEncoder[ContributionsOnlyCountriesTargeting]
+}
+
 case class RegionTargeting(
     targetedCountryGroups: List[Region] = Nil,
-    targetedCountryCodes: Option[List[String]] = None
+    targetedCountryCodes: Option[List[String]] = None,
+    contributionsOnlyCountriesTargeting: Option[ContributionsOnlyCountriesTargeting] = None
 )

--- a/public/src/components/channelManagement/bannerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/bannerTests/utils/defaults.ts
@@ -46,6 +46,7 @@ export const getDefaultVariant = (): BannerVariant => {
 export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryGroups: [],
   targetedCountryCodes: [],
+  contributionsOnlyCountriesTargeting: 'Exclude',
 };
 
 const CODE_DEFAULT_BANNER_TEST: BannerTest = {

--- a/public/src/components/channelManagement/epicTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/epicTests/utils/defaults.ts
@@ -58,6 +58,7 @@ export const getDefaultVariant = (): EpicVariant => {
 export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryGroups: [],
   targetedCountryCodes: [],
+  contributionsOnlyCountriesTargeting: 'Exclude',
 };
 
 const CODE_DEFAULT_TEST: EpicTest = {

--- a/public/src/components/channelManagement/gutterTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/gutterTests/utils/defaults.ts
@@ -49,6 +49,7 @@ export const getDefaultVariant = (): GutterVariant => {
 export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryGroups: [],
   targetedCountryCodes: [],
+  contributionsOnlyCountriesTargeting: 'Exclude',
 };
 
 const CODE_DEFAULT_GUTTER_TEST: GutterTest = {

--- a/public/src/components/channelManagement/headerTests/utils/defaults.ts
+++ b/public/src/components/channelManagement/headerTests/utils/defaults.ts
@@ -41,6 +41,7 @@ export const getDefaultVariant = (): HeaderVariant => {
 export const DEFAULT_REGION_TARGETING: RegionTargeting = {
   targetedCountryGroups: [],
   targetedCountryCodes: [],
+  contributionsOnlyCountriesTargeting: 'Exclude',
 };
 
 const CODE_DEFAULT_BANNER_TEST: HeaderTest = {

--- a/public/src/components/channelManagement/helpers/shared.ts
+++ b/public/src/components/channelManagement/helpers/shared.ts
@@ -297,9 +297,12 @@ export interface BylineWithImage {
 
 export type SignedInStatus = 'SignedIn' | 'SignedOut' | 'All';
 
+export type ContributionsOnlyCountriesTargeting = 'Include' | 'Exclude';
+
 export interface RegionTargeting {
   targetedCountryGroups: Region[];
   targetedCountryCodes?: string[];
+  contributionsOnlyCountriesTargeting?: ContributionsOnlyCountriesTargeting;
 }
 
 export type PermissionLevel = 'Read' | 'Write' | 'None';

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Region } from '../../utils/models';
 import {
   ConsentStatus,
+  ContributionsOnlyCountriesTargeting,
   DeviceType,
   RegionTargeting,
   SignedInStatus,
@@ -103,6 +104,24 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
             onRegionTargetingUpdate={onRegionTargetingUpdate}
           />
         )}
+        <div style={{ marginTop: 16 }}>
+          <Typography className={classes.heading}>Contributions-only countries</Typography>
+          <TypedRadioGroup<'All' | ContributionsOnlyCountriesTargeting>
+            selectedValue={regionTargeting.contributionsOnlyCountriesTargeting ?? 'All'}
+            onChange={(value) =>
+              onRegionTargetingUpdate({
+                ...regionTargeting,
+                contributionsOnlyCountriesTargeting: value === 'All' ? undefined : value,
+              })
+            }
+            isDisabled={isDisabled}
+            labels={{
+              All: 'All countries (no targeting)',
+              Include: 'Only contributions-only countries',
+              Exclude: 'Exclude contributions-only countries',
+            }}
+          />
+        </div>
       </div>
       <div className={classes.containerSection}>
         {showSupporterStatusSelector && (

--- a/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
+++ b/public/src/components/channelManagement/testEditorTargetAudienceSelector.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles(({ spacing, palette }: Theme) => ({
 }));
 
 interface TestEditorTargetAudienceSelectorProps {
-  regionTargeting: RegionTargeting;
+  regionTargeting?: RegionTargeting;
   onRegionTargetingUpdate: (regionTargeting: RegionTargeting) => void;
   selectedCohort: UserCohort;
   onCohortChange: (updatedCohort: UserCohort) => void;
@@ -85,13 +85,18 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
   mParticleAudienceValidation,
 }: TestEditorTargetAudienceSelectorProps) => {
   const classes = useStyles();
+  const regionTargetingOrDefault: RegionTargeting = regionTargeting ?? {
+    targetedCountryGroups: [],
+    targetedCountryCodes: [],
+    contributionsOnlyCountriesTargeting: 'Exclude',
+  };
 
   return (
     <div className={classes.container}>
       <div className={classes.containerSection}>
         <Typography className={classes.heading}>Region</Typography>
         <TestEditorTargetRegionsSelector
-          regionTargeting={regionTargeting}
+          regionTargeting={regionTargetingOrDefault}
           onRegionTargetingUpdate={onRegionTargetingUpdate}
           supportedRegions={supportedRegions}
           isDisabled={isDisabled}
@@ -100,25 +105,26 @@ const TestEditorTargetAudienceSelector: React.FC<TestEditorTargetAudienceSelecto
         {platform !== 'APPLE_NEWS' && (
           <MultiSelectCountryEditor
             disabled={isDisabled}
-            regionTargeting={regionTargeting}
+            regionTargeting={regionTargetingOrDefault}
             onRegionTargetingUpdate={onRegionTargetingUpdate}
           />
         )}
         <div style={{ marginTop: 16 }}>
           <Typography className={classes.heading}>Contributions-only countries</Typography>
-          <TypedRadioGroup<'All' | ContributionsOnlyCountriesTargeting>
-            selectedValue={regionTargeting.contributionsOnlyCountriesTargeting ?? 'All'}
+          <TypedRadioGroup<ContributionsOnlyCountriesTargeting>
+            selectedValue={
+              regionTargetingOrDefault.contributionsOnlyCountriesTargeting ?? 'Exclude'
+            }
             onChange={(value) =>
               onRegionTargetingUpdate({
-                ...regionTargeting,
-                contributionsOnlyCountriesTargeting: value === 'All' ? undefined : value,
+                ...regionTargetingOrDefault,
+                contributionsOnlyCountriesTargeting: value,
               })
             }
             isDisabled={isDisabled}
             labels={{
-              All: 'All countries (no targeting)',
-              Include: 'Only contributions-only countries',
               Exclude: 'Exclude contributions-only countries',
+              Include: 'Only contributions-only countries',
             }}
           />
         </div>


### PR DESCRIPTION
Adds a `contributionsOnlyCountriesTargeting` field (`Include` / `Exclude` (default)) to `RegionTargeting`, surfaced as a radio control in the shared target audience selector for all channel tests (epic, banner, header, gutter). This lets MRR target tests to include or exclude contributions-only countries, so users in those countries don't see copy mentioning products/promos they can't have. Backward compatible (optional field, no migration). Pair with the support-dotcom-components PR which evaluates the targeting at selection time.

### Screenshot

<img width="333" height="113" alt="image" src="https://github.com/user-attachments/assets/c75a9514-041e-4624-ad9a-84a161009567" />

