### PR TITLE
Bump brace-expansion and fast-uri overrides to patch high-severity DoS/host-confusion advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "remirror": "3.0.3",
     "uuid": "14.0.1"
   },
-
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "build-dev": "webpack --config webpack.dev.js",
@@ -69,13 +68,13 @@
       "handlebars@<4.7.9": ">=4.7.9",
       "node-forge@<1.4.0": ">=1.4.0",
       "lodash-es@<=4.17.23": "4.18.0",
-      "brace-expansion@>=2.0.0 <2.1.2": ">=2.1.2 <3",
-      "brace-expansion@<1.1.16": ">=1.1.16 <2",
-      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7 <6",
+      "brace-expansion@>=2.0.0 <2.1.4": ">=2.1.4 <3",
+      "brace-expansion@<1.1.18": ">=1.1.18 <2",
+      "brace-expansion@>=3.0.0 <5.0.9": ">=5.0.9 <6",
       "js-yaml@>=4.0.0 <4.3.0": ">=4.3.0 <5",
       "js-yaml@>=3.0.0 <3.15.0": ">=3.15.0 <4",
       "shell-quote@<=1.8.4": ">=1.9.0 <2",
-      "fast-uri@>=3.0.0 <=3.1.3": ">=3.1.4 <4"
+      "fast-uri@>=3.0.0 <3.1.5": ">=3.1.5 <4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,13 +15,13 @@ overrides:
   handlebars@<4.7.9: '>=4.7.9'
   node-forge@<1.4.0: '>=1.4.0'
   lodash-es@<=4.17.23: 4.18.0
-  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
-  brace-expansion@<1.1.16: '>=1.1.16 <2'
-  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7 <6'
+  brace-expansion@>=2.0.0 <2.1.4: '>=2.1.4 <3'
+  brace-expansion@<1.1.18: '>=1.1.18 <2'
+  brace-expansion@>=3.0.0 <5.0.9: '>=5.0.9 <6'
   js-yaml@>=4.0.0 <4.3.0: '>=4.3.0 <5'
   js-yaml@>=3.0.0 <3.15.0: '>=3.15.0 <4'
   shell-quote@<=1.8.4: '>=1.9.0 <2'
-  fast-uri@>=3.0.0 <=3.1.3: '>=3.1.4 <4'
+  fast-uri@>=3.0.0 <3.1.5: '>=3.1.5 <4'
 
 importers:
 
@@ -2148,14 +2148,14 @@ packages:
   bonjour-service@1.4.4:
     resolution: {integrity: sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2843,8 +2843,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -7809,7 +7809,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8014,16 +8014,16 @@ snapshots:
       fast-deep-equal: 3.1.3
       multicast-dns: 7.2.5
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8791,7 +8791,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fb-watchman@2.0.2:
     dependencies:
@@ -9851,15 +9851,15 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

Updates `pnpm.overrides` ranges to pull in patched versions for 5 high-severity advisories flagged by `pnpm audit`. All affected packages are transitive dev-only dependencies (eslint plugins, webpack) — no runtime code changes.

- `brace-expansion` → `1.1.18` / `2.1.4` / `5.0.9` (GHSA-rgw5-rvv9-x895, GHSA-mh99-v99m-4gvg)
- `fast-uri` → `3.1.5` (GHSA-7p8r-x3mc-p8w7)

`pnpm audit` goes from 6 high → 1 high. The remaining `react-router` advisory (GHSA-qwww-vcr4-c8h2) has no upgrade path: `react-router-dom` tops out at `7.18.2`, which pins `react-router@7.18.2`, and no `react-router-dom@8.x` is published. The advisory only affects the unstable RSC APIs, which this SPA does not use.